### PR TITLE
style(release-picker): breathe above the searching and empty panels

### DIFF
--- a/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.html
+++ b/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.html
@@ -43,7 +43,7 @@
       @if (error()) {
         <div role="alert" class="alert alert-error text-sm">{{ error() }}</div>
       } @else if (showSpinnerPanel()) {
-        <div class="flex min-h-48 flex-col items-center justify-center gap-3 py-8 text-center">
+        <div class="flex min-h-64 flex-col items-center justify-center gap-3 pt-16 pb-10 text-center">
           <span class="loading loading-spinner loading-lg text-base-content/40"></span>
           <p class="max-w-sm text-sm text-base-content/60">{{ 'media_detail.releases_searching' | translate }}</p>
         </div>
@@ -58,7 +58,7 @@
           (grab)="grab.emit($event)"
         />
       } @else if (activeTab() !== null || searched() || !loading()) {
-        <div class="flex min-h-48 flex-col items-center justify-center gap-3 py-8 text-center">
+        <div class="flex min-h-64 flex-col items-center justify-center gap-3 pt-16 pb-10 text-center">
           @switch (emptyPanel().icon) {
             @case ('failed') {
               <svg lucideTriangleAlert class="h-10 w-10 text-warning/60"></svg>


### PR DESCRIPTION
## What

Spacing only, no logic. The searching and empty panels get `min-h-64 pt-16 pb-10` instead of `min-h-48 py-8`.

## Why asymmetric

Padded evenly, both panels read as riding high. The tab strip and its horizontal scrollbar sit directly above the panel, so the space they occupy counts against the block visually — while the flex centring, which only sees the panel's own box, ignores it. More padding above than below puts the optical centre where the mathematical one already was.

Applied to both panels so switching between "searching" and "no results" doesn't shift the content.

## Tests

493 client tests, green — unchanged, since nothing but class names moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)