### PR TITLE
fix(plugins): stop showing an install error twice

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2124,7 +2124,6 @@
       "confirm_uninstall": "„{{name}}“ deinstallieren? Alle zu diesem Plugin gehörenden Daten gehen verloren.",
       "uninstalled": "Plugin uninstalled.",
       "uninstall_error": "Unable to uninstall the plugin.",
-      "inspect_error": "Unable to read this archive.",
       "installed": "Plugin installed.",
       "install_failed_but_kept": "\"{{id}}\" was installed but could not start: {{reason}}",
       "enabled_toast": "Plugin enabled.",
@@ -2232,7 +2231,6 @@
         "update_available": "Update verfügbar",
         "install": "Installieren",
         "no_installable": "Keine installierbare Version",
-        "inspect_error": "Dieses Plugin konnte nicht abgerufen werden.",
         "switch_to": "Auf {{version}} aktualisieren",
         "update_keeps_data": "Deine Einstellungen bleiben erhalten."
       },

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2151,7 +2151,6 @@
       "confirm_uninstall": "Uninstall “{{name}}”? Any data associated with this plugin will be lost.",
       "uninstalled": "Plugin uninstalled.",
       "uninstall_error": "Unable to uninstall the plugin.",
-      "inspect_error": "Unable to read this archive.",
       "installed": "Plugin installed.",
       "install_failed_but_kept": "\"{{id}}\" was installed but could not start: {{reason}}",
       "enabled_toast": "Plugin enabled.",
@@ -2259,7 +2258,6 @@
         "update_available": "Update available",
         "install": "Install",
         "no_installable": "No installable version",
-        "inspect_error": "Unable to fetch this plugin.",
         "switch_to": "Update to {{version}}",
         "update_keeps_data": "Your settings are kept."
       },

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2124,7 +2124,6 @@
       "confirm_uninstall": "¿Desinstalar «{{name}}»? Se perderán los datos asociados a este plugin.",
       "uninstalled": "Plugin uninstalled.",
       "uninstall_error": "Unable to uninstall the plugin.",
-      "inspect_error": "Unable to read this archive.",
       "installed": "Plugin installed.",
       "install_failed_but_kept": "\"{{id}}\" was installed but could not start: {{reason}}",
       "enabled_toast": "Plugin enabled.",
@@ -2232,7 +2231,6 @@
         "update_available": "Actualización disponible",
         "install": "Instalar",
         "no_installable": "Sin versión instalable",
-        "inspect_error": "No se pudo obtener este plugin.",
         "switch_to": "Actualizar a {{version}}",
         "update_keeps_data": "Se conservan tus ajustes."
       },

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2151,7 +2151,6 @@
       "confirm_uninstall": "Désinstaller « {{name}} » ? Les données associées à ce plugin seront perdues.",
       "uninstalled": "Plugin désinstallé.",
       "uninstall_error": "Impossible de désinstaller le plugin.",
-      "inspect_error": "Impossible de lire cette archive.",
       "installed": "Plugin installé.",
       "install_failed_but_kept": "« {{id}} » a été installé mais n'a pas pu démarrer : {{reason}}",
       "enabled_toast": "Plugin activé.",
@@ -2259,7 +2258,6 @@
         "update_available": "Mise à jour disponible",
         "install": "Installer",
         "no_installable": "Aucune version installable",
-        "inspect_error": "Impossible de récupérer ce plugin.",
         "switch_to": "Mettre à jour en {{version}}",
         "update_keeps_data": "Vos réglages sont conservés."
       },

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2124,7 +2124,6 @@
       "confirm_uninstall": "Disinstallare «{{name}}»? I dati associati a questo plugin andranno perduti.",
       "uninstalled": "Plugin uninstalled.",
       "uninstall_error": "Unable to uninstall the plugin.",
-      "inspect_error": "Unable to read this archive.",
       "installed": "Plugin installed.",
       "install_failed_but_kept": "\"{{id}}\" was installed but could not start: {{reason}}",
       "enabled_toast": "Plugin enabled.",
@@ -2232,7 +2231,6 @@
         "update_available": "Aggiornamento disponibile",
         "install": "Installa",
         "no_installable": "Nessuna versione installabile",
