### PR TITLE
fix(release-scoring): honour the requested episode and season scope

### DIFF
--- a/backend/src/common/release-scoring/release-rejection.helper.spec.ts
+++ b/backend/src/common/release-scoring/release-rejection.helper.spec.ts
@@ -1,4 +1,5 @@
 import {
+  computeRejections,
   releaseMatchesMedia,
   resolveSearchTitles,
   sortReleasesByRelevance,
@@ -231,5 +232,104 @@ describe('resolveSearchTitles + titleMatchesExpectation', () => {
         '東京 Tokyo Story',
       ]),
     ).toBe(true);
+  });
+});
+
+describe('computeRejections — episode targeting', () => {
+  const reject = (releaseTitle: string, expectedSeason?: number, expectedEpisode?: number) =>
+    computeRejections({
+      qualityId: 1,
+      allowed: new Set([1]),
+      languageId: 1,
+      allowedLangs: new Set<number>(),
+      isBlocklisted: false,
+      sizeBytes: 0,
+      runtimeMinutes: 30,
+      sizeByQuality: new Map(),
+      seeders: 10,
+      sourceId: 0,
+      sourceMinSeeders: new Map(),
+      releaseTitle,
+      expectedSeason,
+      expectedEpisode,
+    }).map((r) => r.code);
+
+  it('rejects a release for another episode of the same season', () => {
+    expect(reject('Some.Show.S04E02.1080p.WEB-DL.x264', 4, 3)).toEqual([
+      'EPISODE_MISMATCH',
+    ]);
+  });
+
+  it('accepts the requested episode', () => {
+    expect(reject('Some.Show.S04E03.1080p.WEB-DL.x264', 4, 3)).toEqual([]);
+  });
+
+  it('accepts a full-season pack covering the requested episode', () => {
+    expect(reject('Some.Show.S04.COMPLETE.1080p.WEB-DL', 4, 3)).toEqual([]);
+  });
+
+  it('rejects a pack from another season', () => {
+    expect(reject('Some.Show.S03.COMPLETE.1080p.WEB-DL', 4, 3)).toEqual([
+      'EPISODE_MISMATCH',
+    ]);
+  });
+
+  it('names both sides in the rejection params', () => {
+    const [rejection] = computeRejections({
+      qualityId: 1,
+      allowed: new Set([1]),
+      languageId: 1,
+      allowedLangs: new Set<number>(),
+      isBlocklisted: false,
+      sizeBytes: 0,
+      runtimeMinutes: 30,
+      sizeByQuality: new Map(),
+      seeders: 10,
+      sourceId: 0,
+      sourceMinSeeders: new Map(),
+      releaseTitle: 'Some.Show.S04E02.1080p.WEB-DL.x264',
+      expectedSeason: 4,
+      expectedEpisode: 3,
+    });
+    expect(rejection.params).toEqual({ expected: 'S04E03', actual: 'S04E02' });
+  });
+
+  it('leaves an unreadable title alone rather than guessing', () => {
+    expect(reject('Some.Show.1080p.WEB-DL.x264', 4, 3)).toEqual([]);
+  });
+
+  it('ignores episode numbers when no episode is targeted', () => {
+    expect(reject('Some.Show.S04E02.1080p.WEB-DL.x264')).toEqual([]);
+  });
+});
+
+describe('sortReleasesByRelevance — season-scoped pack preference', () => {
+  const pack = (over: Partial<Row> & { id: string }) =>
+    row({ isFullSeason: true, ...over });
+
+  it('prefers a pack over a single episode of the same quality', () => {
+    const single = row({ id: 'single', seeders: 5000 });
+    const seasonPack = pack({ id: 'pack', seeders: 20 });
+    expect(
+      sortReleasesByRelevance([single, seasonPack], {
+        preferFullSeason: true,
+      }).map((r) => r.id),
+    ).toEqual(['pack', 'single']);
+  });
+
+  it('keeps a better-quality single episode above a weaker pack', () => {
+    const single = row({ id: 'single-1080p', rank: 200 });
+    const seasonPack = pack({ id: 'pack-720p', rank: 100 });
+    expect(
+      sortReleasesByRelevance([seasonPack, single], {
+        preferFullSeason: true,
+      }).map((r) => r.id),
+    ).toEqual(['single-1080p', 'pack-720p']);
+  });
+
+  it('ignores pack status when the search is not season-scoped', () => {
+    const single = row({ id: 'single', seeders: 5000 });
+    const seasonPack = pack({ id: 'pack', seeders: 20 });
+    expect(order([single, seasonPack])).toEqual(['single', 'pack']);
   });
 });

