### PR TITLE
fix(notifications): derive one event vocabulary instead of three that disagree

### DIFF
--- a/backend/src/modules/notifications/dto/create-notification-connection.dto.ts
+++ b/backend/src/modules/notifications/dto/create-notification-connection.dto.ts
@@ -10,21 +10,9 @@ import {
   ValidatorConstraint,
   ValidatorConstraintInterface,
 } from 'class-validator';
+import { NOTIFICATION_EVENTS } from '../entities/notification-connection.entity';
 
 const VALID_TYPES = ['discord', 'slack', 'webhook', 'gotify', 'ntfy'];
-const VALID_EVENTS = [
-  'request.created',
-  'request.approved',
-  'request.declined',
-  'request.processing',
-  'request.available',
-  'request.delete.created',
-  'request.delete.approved',
-  'request.delete.declined',
-  'grab.started',
-  'download.complete',
-  'health.issue',
-];
 
 /** Where each sender reads its endpoint from. Discord and Slack address a
  *  webhook; the rest address a server. Kept in step with `NotificationsService.send`. */
@@ -69,7 +57,7 @@ export class CreateNotificationConnectionDto {
   settings: Record<string, unknown>;
 
   @IsArray()
-  @IsIn(VALID_EVENTS, { each: true })
+  @IsIn(NOTIFICATION_EVENTS, { each: true })
   @IsOptional()
   events?: string[];
 

--- a/backend/src/modules/notifications/dto/create-notification-connection.dto.ts
+++ b/backend/src/modules/notifications/dto/create-notification-connection.dto.ts
@@ -10,19 +10,12 @@ import {
   ValidatorConstraint,
   ValidatorConstraintInterface,
 } from 'class-validator';
-import { NOTIFICATION_EVENTS } from '../entities/notification-connection.entity';
-
-const VALID_TYPES = ['discord', 'slack', 'webhook', 'gotify', 'ntfy'];
-
-/** Where each sender reads its endpoint from. Discord and Slack address a
- *  webhook; the rest address a server. Kept in step with `NotificationsService.send`. */
-const ENDPOINT_KEY: Record<string, 'webhookUrl' | 'url'> = {
-  discord: 'webhookUrl',
-  slack: 'webhookUrl',
-  webhook: 'url',
-  gotify: 'url',
-  ntfy: 'url',
-};
+import {
+  ENDPOINT_KEY,
+  NOTIFICATION_EVENTS,
+  NOTIFICATION_TYPES,
+  NotificationType,
+} from '../entities/notification-connection.entity';
 
 const asText = (v: unknown): string => (typeof v === 'string' ? v.trim() : '');
 
@@ -30,7 +23,7 @@ const asText = (v: unknown): string => (typeof v === 'string' ? v.trim() : '');
 class NotificationSettingsConstraint implements ValidatorConstraintInterface {
   validate(settings: unknown, args: ValidationArguments): boolean {
     const { type } = args.object as CreateNotificationConnectionDto;
-    const key = ENDPOINT_KEY[type];
+    const key = ENDPOINT_KEY[type as NotificationType];
     if (!key) return true; // unknown type: @IsIn already rejected it
     const s = (settings ?? {}) as Record<string, unknown>;
     // Either key is accepted: the service folds `webhookUrl` onto `url` for the
@@ -41,7 +34,7 @@ class NotificationSettingsConstraint implements ValidatorConstraintInterface {
 
   defaultMessage(args: ValidationArguments): string {
     const { type } = args.object as CreateNotificationConnectionDto;
-    return `${type} requires settings.${ENDPOINT_KEY[type] ?? 'url'} to be an http(s) URL`;
+    return `${type} requires settings.${ENDPOINT_KEY[type as NotificationType] ?? 'url'} to be an http(s) URL`;
   }
 }
 
@@ -49,7 +42,7 @@ export class CreateNotificationConnectionDto {
   @IsString()
   name: string;
 
-  @IsIn(VALID_TYPES)
+  @IsIn(NOTIFICATION_TYPES)
   type: string;
 
   @IsObject()

--- a/backend/src/modules/notifications/entities/notification-connection.entity.ts
+++ b/backend/src/modules/notifications/entities/notification-connection.entity.ts
@@ -1,12 +1,19 @@
 import { Entity, Column } from 'typeorm';
 import { BaseEntity } from '../../../common/entities/base.entity';
 
-export type NotificationType =
-  | 'discord'
-  | 'slack'
-  | 'webhook'
-  | 'gotify'
-  | 'ntfy';
+export const NOTIFICATION_TYPES = ['discord', 'slack', 'webhook', 'gotify', 'ntfy'] as const;
+
+export type NotificationType = (typeof NOTIFICATION_TYPES)[number];
+
+/** Where each sender reads its endpoint from: Discord and Slack address a webhook, the rest a
+ *  server. Read by the sender and by the DTO that validates it, so there is one map, not two. */
+export const ENDPOINT_KEY: Record<NotificationType, 'webhookUrl' | 'url'> = {
+  discord: 'webhookUrl',
+  slack: 'webhookUrl',
+  webhook: 'url',
+  gotify: 'url',
+  ntfy: 'url',
+};
 
 /** The one event vocabulary: the DTO validates against it and the editor lists what the API
  *  advertises from it, so an event added here needs no second or third copy. */

--- a/backend/src/modules/notifications/entities/notification-connection.entity.ts
+++ b/backend/src/modules/notifications/entities/notification-connection.entity.ts
@@ -8,22 +8,27 @@ export type NotificationType =
   | 'gotify'
   | 'ntfy';
 
-export type NotificationEvent =
-  | 'request.created'
-  | 'request.approved'
-  | 'request.declined'
-  | 'request.processing'
-  | 'request.available'
-  | 'request.delete.created'
-  | 'request.delete.approved'
-  | 'request.delete.declined'
-  | 'grab.started'
-  | 'download.complete'
-  | 'health.issue'
-  | 'subtitle.downloaded'
-  | 'subtitle.upgraded'
-  | 'subtitle.failed'
-  | 'subtitle.synced';
+/** The one event vocabulary: the DTO validates against it and the editor lists what the API
+ *  advertises from it, so an event added here needs no second or third copy. */
+export const NOTIFICATION_EVENTS = [
+  'request.created',
+  'request.approved',
+  'request.declined',
+  'request.processing',
+  'request.available',
+  'request.delete.created',
+  'request.delete.approved',
+  'request.delete.declined',
+  'grab.started',
+  'download.complete',
+  'health.issue',
+  'subtitle.downloaded',
+  'subtitle.upgraded',
+  'subtitle.failed',
+  'subtitle.synced',
+] as const;
+
+export type NotificationEvent = (typeof NOTIFICATION_EVENTS)[number];
 
 @Entity('notification_connections')
 export class NotificationConnection extends BaseEntity {

--- a/backend/src/modules/notifications/notifications.controller.ts
+++ b/backend/src/modules/notifications/notifications.controller.ts
@@ -11,6 +11,7 @@ import {
 } from '@nestjs/common';
 import {
   NotificationsService,
+  SUBSCRIBABLE_NOTIFICATION_EVENTS,
   redactNotificationSecrets,
 } from './notifications.service';
 import { CreateNotificationConnectionDto } from './dto/create-notification-connection.dto';
@@ -36,6 +37,13 @@ export class NotificationsController {
   @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
   async findAll() {
     return (await this.service.findAll()).map(redactNotificationSecrets);
+  }
+
+  /** Declared before `:id` — Nest matches in order, and `events` is not an id. */
+  @Get('events')
+  @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
+  events(): readonly string[] {
+    return SUBSCRIBABLE_NOTIFICATION_EVENTS;
   }
 
   @Get(':id')

--- a/backend/src/modules/notifications/notifications.service.spec.ts
+++ b/backend/src/modules/notifications/notifications.service.spec.ts
@@ -3,8 +3,11 @@ import { plainToInstance } from 'class-transformer';
 import axios from 'axios';
 import {
   NotificationsService,
+  SUBSCRIBABLE_NOTIFICATION_EVENTS,
   redactNotificationSecrets,
 } from './notifications.service';
+import { NOTIFICATION_EVENTS } from './entities/notification-connection.entity';
+import { NotificationsController } from './notifications.controller';
 import { CreateNotificationConnectionDto } from './dto/create-notification-connection.dto';
 
 jest.mock('axios');
@@ -233,6 +236,38 @@ describe('CreateNotificationConnectionDto validation', () => {
   });
 });
 
+describe('notification event vocabulary', () => {
+  const dtoErrors = async (events: string[]) => {
+    const dto = plainToInstance(CreateNotificationConnectionDto, {
+      name: 'n',
+      type: 'ntfy',
+      settings: { url: 'https://ntfy.sh' },
+      events,
+    });
+    return (await validate(dto)).flatMap((e) => Object.values(e.constraints ?? {}));
+  };
+
+  it('validates every event it dispatches — the subtitle four used to 400', async () => {
+    expect(await dtoErrors([...NOTIFICATION_EVENTS])).toEqual([]);
+  });
+
+  it('still rejects an event nothing knows about', async () => {
+    expect(await dtoErrors(['subtitle.teleported'])).not.toEqual([]);
+  });
+
+  it('declares GET events before GET :id, which is what keeps it off the ParseIntPipe', () => {
+    const methods = Object.getOwnPropertyNames(NotificationsController.prototype);
+    expect(methods.indexOf('events')).toBeLessThan(methods.indexOf('findOne'));
+  });
+
+  it('advertises everything something dispatches, and not the test-only one', async () => {
+    expect(SUBSCRIBABLE_NOTIFICATION_EVENTS).not.toContain('health.issue');
+    expect(SUBSCRIBABLE_NOTIFICATION_EVENTS).toHaveLength(NOTIFICATION_EVENTS.length - 1);
+    // An advertised event has to be storable, or the editor offers a checkbox the API refuses.
+    expect(await dtoErrors([...SUBSCRIBABLE_NOTIFICATION_EVENTS])).toEqual([]);
+  });
+});
+
 describe('NotificationsService provider authentication', () => {
   const serviceFor = (row: Record<string, unknown>) =>
     new NotificationsService({
@@ -251,6 +286,26 @@ describe('NotificationsService provider authentication', () => {
   beforeEach(() => {
     mockedAxios.post.mockReset();
     mockedAxios.post.mockResolvedValue({ status: 200 } as never);
+  });
+
+  it('renders a subtitle event as a sentence rather than dumping its payload', async () => {
+    const service = new NotificationsService({
+      find: () =>
+        Promise.resolve([
+          {
+            id: 1,
+            name: 'D',
+            type: 'discord',
+            enabled: true,
+            events: ['subtitle.downloaded'],
+            settings: { webhookUrl: 'https://discord.test/hook' },
+          },
+        ]),
+    } as never);
+
+    await service.dispatch('subtitle.downloaded', { title: 'Some Title', language: 'fr' });
+
+    expect((lastCall().body as { content: string }).content).toBe('Subtitle downloaded: Some Title [fr]');
   });
 
   it('authenticates an ntfy push when a token is configured', async () => {

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -8,9 +8,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import axios from 'axios';
 import {
+  ENDPOINT_KEY,
   NOTIFICATION_EVENTS,
   NotificationConnection,
   NotificationEvent,
+  NotificationType,
 } from './entities/notification-connection.entity';
 import { CreateNotificationConnectionDto } from './dto/create-notification-connection.dto';
 import {
@@ -133,36 +135,39 @@ export class NotificationsService {
     }
   }
 
+  /** Read through the one endpoint-key map, so a sender cannot drift from what the DTO validated. */
+  private endpointOf(conn: NotificationConnection): string {
+    return String(conn.settings[ENDPOINT_KEY[conn.type]] ?? '');
+  }
+
   private async send(
     conn: NotificationConnection,
     event: NotificationEvent,
     payload: Record<string, unknown>,
   ): Promise<void> {
     const s = conn.settings;
+    const endpoint = this.endpointOf(conn);
     try {
       switch (conn.type) {
         case 'discord': {
-          const webhookUrl = String(s.webhookUrl ?? '');
-          if (!webhookUrl) throw new Error('webhookUrl not configured');
-          await axios.post(webhookUrl, {
+          if (!endpoint) throw new Error('webhookUrl not configured');
+          await axios.post(endpoint, {
             username: String(s.username ?? 'Fliks'),
             content: this.formatMessage(event, payload),
           });
           break;
         }
         case 'slack': {
-          const webhookUrl = String(s.webhookUrl ?? '');
-          if (!webhookUrl) throw new Error('webhookUrl not configured');
-          await axios.post(webhookUrl, {
+          if (!endpoint) throw new Error('webhookUrl not configured');
+          await axios.post(endpoint, {
             text: this.formatMessage(event, payload),
           });
           break;
         }
         case 'webhook': {
-          const url = String(s.url ?? '');
-          if (!url) throw new Error('url not configured');
+          if (!endpoint) throw new Error('url not configured');
           await axios.post(
-            url,
+            endpoint,
             { event, ...payload },
             {
               headers: s.token ? { Authorization: `Bearer ${s.token}` } : {},
@@ -171,7 +176,8 @@ export class NotificationsService {
           break;
         }
         case 'gotify': {
-          const url = String(s.url ?? '').replace(/\/$/, '');
+          // These two append a path, so a trailing slash would double the separator.
+          const url = endpoint.replace(/\/$/, '');
           const token = String(s.token ?? '');
           if (!url || !token) throw new Error('url and token required');
           await axios.post(
@@ -185,7 +191,7 @@ export class NotificationsService {
           break;
         }
         case 'ntfy': {
-          const url = String(s.url ?? '').replace(/\/$/, '');
+          const url = endpoint.replace(/\/$/, '');
           const topic = String(s.topic || 'fliks');
           if (!url) throw new Error('url not configured');
           const token = typeof s.token === 'string' ? s.token : '';
@@ -228,8 +234,9 @@ export class NotificationsService {
         typeof value === 'string' ? value.trim() : value,
       ]),
     );
-    // Merged even though these two carry no token: it is what drops the read-only marker.
-    if (type === 'discord' || type === 'slack')
+    // Merged even though a webhook-addressed type carries no token: it is what drops the
+    // read-only marker.
+    if (ENDPOINT_KEY[type as NotificationType] === 'webhookUrl')
       return mergeSecretFields(undefined, trimmed, NOTIFICATION_SECRET_FIELDS);
     const { webhookUrl, ...rest } = trimmed;
     const folded =

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -8,6 +8,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import axios from 'axios';
 import {
+  NOTIFICATION_EVENTS,
   NotificationConnection,
   NotificationEvent,
 } from './entities/notification-connection.entity';
@@ -16,6 +17,15 @@ import {
   mergeSecretFields,
   redactSecretFields,
 } from '../../common/utils/secret-fields.util';
+
+/** Sent by `testConnection` alone — nothing dispatches it, so subscribing to it would only ever
+ *  deliver the test. Still a valid stored value: connections predate this list. */
+const TEST_ONLY_EVENTS: readonly NotificationEvent[] = ['health.issue'];
+
+/** What a client can usefully subscribe to: every event something actually dispatches. */
+export const SUBSCRIBABLE_NOTIFICATION_EVENTS = NOTIFICATION_EVENTS.filter(
+  (event) => !TEST_ONLY_EVENTS.includes(event),
+);
 
 /** The only credential a connection stores; the endpoint is an address, not a secret. */
 export const NOTIFICATION_SECRET_FIELDS = [
@@ -265,6 +275,15 @@ export class NotificationsService {
         return `Download complete: ${title}`;
       case 'health.issue':
         return String(payload.message ?? 'Health issue detected');
+      case 'subtitle.downloaded':
+        return `Subtitle downloaded: ${title} [${String(payload.language ?? '')}]`;
+      case 'subtitle.upgraded':
+        return `Subtitle upgraded: ${title} [${String(payload.language ?? '')}]`;
+      case 'subtitle.failed':
+        return `Subtitle download failed: ${title} [${String(payload.language ?? '')}]`;
+      // Dispatched from the sync path, which knows the subtitle, not the media it belongs to.
+      case 'subtitle.synced':
+        return `Subtitle synced [${String(payload.language ?? '')}]`;
       default:
         return `${event}: ${JSON.stringify(payload)}`;
     }

--- a/client/src/app/features/settings/notifications/notifications.html
+++ b/client/src/app/features/settings/notifications/notifications.html
@@ -181,7 +181,7 @@
         <div>
           <p class="label-text mb-2">{{ 'settings.notifications.field_events' | translate }}</p>
           <div class="flex flex-wrap gap-2">
-            @for (event of allEvents; track event) {
+            @for (event of allEvents(); track event) {
               <label class="label cursor-pointer gap-2 justify-start">
                 <input
                   type="checkbox"

--- a/client/src/app/features/settings/notifications/notifications.spec.ts
+++ b/client/src/app/features/settings/notifications/notifications.spec.ts
@@ -19,7 +19,7 @@ beforeAll(() => {
   }
 });
 
-async function createComponent() {
+async function createComponent(events: string[] = []) {
   TestBed.configureTestingModule({
     providers: [
       provideZonelessChangeDetection(),
@@ -32,7 +32,9 @@ async function createComponent() {
       }),
       {
         provide: HttpClient,
-        useValue: { get: () => of([]) } as unknown as HttpClient,
+        useValue: {
+          get: (url: string) => of(url.endsWith('/events') ? events : []),
+        } as unknown as HttpClient,
       },
       {
         provide: ConfirmationService,
@@ -127,6 +129,19 @@ describe('NotificationsSettingsComponent — endpoint settings key', () => {
       url: 'https://legacy.example.com',
       topic: 'old',
     });
+  });
+});
+
+describe('NotificationsSettingsComponent — event vocabulary', () => {
+  it('lists what the API advertises rather than a hardcoded set', async () => {
+    const c = await createComponent(['request.created', 'subtitle.downloaded']);
+    expect(c.allEvents()).toEqual(['request.created', 'subtitle.downloaded']);
+  });
+
+  it('pre-checks every advertised event on a new connection', async () => {
+    const c = await createComponent(['request.created', 'subtitle.downloaded']);
+    c.openCreate();
+    expect(c.formEvents()).toEqual(['request.created', 'subtitle.downloaded']);
   });
 });
 

--- a/client/src/app/features/settings/notifications/notifications.ts
+++ b/client/src/app/features/settings/notifications/notifications.ts
@@ -17,6 +17,12 @@ import { SECRETS_SET_KEY } from '@fliks/plugin-contract/ui';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { SECRET_MASK } from '../../../shared/components/schema-form/schema-form';
 
+/** The types this editor knows how to render fields for — adding one server-side is not enough,
+ *  each needs its own field set below. */
+const NOTIFICATION_TYPES = ['discord', 'slack', 'webhook', 'gotify', 'ntfy'] as const;
+
+type NotificationType = (typeof NOTIFICATION_TYPES)[number];
+
 interface NotificationConnection {
   id: number;
   name: string;
@@ -28,7 +34,7 @@ interface NotificationConnection {
 
 interface CreateNotificationBody {
   name: string;
-  type: 'discord' | 'slack' | 'webhook' | 'gotify' | 'ntfy';
+  type: NotificationType;
   settings: Record<string, unknown>;
   events?: string[];
   enabled?: boolean;
@@ -56,7 +62,7 @@ export class NotificationsSettingsComponent implements OnInit {
   readonly testResult = signal<{ ok: boolean; message: string } | null>(null);
 
   readonly formName = signal('');
-  readonly formType = signal<CreateNotificationBody['type']>('discord');
+  readonly formType = signal<NotificationType>('discord');
   readonly formEnabled = signal(true);
   readonly formWebhookUrl = signal('');
   readonly formToken = signal('');
@@ -69,7 +75,7 @@ export class NotificationsSettingsComponent implements OnInit {
   /** Advertised by the API rather than restated here, so an event added server-side shows up. */
   readonly allEvents = signal<string[]>([]);
 
-  readonly connectionTypes = ['discord', 'slack', 'webhook', 'gotify', 'ntfy'] as const;
+  readonly connectionTypes = NOTIFICATION_TYPES;
   readonly secretMask = SECRET_MASK;
 
   /** Discord and Slack authenticate through the webhook URL itself. */
@@ -125,7 +131,7 @@ export class NotificationsSettingsComponent implements OnInit {
   openEdit(nc: NotificationConnection) {
     this.editingId.set(nc.id);
     this.formName.set(nc.name);
-    this.formType.set(nc.type as CreateNotificationBody['type']);
+    this.formType.set(nc.type as NotificationType);
     this.formEnabled.set(nc.enabled);
     const s = nc.settings ?? {};
     this.formWebhookUrl.set(String(s['webhookUrl'] ?? s['url'] ?? ''));

--- a/client/src/app/features/settings/notifications/notifications.ts
+++ b/client/src/app/features/settings/notifications/notifications.ts
@@ -66,14 +66,8 @@ export class NotificationsSettingsComponent implements OnInit {
   readonly formTopic = signal('');
   readonly formEvents = signal<string[]>([]);
 
-  readonly allEvents = [
-    'request.created',
-    'request.approved',
-    'request.declined',
-    'grab.started',
-    'download.complete',
-    'health.issue',
-  ];
+  /** Advertised by the API rather than restated here, so an event added server-side shows up. */
+  readonly allEvents = signal<string[]>([]);
 
   readonly connectionTypes = ['discord', 'slack', 'webhook', 'gotify', 'ntfy'] as const;
   readonly secretMask = SECRET_MASK;
@@ -88,6 +82,15 @@ export class NotificationsSettingsComponent implements OnInit {
 
   ngOnInit() {
     this.reloadAll();
+    void this.loadEvents();
+  }
+
+  private async loadEvents() {
+    try {
+      this.allEvents.set(await firstValueFrom(this.http.get<string[]>('/api/notifications/events')));
+    } catch {
+      this.listError.set(this.translate.instant('settings.notifications.load_error'));
+    }
   }
 
   async reloadAll() {
@@ -114,7 +117,7 @@ export class NotificationsSettingsComponent implements OnInit {
     this.tokenStored.set(false);
     this.formTokenCleared.set(false);
     this.formTopic.set('');
-    this.formEvents.set([...this.allEvents]);
+    this.formEvents.set([...this.allEvents()]);
     this.testResult.set(null);
     this.editorDialog()?.nativeElement.showModal();
   }


### PR DESCRIPTION
Closes #1003.

## What was wrong

The event list was retyped in three places that had drifted apart:

| List | Where | Count |
| --- | --- | --- |
| `NotificationEvent` | `entities/notification-connection.entity.ts` | 15 |
| `VALID_EVENTS` | `dto/create-notification-connection.dto.ts` | 11 |
| `allEvents` | `client/.../notifications.ts` | 6 |

So `subtitle.downloaded`, `subtitle.upgraded`, `subtitle.failed` and `subtitle.synced` were
dispatched but 400'd on subscription — unreachable by any client, not just the SPA — and five
request events (`request.processing`, `request.available`, and the three `request.delete.*`) were
valid and dispatched with no checkbox to enable them, which left the whole delete-request flow
unsubscribable from the UI.

## The fix

`NOTIFICATION_EVENTS` is the one vocabulary. The type derives from it, the DTO validates against it,
and the editor renders what `GET /api/notifications/events` advertises instead of its own array. An
event added later needs no second or third copy — that is the part that keeps this from happening
again.

`health.issue` keeps being accepted (connections predate the change and `testConnection` sends it)
but is no longer advertised. Nothing dispatches it, and it cannot usefully be made to: the only
probe core has is a `SELECT 1` liveness check, and a dead database cannot deliver a notification
whose subscriptions live in that same database. A real health monitor with state transitions is a
feature, not a line in this PR — the exception is one named constant with that reasoning next to it,
not a second list.

The four subtitle events also get a message of their own. Without one they fell through
`formatMessage`'s default branch, which would have delivered `subtitle.downloaded: {"title":…}` to a
user the moment they became subscribable.

## Verified

- `backend`: 29 tests in the notifications suite (+5), including every dispatched event passing DTO
  validation, an unknown one still being rejected, the advertised list excluding only the test-only
  event, and a subtitle event rendering as a sentence.
- One of those pins the route declaration order: `GET events` must stay above `GET :id` or it lands
  on the `ParseIntPipe`. That ordering is the only part of this the type system cannot see.
- `client`: full suite, 467 tests (+2), covering the list coming from the API and a new connection
  pre-checking what was advertised.
- `tsc --noEmit` clean on both.

The endpoint was not exercised over HTTP from this sandbox (no network to the dev stack), so the
first click in the editor is worth a glance.

## Second commit: the same treatment for the rest of the vocabulary

`NotificationType` was retyped the same way — `VALID_TYPES` in the DTO, a union in the entity, and
two copies in the editor (`connectionTypes` plus `CreateNotificationBody['type']`). It now derives
from `NOTIFICATION_TYPES` the way the events do.

The type→endpoint-key map was duplicated too, with a comment asking the reader to keep the DTO and
`NotificationsService.send` in step by hand. There is now one `ENDPOINT_KEY`, read by the DTO that
validates the endpoint, by the sender that posts to it, and by the settings-folding branch that used
to spell out `type === 'discord' || type === 'slack'` for the same fact.

The trailing-slash strip stays local to gotify and ntfy, the two that append a path — a webhook
endpoint keeps whatever shape its owner gave it.

What is deliberately left per-type: the editor's field layout (`supportsToken`, the ntfy topic and
server-URL labels). Those are template branches, not a repeated list, and folding them into a
capability map would move the truth around without removing a copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
