### PR TITLE
feat(secrets): let a client erase a stored credential with an explicit null

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -48,6 +48,13 @@ export interface UiContribution {
   action: { kind: 'route'; path: string } | { kind: 'action'; actionId: string };
 }
 
+/**
+ * Key a read response adds to `settings` to name the `secret: true` fields that hold a stored
+ * value — the editor renders those masked and offers to erase them. Read-only: a resource must
+ * strip it on write rather than persist it.
+ */
+export const SECRETS_SET_KEY = 'secretsSet';
+
 /** The seven field kinds `<app-schema-form>` renders, over three form components. */
 export type FieldType = 'text' | 'email' | 'password' | 'url' | 'number' | 'toggle' | 'select';
 
@@ -63,7 +70,12 @@ export interface FieldDef {
   hint?: string;
   placeholder?: string;
   required?: boolean;
-  /** Stripped from every read response; only written back when non-empty. */
+  /**
+   * Stripped from every read response; only written back when non-empty. A resource honouring
+   * this lists its set keys under `SECRETS_SET_KEY` so the editor can mask a stored value it
+   * never receives, and treats an incoming `null` as "erase it" — blank already means
+   * "unchanged", so removal needs a spelling of its own (the one JSON Merge Patch uses).
+   */
   secret?: boolean;
   default?: string | number | boolean;
   options?: { value: string; labelKey: string }[];

--- a/backend/src/common/utils/secret-fields.util.spec.ts
+++ b/backend/src/common/utils/secret-fields.util.spec.ts
@@ -1,4 +1,4 @@
-import { redactSecretFields, mergeSecretFields } from './secret-fields.util';
+import { redactSecretFields, mergeSecretFields, SECRETS_SET_KEY } from './secret-fields.util';
 import { FieldDef } from '../plugin-contract/ui-contribution';
 
 const FIELDS: FieldDef[] = [
@@ -9,11 +9,16 @@ const FIELDS: FieldDef[] = [
 describe('redactSecretFields', () => {
   it('strips only the fields the schema marks secret', () => {
     const out = redactSecretFields({ apiKey: 'k', baseUrl: 'https://x' }, FIELDS);
-    expect(out).toEqual({ baseUrl: 'https://x' });
+    expect(out).toEqual({ baseUrl: 'https://x', [SECRETS_SET_KEY]: ['apiKey'] });
+  });
+
+  it('reports a stripped secret as set, so an editor can mask it without holding it', () => {
+    expect(redactSecretFields({ apiKey: 'k' }, FIELDS)[SECRETS_SET_KEY]).toEqual(['apiKey']);
+    expect(redactSecretFields({ apiKey: '' }, FIELDS)[SECRETS_SET_KEY]).toEqual([]);
   });
 
   it('tolerates missing settings', () => {
-    expect(redactSecretFields(undefined, FIELDS)).toEqual({});
+    expect(redactSecretFields(undefined, FIELDS)).toEqual({ [SECRETS_SET_KEY]: [] });
   });
 });
 
@@ -31,6 +36,17 @@ describe('mergeSecretFields', () => {
   it('writes a non-empty incoming secret over the stored one', () => {
     const out = mergeSecretFields({ apiKey: 'stored' }, { apiKey: 'new' }, FIELDS);
     expect(out.apiKey).toBe('new');
+  });
+
+  it('erases the stored secret when the incoming value is an explicit null', () => {
+    const out = mergeSecretFields({ apiKey: 'stored' }, { apiKey: null, baseUrl: 'https://x' }, FIELDS);
+    expect(out).toEqual({ baseUrl: 'https://x' });
+    expect('apiKey' in out).toBe(false);
+  });
+
+  it('never persists the read-only set marker a client echoes back', () => {
+    const out = mergeSecretFields({ apiKey: 'stored' }, { [SECRETS_SET_KEY]: ['apiKey'] }, FIELDS);
+    expect(out).toEqual({ apiKey: 'stored' });
   });
 
   it('never touches a non-secret field beyond passing it through', () => {

--- a/backend/src/common/utils/secret-fields.util.spec.ts
+++ b/backend/src/common/utils/secret-fields.util.spec.ts
@@ -1,5 +1,5 @@
-import { redactSecretFields, mergeSecretFields, SECRETS_SET_KEY } from './secret-fields.util';
-import { FieldDef } from '../plugin-contract/ui-contribution';
+import { redactSecretFields, mergeSecretFields } from './secret-fields.util';
+import { FieldDef, SECRETS_SET_KEY } from '../plugin-contract/ui-contribution';
 
 const FIELDS: FieldDef[] = [
   { key: 'apiKey', type: 'text', labelKey: 'x', secret: true },

--- a/backend/src/common/utils/secret-fields.util.ts
+++ b/backend/src/common/utils/secret-fields.util.ts
@@ -1,10 +1,6 @@
-import { FieldDef } from '../plugin-contract/ui-contribution';
+import { FieldDef, SECRETS_SET_KEY } from '../plugin-contract/ui-contribution';
 
 type SecretKeyed = Pick<FieldDef, 'key' | 'secret'>;
-
-/** Names the secret fields that hold a stored value, so an editor can show `●●●●` without the
- *  value itself. Read-only: writes strip it back out rather than persisting it. */
-export const SECRETS_SET_KEY = 'secretsSet';
 
 /** Strips every `secret: true` field's value from `settings`, by schema key, and reports which
  *  of them are set under `SECRETS_SET_KEY`. */

--- a/backend/src/common/utils/secret-fields.util.ts
+++ b/backend/src/common/utils/secret-fields.util.ts
@@ -2,28 +2,40 @@ import { FieldDef } from '../plugin-contract/ui-contribution';
 
 type SecretKeyed = Pick<FieldDef, 'key' | 'secret'>;
 
-/** Strips every `secret: true` field's value from `settings`, by schema key. */
+/** Names the secret fields that hold a stored value, so an editor can show `●●●●` without the
+ *  value itself. Read-only: writes strip it back out rather than persisting it. */
+export const SECRETS_SET_KEY = 'secretsSet';
+
+/** Strips every `secret: true` field's value from `settings`, by schema key, and reports which
+ *  of them are set under `SECRETS_SET_KEY`. */
 export function redactSecretFields(
   settings: Record<string, unknown> | null | undefined,
   fields: readonly SecretKeyed[],
 ): Record<string, unknown> {
   const out = { ...(settings ?? {}) };
+  const set: string[] = [];
   for (const field of fields) {
-    if (field.secret) delete out[field.key];
+    if (!field.secret) continue;
+    if (out[field.key]) set.push(field.key);
+    delete out[field.key];
   }
+  out[SECRETS_SET_KEY] = set;
   return out;
 }
 
-/** On write, keeps each secret field's stored value when the incoming one is absent/empty. */
+/** On write, keeps each secret field's stored value when the incoming one is absent or blank;
+ *  an explicit `null` erases it, as JSON Merge Patch (RFC 7396) defines it. */
 export function mergeSecretFields(
   existing: Record<string, unknown> | null | undefined,
   incoming: Record<string, unknown>,
   fields: readonly SecretKeyed[],
 ): Record<string, unknown> {
   const out = { ...incoming };
+  delete out[SECRETS_SET_KEY];
   for (const field of fields) {
     if (!field.secret) continue;
-    if (!out[field.key]) out[field.key] = (existing ?? {})[field.key];
+    if (out[field.key] === null) delete out[field.key];
+    else if (!out[field.key]) out[field.key] = (existing ?? {})[field.key];
   }
   return out;
 }

--- a/backend/src/modules/notifications/notifications.service.spec.ts
+++ b/backend/src/modules/notifications/notifications.service.spec.ts
@@ -104,6 +104,56 @@ describe('NotificationsService settings normalization', () => {
     });
   });
 
+  it('erases the stored token when the editor sends an explicit null', async () => {
+    stored = {
+      type: 'ntfy',
+      settings: { url: 'https://ntfy.sh', topic: 'media', token: 'tk_stored' },
+    };
+    await service.update(1, {
+      name: 'Ntfy',
+      type: 'ntfy',
+      settings: { url: 'https://ntfy.sh', topic: 'media', token: null },
+    });
+    expect(saved[0].settings).toEqual({ url: 'https://ntfy.sh', topic: 'media' });
+    expect(saved[0].settings).not.toHaveProperty('token');
+  });
+
+  it('refuses to erase a gotify token, since that connection cannot send without one', async () => {
+    stored = {
+      type: 'gotify',
+      settings: { url: 'https://gotify.example.com', token: 'tk_stored' },
+    };
+    await expect(
+      service.update(1, {
+        name: 'Gotify',
+        type: 'gotify',
+        settings: { url: 'https://gotify.example.com', token: null },
+      }),
+    ).rejects.toThrow('gotify requires a non-empty settings.token');
+  });
+
+  it('never persists the read-only secretsSet marker the editor received', async () => {
+    stored = {
+      type: 'ntfy',
+      settings: { url: 'https://ntfy.sh', token: 'tk_stored' },
+    };
+    await service.update(1, {
+      name: 'Ntfy',
+      type: 'ntfy',
+      settings: { url: 'https://ntfy.sh', secretsSet: ['token'] },
+    });
+    expect(saved[0].settings).toEqual({ url: 'https://ntfy.sh', token: 'tk_stored' });
+  });
+
+  it('never persists the marker on discord either, which bypasses the token merge', async () => {
+    await service.create({
+      name: 'd',
+      type: 'discord',
+      settings: { webhookUrl: 'https://discord.test/hook', secretsSet: [] },
+    });
+    expect(saved[0].settings).toEqual({ webhookUrl: 'https://discord.test/hook' });
+  });
+
   it('drops the stored token when the connection changes provider', async () => {
     stored = {
       type: 'gotify',
@@ -287,6 +337,15 @@ describe('redactNotificationSecrets', () => {
     expect(redactNotificationSecrets(conn as never).settings).toEqual({
       url: 'https://ntfy.sh',
       topic: 'media',
+      secretsSet: ['token'],
+    });
+  });
+
+  it('reports no set secret when the connection stores none', () => {
+    const conn = { id: 1, type: 'ntfy', settings: { url: 'https://ntfy.sh' } };
+    expect(redactNotificationSecrets(conn as never).settings).toEqual({
+      url: 'https://ntfy.sh',
+      secretsSet: [],
     });
   });
 });

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -218,7 +218,9 @@ export class NotificationsService {
         typeof value === 'string' ? value.trim() : value,
       ]),
     );
-    if (type === 'discord' || type === 'slack') return trimmed;
+    // Merged even though these two carry no token: it is what drops the read-only marker.
+    if (type === 'discord' || type === 'slack')
+      return mergeSecretFields(undefined, trimmed, NOTIFICATION_SECRET_FIELDS);
     const { webhookUrl, ...rest } = trimmed;
     const folded =
       webhookUrl === undefined

--- a/backend/src/modules/subtitles/subtitle-provider.secrets.spec.ts
+++ b/backend/src/modules/subtitles/subtitle-provider.secrets.spec.ts
@@ -21,11 +21,18 @@ describe('subtitle provider credentials', () => {
       provider({ username: 'someone', password: 'secret', apiKey: 'k', language: 'fr' }),
     );
 
-    expect(redacted.settings).toEqual({ username: 'someone', language: 'fr' });
+    expect(redacted.settings).toEqual({
+      username: 'someone',
+      language: 'fr',
+      secretsSet: ['password', 'apiKey'],
+    });
   });
 
   it('leaves a provider carrying no credential untouched', () => {
-    expect(redactProviderSecrets(provider({ language: 'fr' })).settings).toEqual({ language: 'fr' });
+    expect(redactProviderSecrets(provider({ language: 'fr' })).settings).toEqual({
+      language: 'fr',
+      secretsSet: [],
+    });
   });
 
   it('keeps the stored credential when a save omits it, since no response ever returned it', async () => {
@@ -46,6 +53,25 @@ describe('subtitle provider credentials', () => {
     const saved = await service.update(1, { settings: { username: 'someone', password: 'fresh' } } as never);
 
     expect(saved.settings).toEqual({ username: 'someone', password: 'fresh' });
+  });
+
+  it('erases the stored credential when the client sends an explicit null', async () => {
+    const repo = fakeRepo(provider({ username: 'someone', password: 'stored-secret' }));
+    const service = new SubtitleProviderService(repo as never, {} as never);
+
+    const saved = await service.update(1, { settings: { username: 'someone', password: null } } as never);
+
+    expect(saved.settings).toEqual({ username: 'someone' });
+  });
+
+  it('drops a null credential on create instead of storing it', async () => {
+    const repo = fakeRepo(provider({}));
+    repo.create = jest.fn((p) => p as never);
+    const service = new SubtitleProviderService(repo as never, {} as never);
+
+    const saved = await service.create({ name: 'p', type: 'opensubtitles', settings: { apiKey: null } } as never);
+
+    expect(saved.settings).toEqual({});
   });
 
   it('does not redact inside the service, because that is the path that authenticates', async () => {

--- a/backend/src/modules/subtitles/subtitle-provider.service.ts
+++ b/backend/src/modules/subtitles/subtitle-provider.service.ts
@@ -30,7 +30,7 @@ export class SubtitleProviderService {
     const provider = this.repo.create({
       name: dto.name,
       type: dto.type,
-      settings: dto.settings ?? {},
+      settings: mergeSecretFields(undefined, dto.settings ?? {}, SUBTITLE_PROVIDER_SECRET_FIELDS),
       enabled: dto.enabled ?? true,
       priority: dto.priority ?? 25,
     });
@@ -63,7 +63,7 @@ export class SubtitleProviderService {
     if (dto.name !== undefined) provider.name = dto.name;
     if (dto.type !== undefined) provider.type = dto.type;
     // A response never carries the stored credential, so an incoming blank means
-    // "unchanged" rather than "erase" — otherwise every save would wipe it.
+    // "unchanged"; an explicit null is how a client erases it.
     if (dto.settings !== undefined) {
       provider.settings = mergeSecretFields(provider.settings, dto.settings, SUBTITLE_PROVIDER_SECRET_FIELDS);
     }

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1305,7 +1305,10 @@
     "saved": "Gespeichert",
     "selections_cleared": "Auswahl gelöscht",
     "retry": "Erneut versuchen",
-    "offline_banner": "Offline-Modus — die angezeigten Daten sind möglicherweise nicht aktuell"
+    "offline_banner": "Offline-Modus — die angezeigten Daten sind möglicherweise nicht aktuell",
+    "secret_clear": "Gespeicherten Wert löschen",
+    "secret_keep": "Beibehalten",
+    "secret_will_clear": "Der gespeicherte Wert wird beim Speichern entfernt."
   },
   "pagination": {
     "label": "Seitennummerierung",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1315,7 +1315,10 @@
     "saved": "Saved",
     "selections_cleared": "Selections cleared",
     "retry": "Retry",
-    "offline_banner": "Offline mode — the data shown may be out of date"
+    "offline_banner": "Offline mode — the data shown may be out of date",
+    "secret_clear": "Clear stored value",
+    "secret_keep": "Keep it",
+    "secret_will_clear": "The stored value will be removed on save."
   },
   "pagination": {
     "label": "Pagination",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1305,7 +1305,10 @@
     "saved": "Guardado",
     "selections_cleared": "Selecciones borradas",
     "retry": "Reintentar",
-    "offline_banner": "Modo sin conexión — los datos mostrados pueden no estar actualizados"
+    "offline_banner": "Modo sin conexión — los datos mostrados pueden no estar actualizados",
+    "secret_clear": "Borrar el valor guardado",
+    "secret_keep": "Conservarlo",
+    "secret_will_clear": "El valor guardado se eliminará al guardar."
   },
   "pagination": {
     "label": "Paginación",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1315,7 +1315,10 @@
     "saved": "Enregistré",
     "selections_cleared": "Sélections effacées",
     "retry": "Réessayer",
-    "offline_banner": "Mode hors-ligne — les données affichées peuvent ne pas être à jour"
+    "offline_banner": "Mode hors-ligne — les données affichées peuvent ne pas être à jour",
+    "secret_clear": "Effacer la valeur enregistrée",
+    "secret_keep": "La conserver",
+    "secret_will_clear": "La valeur enregistrée sera supprimée à l'enregistrement."
   },
   "pagination": {
     "label": "Pagination",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1305,7 +1305,10 @@
     "saved": "Salvato",
     "selections_cleared": "Selezioni cancellate",
     "retry": "Riprova",
-    "offline_banner": "Modalità offline — i dati mostrati potrebbero non essere aggiornati"
+    "offline_banner": "Modalità offline — i dati mostrati potrebbero non essere aggiornati",
+    "secret_clear": "Cancella il valore salvato",
+    "secret_keep": "Mantienilo",
+    "secret_will_clear": "Il valore salvato verrà rimosso al salvataggio."
   },
   "pagination": {
     "label": "Impaginazione",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1305,7 +1305,10 @@
     "saved": "Guardado",
     "selections_cleared": "Seleções limpas",
     "retry": "Tentar novamente",
-    "offline_banner": "Modo offline — os dados apresentados podem não estar atualizados"
+    "offline_banner": "Modo offline — os dados apresentados podem não estar atualizados",
+    "secret_clear": "Apagar o valor guardado",
+    "secret_keep": "Manter",
+    "secret_will_clear": "O valor guardado será removido ao guardar."
   },
   "pagination": {
     "label": "Paginação",

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -228,7 +228,8 @@ export class PluginViewComponent {
       // A `status` key is loaded into the same value bag for display, but the plugin owns
       // it — writing it back here would race whatever it writes via `config.set`.
       for (const [k, v] of Object.entries(this.formValue())) {
-        if (editableKeys.has(k)) patch[prefix + k] = String(v);
+        // `null` is the value bag's erase marker; these settings are text, so it stores as blank.
+        if (editableKeys.has(k)) patch[prefix + k] = v === null ? '' : String(v);
       }
       await this.settingsApi.setBulk(patch);
     } finally {

--- a/client/src/app/features/settings/notifications/notifications.html
+++ b/client/src/app/features/settings/notifications/notifications.html
@@ -132,10 +132,32 @@
             <input
               type="password"
               class="input input-bordered input-sm w-full"
+              [placeholder]="tokenStored() && !formTokenCleared() ? secretMask : ''"
               [ngModel]="formToken()"
-              (ngModelChange)="formToken.set($event)"
+              (ngModelChange)="onTokenInput($event)"
             />
-            @if (editingId() !== null) {
+            @if (canClearToken()) {
+              @if (formTokenCleared()) {
+                <span class="label-text-alt text-warning">
+                  {{ 'common.secret_will_clear' | translate }}
+                  <button
+                    type="button"
+                    class="link link-hover font-medium"
+                    (click)="formTokenCleared.set(false)"
+                  >
+                    {{ 'common.secret_keep' | translate }}
+                  </button>
+                </span>
+              } @else {
+                <button
+                  type="button"
+                  class="link link-hover label-text-alt self-start text-base-content/60"
+                  (click)="formTokenCleared.set(true)"
+                >
+                  {{ 'common.secret_clear' | translate }}
+                </button>
+              }
+            } @else if (editingId() !== null) {
               <span class="label-text-alt text-base-content/50">
                 {{ 'settings.notifications.token_hint' | translate }}
               </span>

--- a/client/src/app/features/settings/notifications/notifications.spec.ts
+++ b/client/src/app/features/settings/notifications/notifications.spec.ts
@@ -153,6 +153,54 @@ describe('NotificationsSettingsComponent — provider tokens', () => {
     expect(settingsOf(c)).toEqual({ url: 'https://ntfy.sh', topic: 'media' });
   });
 
+  it('sends an explicit null once the stored token is erased, and only where erasing is allowed', async () => {
+    const c = await createComponent();
+    c.openEdit({
+      id: 1,
+      name: 'Ntfy',
+      type: 'ntfy',
+      enabled: true,
+      events: [],
+      settings: { url: 'https://ntfy.sh', topic: 'media', secretsSet: ['token'] },
+    });
+    expect(c.tokenStored()).toBe(true);
+    expect(c.canClearToken()).toBe(true);
+
+    c.formTokenCleared.set(true);
+    expect(settingsOf(c)).toEqual({ url: 'https://ntfy.sh', topic: 'media', token: null });
+
+    // gotify cannot send without one, so the affordance is not offered there.
+    c.formType.set('gotify');
+    expect(c.canClearToken()).toBe(false);
+  });
+
+  it('cancels a pending erase as soon as a replacement token is typed', async () => {
+    const c = await createComponent();
+    c.formType.set('ntfy');
+    c.formWebhookUrl.set('https://ntfy.sh');
+    c.formTopic.set('media');
+    c.formTokenCleared.set(true);
+
+    c.onTokenInput('fresh');
+
+    expect(c.formTokenCleared()).toBe(false);
+    expect(settingsOf(c)).toEqual({ url: 'https://ntfy.sh', topic: 'media', token: 'fresh' });
+  });
+
+  it('reports no stored token when the response lists none', async () => {
+    const c = await createComponent();
+    c.openEdit({
+      id: 1,
+      name: 'Ntfy',
+      type: 'ntfy',
+      enabled: true,
+      events: [],
+      settings: { url: 'https://ntfy.sh', secretsSet: [] },
+    });
+    expect(c.tokenStored()).toBe(false);
+    expect(c.canClearToken()).toBe(false);
+  });
+
   it('leaves the token blank on edit, so saving keeps the stored one', async () => {
     const c = await createComponent();
     c.openEdit({

--- a/client/src/app/features/settings/notifications/notifications.ts
+++ b/client/src/app/features/settings/notifications/notifications.ts
@@ -13,6 +13,7 @@ import { HttpClient } from '@angular/common/http';
 import { LucideX } from '@lucide/angular';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { firstValueFrom } from 'rxjs';
+import { SECRETS_SET_KEY } from '@fliks/plugin-contract/ui';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { SECRET_MASK } from '../../../shared/components/schema-form/schema-form';
 
@@ -126,7 +127,7 @@ export class NotificationsSettingsComponent implements OnInit {
     const s = nc.settings ?? {};
     this.formWebhookUrl.set(String(s['webhookUrl'] ?? s['url'] ?? ''));
     this.formToken.set('');
-    const secretsSet = s['secretsSet'];
+    const secretsSet = s[SECRETS_SET_KEY];
     this.tokenStored.set(Array.isArray(secretsSet) && secretsSet.includes('token'));
     this.formTokenCleared.set(false);
     this.formTopic.set(String(s['topic'] ?? ''));

--- a/client/src/app/features/settings/notifications/notifications.ts
+++ b/client/src/app/features/settings/notifications/notifications.ts
@@ -14,6 +14,7 @@ import { LucideX } from '@lucide/angular';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { firstValueFrom } from 'rxjs';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
+import { SECRET_MASK } from '../../../shared/components/schema-form/schema-form';
 
 interface NotificationConnection {
   id: number;
@@ -58,6 +59,9 @@ export class NotificationsSettingsComponent implements OnInit {
   readonly formEnabled = signal(true);
   readonly formWebhookUrl = signal('');
   readonly formToken = signal('');
+  /** The connection stores a token the response never carries; `●●●●` stands in for it. */
+  readonly tokenStored = signal(false);
+  readonly formTokenCleared = signal(false);
   readonly formTopic = signal('');
   readonly formEvents = signal<string[]>([]);
 
@@ -71,11 +75,15 @@ export class NotificationsSettingsComponent implements OnInit {
   ];
 
   readonly connectionTypes = ['discord', 'slack', 'webhook', 'gotify', 'ntfy'] as const;
+  readonly secretMask = SECRET_MASK;
 
   /** Discord and Slack authenticate through the webhook URL itself. */
   readonly supportsToken = computed(
     () => this.formType() !== 'discord' && this.formType() !== 'slack',
   );
+
+  /** gotify cannot send without a token, so erasing one is never offered there. */
+  readonly canClearToken = computed(() => this.tokenStored() && this.formType() !== 'gotify');
 
   ngOnInit() {
     this.reloadAll();
@@ -102,6 +110,8 @@ export class NotificationsSettingsComponent implements OnInit {
     this.formEnabled.set(true);
     this.formWebhookUrl.set('');
     this.formToken.set('');
+    this.tokenStored.set(false);
+    this.formTokenCleared.set(false);
     this.formTopic.set('');
     this.formEvents.set([...this.allEvents]);
     this.testResult.set(null);
@@ -116,6 +126,9 @@ export class NotificationsSettingsComponent implements OnInit {
     const s = nc.settings ?? {};
     this.formWebhookUrl.set(String(s['webhookUrl'] ?? s['url'] ?? ''));
     this.formToken.set('');
+    const secretsSet = s['secretsSet'];
+    this.tokenStored.set(Array.isArray(secretsSet) && secretsSet.includes('token'));
+    this.formTokenCleared.set(false);
     this.formTopic.set(String(s['topic'] ?? ''));
     this.formEvents.set([...nc.events]);
     this.testResult.set(null);
@@ -124,6 +137,11 @@ export class NotificationsSettingsComponent implements OnInit {
 
   closeEditor() {
     this.editorDialog()?.nativeElement.close();
+  }
+
+  onTokenInput(value: string) {
+    this.formToken.set(value);
+    if (value.trim()) this.formTokenCleared.set(false);
   }
 
   toggleEvent(event: string) {
@@ -137,19 +155,21 @@ export class NotificationsSettingsComponent implements OnInit {
     if (type === 'discord' || type === 'slack') {
       return { webhookUrl: this.formWebhookUrl() };
     }
-    // These three read `url` server-side.
-    const token = this.formToken().trim();
-    if (type === 'webhook') {
-      return { url: this.formWebhookUrl(), ...(token ? { token } : {}) };
-    }
+    // These three read `url` server-side. A blank token means "unchanged"; `null` erases the
+    // stored one, the way JSON Merge Patch spells removal.
+    const token = this.formTokenCleared() ? null : this.formToken().trim();
     if (type === 'gotify') {
       return { url: this.formWebhookUrl(), token };
+    }
+    const optionalToken = token === null || token ? { token } : {};
+    if (type === 'webhook') {
+      return { url: this.formWebhookUrl(), ...optionalToken };
     }
     if (type === 'ntfy') {
       return {
         url: this.formWebhookUrl(),
         topic: this.formTopic(),
-        ...(token ? { token } : {}),
+        ...optionalToken,
       };
     }
     return {};

--- a/client/src/app/shared/components/provider-list/provider-list.html
+++ b/client/src/app/shared/components/provider-list/provider-list.html
@@ -134,7 +134,7 @@
       }
 
       @if (currentImplementation(); as impl) {
-        <app-schema-form [fields]="impl.fields" [(value)]="draftValue" />
+        <app-schema-form [fields]="impl.fields" [(value)]="draftValue" [secretsSet]="secretsSet()" />
       } @else if (draftImplementation()) {
         <p class="text-sm text-warning">{{ 'provider_list.unknown_implementation' | translate }}</p>
       }

--- a/client/src/app/shared/components/provider-list/provider-list.spec.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.spec.ts
@@ -184,6 +184,32 @@ describe('ProviderListComponent — characterisation', () => {
     expect(run).toHaveBeenCalledWith({ implementation: 'demo', settings: { url: 'http://x' }, id: 7 });
   });
 
+  it('carries the erase of a stored secret through to the save body as an explicit null', async () => {
+    const put = vi.fn((_url: string, _body: unknown) => of({}));
+    const fixture = await createComponent({
+      get: () =>
+        of([
+          {
+            id: 7,
+            name: 'A',
+            implementation: 'demo',
+            enabled: true,
+            priority: 1,
+            settings: { url: 'http://x', secretsSet: ['apiKey'] },
+          },
+        ]),
+      put,
+    });
+    fixture.componentInstance.openEdit(fixture.componentInstance.rows()[0]);
+    expect(fixture.componentInstance.secretsSet()).toEqual(['apiKey']);
+
+    fixture.componentInstance.draftValue.update((v) => ({ ...v, apiKey: null }));
+    await fixture.componentInstance.save();
+
+    const [, body] = put.mock.calls[0] as [string, Record<string, unknown>];
+    expect((body['settings'] as Record<string, unknown>)['apiKey']).toBeNull();
+  });
+
   it('deletes after confirmation and reloads', async () => {
     const del = vi.fn(() => of(undefined));
     const fixture = await createComponent({ get: () => of([]), delete: del });

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -117,6 +117,8 @@ export class ProviderListComponent implements OnInit {
   readonly draftEnabled = signal(true);
   readonly draftImplementation = signal('');
   readonly draftValue = signal<SchemaFormValue>({});
+  /** Which credentials the row already stores, straight from the redacted response. */
+  readonly secretsSet = signal<readonly string[]>([]);
 
   readonly testLoading = signal(false);
   readonly testResult = signal<ProviderTestResult | null>(null);
@@ -192,6 +194,7 @@ export class ProviderListComponent implements OnInit {
     this.draftPriority.set(this.defaultPriority());
     this.draftEnabled.set(this.defaultEnabled());
     this.draftValue.set(impl ? this.seedValue(null, impl) : {});
+    this.secretsSet.set([]);
     this.testResult.set(null);
     this.editorDialog()?.nativeElement.showModal();
   }
@@ -205,8 +208,14 @@ export class ProviderListComponent implements OnInit {
     this.draftImplementation.set(implValue);
     const impl = this.currentImplementation();
     this.draftValue.set(impl ? this.seedValue(row, impl) : {});
+    this.secretsSet.set(this.storedSecrets(row));
     this.testResult.set(null);
     this.editorDialog()?.nativeElement.showModal();
+  }
+
+  private storedSecrets(row: ProviderInstance): readonly string[] {
+    const set = (row.settings as Record<string, unknown> | undefined)?.['secretsSet'];
+    return Array.isArray(set) ? set.map(String) : [];
   }
 
   onImplementationChange(value: string): void {

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -20,6 +20,7 @@ import { ConfirmationService } from '../../../core/services/confirmation.service
 import { InputFieldComponent } from '../forms/input-field/input-field';
 import { ToggleFieldComponent } from '../forms/toggle-field/toggle-field';
 import { SelectFieldComponent } from '../forms/select-field/select-field';
+import { SECRETS_SET_KEY } from '@fliks/plugin-contract/ui';
 import { SchemaFormComponent, SchemaFormValue } from '../schema-form/schema-form';
 import {
   ProviderDraft,
@@ -214,7 +215,7 @@ export class ProviderListComponent implements OnInit {
   }
 
   private storedSecrets(row: ProviderInstance): readonly string[] {
-    const set = (row.settings as Record<string, unknown> | undefined)?.['secretsSet'];
+    const set = (row.settings as Record<string, unknown> | undefined)?.[SECRETS_SET_KEY];
     return Array.isArray(set) ? set.map(String) : [];
   }
 

--- a/client/src/app/shared/components/schema-form/schema-form.html
+++ b/client/src/app/shared/components/schema-form/schema-form.html
@@ -6,11 +6,30 @@
           [type]="inputType(field)"
           [label]="field.labelKey | translate"
           [hint]="field.hint ? (field.hint | translate) : ''"
-          [placeholder]="field.placeholder ? (field.placeholder | translate) : ''"
+          [placeholder]="secretMask(field) || (field.placeholder ? (field.placeholder | translate) : '')"
           [disabled]="disabled()"
           [value]="fieldValue(field)"
           (valueChange)="setValue(field, $event)"
         />
+        @if (isSecretStored(field)) {
+          @if (isCleared(field)) {
+            <p class="text-warning text-xs">
+              {{ 'common.secret_will_clear' | translate }}
+              <button type="button" class="link link-hover font-medium" (click)="setValue(field, '')">
+                {{ 'common.secret_keep' | translate }}
+              </button>
+            </p>
+          } @else {
+            <button
+              type="button"
+              class="link link-hover text-xs self-start text-base-content/60"
+              [disabled]="disabled()"
+              (click)="clearSecret(field)"
+            >
+              {{ 'common.secret_clear' | translate }}
+            </button>
+          }
+        }
         @for (err of fieldErrors(field); track err.key) {
           <p class="text-error text-xs">{{ err.key | translate: err.params }}</p>
         }

--- a/client/src/app/shared/components/schema-form/schema-form.spec.ts
+++ b/client/src/app/shared/components/schema-form/schema-form.spec.ts
@@ -5,7 +5,11 @@ import { of } from 'rxjs';
 import { SchemaFormComponent } from './schema-form';
 import type { FieldDef, FormItem } from '@fliks/plugin-contract/ui';
 
-function createComponent(fields: readonly FormItem[], value: Record<string, unknown>) {
+function createComponent(
+  fields: readonly FormItem[],
+  value: Record<string, unknown>,
+  secretsSet: readonly string[] = [],
+) {
   TestBed.configureTestingModule({
     providers: [
       provideZonelessChangeDetection(),
@@ -18,6 +22,7 @@ function createComponent(fields: readonly FormItem[], value: Record<string, unkn
   const fixture = TestBed.createComponent(SchemaFormComponent);
   fixture.componentRef.setInput('fields', fields);
   fixture.componentRef.setInput('value', value);
+  fixture.componentRef.setInput('secretsSet', secretsSet);
   fixture.detectChanges();
   return fixture;
 }
@@ -86,6 +91,37 @@ describe('SchemaFormComponent — secret fields never re-send an unchanged value
 
     setInputAndDispatch(input, '');
     expect('password' in fixture.componentInstance.value()).toBe(false);
+  });
+
+  it('offers no erase action for a secret the server does not report as set', () => {
+    const fixture = createComponent([secretField], {});
+    const input = fixture.nativeElement.querySelector('input[type="password"]') as HTMLInputElement;
+
+    expect(fixture.nativeElement.querySelector('button')).toBeNull();
+    expect(input.placeholder).toBe('');
+  });
+
+  it('masks a stored secret and erases it with an explicit null, the merge-patch spelling', () => {
+    const fixture = createComponent([secretField], {}, ['password']);
+    const input = fixture.nativeElement.querySelector('input[type="password"]') as HTMLInputElement;
+    expect(input.placeholder).toBe('●●●●●●●●');
+
+    (fixture.nativeElement.querySelector('button') as HTMLButtonElement).click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.value()['password']).toBeNull();
+
+    // Undoing puts it back to "unchanged", not to blank.
+    (fixture.nativeElement.querySelector('button') as HTMLButtonElement).click();
+    fixture.detectChanges();
+    expect('password' in fixture.componentInstance.value()).toBe(false);
+  });
+
+  it('cancels a pending erase as soon as a replacement is typed', () => {
+    const fixture = createComponent([secretField], { password: null }, ['password']);
+    const input = fixture.nativeElement.querySelector('input[type="password"]') as HTMLInputElement;
+
+    setInputAndDispatch(input, 'newpass');
+    expect(fixture.componentInstance.value()['password']).toBe('newpass');
   });
 
   it('does not enforce required on a secret field — blank is ambiguous, not invalid', () => {

--- a/client/src/app/shared/components/schema-form/schema-form.ts
+++ b/client/src/app/shared/components/schema-form/schema-form.ts
@@ -8,7 +8,10 @@ import { ToggleFieldComponent } from '../forms/toggle-field/toggle-field';
 
 /** Keyed by `FieldDef.key`; a select/text/number value is always a string here, coerced on read.
  *  A `status` item's current value is keyed by its own `settingKey` in this same bag. */
-export type SchemaFormValue = Record<string, string | number | boolean>;
+export type SchemaFormValue = Record<string, string | number | boolean | null>;
+
+/** Shown in place of a stored credential the server never echoes back. */
+export const SECRET_MASK = '●●●●●●●●';
 
 type FieldKind = 'input' | 'toggle' | 'select';
 type ItemKind = 'field' | 'caption' | 'group' | 'status';
@@ -30,6 +33,10 @@ interface FieldError {
  * never echoes a secret back, so "blank" and "untouched" are indistinguishable
  * on purpose. `required` is not enforced on secret fields: the component has
  * no create/edit context to know whether blank means "unset" or "keep as is".
+ *
+ * `secretsSet` names the keys that already hold a stored value: those render
+ * masked, with an erase action that writes `null` — the JSON Merge Patch
+ * (RFC 7396) spelling of "remove this member".
  */
 @Component({
   selector: 'app-schema-form',
@@ -41,6 +48,8 @@ export class SchemaFormComponent {
   readonly fields = input.required<readonly FormItem[]>();
   readonly value = model.required<SchemaFormValue>();
   readonly disabled = input(false);
+  /** Keys of `secret: true` fields the server reports as already set. */
+  readonly secretsSet = input<readonly string[]>([]);
 
   /** True while a value breaks a declared constraint. A `required` field left empty is shown as a
    *  hint but does not hold here: clearing one is how an operator unsets it. */
@@ -100,6 +109,24 @@ export class SchemaFormComponent {
 
   protected inputType(field: FieldDef): InputFieldType {
     return field.type as InputFieldType;
+  }
+
+  protected isSecretStored(field: FieldDef): boolean {
+    return Boolean(field.secret) && this.secretsSet().includes(field.key);
+  }
+
+  /** `null` is the pending erase; a typed value or an undo replaces it. */
+  protected isCleared(field: FieldDef): boolean {
+    return this.value()[field.key] === null;
+  }
+
+  protected clearSecret(field: FieldDef): void {
+    this.value.set({ ...this.value(), [field.key]: null });
+  }
+
+  /** Empty unless a stored credential is standing in for a real value. */
+  protected secretMask(field: FieldDef): string {
+    return this.isSecretStored(field) && !this.isCleared(field) ? SECRET_MASK : '';
   }
 
   protected fieldValue(field: FieldDef): string {


### PR DESCRIPTION
Closes #1004.

## The ceiling

`mergeSecretFields` kept the stored value whenever the incoming one was blank, because a redacted
editor has to be able to round-trip: the response never carries the secret, so blank has to mean
"unchanged". The side effect was that a credential could be replaced but never removed — a private
ntfy topic could not be made public again, and a subtitle provider that no longer needed a password
kept it stored. Deleting and recreating the row was the only way out.

## The fix

`null` erases the field. That is the JSON Merge Patch (RFC 7396) spelling of "remove this member",
it needs no DTO plumbing (`settings` is already a free-form record), and it leaves `''` meaning
"unchanged" exactly as #1002 established. It lands once in the shared merge, so notification
connections and subtitle providers both inherit it.

The editor also could not tell a stored credential from an empty one, so `redactSecretFields` now
reports which secret keys are set, next to the stripped values. That is the same shape other
products use for this problem (a "which secrets exist" map beside the redacted payload). The marker
is read-only: every write path strips it rather than persisting it, including the discord/slack
branch that bypasses the token merge.

Both editors use it to show `●●●●●●●●` in place of the value, and to offer *Clear stored value*
only when there is something to clear, with an undo that returns to "unchanged" rather than to
blank. Typing a replacement cancels a pending erase.

gotify cannot send without a token: erasing one is refused server-side (the existing guard already
fails closed) and the affordance is not offered for that type.

## Verified

- `backend`: 104 tests across the touched modules, including erase, the gotify refusal, and the
  marker never being persisted on either the merging or the discord path.
- `client`: full suite, 465 tests (+7), covering the mask, the erase writing `null`, the undo, and
  the erase reaching the save body.
- `tsc --noEmit` clean on both.

## Reachable from a plugin (second commit)

A plugin's `providers` page is rendered by this very provider list, so it inherits the mask and the
erase action for free — provided its own routes speak the convention. The marker key therefore moved
to `@fliks/plugin-contract/ui` as `SECRETS_SET_KEY`, next to the `FieldDef.secret` doc that already
states the redaction contract, and the null rule is written there too. Core imports the constant from
the contract; the two helpers stay core-side.

Backward compatible: a resource emitting no marker keeps today's behaviour and gets no erase action.

## Out of scope

- Discord and Slack still return their webhook URL unredacted — it is bearer-equivalent, but
  redacting it means showing a blank endpoint field, which is what #1001 fixed. Unchanged
  deliberately; #1004 flags it for a separate decision.
- Plugin `form` pages store their settings as plain text with no redaction at all, so they get no
  mask and no clear action. Their save path now translates a `null` to blank rather than to the
  string `"null"`, but making those secrets redacted is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
