### PR TITLE
fix(release-picker): stop the release table nesting a second vertical scrollbar

### DIFF
--- a/client/src/app/features/media-detail/components/releases-table/releases-table.component.html
+++ b/client/src/app/features/media-detail/components/releases-table/releases-table.component.html
@@ -1,4 +1,4 @@
-<div class="overflow-x-auto">
+<div class="overflow-x-auto overflow-y-hidden">
   <!-- `table-fixed` ignores a cell's min-width, so the title column's floor lives here. -->
   <table class="table table-fixed w-full sm:min-w-[64rem]">
     <thead>
@@ -19,7 +19,7 @@
         <tr [class.opacity-50]="r.blocklisted || !r.languageAllowed || r.rejections.length > 0">
           <td class="text-sm min-w-0">
             <!-- Title scrolls horizontally on its own -->
-            <div class="overflow-x-auto">
+            <div class="overflow-x-auto overflow-y-hidden">
               <p class="whitespace-nowrap inline-flex items-center gap-1.5">
                 @if (r.isFullSeason) {
                   <svg lucidePackage class="h-4 w-4 shrink-0 text-info" [attr.title]="'media_detail.season_pack' | translate"></svg>


### PR DESCRIPTION
## What

`overflow-x-auto` on the table wrapper needs its `overflow-y` stated. Per CSS, a `visible` axis paired with a non-visible one computes to `auto` — so the wrapper grew its own vertical scrollbar inside the modal's scroll panel, giving two side by side.

Horizontal scrolling is kept, which is the point of the wrapper: it is what lets the title column keep its floor from #1045.

## Note

Same cause as the tab strip fix in #1041, reintroduced by #1045 one commit later. The lesson is that `overflow-x-auto` is never safe on its own in a nested scroll container — the pairing has to be explicit.

## Tests

493 client tests, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)