### PR TITLE
fix(plugin-ui): re-merge plugin translations whenever the registry reloads

### DIFF
--- a/client/src/app/core/plugin-ui/plugin-i18n.service.spec.ts
+++ b/client/src/app/core/plugin-ui/plugin-i18n.service.spec.ts
@@ -1,4 +1,4 @@
-import { provideZonelessChangeDetection } from '@angular/core';
+import { ApplicationRef, provideZonelessChangeDetection, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   TranslateLoader,
@@ -18,6 +18,13 @@ describe('PluginI18nService', () => {
   });
 
   function setup(pluginI18n: Record<string, Record<string, string>>) {
+    // Signal-backed like the real registry, so `install()` reproduces what a
+    // runtime `registry.load()` does to every consumer that reads it.
+    const dicts = signal(pluginI18n);
+    const fakeRegistry = {
+      i18nFor: (lang: string) => dicts()[lang],
+      pluginEntries: () => Object.keys(dicts()),
+    };
     TestBed.configureTestingModule({
       providers: [
         provideZonelessChangeDetection(),
@@ -29,12 +36,13 @@ describe('PluginI18nService', () => {
             useValue: { getTranslation: (lang: string) => of(loaderData[lang] ?? {}) },
           },
         }),
-        { provide: PluginUiRegistryService, useValue: { i18nFor: (lang: string) => pluginI18n[lang] } },
+        { provide: PluginUiRegistryService, useValue: fakeRegistry },
       ],
     });
     return {
       translate: TestBed.inject(TranslateService),
       i18n: TestBed.inject(PluginI18nService),
+      install: (next: Record<string, Record<string, string>>) => dicts.set(next),
     };
   }
 
@@ -128,5 +136,20 @@ describe('PluginI18nService', () => {
     // 'fr' has no plugin dict at all; ngx-translate's own fallbackLang picks
     // up the key from 'en', where the plugin's merge landed at init.
     expect(translate.instant('fliks.foo.title')).toBe('Foo');
+  });
+
+  // Installing a plugin reloads the registry mid-session; before this the merge only
+  // ran from the app initializer, so its labels stayed raw until a full page reload.
+  it('VERDICT: a plugin installed after boot resolves its labels with no page reload', async () => {
+    loaderData['en'] = { nav: { home: 'Home' } };
+    const { translate, i18n, install } = setup({});
+    i18n.init();
+    expect(translate.instant('acme.hello')).toBe('acme.hello');
+
+    install({ en: { 'acme.hello': 'Hello' } });
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(translate.instant('acme.hello')).toBe('Hello');
+    expect(translate.instant('nav.home')).toBe('Home');
   });
 });

--- a/client/src/app/core/plugin-ui/plugin-i18n.service.ts
+++ b/client/src/app/core/plugin-ui/plugin-i18n.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, effect, inject } from '@angular/core';
 import { TranslateService, TranslateStore, insertValue, mergeDeep, type TranslationObject } from '@ngx-translate/core';
 import { PluginUiRegistryService } from './plugin-ui-registry.service';
 
@@ -22,6 +22,15 @@ export class PluginI18nService {
     // including a later runtime language switch.
     this.translate.onLangChange.subscribe(({ lang }) => this.mergeIntoLang(lang));
     this.translate.onFallbackLangChange.subscribe(({ lang }) => this.mergeIntoLang(lang));
+
+    // Installing, enabling or disabling a plugin reloads the registry; without this
+    // its labels stay unresolved until the next full page load. The entries read is
+    // the dependency — `getLangs()` can be empty, so relying on `mergeIntoLang` to
+    // register it would leave the effect subscribed to nothing.
+    effect(() => {
+      this.registry.pluginEntries();
+      for (const lang of this.translate.getLangs()) this.mergeIntoLang(lang);
+    });
   }
 
   /** Called once from the app initializer, after the registry has loaded.


### PR DESCRIPTION
## The bug

Installing a plugin surfaced its menu entries straight away, but with their translation keys showing raw. Only a manual page reload made the labels appear.

The registry is a signal, so `registry.load()` after an install re-runs every consumer's `computed` and the contributions render immediately. The translations do not follow: the merge into ngx-translate only ever ran from the app initializer.

```ts
.then(() => pluginUi.load())
.then(() => pluginI18n.init())   // app.config.ts — once, at boot
```

Four call sites reload the registry mid-session — `plugins.ts` on install, enable and disable, and `plugin-catalogue-page.ts` — and none of them re-merged. A reload re-ran the initializer, which is why refreshing "fixed" it.

## The fix

The service now reacts to the registry rather than being told by its callers:

```ts
effect(() => {
  this.registry.pluginEntries();
  for (const lang of this.translate.getLangs()) this.mergeIntoLang(lang);
});
```

Adding `pluginI18n.init()` to those four call sites would work today and rot at the fifth. Reacting to the source of truth covers every present and future reload path in one place.

Three things worth reviewing:

- **The `pluginEntries()` read is the dependency, deliberately explicit.** Relying on `mergeIntoLang` to register it would be a trap: when `getLangs()` is empty the loop body never runs, no signal is read, and the effect would be subscribed to nothing — never firing again.
- **No re-entrancy.** `TranslateStore` in ngx-translate 17 keeps plain objects behind RxJS subjects, with no signals, so the merge's `setTranslations` write cannot feed back into the effect. (The existing "a language switch never re-enters the merge" test guards the sibling path.)
- **`init()` stays.** It merges synchronously during the initializer, before the first render; the effect only runs on the first change-detection pass. The overlap is one idempotent extra merge at boot.

Already-rendered labels update because they resolve through the `translate` pipe, which subscribes to the `onTranslationChange` that `setTranslations` emits.

## Verification

`npx ng test` — 57 files, 469 tests, 0 failures. `npx tsc --noEmit` clean.

One test added, and **checked that it fails without the fix**: disabling the effect turns it red (`× VERDICT: a plugin installed after boot resolves its labels with no page reload`), and green again once restored. The spec's fake registry is signal-backed like the real one, so `install()` reproduces what a runtime `registry.load()` actually does to its consumers rather than merely calling the merge by hand.
