### PR TITLE
feat(provider-list): show the cooldown a row is in, and thin the actions cell

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -149,6 +149,14 @@ export type FormActionId = (typeof FORM_ACTION_IDS)[number];
 export const TABLE_ROW_ACTION_IDS = ['table.open-media'] as const;
 export type TableRowActionId = (typeof TABLE_ROW_ACTION_IDS)[number];
 
+/**
+ * Where a `providers` row action renders instead of as its own labelled button. `cooldown-reset`
+ * puts it beside the cooldown a row reports, so clearing one sits next to the thing it clears.
+ * Closed vocabulary: an unknown value falls back to a plain button rather than disappearing.
+ */
+export const PROVIDER_ROW_ACTION_SLOTS = ['cooldown-reset'] as const;
+export type ProviderRowActionSlot = (typeof PROVIDER_ROW_ACTION_SLOTS)[number];
+
 export interface FormConfigPage extends ConfigPageBase {
   kind?: 'form';
   fields: FormItem[];
@@ -247,6 +255,8 @@ export interface ProvidersConfigPage extends ConfigPageBase {
     route: string;
     scope: 'row' | 'list';
     confirmKey?: string;
+    /** Renders this action in a known place rather than as its own button. `scope: 'row'` only. */
+    slot?: ProviderRowActionSlot;
     /** How core renders what a `GET` answers — an array of rows, in declared columns.
      *  A `GET` without it renders no button: core has no domain view to fall back on. */
     result?: { kind: 'table'; columns: TableColumn[]; emptyKey: string };

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2412,6 +2412,11 @@
     "status_unset": "Noch nicht festgelegt"
   },
   "provider_list": {
+    "col_cooldown": "Cooldown",
+    "cooldown_minutes": "{{minutes}} Min. übrig",
+    "cooldown_hours": "{{hours}} Std. übrig",
+    "cooldown_rate_limit": "Ratenlimit",
+    "cooldown_failures": "nach Fehlern",
     "new": "Neu",
     "col_name": "Name",
     "col_implementation": "Typ",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2440,6 +2440,11 @@
     "status_unset": "Not set yet"
   },
   "provider_list": {
+    "col_cooldown": "Cooldown",
+    "cooldown_minutes": "{{minutes}} min left",
+    "cooldown_hours": "{{hours}} h left",
+    "cooldown_rate_limit": "rate limited",
+    "cooldown_failures": "after failures",
     "new": "New",
     "col_name": "Name",
     "col_implementation": "Type",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2412,6 +2412,11 @@
     "status_unset": "Aún no establecido"
   },
   "provider_list": {
+    "col_cooldown": "Cooldown",
+    "cooldown_minutes": "{{minutes}} min restantes",
+    "cooldown_hours": "{{hours}} h restantes",
+    "cooldown_rate_limit": "límite alcanzado",
+    "cooldown_failures": "tras fallos",
     "new": "Nuevo",
     "col_name": "Nombre",
     "col_implementation": "Tipo",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2440,6 +2440,11 @@
     "status_unset": "Non défini"
   },
   "provider_list": {
+    "col_cooldown": "Cooldown",
+    "cooldown_minutes": "{{minutes}} min restantes",
+    "cooldown_hours": "{{hours}} h restantes",
+    "cooldown_rate_limit": "quota atteint",
+    "cooldown_failures": "après échecs",
     "new": "Nouveau",
     "col_name": "Nom",
     "col_implementation": "Type",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2412,6 +2412,11 @@
     "status_unset": "Non ancora impostato"
   },
   "provider_list": {
+    "col_cooldown": "Cooldown",
+    "cooldown_minutes": "{{minutes}} min rimasti",
+    "cooldown_hours": "{{hours}} h rimaste",
+    "cooldown_rate_limit": "limite raggiunto",
+    "cooldown_failures": "dopo errori",
     "new": "Nuovo",
     "col_name": "Nome",
     "col_implementation": "Tipo",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2412,6 +2412,11 @@
     "status_unset": "Ainda não definido"
   },
   "provider_list": {
+    "col_cooldown": "Cooldown",
+    "cooldown_minutes": "{{minutes}} min restantes",
+    "cooldown_hours": "{{hours}} h restantes",
+    "cooldown_rate_limit": "limite atingido",
+    "cooldown_failures": "após falhas",
     "new": "Novo",
     "col_name": "Nome",
     "col_implementation": "Tipo",

--- a/client/src/app/features/plugin-view/plugin-view.html
+++ b/client/src/app/features/plugin-view/plugin-view.html
@@ -37,6 +37,7 @@
           [reorderable]="view.reorderable ?? false"
           [listActions]="providerListActions(view)"
           [rowActions]="providerRowActions(view)"
+          [cooldownAction]="providerCooldownAction(view)"
           [testConnection]="providerTestConnection(view)"
         />
       } @else {

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -288,14 +288,25 @@ export class PluginViewComponent {
    *  since only it holds the row. */
   providerRowActions(view: ProvidersView): ProviderRowAction[] {
     return (view.actions ?? [])
-      .filter((a) => a.scope === 'row')
-      .map((a) => ({
-        labelKey: a.labelKey,
-        method: a.method,
-        route: this.resourceUrl(a.route),
-        confirmKey: a.confirmKey,
-        result: a.result,
-      }));
+      .filter((a) => a.scope === 'row' && a.slot !== 'cooldown-reset')
+      .map((a) => this.toProviderRowAction(a));
+  }
+
+  /** The cooldown reset renders beside the cooldown instead of as another button, so it is
+   *  pulled out of `providerRowActions` rather than rendered twice. */
+  providerCooldownAction(view: ProvidersView): ProviderRowAction | null {
+    const action = (view.actions ?? []).find((a) => a.scope === 'row' && a.slot === 'cooldown-reset');
+    return action ? this.toProviderRowAction(action) : null;
+  }
+
+  private toProviderRowAction(a: NonNullable<ProvidersView['actions']>[number]): ProviderRowAction {
+    return {
+      labelKey: a.labelKey,
+      method: a.method,
+      route: this.resourceUrl(a.route),
+      confirmKey: a.confirmKey,
+      result: a.result,
+    };
   }
 
   /** `actions[].scope: 'list'` — rendered once above the rows, run with no draft. */

--- a/client/src/app/shared/components/provider-list/provider-list.html
+++ b/client/src/app/shared/components/provider-list/provider-list.html
@@ -37,30 +37,67 @@
         <thead>
           <tr>
             <th>{{ labels().colNameKey | translate }}</th>
-            <th>{{ labels().colImplementationKey | translate }}</th>
+            @if (showImplementation()) { <th>{{ labels().colImplementationKey | translate }}</th> }
             @if (showPriority()) { <th class="text-end">{{ labels().colPriorityKey | translate }}</th> }
             <th class="text-center">{{ labels().colEnabledKey | translate }}</th>
+            @if (showCooldown()) { <th>{{ 'provider_list.col_cooldown' | translate }}</th> }
             @if (rowExtraStatus()) { <th></th> }
-            <th class="text-end w-40">{{ labels().actionsKey | translate }}</th>
+            <th class="text-end">{{ labels().actionsKey | translate }}</th>
           </tr>
         </thead>
         <tbody>
           @for (row of orderedRows(); track row.id; let i = $index) {
             <tr>
-              <td class="font-medium">{{ row.name }}</td>
-              <td class="text-sm">{{ implementationLabel(row[implementationKey()] + '') }}</td>
+              <td>
+                <button type="button" class="link link-hover font-medium" (click)="openEdit(row)">{{ row.name }}</button>
+              </td>
+              @if (showImplementation()) {
+                <td class="text-sm">{{ implementationLabel(row[implementationKey()] + '') }}</td>
+              }
               @if (showPriority()) { <td class="text-end tabular-nums">{{ row.priority }}</td> }
               <td class="text-center">
-                @if (row.enabled) {
-                  <span class="badge badge-success badge-sm">{{ 'common.yes' | translate }}</span>
-                } @else {
-                  <span class="badge badge-ghost badge-sm">{{ 'common.no' | translate }}</span>
-                }
+                <input
+                  type="checkbox"
+                  class="toggle toggle-sm toggle-success"
+                  [checked]="row.enabled"
+                  [disabled]="togglingId() === row.id"
+                  [attr.aria-label]="labels().colEnabledKey | translate"
+                  (change)="toggleEnabled(row)"
+                />
               </td>
+              @if (showCooldown()) {
+                <td class="text-sm">
+                  @if (cooldownOf(row); as cd) {
+                    <span class="inline-flex flex-nowrap items-center gap-1.5">
+                      <span class="badge badge-sm badge-warning whitespace-nowrap">{{ cooldownRemaining(cd) }}</span>
+                      <span class="text-xs text-base-content/60">{{ cooldownReasonKey(cd) | translate }}</span>
+                      @if (cooldownAction(); as action) {
+                        <button
+                          type="button"
+                          class="btn btn-ghost btn-xs btn-square"
+                          [disabled]="rowActionBusy() === rowActionKey(row, action)"
+                          [attr.aria-label]="action.labelKey | translate"
+                          [attr.title]="action.labelKey | translate"
+                          (click)="runRowAction(row, action)"
+                        >
+                          @if (rowActionBusy() === rowActionKey(row, action)) {
+                            <span class="loading loading-spinner loading-xs"></span>
+                          } @else {
+                            <svg lucideRotateCcw class="h-4 w-4"></svg>
+                          }
+                        </button>
+                      }
+                    </span>
+                  } @else {
+                    <span class="text-base-content/30">—</span>
+                  }
+                </td>
+              }
               @if (rowExtraStatus(); as tpl) {
                 <td><ng-container *ngTemplateOutlet="tpl; context: { $implicit: row }" /></td>
               }
               <td class="text-end">
+                <span class="inline-flex flex-nowrap items-center justify-end gap-1">
                 @if (reorderable()) {
                   <button type="button" class="btn btn-ghost btn-xs btn-square" [disabled]="i === 0"
                           (click)="moveRow(row, -1)" [attr.aria-label]="'provider_list.move_up' | translate">
@@ -87,12 +124,10 @@
                     {{ action.labelKey | translate }}
                   </button>
                 }
-                <button type="button" class="btn btn-ghost btn-xs" (click)="openEdit(row)">
-                  {{ labels().editKey | translate }}
-                </button>
                 <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteRow(row)">
                   {{ labels().deleteKey | translate }}
                 </button>
+                </span>
               </td>
             </tr>
           }

--- a/client/src/app/shared/components/provider-list/provider-list.spec.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.spec.ts
@@ -82,6 +82,7 @@ async function createComponent(
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     confirmation: { confirm: (...a: any[]) => Promise<boolean>; alert: (...a: any[]) => Promise<void> };
     labels: ProviderListLabels;
+    cooldownAction: ProviderRowAction | null;
   }> = {},
 ) {
   TestBed.configureTestingModule({
@@ -106,6 +107,7 @@ async function createComponent(
   if (opts.reorderable) fixture.componentRef.setInput('reorderable', opts.reorderable);
   if (opts.listActions) fixture.componentRef.setInput('listActions', opts.listActions);
   if (opts.rowActions) fixture.componentRef.setInput('rowActions', opts.rowActions);
+  if (opts.cooldownAction !== undefined) fixture.componentRef.setInput('cooldownAction', opts.cooldownAction);
   fixture.detectChanges();
   await fixture.whenStable();
   await new Promise((r) => setTimeout(r, 0));
@@ -382,5 +384,87 @@ describe('ProviderListComponent — editor dialog chrome', () => {
 
     expect(post).not.toHaveBeenCalled();
     expect(fixture.componentInstance.editingId()).toBeNull();
+  });
+});
+
+const RESET: ProviderRowAction = {
+  labelKey: 'x.clear_cooldown',
+  method: 'DELETE',
+  route: '/api/x/:id/cooldown',
+  confirmKey: 'x.confirm_clear',
+};
+
+function row(over: Record<string, unknown> = {}) {
+  return { id: 1, name: 'A', implementation: 'demo', enabled: true, priority: 1, settings: {}, ...over };
+}
+
+describe('ProviderListComponent — cooldown column', () => {
+  it('VERDICT: a cooling row reports it, instead of only offering to clear something invisible', async () => {
+    const cooling = row({ cooldown: { reason: 'failures', remainingMs: 90_000, until: 'x', failureCount: 2 } });
+    const fixture = await createComponent({ get: () => of([cooling]) }, { cooldownAction: RESET });
+
+    expect(fixture.componentInstance.showCooldown()).toBe(true);
+    expect(fixture.componentInstance.cooldownOf(fixture.componentInstance.rows()[0])).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('svg[lucideRotateCcw]')).not.toBeNull();
+  });
+
+  it('a healthy row keeps the column but offers nothing to reset', async () => {
+    const fixture = await createComponent({ get: () => of([row({ cooldown: null })]) }, { cooldownAction: RESET });
+    expect(fixture.componentInstance.showCooldown()).toBe(true);
+    expect(fixture.componentInstance.cooldownOf(fixture.componentInstance.rows()[0])).toBeNull();
+    expect(fixture.nativeElement.querySelector('svg[lucideRotateCcw]')).toBeNull();
+  });
+
+  it('a resource that tracks no backoff shows no column at all', async () => {
+    const fixture = await createComponent({ get: () => of([row()]) }, { cooldownAction: null });
+    expect(fixture.componentInstance.showCooldown()).toBe(false);
+  });
+
+  // The test loader resolves no strings, so these assert on the key chosen — which is the
+  // decision under test: a six-hour backoff read as "360 min" would be unreadable.
+  it('reads a long backoff in hours rather than as hundreds of minutes', async () => {
+    const fixture = await createComponent({ get: () => of([row()]) });
+    const c = fixture.componentInstance;
+    expect(c.cooldownRemaining({ reason: 'failures', remainingMs: 90_000, until: 'x' })).toContain('minutes');
+    expect(c.cooldownRemaining({ reason: 'failures', remainingMs: 6 * 3_600_000, until: 'x' })).toContain('hours');
+  });
+
+  it('names the reason, so a rate limit is not read as a broken indexer', async () => {
+    const fixture = await createComponent({ get: () => of([row()]) });
+    const c = fixture.componentInstance;
+    expect(c.cooldownReasonKey({ reason: 'rate-limit', remainingMs: 1, until: 'x' })).toContain('rate_limit');
+    expect(c.cooldownReasonKey({ reason: 'failures', remainingMs: 1, until: 'x' })).toContain('failures');
+  });
+});
+
+describe('ProviderListComponent — row controls', () => {
+  it('VERDICT: the name opens the editor, so the row carries no separate edit button', async () => {
+    const fixture = await createComponent({ get: () => of([row()]) });
+    const nameButton = fixture.nativeElement.querySelector('td button') as HTMLButtonElement;
+    nameButton.click();
+    await fixture.whenStable();
+    expect(fixture.componentInstance.editingId()).toBe(1);
+  });
+
+  it('the enabled toggle persists the whole row, so a redacted secret is never written as a value', async () => {
+    const put = vi.fn(() => of({}));
+    const stored = row({ enabled: true, settings: { apiKey: '***' } });
+    const fixture = await createComponent({ get: () => of([stored]), put });
+    await fixture.componentInstance.toggleEnabled(fixture.componentInstance.rows()[0]);
+
+    expect(put).toHaveBeenCalledWith('/api/x/1', expect.objectContaining({ enabled: false, settings: { apiKey: '***' } }));
+  });
+
+  it('hides the implementation column when there is only one to tell apart', async () => {
+    const fixture = await createComponent({ get: () => of([row()]) }, { implementations: IMPLS });
+    expect(fixture.componentInstance.showImplementation()).toBe(false);
+  });
+
+  it('keeps the implementation column as soon as rows can differ', async () => {
+    const fixture = await createComponent(
+      { get: () => of([row()]) },
+      { implementations: [...IMPLS, { implementation: 'other', labelKey: 'x.impl_other', fields: [] }] },
+    );
+    expect(fixture.componentInstance.showImplementation()).toBe(true);
   });
 });

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -15,7 +15,7 @@ import { HttpClient } from '@angular/common/http';
 import { NgTemplateOutlet } from '@angular/common';
 import { firstValueFrom } from 'rxjs';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { LucideArrowUp, LucideArrowDown } from '@lucide/angular';
+import { LucideArrowUp, LucideArrowDown, LucideRotateCcw } from '@lucide/angular';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { InputFieldComponent } from '../forms/input-field/input-field';
 import { ToggleFieldComponent } from '../forms/toggle-field/toggle-field';
@@ -26,6 +26,7 @@ import {
   ProviderDraft,
   ProviderImplementation,
   ProviderInstance,
+  ProviderCooldown,
   ProviderListAction,
   ProviderListLabels,
   ProviderRowAction,
@@ -67,6 +68,7 @@ export function resolveRowActionRoute(route: string, id: number | string): strin
     DataTableComponent,
     LucideArrowUp,
     LucideArrowDown,
+    LucideRotateCcw,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './provider-list.html',
@@ -75,6 +77,7 @@ export class ProviderListComponent implements OnInit {
   private readonly http = inject(HttpClient);
   private readonly translate = inject(TranslateService);
   private readonly confirmation = inject(ConfirmationService);
+  readonly togglingId = signal<number | null>(null);
   private readonly editorDialog = viewChild<ElementRef<HTMLDialogElement>>('editorDialog');
   private readonly resultDialog = viewChild<ElementRef<HTMLDialogElement>>('resultDialog');
 
@@ -95,6 +98,10 @@ export class ProviderListComponent implements OnInit {
   readonly listActions = input<readonly ProviderListAction[]>([]);
   /** Rendered per row (`ProvidersConfigPage.actions[].scope: 'row'`) — every entry gets its own button. */
   readonly rowActions = input<readonly ProviderRowAction[]>([]);
+  /** The action that clears a row's cooldown, rendered beside the cooldown itself rather than
+   *  as another button in the actions cell. Routed through `runRowAction`, so it keeps that
+   *  path's confirmation, busy state and reload. */
+  readonly cooldownAction = input<ProviderRowAction | null>(null);
   /** Matches subtitle-providers' current UX: renaming the draft to the driver's label while creating. */
   readonly autoFillNameFromImplementation = input(false);
   /** Runs against the unsaved draft (before create/update), catching a bad connection before it's saved. */
@@ -347,6 +354,46 @@ export class ProviderListComponent implements OnInit {
       await this.reload();
     } finally {
       this.listActionBusy.set(null);
+    }
+  }
+
+  /** The implementation column earns its place only when there is something to tell apart —
+   *  the editor already hides its selector on a single implementation for the same reason. */
+  readonly showImplementation = computed(() => this.implementations().length > 1);
+
+  /** The column appears for resources that track backoff at all, so a healthy list still shows
+   *  the column its rows can report into rather than the table reshaping on the first failure. */
+  readonly showCooldown = computed(
+    () => this.cooldownAction() !== null || this.rows().some((r) => r.cooldown !== undefined),
+  );
+
+  cooldownOf(row: ProviderInstance): ProviderCooldown | null {
+    return row.cooldown ?? null;
+  }
+
+  /** Coarse on purpose: a backoff of hours read to the second would be noise, and the value is
+   *  a snapshot the list does not tick. */
+  cooldownRemaining(cd: ProviderCooldown): string {
+    const minutes = Math.ceil(cd.remainingMs / 60_000);
+    if (minutes < 60) return this.translate.instant('provider_list.cooldown_minutes', { minutes });
+    return this.translate.instant('provider_list.cooldown_hours', { hours: Math.ceil(minutes / 60) });
+  }
+
+  cooldownReasonKey(cd: ProviderCooldown): string {
+    return cd.reason === 'rate-limit' ? 'provider_list.cooldown_rate_limit' : 'provider_list.cooldown_failures';
+  }
+
+  /** Persists the whole row, as `moveRow` does: the resource merges secrets on update, so
+   *  echoing a redacted settings bag back never overwrites the stored one. */
+  async toggleEnabled(row: ProviderInstance): Promise<void> {
+    this.togglingId.set(row.id);
+    try {
+      await firstValueFrom(this.http.put(`${this.listUrl()}/${row.id}`, { ...row, enabled: !row.enabled }));
+      await this.reload();
+    } catch {
+      // handled by the global error interceptor
+    } finally {
+      this.togglingId.set(null);
     }
   }
 

--- a/client/src/app/shared/components/provider-list/provider-list.types.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.types.ts
@@ -11,6 +11,8 @@ export interface ProviderInstance {
   enabled: boolean;
   priority: number;
   settings?: Record<string, unknown>;
+  /** Present only on resources that track backoff; `null` while the row is healthy. */
+  cooldown?: ProviderCooldown | null;
   [extra: string]: unknown;
 }
 
@@ -52,6 +54,16 @@ export interface ProviderRowAction {
   confirmKey?: string;
   /** How a `GET`'s answer renders (`ProvidersConfigPage.actions[].result`). */
   result?: { kind: 'table'; columns: TableColumn[]; emptyKey: string };
+}
+
+/** What a row reports about its own backoff, when the resource tracks one. Rendered as its own
+ *  column: a page offering "clear the cooldown" while never showing one is the shape this fills. */
+export interface ProviderCooldown {
+  reason: 'rate-limit' | 'failures';
+  remainingMs: number;
+  until: string;
+  failureCount?: number;
+  detail?: string;
 }
 
 export interface ProviderListLabels {


### PR DESCRIPTION
## What

Reworks the shared `provider-list` renderer, which is what draws the Indexers page (and the subtitle-providers page — see the note at the end).

| before | after |
|---|---|
| "Clear cooldown" on every row, no cooldown ever shown | **Cooldown** column: remaining time, reason, reset icon beside it |
| 4 stacked buttons, rows 3 lines tall | name opens the editor; stats + delete on one line |
| Type column reading `Torznab` on every row | hidden when there is only one implementation |
| Active as a read-only badge | a toggle |

## The cooldown was being thrown away

`/indexers` already returns `cooldown: { reason, remainingMs, until, failureCount?, detail? } | null` per row, and `ProviderInstance` passes unknown fields through untouched. The renderer simply never read it — so an indexer sitting out a six-hour failure backoff looked identical to a healthy one, while the row still offered to clear a cooldown you could not see. That is the same invisibility as the release modal's skipped indexers, one page upstream.

Rendered as remaining time (coarse: minutes under an hour, then hours — a snapshot the list does not tick) plus why, since a rate limit and a broken indexer call for different reactions.

## Why `slot` and not a known id

The reset has to render inside the cooldown cell, so core must know *which* declared action it is. Recognising a route shape or a specific action id would put plugin knowledge in core. Instead `ProvidersConfigPage.actions[].slot` declares the placement — a closed vocabulary (`PROVIDER_ROW_ACTION_SLOTS`) alongside the existing `FORM_ACTION_IDS` and `TABLE_ROW_ACTION_IDS`. An unknown value falls back to a plain button rather than vanishing.

It routes through `runRowAction`, so it keeps that path's confirmation, busy state and reload for free. The confirmation text comes from the manifest's `confirmKey`.

## The toggle and secrets

`toggleEnabled` PUTs `{ ...row, enabled: !row.enabled }`, the same whole-row write the reorder buttons already use. That matters because list rows carry *redacted* secrets: it is safe only because the resource merges secret settings on update rather than replacing them. A test pins that the redacted bag is sent as-is and relies on that merge.

## Shared component, two pages

`provider-list` also draws Settings → Subtitle providers. The name-opens-editor change and the toggle apply there too. That is deliberate — one renderer should not offer two different interaction models — but it is a change to a page nobody asked about, so flagging it. The cooldown column stays absent there: it appears only for resources that declare the reset slot or return the field.

## Not included

`reorderable` for the priority column (proposal 4) is a manifest change, and the `enableRss`/`enableSearch` split is a data-model question rather than a rendering one. Both left out.

## Tests

Client 502, backend plugins suite 810, both green. New coverage: a cooling row reports it and offers the reset, a healthy row keeps the column but offers nothing, a resource with no backoff shows no column, a long backoff reads in hours, the reason is named, the name opens the editor, and the toggle sends the whole row with its redacted settings intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)