### PR TITLE
build(android): target API 36 so Play keeps accepting updates

### DIFF
--- a/client/android/variables.gradle
+++ b/client/android/variables.gradle
@@ -1,7 +1,7 @@
 ext {
     minSdkVersion = 23
     compileSdkVersion = 36
-    targetSdkVersion = 35
+    targetSdkVersion = 36
     androidxActivityVersion = '1.9.2'
     androidxAppCompatVersion = '1.7.0'
     androidxCoordinatorLayoutVersion = '1.2.0'


### PR DESCRIPTION
## What

`targetSdkVersion` 35 → 36 in [client/android/variables.gradle](client/android/variables.gradle). One line; it is the only place the value is pinned.

## Why now

Play stops accepting updates from **31 August 2026** — five days — for an app not targeting an API level released within a year of the latest Android release. Today's 3.2.0 upload still declared 35, which is what triggered the notice.

## Why the toolchain needs nothing

`compileSdkVersion` was **already 36**, and every Play build has been green against it (3.0.0, 3.1.0, 3.2.0). AGP 8.9.1 with Gradle 8.11.1 compiles at that level, and Capacitor 8.3 defaults to 36 for both `compileSdk` and `targetSdk` — the app was holding it back, not the other way round. Raising `targetSdk` changes runtime behaviour only, never build requirements.

## The Android 16 behaviour changes, checked one by one

The three that would normally hurt a media player do not apply:

- **Edge-to-edge enforcement.** Already enforced at targetSdk 35, which this app has been on. Nothing opted out via `windowOptOutEdgeToEdgeEnforcement` — the flag that stops working in 16 — so there is nothing left to lose.
- **Orientation and aspect-ratio restrictions ignored on screens ≥600dp.** No activity declares `screenOrientation`, and the in-player orientation lock is gated behind `canLockOrientation = Capacitor.getPlatform() === 'ios'`, so Android never locks. Nothing to be ignored.
- **Predictive back on by default.** `@capacitor/app` registers its handler through `OnBackPressedDispatcher`/`OnBackPressedCallback`, the AndroidX API predictive back is built around: an enabled callback still intercepts the gesture, so the `backButton` event the app navigates on keeps firing. `androidxActivityVersion` is 1.9.2, well past the 1.8 that needs.

Also checked and unaffected: the `dataSync` foreground service (capped in 15, unchanged in 16) and `largeHeap`.

## What I could not verify

**No JDK on this machine**, so Gradle never ran — I could not build or configure the project locally, only read the toolchain versions and reason from them. The API 36 platform and build-tools are installed, but without Java that buys nothing.

So this wants the CI build to confirm it compiles, and a device pass on the player before the release goes to a public track: back navigation, PiP, and fullscreen insets are the three things behaviour changes at 36 could plausibly touch, however the reasoning above lands.

## Landing it before the deadline

Merging this is not enough on its own — the AAB is built from a release tag, so a new release has to go out for Play to see 36. That means release-please's version PR, which is yours to merge, then `play-store-publish` uploads to the internal track. Five days is comfortable, but not if the release PR waits.

## Noted, not changed

`@capacitor/cli` is `^7.6.1` while `@capacitor/core`, `android` and `ios` are all `^8.3.0` — the CLI is a major version behind the platforms it runs `cap sync` against in CI. Unrelated to this deadline and not something to touch in the same change, but worth its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)