### PR TITLE
feat(media-detail): show the file import date in the file info panel

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -9,6 +9,7 @@
     "path": "Datei",
     "quality": "Qualität",
     "size": "Größe",
+    "added_at": "Hinzugefügt am",
     "original_file_bitrate": "Bitrate",
     "codec": "Codec",
     "profile": "Profil",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -9,6 +9,7 @@
     "path": "File",
     "quality": "Quality",
     "size": "Size",
+    "added_at": "Added on",
     "original_file_bitrate": "Bitrate",
     "codec": "Codec",
     "profile": "Profile",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -9,6 +9,7 @@
     "path": "Archivo",
     "quality": "Calidad",
     "size": "Tamaño",
+    "added_at": "Añadido el",
     "original_file_bitrate": "Tasa de bits",
     "codec": "Códec",
     "profile": "Perfil",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -9,6 +9,7 @@
     "path": "Fichier",
     "quality": "Qualité",
     "size": "Taille",
+    "added_at": "Ajouté le",
     "original_file_bitrate": "Débit",
     "codec": "Codec",
     "profile": "Profil",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -9,6 +9,7 @@
     "path": "File",
     "quality": "Qualità",
     "size": "Dimensione",
+    "added_at": "Aggiunto il",
     "original_file_bitrate": "Bitrate",
     "codec": "Codec",
     "profile": "Profilo",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -9,6 +9,7 @@
     "path": "Ficheiro",
     "quality": "Qualidade",
     "size": "Tamanho",
+    "added_at": "Adicionado em",
     "original_file_bitrate": "Débito",
     "codec": "Codec",
     "profile": "Perfil",

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -84,7 +84,7 @@ export interface Media {
   digitalRelease?: string | null;
   physicalRelease?: string | null;
   seasons?: Season[];
-  files?: { id: number; quality: string; relativePath: string; size: number; episodeId?: number | null; streamInfo?: MediaFileInfo | null }[];
+  files?: { id: number; quality: string; relativePath: string; size: number; createdAt?: string; episodeId?: number | null; streamInfo?: MediaFileInfo | null }[];
   qualityProfile?: QualityProfileBrief | null;
   languageProfile?: { id: number; name: string } | null;
   minimumAvailability?: 'announced' | 'inCinemas' | 'released';

--- a/client/src/app/shared/components/media-file-info.html
+++ b/client/src/app/shared/components/media-file-info.html
@@ -7,6 +7,9 @@
       @if (fullPath()) {
         <div class="col-span-full"><span class="text-base-content/50">{{ 'file_info.path' | translate }} :&nbsp;</span><span class="font-medium break-all">{{ fullPath() }}</span></div>
       }
+      @if (formatAddedAt(f.createdAt); as added) {
+        <div class="col-span-full"><span class="text-base-content/50">{{ 'file_info.added_at' | translate }} :&nbsp;</span><span class="font-medium">{{ added }}</span></div>
+      }
       @if (f.quality) {
         <div><span class="text-base-content/50">{{ 'file_info.quality' | translate }} :&nbsp;</span><span class="font-medium">{{ f.quality }}</span></div>
       }

--- a/client/src/app/shared/components/media-file-info.ts
+++ b/client/src/app/shared/components/media-file-info.ts
@@ -20,6 +20,7 @@ type FileInput = {
   relativePath: string;
   size: number;
   quality: string;
+  createdAt?: string;
   streamInfo?: MediaFileInfo | null;
 };
 
@@ -95,6 +96,19 @@ export class MediaFileInfoComponent {
     if (n >= 1_073_741_824) return (n / 1_073_741_824).toFixed(2) + ' GB';
     if (n >= 1_048_576) return (n / 1_048_576).toFixed(1) + ' MB';
     return (n / 1024).toFixed(0) + ' KB';
+  }
+
+  formatAddedAt(iso?: string): string {
+    if (!iso) return '';
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
+    return d.toLocaleString(this.translate.currentLang || undefined, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
   }
 
   formatBitrate(bps?: number): string {


### PR DESCRIPTION
## What

Adds an **Added on** row to the file information panel on the media detail page, right under the file path, spanning the full width.

## Why

The panel showed size, quality, codecs and streams but nothing about *when* the file arrived. Telling a fresh grab from a months-old file meant dropping to a shell.

## How

`MediaFile.createdAt` comes from `BaseEntity` and the detail endpoint already returns the full entity, so no backend change was needed — only wiring it through the client type, a locale-aware formatter (`toLocaleString`, date + hour/minute in the active UI language) and one template row. Translation key `file_info.added_at` added to all six locales.

## Caveat

The value is the DB row creation date: the download date for grabbed files, the scan date for files that existed before the library was added. A dedicated `downloadedAt` column would be needed to separate the two — deliberately skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)