### PR TITLE
fix(plugins): only offer a catalog version core could verify

### DIFF
--- a/backend/src/modules/plugins/catalog/catalog.spec.ts
+++ b/backend/src/modules/plugins/catalog/catalog.spec.ts
@@ -14,8 +14,12 @@ import { PLUGIN_API_VERSION, SUPPORTED_PLUGIN_API_VERSIONS } from '../../../comm
  *  convention as `plugin-registry.service.spec.ts`'s `COMPATIBLE_RANGE`). */
 const COMPATIBLE_RANGE = '>=1.0.0';
 
+/** A real archive by default: an entry without one is not installable, so a fixture omitting it
+ *  described a row that could never have been offered. */
+const ARCHIVE = { zipUrl: 'https://example.com/p-1.0.0.fkplugin', sha256: 'a'.repeat(64) };
+
 function version(overrides: Partial<CatalogVersionEntry> = {}): CatalogVersionEntry {
-  return { version: '1.0.0', pluginApi: PLUGIN_API_VERSION, fliks: COMPATIBLE_RANGE, ...overrides };
+  return { version: '1.0.0', pluginApi: PLUGIN_API_VERSION, fliks: COMPATIBLE_RANGE, ...ARCHIVE, ...overrides };
 }
 
 function document(overrides: Partial<CatalogDocument['plugins'][number]> = {}): CatalogDocument {
@@ -142,6 +146,39 @@ describe('filterCatalog()', () => {
     const result = filterCatalog(doc, SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1');
     expect(result.plugins[0].installable).toEqual([version()]);
     expect(result.plugins[0].hidden).toBeNull();
+  });
+
+  // A catalog commits a version's descriptor before its archive is built and signed, carrying an
+  // all-zero sha256 until then. Offering it made every install attempt fail its checksum check —
+  // and an admin whose cache held that entry could not act on the error at all.
+  it('VERDICT: never offers a version whose checksum is the unsigned placeholder', () => {
+    const unsigned = version({ sha256: '0'.repeat(64) });
+    const result = filterCatalog(document({ versions: [unsigned] }), SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1');
+    expect(result.plugins[0].installable).toEqual([]);
+  });
+
+  it('never offers a version whose checksum is malformed rather than merely absent', () => {
+    for (const sha256 of ['deadbeef', 'A'.repeat(64), 'z'.repeat(64), '']) {
+      const result = filterCatalog(document({ versions: [version({ sha256 })] }), SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1');
+      expect(result.plugins[0].installable).toEqual([]);
+    }
+  });
+
+  it('never offers a version with no archive to download', () => {
+    const noUrl = { version: '1.0.0', pluginApi: PLUGIN_API_VERSION, fliks: COMPATIBLE_RANGE, sha256: 'a'.repeat(64) };
+    const result = filterCatalog(
+      document({ versions: [noUrl as CatalogVersionEntry] }),
+      SUPPORTED_PLUGIN_API_VERSIONS,
+      '2.0.1',
+    );
+    expect(result.plugins[0].installable).toEqual([]);
+  });
+
+  it('an unsigned version does not tell the admin a core upgrade would reveal it', () => {
+    const unsigned = version({ sha256: '0'.repeat(64) });
+    const result = filterCatalog(document({ versions: [unsigned] }), SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1');
+    // Its `fliks` range is satisfied, so no version number fixes it — only the publisher does.
+    expect(result.plugins[0].hidden).toEqual({ count: 1, minFliksVersion: null });
   });
 
   it('hides a version whose pluginApi does not match exactly, and counts it', () => {

--- a/backend/src/modules/plugins/catalog/catalog.ts
+++ b/backend/src/modules/plugins/catalog/catalog.ts
@@ -142,8 +142,29 @@ export interface FilteredCatalog {
   denyList: CatalogDenyEntry[];
 }
 
+/** What a catalog publishes on a version whose archive has not been built and signed yet. It is
+ *  valid lowercase hex, so no format check tells it apart from a real checksum. */
+const PLACEHOLDER_SHA256 = '0'.repeat(64);
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+
+/**
+ * A version core could not verify if it downloaded it. `zipUrl`/`sha256` are install-pipeline
+ * fields, read here because "can this be installed" is this function's question: an entry whose
+ * checksum is a placeholder or malformed fails its checksum check on every attempt, so offering
+ * it turns a publisher's mid-release state into an error the admin has no way to act on.
+ */
+function hasVerifiableArchive(v: CatalogVersionEntry): boolean {
+  const { zipUrl, sha256 } = v as { zipUrl?: unknown; sha256?: unknown };
+  if (typeof zipUrl !== 'string' || zipUrl.length === 0) return false;
+  return typeof sha256 === 'string' && SHA256_PATTERN.test(sha256) && sha256 !== PLACEHOLDER_SHA256;
+}
+
 function isInstallable(v: CatalogVersionEntry, supportedApiVersions: readonly number[], fliksVersion: string): boolean {
-  return supportedApiVersions.includes(v.pluginApi) && semver.satisfies(fliksRangeVersion(fliksVersion), v.fliks);
+  return (
+    supportedApiVersions.includes(v.pluginApi) &&
+    semver.satisfies(fliksRangeVersion(fliksVersion), v.fliks) &&
+    hasVerifiableArchive(v)
+  );
 }
 
 function summarizeHidden(

--- a/backend/src/modules/plugins/plugin-catalog-client.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-catalog-client.service.spec.ts
@@ -33,7 +33,18 @@ function catalogWith(versionOverrides: Record<string, unknown> = {}): CatalogDoc
         description: 'A fixture.',
         author: 'Fliks',
         kind: 'data',
-        versions: [{ version: '1.0.0', pluginApi: PLUGIN_API_VERSION, fliks: COMPATIBLE_RANGE, ...versionOverrides }],
+        versions: [
+          {
+            version: '1.0.0',
+            pluginApi: PLUGIN_API_VERSION,
+            fliks: COMPATIBLE_RANGE,
+            // A version with no verifiable archive is not installable, so a fixture without one
+            // describes a row the filter would never offer.
+            zipUrl: 'https://example.com/p-1.0.0.fkplugin',
+            sha256: 'a'.repeat(64),
+            ...versionOverrides,
+          },
+        ],
       },
     ],
   } as CatalogDocument;
@@ -95,7 +106,9 @@ describe('PluginCatalogClientService', () => {
       plugins: [
         expect.objectContaining({
           id: 'fliks.test-plugin',
-          installable: [{ version: '1.0.0', pluginApi: PLUGIN_API_VERSION, fliks: COMPATIBLE_RANGE }],
+          installable: [
+            expect.objectContaining({ version: '1.0.0', pluginApi: PLUGIN_API_VERSION, fliks: COMPATIBLE_RANGE }),
+          ],
           hidden: null,
         }),
       ],


### PR DESCRIPTION
## What

`isInstallable` weighed only `pluginApi` and the `fliks` range. It now also requires an archive core could actually verify: a `zipUrl`, and a `sha256` that is well-formed hex and not the all-zero placeholder.

## Why

A catalog commits a version's descriptor before the packaging workflow builds and signs its archive, carrying `0000…0000` until then. Core cached that entry, offered it as an available update, downloaded the real archive, and failed:

> the downloaded archive does not match the signed catalog checksum

Every attempt, for as long as the cache held it, with nothing the admin could do — the version was advertised by the same document that made it uninstallable.

The principle, put plainly: a catalog should only offer the updates it actually knows. An entry whose checksum is a placeholder is not knowledge, it is a publisher's intermediate state.

## Why here and not only in the catalog

fliks-app/fliks-plugin-catalog#17 stops *publishing* such an entry. That does nothing for an installation whose cache already holds one — which is every installation that refreshed during a release window. This is the half that helps them: the bad entry is simply not offered, and the real one appears on the next refresh.

Two layers, deliberately: the publisher stops emitting it, and core stops trusting it.

## Details

- A malformed checksum is refused on the same grounds — it can never match, so downloading it is wasted work and a confusing error.
- The all-zero case needs naming separately, because 64 zeros are valid lowercase hex and no format rule distinguishes them from a real digest.
- An entry with no `zipUrl` or no `sha256` was *already* refused further down (`catalogArchiveInfo` returns null → 404). It was merely advertised first. Now it is not advertised.
- Such a version counts as hidden with `minFliksVersion: null`, which is correct: its `fliks` range is satisfied, so no core upgrade reveals it — only the publisher finishing the release does.

## Test fixtures

Two fixtures built version entries with no `zipUrl`/`sha256`, describing rows that could never have been installed. They now carry a real archive, which is what the filter has always implicitly required.

## Tests

Backend 1657, green. Four added: the placeholder is never offered, a malformed checksum is never offered, a version with no archive is never offered, and an unsigned version does not falsely promise that a core upgrade would reveal it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)