### PR TITLE
style(release-picker): stop the release title column from being squeezed

### DIFF
--- a/client/src/app/features/media-detail/components/releases-table/releases-table.component.html
+++ b/client/src/app/features/media-detail/components/releases-table/releases-table.component.html
@@ -1,5 +1,6 @@
-<div>
-  <table class="table table-fixed w-full">
+<div class="overflow-x-auto">
+  <!-- `table-fixed` ignores a cell's min-width, so the title column's floor lives here. -->
+  <table class="table table-fixed w-full sm:min-w-[64rem]">
     <thead>
       <tr>
         <th>{{ 'media_detail.col_release' | translate }}</th>


### PR DESCRIPTION
## What

The release table gets `sm:min-w-[64rem]` and its wrapper gets `overflow-x-auto`.

## Why

Six fixed columns — quality `w-72`, CF `w-16`, size `w-20`, peers `w-32`, source `w-32`, grab `w-10` — take 45.5rem of a `table-fixed w-full`. The title column gets whatever is left, so on a narrow window it collapsed to a sliver and every title fell back to scrolling inside its own cell.

The floor leaves the title ~18rem before the table starts scrolling instead.

## Why the floor is on the table, not the cell

`table-fixed` derives column widths from the first row's `width` alone; a cell's `min-width` never enters that calculation, so `min-w-*` on the `<th>` would have looked right and done nothing. The table's own width is the only lever the fixed algorithm respects.

It applies from `sm` up, which is where those six columns exist at all — below that breakpoint the title is the only column and has to stay fluid.

## Tests

493 client tests, green — class names only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)