### PR TITLE
fix(release-picker): give an empty search its own centred state

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -900,7 +900,7 @@
     "blocklisted": "Blockiert",
     "releases_empty": "Keine Release gefunden. Überprüfen Sie Ihre konfigurierten Quellen.",
     "releases_tab_all": "Alle",
-    "releases_empty_indexer": "Dieser Indexer hat für diese Suche nichts geliefert.",
+    "releases_empty_indexer": "Keine Ergebnisse für diesen Indexer.",
     "indexer_failed": "Dieser Indexer hat nicht rechtzeitig geantwortet",
     "indexer_cooldown": "Übersprungen — dieser Indexer pausiert nach einem Fehler",
     "releases_error": "Die Releases konnten nicht geladen werden.",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -905,7 +905,7 @@
     "blocklisted": "Blocked",
     "releases_empty": "No releases found. Check your configured sources.",
     "releases_tab_all": "All",
-    "releases_empty_indexer": "This indexer returned nothing for this search.",
+    "releases_empty_indexer": "No results for this indexer.",
     "indexer_failed": "This indexer did not answer in time",
     "indexer_cooldown": "Skipped — this indexer is cooling down after an error",
     "releases_error": "Unable to load releases.",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -900,7 +900,7 @@
     "blocklisted": "Bloqueado",
     "releases_empty": "No se encontró ninguna release. Compruebe sus fuentes configuradas.",
     "releases_tab_all": "Todos",
-    "releases_empty_indexer": "Este indexador no devolvió nada para esta búsqueda.",
+    "releases_empty_indexer": "Sin resultados para este indexador.",
     "indexer_failed": "Este indexador no respondió a tiempo",
     "indexer_cooldown": "Omitido — este indexador está en pausa tras un error",
     "releases_error": "No se pueden cargar las releases.",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -905,7 +905,7 @@
     "blocklisted": "Bloqué",
     "releases_empty": "Aucune release trouvée. Vérifiez vos sources configurées.",
     "releases_tab_all": "Tous",
-    "releases_empty_indexer": "Cet indexeur n’a rien renvoyé pour cette recherche.",
+    "releases_empty_indexer": "Aucun résultat pour cet indexeur.",
     "indexer_failed": "Cet indexeur n’a pas répondu à temps",
     "indexer_cooldown": "Ignoré — cet indexeur est en pause après une erreur",
     "releases_error": "Impossible de charger les releases.",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -900,7 +900,7 @@
     "blocklisted": "Bloccato",
     "releases_empty": "Nessuna release trovata. Verifica le tue fonti configurate.",
     "releases_tab_all": "Tutti",
-    "releases_empty_indexer": "Questo indicizzatore non ha restituito nulla per questa ricerca.",
+    "releases_empty_indexer": "Nessun risultato per questo indicizzatore.",
     "indexer_failed": "Questo indicizzatore non ha risposto in tempo",
     "indexer_cooldown": "Ignorato — questo indicizzatore è in pausa dopo un errore",
     "releases_error": "Impossibile caricare le release.",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -900,7 +900,7 @@
     "blocklisted": "Bloqueado",
     "releases_empty": "Nenhuma release encontrada. Verifique as suas fontes configuradas.",
     "releases_tab_all": "Todos",
-    "releases_empty_indexer": "Este indexador não devolveu nada para esta pesquisa.",
+    "releases_empty_indexer": "Sem resultados para este indexador.",
     "indexer_failed": "Este indexador não respondeu a tempo",
     "indexer_cooldown": "Ignorado — este indexador está em pausa após um erro",
     "releases_error": "Não foi possível carregar as releases.",

--- a/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.html
+++ b/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.html
@@ -56,10 +56,11 @@
           [grabPrefix]="grabPrefix()"
           (grab)="grab.emit($event)"
         />
-      } @else if (activeTab() !== null) {
-        <p class="text-sm text-base-content/60 py-4">{{ 'media_detail.releases_empty_indexer' | translate }}</p>
-      } @else if (searched() || !loading()) {
-        <p class="text-sm text-base-content/60 py-4">{{ emptyMessage() | translate }}</p>
+      } @else if (activeTab() !== null || searched() || !loading()) {
+        <div class="flex min-h-48 flex-col items-center justify-center gap-3 py-8 text-center">
+          <svg lucideSearchX class="h-10 w-10 text-base-content/25"></svg>
+          <p class="max-w-sm text-sm text-base-content/60">{{ emptyKey() | translate }}</p>
+        </div>
       }
     </div>
 

