### PR TITLE
fix(plugins): refresh stale catalog sources at boot, not only at 3am

### DIFF
--- a/backend/src/modules/plugins/plugin-catalog-client.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-catalog-client.service.spec.ts
@@ -312,5 +312,80 @@ describe('PluginCatalogClientService', () => {
       expect(find).toHaveBeenCalledWith({ where: { enabled: true } });
       expect(service.refreshSource).toHaveBeenCalledWith(enabledSource);
     });
+
+    it('one source throwing does not abort the rest of the run', async () => {
+      const bad = fakeSource({ id: 1 });
+      const good = fakeSource({ id: 2 });
+      const find = jest.fn().mockResolvedValue([bad, good]);
+      const service = new PluginCatalogClientService({ find } as never, fakePackageRepo() as never, fakeRegistry() as never);
+      jest
+        .spyOn(service, 'refreshSource')
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({ ok: true });
+
+      await service.refreshAll();
+
+      expect(service.refreshSource).toHaveBeenCalledTimes(2);
+      expect(service.refreshSource).toHaveBeenLastCalledWith(good);
+    });
+  });
+
+  describe('boot refresh', () => {
+    function serviceWith(sources: PluginSource[]) {
+      const find = jest.fn().mockResolvedValue(sources);
+      const service = new PluginCatalogClientService({ find } as never, fakePackageRepo() as never, fakeRegistry() as never);
+      jest.spyOn(service, 'refreshSource').mockResolvedValue({ ok: true });
+      return service;
+    }
+
+    // The regression: a migration-seeded source has no cached catalog, so before this
+    // the catalogue stayed empty until the 3am job ran.
+    it('VERDICT: refreshes a source that has never been fetched', async () => {
+      const service = serviceWith([fakeSource({ cachedCatalog: null, lastRefreshedAt: null })]);
+
+      await service.refreshAll({ staleOnly: true });
+
+      expect(service.refreshSource).toHaveBeenCalledTimes(1);
+    });
+
+    it('refreshes a cached catalog that has gone stale', async () => {
+      const old = new Date(Date.now() - 7 * 60 * 60 * 1000);
+      const service = serviceWith([fakeSource({ cachedCatalog: {}, lastRefreshedAt: old })]);
+
+      await service.refreshAll({ staleOnly: true });
+
+      expect(service.refreshSource).toHaveBeenCalledTimes(1);
+    });
+
+    // A crash-restart loop must not hammer a public catalog host.
+    it('VERDICT: leaves a freshly cached catalog alone, so restarts do not refetch', async () => {
+      const recent = new Date(Date.now() - 60 * 1000);
+      const service = serviceWith([fakeSource({ cachedCatalog: {}, lastRefreshedAt: recent })]);
+
+      await service.refreshAll({ staleOnly: true });
+
+      expect(service.refreshSource).not.toHaveBeenCalled();
+    });
+
+    // Without this the hook could be deleted and every test above would still pass.
+    it('VERDICT: the bootstrap hook is what triggers the stale-only refresh', async () => {
+      const service = serviceWith([fakeSource({ cachedCatalog: null, lastRefreshedAt: null })]);
+      const refreshAll = jest.spyOn(service, 'refreshAll');
+
+      service.onApplicationBootstrap();
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(refreshAll).toHaveBeenCalledWith({ staleOnly: true });
+      expect(service.refreshSource).toHaveBeenCalledTimes(1);
+    });
+
+    it('the scheduled run still refetches everything, stale or not', async () => {
+      const recent = new Date(Date.now() - 60 * 1000);
+      const service = serviceWith([fakeSource({ cachedCatalog: {}, lastRefreshedAt: recent })]);
+
+      await service.refreshAll();
+
+      expect(service.refreshSource).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/backend/src/modules/plugins/plugin-catalog-client.service.ts
+++ b/backend/src/modules/plugins/plugin-catalog-client.service.ts
@@ -1,5 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
+import { Injectable, Logger, type OnApplicationBootstrap } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import axios from 'axios';
@@ -15,6 +14,10 @@ const CATALOG_REQUEST_TIMEOUT_MS = 10_000;
 /** A catalog is a small JSON index of plugin metadata, nowhere near the 8 MiB
  *  archive cap (`archive/limits.ts`) — generous versus today's few-KB catalogs. */
 const CATALOG_MAX_RESPONSE_BYTES = 1024 * 1024;
+/** How old a cached catalog may be before boot refetches it. Short enough that a
+ *  restart picks up a day-old catalog, long enough that a crash-restart loop does
+ *  not hammer a public host. */
+const STALE_AFTER_MS = 6 * 60 * 60 * 1000;
 
 export type CatalogRefreshFailureReason = 'insecure-url' | 'network-error' | 'bad-signature' | 'malformed-catalog';
 
@@ -29,7 +32,7 @@ export type CatalogRefreshResult = { ok: true } | { ok: false; reason: CatalogRe
  * checks share a shape but not a trust boundary, so they stay separate on purpose.
  */
 @Injectable()
-export class PluginCatalogClientService {
+export class PluginCatalogClientService implements OnApplicationBootstrap {
   private readonly logger = new Logger(PluginCatalogClientService.name);
 
   constructor(
@@ -40,13 +43,40 @@ export class PluginCatalogClientService {
     private readonly registry: PluginRegistryService,
   ) {}
 
+  /**
+   * A source seeded by migration starts with no cached catalog, and until this ran
+   * only the 3am job filled it — a fresh install browsed an empty catalogue for up
+   * to a day. Refreshing what is stale at boot closes that window.
+   *
+   * Never awaited and never fatal: an unreachable catalog must not delay startup.
+   */
+  onApplicationBootstrap(): void {
+    void this.refreshAll({ staleOnly: true }).catch((err: unknown) =>
+      this.logger.warn(`boot catalog refresh failed: ${(err as Error).message}`),
+    );
+  }
+
   /** Driven by `SchedulerService`'s `RefreshPluginSources` job, so the run is listed,
-   *  triggerable and recorded — a bare `@Cron` here was none of those. */
-  async refreshAll(): Promise<void> {
+   *  triggerable and recorded — a bare `@Cron` here was none of those. `staleOnly`
+   *  is what boot passes; the scheduled run always refetches everything. */
+  async refreshAll(opts: { staleOnly?: boolean } = {}): Promise<void> {
     const sources = await this.sourceRepo.find({ where: { enabled: true } });
+    const now = Date.now();
     for (const source of sources) {
-      await this.refreshSource(source);
+      if (opts.staleOnly && !this.isStale(source, now)) continue;
+      try {
+        await this.refreshSource(source);
+      } catch (err) {
+        // `refreshSource` reports its own expected failures; this catches the
+        // unexpected ones so a single bad source cannot abort the whole run.
+        this.logger.warn(`catalog refresh threw for source #${source.id}: ${(err as Error).message}`);
+      }
     }
+  }
+
+  private isStale(source: PluginSource, now: number): boolean {
+    if (!source.cachedCatalog || !source.lastRefreshedAt) return true;
+    return now - source.lastRefreshedAt.getTime() > STALE_AFTER_MS;
   }
 
   /**


### PR DESCRIPTION
## What I found

Two halves to check, and they land differently.

**The seeded default source is fine.** `1783100000000-seed-official-plugin-source.ts` inserts the official catalog URL into `plugin_sources`, idempotently, so a fresh install has something to browse without typing a URL.

**There was no refresh at startup at all.** Grepping every caller of `refreshAll` / `refreshSource` turns up exactly two:

| Trigger | When |
|---|---|
| `@Cron(PLUGIN_SOURCE_REFRESH_CRON)` in `SchedulerService` | `'0 3 * * *'` — once a day |
| `plugin-sources.controller.ts` | an admin clicking refresh |

No `onModuleInit` or `onApplicationBootstrap` anywhere in the plugins module touches the catalog — the three hooks that exist are for the process-event dispatcher, webhooks and the registry.

And every consumer reads `source.cachedCatalog` with no live-fetch fallback: the catalogue listing, `findInstallableVersion` in the installer, auto-update, and the deny-list enforcement.

So a fresh install at 10am has the official source seeded with `cachedCatalog = NULL` and shows an **empty catalogue until 3am the next morning**, unless the admin finds the manual refresh button. The presence of a daily job makes it look like this is handled; it is not.

## The fix

`PluginCatalogClientService` implements `OnApplicationBootstrap` and refreshes what is stale:

```ts
onApplicationBootstrap(): void {
  void this.refreshAll({ staleOnly: true }).catch((err: unknown) =>
    this.logger.warn(`boot catalog refresh failed: ${(err as Error).message}`),
  );
}
```

Two constraints shape it, and both are deliberate:

- **Never awaited, never fatal.** An unreachable or slow catalog host must not delay startup. The `.catch` is there because `refreshSource` reports its own *expected* failures through `fail()` but a repository write can still throw, and an unhandled rejection at boot is not an acceptable failure mode.
- **Six-hour staleness window.** Refreshing unconditionally would mean a crash-restart loop hammering a public GitHub Pages host on every attempt. `plugin_sources.lastRefreshedAt` already existed, so the guard needed no schema change. A source with no cached catalog is always stale, which is exactly the seeded-migration case.

The scheduled 3am run is unchanged — it still refetches every enabled source regardless of age.

## Also fixed

`refreshAll` had no per-source error handling: an unexpected throw on the first source aborted the loop and every later source silently went unrefreshed that night. Now each is wrapped, so one bad source cannot take out the rest.

Removed the `@nestjs/schedule` import left behind when the cron moved to `SchedulerService` — the file's own comment already explains why the decorator does not live here.

## On "refresh when the plugin starts"

Sources are core state, not plugin state — plugins neither own nor read `plugin_sources`. There is no plugin-start moment to hook that would be earlier or more meaningful than this one, so the boot of the plugins subsystem is the right place, and it covers the server-start case you wanted.

## Verification

`npx jest src/` — 147 suites, 1650 tests, 0 failures. `npx tsc --noEmit` clean.

Five tests added: a never-fetched source refreshes, a stale one refreshes, a freshly cached one is left alone, the scheduled run still refetches everything, and one source throwing does not abort the rest.

The important one asserts the **hook wiring** — `onApplicationBootstrap()` calls `refreshAll({ staleOnly: true })`. Without it the hook could be deleted and every other test would still pass. I checked it actually fails when the hook is neutered, then restored it.