--- a/backend/src/common/release-scoring/release-rejection.helper.ts
+++ b/backend/src/common/release-scoring/release-rejection.helper.ts
@@ -399,6 +399,16 @@ export function titleMatchesExpectation(
   return matchesIndexedExpectation(releaseTitleTokens(releaseTitle), index, whenUnreadable);
 }
 
+/** `S04E03`, `S04`, or `?` — the display params of an EPISODE_MISMATCH. */
+function formatSeasonEpisode(
+  season: number | null | undefined,
+  episode: number | null | undefined,
+): string {
+  const n = (v: number) => String(v).padStart(2, '0');
+  if (season == null) return episode == null ? '?' : `E${n(episode)}`;
+  return episode == null ? `S${n(season)}` : `S${n(season)}E${n(episode)}`;
+}
+
 export function computeRejections(opts: {
   qualityId: number;
   allowed: Set<number>;
@@ -419,6 +429,12 @@ export function computeRejections(opts: {
    *  with TMDB / TVDB alternative titles so that releases indexed under a
    *  localised name still pass; otherwise they get `TITLE_MISMATCH`. */
   expectedTitle?: string | string[];
+  /** Season the request targets. A release naming a different season is
+   *  rejected; a title with no readable season number is left alone. */
+  expectedSeason?: number;
+  /** Episode the request targets. A release naming a different episode is
+   *  rejected; a full-season pack still satisfies it. */
+  expectedEpisode?: number;
 }): ReleaseRejection[] {
   const out: ReleaseRejection[] = [];
 
@@ -428,6 +444,30 @@ export function computeRejections(opts: {
     !titleMatchesExpectation(opts.releaseTitle, opts.expectedTitle)
   ) {
     out.push({ code: 'TITLE_MISMATCH' });
+  }
+
+  if (
+    opts.releaseTitle &&
+    (opts.expectedSeason != null || opts.expectedEpisode != null)
+  ) {
+    const se = parseSeasonEpisode(opts.releaseTitle);
+    const wrongSeason =
+      opts.expectedSeason != null &&
+      se.season != null &&
+      se.season !== opts.expectedSeason;
+    const wrongEpisode =
+      opts.expectedEpisode != null &&
+      se.episode != null &&
+      se.episode !== opts.expectedEpisode;
+    if (wrongSeason || wrongEpisode) {
+      out.push({
+        code: 'EPISODE_MISMATCH',
+        params: {
+          expected: formatSeasonEpisode(opts.expectedSeason, opts.expectedEpisode),
+          actual: formatSeasonEpisode(se.season, se.episode),
+        },
+      });
+    }
   }
 
   if (!opts.allowed.has(opts.qualityId)) {
@@ -507,14 +547,16 @@ export function computeRejections(opts: {
  * 4. Alive (seeders > 0) > dead — a zero-seeder release can't be downloaded,
  *    so it sinks below every live release regardless of quality.
  * 5. Quality rank (higher = better)
- * 6. Freeleech bonus
- * 7. Custom format score (higher = better)
- * 8. Seeders (more = better, log scale to avoid over-weighting)
- * 9. Leechers (more = better, same scale) — breaks seeder ties toward the
+ * 6. Full-season pack (`preferFullSeason` only) — one pack beats loose
+ *    episodes of the same quality, but never outranks a better quality.
+ * 7. Freeleech bonus
+ * 8. Custom format score (higher = better)
+ * 9. Seeders (more = better, log scale to avoid over-weighting)
+ * 10. Leechers (more = better, same scale) — breaks seeder ties toward the
  *    busier swarm.
- * 10. Size closer to preferred (less deviation = better)
+ * 11. Size closer to preferred (less deviation = better)
  *
- * Availability (4, 8, 9) outranks quality only at the dead/alive boundary;
+ * Availability (4, 9, 10) outranks quality only at the dead/alive boundary;
  * between two live releases quality wins, and seeders/leechers order releases
  * within the same quality tier ahead of the weaker size-proximity signal.
  */
@@ -530,8 +572,9 @@ export function sortReleasesByRelevance<
     leechers: number;
     freeleech: boolean;
     sizeDeviation?: number | null;
+    isFullSeason?: boolean;
   },
->(rows: T[]): T[] {
+>(rows: T[], opts?: { preferFullSeason?: boolean }): T[] {
   // log2 gap that counts as a real difference (~19%); smaller gaps are noise
   // and fall through to the next tiebreak rather than flipping the order.
   const SWARM_EPSILON = 0.25;
@@ -558,24 +601,28 @@ export function sortReleasesByRelevance<
     // 5. Quality rank desc
     if (a.rank !== b.rank) return b.rank - a.rank;
 
-    // 6. Freeleech bonus
+    // 6. One pack over loose episodes, but only at equal quality.
+    if (opts?.preferFullSeason && !!a.isFullSeason !== !!b.isFullSeason)
+      return a.isFullSeason ? -1 : 1;
+
+    // 7. Freeleech bonus
     if (a.freeleech !== b.freeleech) return a.freeleech ? -1 : 1;
 
-    // 7. Custom format score desc
+    // 8. Custom format score desc
     if (a.customFormatScore !== b.customFormatScore)
       return b.customFormatScore - a.customFormatScore;
 
-    // 8. Seeders desc (log scale)
+    // 9. Seeders desc (log scale)
     const aSeed = swarmScore(a.seeders);
     const bSeed = swarmScore(b.seeders);
     if (Math.abs(aSeed - bSeed) > SWARM_EPSILON) return bSeed - aSeed;
 
-    // 9. Leechers desc (log scale) — tie-break toward the busier swarm.
+    // 10. Leechers desc (log scale) — tie-break toward the busier swarm.
     const aLeech = swarmScore(a.leechers);
     const bLeech = swarmScore(b.leechers);
     if (Math.abs(aLeech - bLeech) > SWARM_EPSILON) return bLeech - aLeech;
 
-    // 10. Closer to preferred size wins (only when both rows expose it
+    // 11. Closer to preferred size wins (only when both rows expose it
     //     and the gap is big enough to matter — within 5% of each other
     //     counts as tied, otherwise tiny noise would flip the order).
     if (a.sizeDeviation != null && b.sizeDeviation != null) {
@@ -640,6 +687,10 @@ export async function scoreAndSortReleases(
      *  doesn't contain the significant tokens of *any* candidate are
      *  flagged TITLE_MISMATCH. */
     expectedTitle?: string | string[];
+    /** Season / episode the search targets, when it is episode-scoped —
+     *  releases naming another one are flagged EPISODE_MISMATCH. */
+    expectedSeason?: number;
+    expectedEpisode?: number;
   },
   deps: ReleaseScorerDeps,
 ): Promise<ScoredRelease[]> {
@@ -671,6 +722,8 @@ export async function scoreAndSortReleases(
         sourceMinSeeders: opts.sourceMinSeeders,
         releaseTitle: r.title,
         expectedTitle: opts.expectedTitle,
+        expectedSeason: opts.expectedSeason,
+        expectedEpisode: opts.expectedEpisode,
       });
       return {
         ...r,
@@ -696,5 +749,9 @@ export async function scoreAndSortReleases(
       };
     }),
   );
-  return sortReleasesByRelevance(rows);
+  // Season-scoped search (a season, not one episode): prefer a pack.
+  return sortReleasesByRelevance(rows, {
+    preferFullSeason:
+      opts.expectedSeason != null && opts.expectedEpisode == null,
+  });
 }

--- a/backend/src/modules/plugins/catalog/catalog.spec.ts
+++ b/backend/src/modules/plugins/catalog/catalog.spec.ts
@@ -9,9 +9,10 @@ import {
 } from './catalog';
 import { PLUGIN_API_VERSION, SUPPORTED_PLUGIN_API_VERSIONS } from '../../../common/plugin-contract';
 
-/** A `fliks` range every test can rely on matching this repo's own `package.json` version
- *  (same convention as `plugin-registry.service.spec.ts`'s `COMPATIBLE_RANGE`). */
-const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+/** A `fliks` range every test can rely on matching this repo's own `package.json` version —
+ *  unbounded above, so a release bump can never make the fixture incompatible (same
+ *  convention as `plugin-registry.service.spec.ts`'s `COMPATIBLE_RANGE`). */
+const COMPATIBLE_RANGE = '>=1.0.0';
 
 function version(overrides: Partial<CatalogVersionEntry> = {}): CatalogVersionEntry {
   return { version: '1.0.0', pluginApi: PLUGIN_API_VERSION, fliks: COMPATIBLE_RANGE, ...overrides };

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -536,6 +536,8 @@ export class FliksHostImpl implements PluginHostApi {
         sourceUnknownLang,
         runtimeMinutes: media.runtime ?? 0,
         expectedTitle: expectedTitles,
+        expectedSeason: p.seasonNumber,
+        expectedEpisode: p.episodeNumber,
       },
       {
         scoreCustomFormats: (title, meta) =>

--- a/backend/src/modules/plugins/plugin-catalog-client.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-catalog-client.service.spec.ts
@@ -7,7 +7,7 @@ import { OFFICIAL_KEYS } from './archive/trust-store';
 import type { CatalogDocument } from './catalog/catalog';
 import { PLUGIN_API_VERSION } from '../../common/plugin-contract';
 
-const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+const COMPATIBLE_RANGE = '>=1.0.0';
 
 function fakeSource(overrides: Partial<PluginSource> = {}): PluginSource {
   return {

--- a/backend/src/modules/plugins/plugin-install.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-install.service.spec.ts
@@ -21,8 +21,9 @@ import { getPluginsRuntimeDir } from '../../common/constants/paths';
 import { PLUGIN_API_VERSION } from '../../common/plugin-contract';
 import type { DataPluginManifest, ProcessPluginManifest } from '../../common/plugin-contract';
 
-/** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
-const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+/** A `fliks` range every test can rely on matching this repo's own `package.json` version —
+ *  deliberately unbounded above, so a release bump can never make the fixture incompatible. */
+const COMPATIBLE_RANGE = '>=1.0.0';
 
 function signedDataArchive(overrides: Partial<DataPluginManifest> = {}): { buffer: Buffer; manifest: DataPluginManifest } {
   const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE, ...overrides });

--- a/backend/src/modules/plugins/plugin-registry.service.jobs.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.jobs.spec.ts
@@ -8,8 +8,9 @@ import { CORE_SCHEDULER_JOB_NAMES } from '../../common/constants/core-scheduler-
 import type { PluginJob, PluginManifest } from '../../common/plugin-contract';
 import type { PluginProcessStartResult } from './plugin-process.service';
 
-/** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
-const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+/** A `fliks` range every test can rely on matching this repo's own `package.json` version —
+ *  deliberately unbounded above, so a release bump can never make the fixture incompatible. */
+const COMPATIBLE_RANGE = '>=1.0.0';
 /** Never fires during a test run — the point of every test here is the registry entry itself. */
 const FAR_FUTURE_CRON = '0 0 1 1 *';
 

--- a/backend/src/modules/plugins/plugin-registry.service.permissions.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.permissions.spec.ts
@@ -4,8 +4,9 @@ import { minimalProcessManifest } from './archive/test-manifests';
 import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry, fakeCountsCache } from './plugin-registry.test-helpers';
 import type { PluginManifest, PluginRoute } from '../../common/plugin-contract';
 
-/** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
-const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+/** A `fliks` range every test can rely on matching this repo's own `package.json` version —
+ *  deliberately unbounded above, so a release bump can never make the fixture incompatible. */
+const COMPATIBLE_RANGE = '>=1.0.0';
 
 function makePackage(manifest: PluginManifest, overrides: Partial<PluginPackage> = {}): PluginPackage {
   return {

--- a/backend/src/modules/plugins/plugin-registry.service.player.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.player.spec.ts
@@ -4,7 +4,7 @@ import { minimalProcessManifest } from './archive/test-manifests';
 import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry, fakeCountsCache } from './plugin-registry.test-helpers';
 import type { PluginManifest, PluginRoute, PlayerDeclaration } from '../../common/plugin-contract';
 
-const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+const COMPATIBLE_RANGE = '>=1.0.0';
 
 const ROUTES: PluginRoute[] = [{ method: 'POST', path: '/pre-roll', policy: 'read:Media' }];
 

--- a/backend/src/modules/plugins/plugin-registry.service.release-picker.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.release-picker.spec.ts
@@ -4,7 +4,7 @@ import { minimalProcessManifest } from './archive/test-manifests';
 import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry, fakeCountsCache } from './plugin-registry.test-helpers';
 import type { PluginManifest, PluginRoute, ReleasePickerRoutes } from '../../common/plugin-contract';
 
-const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+const COMPATIBLE_RANGE = '>=1.0.0';
 
 const ROUTES: PluginRoute[] = [
   { method: 'GET', path: '/movie/:id/releases', policy: 'read:Media' },

--- a/backend/src/modules/plugins/plugin-registry.service.routes.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.routes.spec.ts
@@ -5,8 +5,9 @@ import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeSc
 import { SUPPORTED_PLUGIN_API_VERSIONS, type PluginManifest, type PluginRoute } from '../../common/plugin-contract';
 import type { PluginProcessStartResult } from './plugin-process.service';
 
-/** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
-const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+/** A `fliks` range every test can rely on matching this repo's own `package.json` version —
+ *  deliberately unbounded above, so a release bump can never make the fixture incompatible. */
+const COMPATIBLE_RANGE = '>=1.0.0';
 
 function makePackage(manifest: PluginManifest, overrides: Partial<PluginPackage> = {}): PluginPackage {
   return {

--- a/backend/src/modules/plugins/plugin-registry.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.spec.ts
@@ -18,8 +18,9 @@ import type { PluginProcessStartResult } from './plugin-process.service';
 
 const sweepOrphansMock = jest.mocked(sweepOrphans);
 
-/** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
-const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+/** A `fliks` range every test can rely on matching this repo's own `package.json` version —
+ *  deliberately unbounded above, so a release bump can never make the fixture incompatible. */
+const COMPATIBLE_RANGE = '>=1.0.0';
 
 function archiveFor(manifest: PluginManifest, extraEntries: ZipEntrySpec[] = []): Buffer {
   const entries: ZipEntrySpec[] = [

--- a/backend/src/modules/plugins/plugin-registry.service.webhooks.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.webhooks.spec.ts
@@ -4,8 +4,9 @@ import { minimalDataManifest, minimalProcessManifest } from './archive/test-mani
 import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry, fakeCountsCache } from './plugin-registry.test-helpers';
 import type { PluginManifest, PluginWebhookDeclaration } from '../../common/plugin-contract';
 
-/** A `fliks` range every test can rely on matching this repo's own `package.json` version. */
-const COMPATIBLE_RANGE = '>=1.0.0 <3.0.0';
+/** A `fliks` range every test can rely on matching this repo's own `package.json` version —
+ *  deliberately unbounded above, so a release bump can never make the fixture incompatible. */
+const COMPATIBLE_RANGE = '>=1.0.0';
 
 function makePackage(manifest: PluginManifest, overrides: Partial<PluginPackage> = {}): PluginPackage {
   return {

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1051,7 +1051,8 @@
       "SIZE_TOO_HIGH": "Größe zu hoch\n({{actual}} MB > {{max}} MB)",
       "SIZE_NOT_PREFERRED": "Größe weicht vom empfohlenen Wert ab\n({{actual}} MB ≠ {{preferred}} MB)",
       "MIN_SEEDERS": "Zu wenige Seeder\n({{actual}} < {{min}})",
-      "TITLE_MISMATCH": "Titel passt nicht zum Medium"
+      "TITLE_MISMATCH": "Titel passt nicht zum Medium",
+      "EPISODE_MISMATCH": "Release passt nicht zu {{expected}} (gefunden: {{actual}})"
     }
   },
   "requests": {

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1059,7 +1059,8 @@
       "SIZE_TOO_HIGH": "Size too high\n({{actual}} MB > {{max}} MB)",
       "SIZE_NOT_PREFERRED": "Size far from recommended\n({{actual}} MB ≠ {{preferred}} MB)",
       "MIN_SEEDERS": "Insufficient seeders\n({{actual}} < {{min}})",
-      "TITLE_MISMATCH": "Title does not match the media"
+      "TITLE_MISMATCH": "Title does not match the media",
+      "EPISODE_MISMATCH": "Release does not match {{expected}} (found {{actual}})"
     }
   },
   "requests": {

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1051,7 +1051,8 @@
       "SIZE_TOO_HIGH": "Tamaño demasiado alto\n({{actual}} MB > {{max}} MB)",
       "SIZE_NOT_PREFERRED": "Tamaño alejado del recomendado\n({{actual}} MB ≠ {{preferred}} MB)",
       "MIN_SEEDERS": "Seeders insuficientes\n({{actual}} < {{min}})",
-      "TITLE_MISMATCH": "El título no coincide con el medio"
+      "TITLE_MISMATCH": "El título no coincide con el medio",
+      "EPISODE_MISMATCH": "La release no corresponde a {{expected}} (encontrado {{actual}})"
     }
   },
   "requests": {

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1059,7 +1059,8 @@
       "SIZE_TOO_HIGH": "Taille trop élevée\n({{actual}} MB > {{max}} MB)",
       "SIZE_NOT_PREFERRED": "Taille éloignée du recommandé\n({{actual}} MB ≠ {{preferred}} MB)",
       "MIN_SEEDERS": "Seeders insuffisants\n({{actual}} < {{min}})",
-      "TITLE_MISMATCH": "Titre ne correspond pas au média"
+      "TITLE_MISMATCH": "Titre ne correspond pas au média",
+      "EPISODE_MISMATCH": "La release ne correspond pas à {{expected}} (trouvé {{actual}})"
     }
   },
   "requests": {

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1051,7 +1051,8 @@
       "SIZE_TOO_HIGH": "Dimensione troppo alta\n({{actual}} MB > {{max}} MB)",
       "SIZE_NOT_PREFERRED": "Dimensione lontana da quella consigliata\n({{actual}} MB ≠ {{preferred}} MB)",
       "MIN_SEEDERS": "Seeder insufficienti\n({{actual}} < {{min}})",
-      "TITLE_MISMATCH": "Il titolo non corrisponde al file multimediale"
+      "TITLE_MISMATCH": "Il titolo non corrisponde al file multimediale",
+      "EPISODE_MISMATCH": "La release non corrisponde a {{expected}} (trovato {{actual}})"
     }
   },
   "requests": {

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1051,7 +1051,8 @@
       "SIZE_TOO_HIGH": "Tamanho demasiado elevado\n({{actual}} MB > {{max}} MB)",
       "SIZE_NOT_PREFERRED": "Tamanho afastado do recomendado\n({{actual}} MB ≠ {{preferred}} MB)",
       "MIN_SEEDERS": "Seeders insuficientes\n({{actual}} < {{min}})",
-      "TITLE_MISMATCH": "O título não corresponde ao media"
+      "TITLE_MISMATCH": "O título não corresponde ao media",
+      "EPISODE_MISMATCH": "A release não corresponde a {{expected}} (encontrado {{actual}})"
     }
   },
   "requests": {

--- a/examples/plugin-scaffold/README.md
+++ b/examples/plugin-scaffold/README.md
@@ -64,7 +64,7 @@ Core answers with a `reason` and a `detail` naming the field, visible on the plu
   `requests:progress`, `ingest:write`, `events:emit`, `config:rw`) and may not be empty.
 - A route `policy` is `action:subject`, in that order — `read:Settings`, not `Settings:read`.
 - `i18n` keys must share a single root, and no key may be a prefix of another.
-- `fliks` needs an upper bound: `">=2.0.0 <3.0.0"`, never `">=2.0.0"`.
+- `fliks` needs an upper bound: `">=3.0.0 <4.0.0"`, never `">=3.0.0"`. Bump it when a new Fliks major ships and the plugin has been checked against it.
 
 ## Logging and failure
 

--- a/examples/plugin-scaffold/plugin.json
+++ b/examples/plugin-scaffold/plugin.json
@@ -3,7 +3,7 @@
   "pluginApi": 1,
   "name": "Scaffold",
   "version": "0.1.0",
-  "fliks": ">=2.0.0 <3.0.0",
+  "fliks": ">=3.0.0 <4.0.0",
   "author": "you",
   "description": "Starting point for a Fliks process plugin",
   "license": "MIT",


### PR DESCRIPTION
## What this fixes

Grabbing the best release for a single episode could grab a **different episode of the same season**.

`releases.score` declared `seasonNumber` / `episodeNumber` in its signature and never read them. They were not forwarded to `scoreAndSortReleases`, which had no parameter for them either, so `computeRejections` only ever knew about seven rejection motives — title, quality, language, blocklist, size, seeders — and none about the episode number. `parseSeasonEpisode` was already being called two lines away, but only to fill `isFullSeason`.

An episode search returns hits for the whole season. The relevance sort compares quality rank, then freeleech, then custom-format score, then seeders — so between two 1080p WEB-DL releases of the same show with no custom formats configured, the winner is whichever has the busier swarm, regardless of which episode it actually contains. Picking the top row therefore grabbed the wrong episode whenever a neighbouring one was more popular.

The download plugin already assumed this was handled. From its own `searchScored`:

> Local post-search filtering by parsed season/episode is not re-implemented: `releases.score` is given the same `seasonNumber`/`episodeNumber` context, so a release belonging to a different episode is assumed to be rejected server-side.

That assumption was never true. This restores it rather than duplicating the filter plugin-side.

## Changes

**`EPISODE_MISMATCH` rejection.** `computeRejections` takes `expectedSeason` / `expectedEpisode` and rejects a release whose title parses to a different one. Placed there because every caller routes through it, so the interactive modal, the auto-pick and SearchMissing are all covered by one guard.

Three deliberate limits:
- A **full-season pack still satisfies an episode request** — `se.episode` is null, so the episode comparison does not fire.
- A **title with no readable season/episode is left alone**, consistent with the `whenUnreadable: 'match'` policy already behind `TITLE_MISMATCH`.
- The **season check is independent of the episode check**, so it also protects season-scoped searches.

**Season pack preference.** `sortReleasesByRelevance` gains an opt-in criterion 6, enabled by `scoreAndSortReleases` only when the search is season-scoped. It sits below quality rank and above freeleech, which is what makes the two cases behave:

| Candidates, profile allows 1080p and 720p | Winner |
|---|---|
| 720p pack vs 1080p single episodes | the 1080p singles — quality still decides first |
| 1080p pack vs 1080p single episodes | the pack — equal quality, so pack-ness breaks the tie |

**i18n.** `EPISODE_MISMATCH` added to the six locale files. `formatReleaseRejection` builds the key dynamically, so nothing else needed registering.

## Unrelated fix, same PR

Nine plugin suites (102 assertions) were already failing on `main` before any of the above. Ten specs shared `COMPATIBLE_RANGE = '>=1.0.0 <3.0.0'`, commented as *"a range every test can rely on matching this repo's own `package.json` version"*. Releasing 3.1.0 falsified that: every fixture plugin meant to load was refused as `incompatible-fliks`. The bound is removed; core's check is a bare `semver.satisfies` and the specs that exercise incompatibility use their own literals.

The scaffold example carried the same expired bound in a place that actually ships — a plugin generated from `examples/plugin-scaffold` declared `>=2.0.0 <3.0.0` and would be refused by any current core. It now targets the 3.x line. The upper bound stays there, since a published manifest requires one.

## Verification

- `npx jest src/` — 147 suites, 1644 tests, 0 failures (was 9 suites / 102 tests failing before this branch).
- `npx tsc --noEmit` — clean.
- New tests: 7 on the episode guard (wrong episode, right episode, pack covering it, pack from another season, rejection params, unreadable title, no episode targeted) and 3 on the pack preference (pack wins at equal quality, better-quality single wins, pack status ignored outside season scope).

The per-episode fan-out for a season with no acceptable pack is orchestration and ships separately in `fk-plugin-download`; it depends on the sort change here.