--- a/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.spec.ts
+++ b/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.spec.ts
@@ -11,7 +11,7 @@ const TRANSLATIONS = {
   media_detail: {
     releases_tab_all: 'All',
     releases_empty: 'No releases found.',
-    releases_empty_indexer: 'This indexer returned nothing.',
+    releases_empty_indexer: 'No results for this indexer.',
     indexer_failed: 'No answer in time',
     indexer_cooldown: 'Cooling down',
   },
@@ -182,6 +182,16 @@ describe('ReleasesModalComponent — per-indexer tabs', () => {
     fixture.componentInstance.activeTab.set(2);
     fixture.detectChanges();
     await fixture.whenStable();
-    expect(fixture.nativeElement.textContent).toContain('This indexer returned nothing.');
+    expect(fixture.nativeElement.textContent).toContain('No results for this indexer.');
+    // Both empty states share one centred block, icon included — an indexer tab that fell back
+    // to a bare paragraph would read as a different screen.
+    expect(fixture.nativeElement.querySelector('svg[lucideSearchX]')).not.toBeNull();
+  });
+
+  it('the whole-search empty message uses the same centred block', async () => {
+    const fixture = await createFixture({ releases: [], indexers: ROSTER, searched: true });
+    expect(fixture.componentInstance.emptyKey()).toBe('media_detail.releases_empty');
+    expect(fixture.nativeElement.textContent).toContain('No releases found.');
+    expect(fixture.nativeElement.querySelector('svg[lucideSearchX]')).not.toBeNull();
   });
 });

--- a/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.ts
+++ b/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.ts
@@ -12,6 +12,7 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
+import { LucideSearchX } from '@lucide/angular';
 import { MovieRelease } from '../../media-detail-release-picker.service';
 import { IndexerRosterEntry } from '../../release-search-stream.service';
 import { ReleasesTableComponent } from '../releases-table/releases-table.component';
@@ -31,7 +32,7 @@ type IndexerSearchStateOrAll = IndexerRosterEntry['state'] | 'all';
 
 @Component({
   selector: 'app-releases-modal',
-  imports: [FormsModule, TranslateModule, ReleasesTableComponent],
+  imports: [FormsModule, TranslateModule, ReleasesTableComponent, LucideSearchX],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './releases-modal.component.html',
 })
@@ -96,6 +97,12 @@ export class ReleasesModalComponent {
   /** Rows and progress coexist: the full-panel spinner is only for a search with nothing
    *  back yet. */
   readonly showSpinnerPanel = computed(() => this.loading() && this.releases().length === 0);
+
+  /** An open indexer tab explains itself; otherwise the whole search speaks, which the caller
+   *  narrows (no quality profile, for instance). */
+  readonly emptyKey = computed(() =>
+    this.activeTab() !== null ? 'media_detail.releases_empty_indexer' : this.emptyMessage(),
+  );
 
   showModal() {
     this.activeTab.set(null);


### PR DESCRIPTION
## What

An indexer tab with no hits rendered a bare left-aligned line under the tab strip, and the modal collapsed to almost nothing around it — it read as a rendering glitch rather than an answer.

Both empty branches now share one centred block: a `search-x` icon above the message, vertically centred with a `min-h-48` floor so the panel keeps a sensible height.

## Why one block for both

An indexer tab that found nothing and a whole search that found nothing are the same situation at different scopes. Styling only the first would have made switching tabs look like switching screens. The message is picked in the component (`emptyKey`), so the template carries one branch instead of two near-identical ones — less markup than before, not more.

## Wording

`releases_empty_indexer` drops the redundant trailing clause: "No results for this indexer." rather than "This indexer returned nothing for this search." The modal *is* the search. Updated in all six locales.

## Tests

488 client tests, green. Two cover this: an empty indexer tab shows its own message inside the shared block, and the whole-search empty message resolves through the same `emptyKey` into the same block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)