### PR TITLE
ci(play-store): migrate the upload action from `track` to `tracks`

### DIFF
--- a/.github/workflows/play-store-publish.yml
+++ b/.github/workflows/play-store-publish.yml
@@ -172,7 +172,9 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
           packageName: media.fliks.app
           releaseFiles: client/android/app/build/outputs/bundle/release/app-release.aab
-          track: ${{ github.event.inputs.track || 'internal' }}
+          # `tracks`, not `track`: the singular is deprecated and the action already converts
+          # it internally. A single value is accepted, so the dispatch input stays a choice.
+          tracks: ${{ github.event.inputs.track || 'internal' }}
           # `draft` is required while the app itself is in draft status
           # in Play Console (no production release ever submitted).
           # Once the app is approved + published live, this can flip to


### PR DESCRIPTION
Closes #852.

## What

One input renamed in `.github/workflows/play-store-publish.yml`: `track:` → `tracks:` on the `r0adkll/upload-google-play` step.

## Still current

The warning fired again on today's 3.2.0 publish ([run 32969404387](https://github.com/fliks-app/fliks/actions/runs/32969404387)):

```
##[warning]WARNING!! 'track' is deprecated and will be removed in a future release. Please migrate to 'tracks'
Validating tracks: 'internal'
```

The line right after the warning is the useful part: the action already normalises the singular into the plural. So this is a rename with no change in behaviour, and the value it validates is identical.

## The two open questions from the issue

**Does the dispatch input become plural?** No. `tracks` accepts a single value — that log line proves it — so the `workflow_dispatch` input stays a `choice` of internal / alpha / beta / production. Making it a multi-track entry would be a new feature rather than part of this migration, and renaming the input would break any saved dispatch parameters for no gain.

**Does `@v1` need to move to a newer major?** No. I read `action.yml` at the pinned `v1` ref and it declares both inputs:

```
26:  track:    "The track in which you want to assign the uploaded app."
29:  tracks:   "The track(s) in which you want to assign the uploaded app."
```

So `tracks` resolves on the current pin. Worth noting `v1` is a moving tag rather than a frozen one — the action's latest release is `v1.1.5` (April 2026) and the repo was active into May 2026 — which is precisely why the removal will eventually reach this workflow, and why the issue was worth acting on rather than closing.

## Verification

`yaml.safe_load` parses the workflow; the upload step's inputs are now `packageName, releaseFiles, serviceAccountJsonPlainText, status, tracks, whatsNewDirectory` with no `track`, and the dispatch choice is intact.

**Not run end to end**, and deliberately so: the only way to exercise this step is a real upload to Play, since the `apk_tag` path skips it by design. It will be exercised by the next release publish. The failure mode if I have this wrong is an unknown-input error at the upload step, which is loud and does not corrupt anything already on the store.

## Sequencing

Independent of #1051 (the API 36 deadline), and kept separate on purpose — a change to the publishing workflow is the last thing to fold into a fix that has to ship in five days. Merge order does not matter, but if only one lands before the release, it should be #1051.

🤖 Generated with [Claude Code](https://claude.com/claude-code)