-        "inspect_error": "Impossibile recuperare questo plugin.",
         "switch_to": "Aggiorna a {{version}}",
         "update_keeps_data": "Le tue impostazioni sono conservate."
       },

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2124,7 +2124,6 @@
       "confirm_uninstall": "Desinstalar «{{name}}»? Os dados associados a este plugin serão perdidos.",
       "uninstalled": "Plugin uninstalled.",
       "uninstall_error": "Unable to uninstall the plugin.",
-      "inspect_error": "Unable to read this archive.",
       "installed": "Plugin installed.",
       "install_failed_but_kept": "\"{{id}}\" was installed but could not start: {{reason}}",
       "enabled_toast": "Plugin enabled.",
@@ -2232,7 +2231,6 @@
         "update_available": "Atualização disponível",
         "install": "Instalar",
         "no_installable": "Sem versão instalável",
-        "inspect_error": "Não foi possível obter este plugin.",
         "switch_to": "Atualizar para {{version}}",
         "update_keeps_data": "As tuas configurações são mantidas."
       },

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.ts
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, OnInit, inject, input, output, signal } from '@angular/core';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { ToastService } from '../../../../core/services/toast.service';
 import { CatalogPluginEntry, PluginInspectReport, PluginsApiService } from '../../../../core/services/api/plugins-api.service';
 
 interface CatalogueRow {
@@ -22,7 +21,6 @@ interface CatalogueRow {
 export class PluginCatalogueComponent implements OnInit {
   private readonly api = inject(PluginsApiService);
   private readonly translate = inject(TranslateService);
-  private readonly toast = inject(ToastService);
 
   readonly installedIds = input<ReadonlySet<string>>(new Set());
   /** Installed version per plugin id — what makes "already installed" and "out of date"
@@ -106,9 +104,9 @@ export class PluginCatalogueComponent implements OnInit {
     try {
       const report = await this.api.inspectFromCatalog(row.sourceId, row.plugin.id, row.latestVersion);
       this.install.emit(report);
-    } catch (err: unknown) {
-      const httpErr = err as { error?: { message?: string } };
-      this.toast.error(httpErr.error?.message ?? this.translate.instant('settings.plugins.catalogue.inspect_error'));
+    } catch {
+      // The global error interceptor already toasts the server's message; a second one here
+      // showed the same text twice.
     } finally {
       this.inspectingKey.set(null);
     }

--- a/client/src/app/features/settings/plugins/plugins.ts
+++ b/client/src/app/features/settings/plugins/plugins.ts
@@ -116,9 +116,9 @@ export class PluginsSettingsComponent implements OnInit {
     try {
       const report: PluginInspectReport = await this.api.inspect(file);
       this.consentSheet()?.open(report);
-    } catch (err: unknown) {
-      const httpErr = err as { error?: { message?: string } };
-      this.toast.error(httpErr.error?.message ?? this.translate.instant('settings.plugins.inspect_error'));
+    } catch {
+      // Same as the catalogue path: the global error interceptor already toasts the server's
+      // message, so a second one here just repeats it.
     } finally {
       this.uploading.set(false);
     }


### PR DESCRIPTION
## What

A failed catalogue install raised the same toast twice.

The global error interceptor toasts the server's message for any 4xx/500/503 ([error.interceptor.ts:35](client/src/app/core/interceptors/error.interceptor.ts#L35)), and `installLatest` raised a second one from its own `catch` with the same `err.error.message`. Per the project convention that the interceptor owns API error toasts, the component's is the one to drop.

## Also fixed

`plugins.ts`'s manual-upload inspect had the identical pattern. Only the catalogue path was reported, but leaving the sibling would have meant the same double toast on the next drag-and-drop — one guard where both paths already were, rather than fixing the path the report named.

Both fallback strings (`settings.plugins.inspect_error`, `settings.plugins.catalogue.inspect_error`) go with them across all six locales: the interceptor supplies a message when the server sends none, so neither key had a reader left.

## Left alone

`toggle_error` and `uninstall_error` also toast alongside the interceptor, but with their own domain wording rather than a duplicate of the server's — a different question from the one reported, and changing them would change what those flows say.

## Tests

506 client tests, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)