### PR TITLE
fix(acquisition): offer a packed season its episodes, and say why a row was skipped

### DIFF
--- a/backend/src/modules/media/acquisition-candidates.service.ts
+++ b/backend/src/modules/media/acquisition-candidates.service.ts
@@ -44,6 +44,16 @@ export interface SeasonPackTarget {
  * from SchedulerService so the query + filter logic can be exercised without
  * the cron/torznab/qBittorrent machinery around it.
  */
+/** `{at-cutoff: 24, upgrades-disabled: 2}` → `"24 at cutoff, 2 upgrades disabled"`. */
+function describeExclusions(reasons: string[]): string {
+  const counts = new Map<string, number>();
+  for (const r of reasons) counts.set(r, (counts.get(r) ?? 0) + 1);
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([reason, n]) => `${n} ${reason.replace(/-/g, ' ')}`)
+    .join(', ');
+}
+
 @Injectable()
 export class AcquisitionCandidatesService {
   private readonly log = new Logger(AcquisitionCandidatesService.name);
@@ -58,7 +68,7 @@ export class AcquisitionCandidatesService {
     private readonly autoGrab: AutoGrabPipelineService,
   ) {}
 
-  async listMovieTargets(mediaIds?: number[]): Promise<MovieTarget[]> {
+  async listMovieTargets(mediaIds?: number[], quiet = false): Promise<MovieTarget[]> {
     const qb = this.mediaRepo
       .createQueryBuilder('m')
       .leftJoinAndSelect('m.qualityProfile', 'qp')
@@ -71,19 +81,23 @@ export class AcquisitionCandidatesService {
       qb.andWhere('m.id IN (:...mediaIds)', { mediaIds });
     }
     const allCandidates = await qb.getMany();
-    const candidates = allCandidates.filter((m) =>
-      this.autoGrab.shouldSearchMissing(m, m.files ?? []),
-    );
-    if (allCandidates.length !== candidates.length) {
+    const candidates: Media[] = [];
+    const excluded: string[] = [];
+    for (const m of allCandidates) {
+      const reason = this.autoGrab.searchExclusionReason(m, m.files ?? []);
+      if (reason) excluded.push(reason);
+      else candidates.push(m);
+    }
+    if (excluded.length && !quiet) {
       this.log.log(
-        `SearchMissing[movies]: ${candidates.length}/${allCandidates.length} need a search (${allCandidates.length - candidates.length} at cutoff, unprofiled, or upgrades disabled)`,
+        `SearchMissing[movies]: ${candidates.length} need a search, ${excluded.length} excluded (${describeExclusions(excluded)})`,
       );
     }
 
     return candidates.map((media) => ({ media, files: media.files ?? [] }));
   }
 
-  async listEpisodeTargets(mediaIds?: number[]): Promise<EpisodeTarget[]> {
+  async listEpisodeTargets(mediaIds?: number[], quiet = false): Promise<EpisodeTarget[]> {
     const today = new Date().toISOString().slice(0, 10);
 
     const qb = this.episodeRepo
@@ -160,17 +174,24 @@ export class AcquisitionCandidatesService {
     const episodeFiles = (ep: Episode): { quality: string | null }[] =>
       ep.hasFile ? [{ quality: fileQualityByEpId.get(ep.id) ?? null }] : [];
 
-    const allEpisodes = episodes;
-    const filteredEpisodes = allEpisodes.filter((ep) => {
-      const media = (ep as unknown as { season: Season }).season
-        .media as Media;
-      return this.autoGrab.shouldSearchMissing(media, episodeFiles(ep));
-    });
-    if (allEpisodes.length !== filteredEpisodes.length) {
-      this.log.log(
-        `SearchMissing[episodes]: ${filteredEpisodes.length}/${allEpisodes.length} need a search (${allEpisodes.length - filteredEpisodes.length} at cutoff, unprofiled, or upgrades disabled)`,
-      );
+    const filteredEpisodes: Episode[] = [];
+    const excluded: string[] = [];
+    for (const ep of episodes) {
+      const media = (ep as unknown as { season: Season }).season.media as Media;
+      const reason = this.autoGrab.searchExclusionReason(media, episodeFiles(ep));
+      if (reason) excluded.push(reason);
+      else filteredEpisodes.push(ep);
     }
+    // The count above only ever saw rows the query returned, so "0 need a search" read as
+    // "nothing is missing" when it could equally mean the query never offered the missing
+    // episodes. Reporting what the query itself left out is what tells those two apart.
+    const ineligible = quiet ? 0 : await this.countIneligibleEpisodes(mediaIds);
+    if (!quiet)
+      this.log.log(
+      `SearchMissing[episodes]: ${filteredEpisodes.length} need a search` +
+        (excluded.length ? `, ${excluded.length} excluded (${describeExclusions(excluded)})` : '') +
+        (ineligible ? `; ${ineligible} monitored episode(s) not eligible at all (already on disk, unaired, or no air date)` : ''),
+    );
     episodes = filteredEpisodes;
 
     return episodes.map((ep) => {
@@ -178,6 +199,29 @@ export class AcquisitionCandidatesService {
       const media = (season as unknown as { media: Media }).media;
       return { media, season, episode: ep, files: episodeFiles(ep) };
     });
+  }
+
+  /**
+   * Monitored, aired episodes the candidate query itself refuses — content already on disk,
+   * or no air date at all. Counted so a run reporting nothing to search says which of the two
+   * it is: an operator can act on "47 have no air date", not on silence.
+   */
+  private async countIneligibleEpisodes(mediaIds?: number[]): Promise<number> {
+    const today = new Date().toISOString().slice(0, 10);
+    const qb = this.episodeRepo
+      .createQueryBuilder('ep')
+      .innerJoin('ep.season', 'season')
+      .innerJoin('season.media', 'media')
+      .where('media.monitored = true')
+      .andWhere('media.type = :type', { type: MediaType.SERIES })
+      .andWhere('season.monitored = true')
+      .andWhere('ep.monitored = true')
+      .andWhere(
+        `(ep."airDate" IS NULL OR ep."airDate" > :today OR ${onDiskSql('ep')})`,
+        { today },
+      );
+    if (mediaIds?.length) qb.andWhere('media.id IN (:...mediaIds)', { mediaIds });
+    return qb.getCount();
   }
 
   async groupIntoSeasonPacks(

--- a/backend/src/modules/media/auto-grab-pipeline.service.spec.ts
+++ b/backend/src/modules/media/auto-grab-pipeline.service.spec.ts
@@ -63,7 +63,7 @@ describe('AutoGrabPipelineService.classifyForSearch — "skip" still carries ran
   it('carries the current/cutoff rank when the file already meets cutoff', () => {
     expect(
       service.classifyForSearch(media, [{ quality: 'WEBDL-1080p' }]),
-    ).toEqual({ mode: 'skip', minRankExclusive: 62, maxRankInclusive: 62 });
+    ).toEqual({ mode: 'skip', minRankExclusive: 62, maxRankInclusive: 62, skipReason: 'at-cutoff' });
   });
 
   it('carries the current/cutoff rank when upgrades are disabled, even below cutoff', () => {
@@ -73,7 +73,7 @@ describe('AutoGrabPipelineService.classifyForSearch — "skip" still carries ran
     } as unknown as Media;
     expect(
       service.classifyForSearch(noUpgrade, [{ quality: 'HDTV-720p' }]),
-    ).toEqual({ mode: 'skip', minRankExclusive: 40, maxRankInclusive: 62 });
+    ).toEqual({ mode: 'skip', minRankExclusive: 40, maxRankInclusive: 62, skipReason: 'upgrades-disabled' });
   });
 
   it('still returns "unprofiled" with no rank data when a profile is missing', () => {
@@ -81,5 +81,29 @@ describe('AutoGrabPipelineService.classifyForSearch — "skip" still carries ran
     expect(service.classifyForSearch(unprofiled, [])).toEqual({
       mode: 'unprofiled',
     });
+  });
+});
+
+describe('AutoGrabPipelineService.searchExclusionReason', () => {
+  const service = Object.create(AutoGrabPipelineService.prototype) as AutoGrabPipelineService;
+  const profile = { cutoff: 16, upgradeAllowed: true, items: [] };
+  const media = { qualityProfile: profile, languageProfile: { audioLanguages: [] } } as unknown as Media;
+
+  it('VERDICT: names which of the three routes to skip was taken', () => {
+    expect(service.searchExclusionReason(media, [{ quality: 'WEBDL-1080p' }])).toBe('at-cutoff');
+
+    const noUpgrade = { ...media, qualityProfile: { ...profile, upgradeAllowed: false } } as unknown as Media;
+    expect(service.searchExclusionReason(noUpgrade, [{ quality: 'HDTV-720p' }])).toBe('upgrades-disabled');
+
+    const noCutoff = { ...media, qualityProfile: { ...profile, cutoff: 99_999 } } as unknown as Media;
+    expect(service.searchExclusionReason(noCutoff, [{ quality: 'HDTV-720p' }])).toBe('no-cutoff-configured');
+
+    const unprofiled = { qualityProfile: null, languageProfile: null } as unknown as Media;
+    expect(service.searchExclusionReason(unprofiled, [])).toBe('unprofiled');
+  });
+
+  it('returns null for a row that does need a search, so it is never counted as excluded', () => {
+    expect(service.searchExclusionReason(media, [])).toBeNull();
+    expect(service.searchExclusionReason(media, [{ quality: 'HDTV-720p' }])).toBeNull();
   });
 });

--- a/backend/src/modules/media/auto-grab-pipeline.service.ts
+++ b/backend/src/modules/media/auto-grab-pipeline.service.ts
@@ -28,6 +28,9 @@ export type SearchDecision =
       minRankExclusive: number;
       /** Releases must have `rank <= maxRankInclusive`. +Infinity for "missing". */
       maxRankInclusive: number;
+      /** Which of the three routes to `skip` was taken. A log that ORs them together cannot
+       *  tell an operator whether to change a profile, a cutoff, or nothing at all. */
+      skipReason?: 'at-cutoff' | 'upgrades-disabled' | 'no-cutoff-configured';
     };
 
 /**
@@ -97,11 +100,11 @@ export class AutoGrabPipelineService {
     // manual search can score releases even though auto-grab has nothing to do.
     const maxRankInclusive = cutoffRank ?? Number.POSITIVE_INFINITY;
     if (!profile.upgradeAllowed)
-      return { mode: 'skip', minRankExclusive: currentRank, maxRankInclusive };
+      return { mode: 'skip', minRankExclusive: currentRank, maxRankInclusive, skipReason: 'upgrades-disabled' };
     if (cutoffRank == null)
-      return { mode: 'skip', minRankExclusive: currentRank, maxRankInclusive };
+      return { mode: 'skip', minRankExclusive: currentRank, maxRankInclusive, skipReason: 'no-cutoff-configured' };
     if (currentRank >= cutoffRank)
-      return { mode: 'skip', minRankExclusive: currentRank, maxRankInclusive: cutoffRank };
+      return { mode: 'skip', minRankExclusive: currentRank, maxRankInclusive: cutoffRank, skipReason: 'at-cutoff' };
     return {
       mode: 'upgrade',
       minRankExclusive: currentRank,
@@ -117,5 +120,16 @@ export class AutoGrabPipelineService {
   ): boolean {
     const decision = this.classifyForSearch(media, files);
     return decision.mode === 'missing' || decision.mode === 'upgrade';
+  }
+
+  /** Why a row was left out, in the vocabulary an operator can act on. */
+  searchExclusionReason(
+    media: Media,
+    files: { quality?: string | null }[],
+  ): string | null {
+    const decision = this.classifyForSearch(media, files);
+    if (decision.mode === 'unprofiled') return 'unprofiled';
+    if (decision.mode === 'skip') return decision.skipReason ?? 'skip';
+    return null;
   }
 }

--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -373,22 +373,119 @@ describe('FliksHostImpl', () => {
         maxRankInclusive: 10,
       });
 
-      const page1 = await h.host['acquisition.candidates']({
-        availableOn: '2099-01-01',
-        limit: 1,
-      });
-      expect(page1.items).toHaveLength(1);
-      expect(page1.cursor).toBe('1');
-      expectJsonSafe(page1);
+      // One movie, one pack, and the pack's two episodes: four targets over four pages.
+      const seen: Awaited<ReturnType<(typeof h.host)['acquisition.candidates']>>['items'] = [];
+      let cursor: string | null | undefined;
+      do {
+        const page = await h.host['acquisition.candidates']({
+          availableOn: '2099-01-01',
+          limit: 1,
+          cursor: cursor ?? undefined,
+        });
+        expect(page.items).toHaveLength(1);
+        expectJsonSafe(page);
+        seen.push(...page.items);
+        cursor = page.cursor;
+      } while (cursor);
 
-      const page2 = await h.host['acquisition.candidates']({
+      expect(seen).toHaveLength(4);
+      expect(seen[0].season).toBeUndefined();
+    });
+
+    // The pack used to be the only candidate for its season, so nothing was left to fall back
+    // to when no pack release won — and an RSS match on a loose episode could not recover its
+    // episode id either. Both readers need the episodes listed alongside the pack.
+    it('VERDICT: offers a packed season BOTH its pack and its episodes, pack first', async () => {
+      const h = makeHarness();
+      const series = makeMedia({ id: 2, type: MediaType.SERIES });
+      const season = makeSeason({ id: 20, mediaId: 2 });
+      const ep1 = makeEpisode({ id: 201, season, episodeNumber: 1 });
+      const ep2 = makeEpisode({ id: 202, season, episodeNumber: 2 });
+
+      h.acquisitionCandidates.listMovieTargets.mockResolvedValue([]);
+      h.acquisitionCandidates.listEpisodeTargets.mockResolvedValue([
+        { media: series, season, episode: ep1, files: [] },
+        { media: series, season, episode: ep2, files: [] },
+      ]);
+      h.acquisitionCandidates.groupIntoSeasonPacks.mockResolvedValue([
+        { media: series, season, episodes: [ep1, ep2], files: [], totalEpisodeCount: 2 },
+      ]);
+      h.autoGrab.classifyForSearch.mockReturnValue({
+        mode: 'missing',
+        minRankExclusive: 0,
+        maxRankInclusive: 10,
+      });
+
+      const { items } = await h.host['acquisition.candidates']({
+        availableOn: '2099-01-01',
+        limit: 10,
+      });
+
+      expect(items.map((t) => t.episode?.number ?? 'pack')).toEqual(['pack', 1, 2]);
+      // The sort has to keep the pack ahead of its own episodes, or a caller walking the list
+      // would commit to loose episodes before it had seen the pack.
+      expect(items.every((t) => t.season?.id === 20)).toBe(true);
+    });
+
+    // Every page used to re-run the whole enumeration, which is where the duplicated log lines
+    // came from — and an offset cursor over a set re-derived each time could skip or repeat rows.
+    it('VERDICT: a paginated walk enumerates once, not once per page', async () => {
+      const h = makeHarness();
+      const movie = makeMedia({ id: 1, type: MediaType.MOVIE, status: 'Released' });
+      h.acquisitionCandidates.listMovieTargets.mockResolvedValue([
+        { media: movie, files: [] },
+        { media: makeMedia({ id: 2, type: MediaType.MOVIE, status: 'Released' }), files: [] },
+        { media: makeMedia({ id: 3, type: MediaType.MOVIE, status: 'Released' }), files: [] },
+      ]);
+      h.acquisitionCandidates.listEpisodeTargets.mockResolvedValue([]);
+      h.acquisitionCandidates.groupIntoSeasonPacks.mockResolvedValue([]);
+      h.autoGrab.classifyForSearch.mockReturnValue({
+        mode: 'missing',
+        minRankExclusive: 0,
+        maxRankInclusive: 10,
+      });
+
+      let cursor: string | null | undefined;
+      let pages = 0;
+      do {
+        const page = await h.host['acquisition.candidates']({
+          availableOn: '2099-01-01',
+          limit: 1,
+          cursor: cursor ?? undefined,
+        });
+        pages++;
+        cursor = page.cursor;
+      } while (cursor);
+
+      expect(pages).toBe(3);
+      expect(h.acquisitionCandidates.listMovieTargets).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-enumerates rather than serving another walk’s page when the scope differs', async () => {
+      const h = makeHarness();
+      h.acquisitionCandidates.listMovieTargets.mockResolvedValue([
+        { media: makeMedia({ id: 1, type: MediaType.MOVIE, status: 'Released' }), files: [] },
+        { media: makeMedia({ id: 2, type: MediaType.MOVIE, status: 'Released' }), files: [] },
+      ]);
+      h.acquisitionCandidates.listEpisodeTargets.mockResolvedValue([]);
+      h.acquisitionCandidates.groupIntoSeasonPacks.mockResolvedValue([]);
+      h.autoGrab.classifyForSearch.mockReturnValue({
+        mode: 'missing',
+        minRankExclusive: 0,
+        maxRankInclusive: 10,
+      });
+
+      const first = await h.host['acquisition.candidates']({ availableOn: '2099-01-01', limit: 1 });
+      // Same cursor, different mediaIds: reusing the cached list would answer the wrong scope.
+      await h.host['acquisition.candidates']({
         availableOn: '2099-01-01',
         limit: 1,
-        cursor: page1.cursor!,
+        cursor: first.cursor!,
+        mediaIds: [7],
       });
-      expect(page2.items).toHaveLength(1);
-      expect(page2.cursor).toBeNull();
-      expectJsonSafe(page2);
+
+      expect(h.acquisitionCandidates.listMovieTargets).toHaveBeenCalledTimes(2);
+      expect(h.acquisitionCandidates.listMovieTargets).toHaveBeenLastCalledWith([7], true);
     });
 
     it('clamps the limit to the contract bound', async () => {
@@ -422,7 +519,7 @@ describe('FliksHostImpl', () => {
       const ep1 = makeEpisode({ id: 201, season, episodeNumber: 1 });
       const ep2 = makeEpisode({ id: 202, season, episodeNumber: 2 });
       // On a season the pack list does not cover, so it survives as a single and
-      // reaches `buildFromEpisodeTarget` — the packed season's episodes never do.
+      // reaches `buildFromEpisodeTarget`, including a packed season's own episodes.
       const loneSeason = makeSeason({ id: 21, mediaId: 2 });
       const ep3 = makeEpisode({ id: 203, season: loneSeason, episodeNumber: 1 });
 
@@ -444,10 +541,12 @@ describe('FliksHostImpl', () => {
       ]);
       // Every branch (movie, single episode, season pack) resolves to a
       // decision the candidates path must drop before it reaches a plugin.
-      h.autoGrab.classifyForSearch
-        .mockReturnValueOnce({ mode: 'skip', minRankExclusive: 40, maxRankInclusive: 62 })
-        .mockReturnValueOnce({ mode: 'unprofiled' })
-        .mockReturnValueOnce({ mode: 'skip', minRankExclusive: 40, maxRankInclusive: 62 });
+      h.autoGrab.classifyForSearch.mockReturnValue({
+        mode: 'skip',
+        minRankExclusive: 40,
+        maxRankInclusive: 62,
+        skipReason: 'at-cutoff',
+      });
 
       const result = await h.host['acquisition.candidates']({
         availableOn: '2099-01-01',

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -71,6 +71,11 @@ const QUEUE_PAGE_SIZE_MAX = 100;
 /** `acquisition.candidates`'s own bound, per the contract's doc comment. */
 const MAX_CANDIDATES_LIMIT = 500;
 
+/** How long a paginated candidate walk may reuse the list it started from. A walk takes seconds;
+ *  this only has to outlive one, and re-enumerating mid-walk was never a consistency guarantee —
+ *  the offset cursor would skip or repeat rows whenever the set shifted underneath it. */
+const CANDIDATES_PAGE_CACHE_MS = 60_000;
+
 type ReleaseMatchResult = Awaited<
   ReturnType<PluginHostApi['releases.match']>
 >[number];
@@ -116,6 +121,10 @@ export class FliksHostImpl implements PluginHostApi {
   ) {}
 
   private readonly progressGates = new Map<number, ProgressGate>();
+
+  /** The enumerated list a cursor walks. One entry: a walk is sequential, and a second caller
+   *  starting its own walk simply re-enumerates rather than reading someone else's page. */
+  private candidatesPage: { key: string; at: number; targets: AcquisitionTarget[] } | null = null;
 
   /** `PluginHostContext` (set only by `PluginHostBindingService`, never by a plugin's
    *  payload) wins when bound; the constructor value is the in-process default. */
@@ -245,6 +254,17 @@ export class FliksHostImpl implements PluginHostApi {
       Math.max(Math.trunc(p.limit) || 1, 1),
       MAX_CANDIDATES_LIMIT,
     );
+    const cacheKey = JSON.stringify([
+      p.kind ?? null,
+      p.mediaIds ? [...p.mediaIds].sort((a, b) => a - b) : null,
+      p.availableOn,
+    ]);
+    // A continuation reuses what the first page enumerated. Without this every page re-ran the
+    // whole enumeration — five identical log lines in one second were the visible half of it.
+    const cached = p.cursor ? this.candidatesPage : null;
+    if (cached && cached.key === cacheKey && Date.now() - cached.at < CANDIDATES_PAGE_CACHE_MS) {
+      return this.pageOf(cached.targets, p.cursor, limit);
+    }
     const wantMovies = p.kind !== 'series';
     const wantSeries = p.kind !== 'movie';
     const targets: AcquisitionTarget[] = [];
@@ -252,6 +272,9 @@ export class FliksHostImpl implements PluginHostApi {
     if (wantMovies) {
       const movieTargets = await this.acquisitionCandidates.listMovieTargets(
         p.mediaIds,
+        // Every page re-enumerates, so only the first one narrates: five identical lines in one
+        // second told an operator nothing except that pagination happened.
+        Boolean(p.cursor),
       );
       for (const t of movieTargets) {
         if (!this.isAvailable(t.media, p.availableOn)) continue;
@@ -262,23 +285,25 @@ export class FliksHostImpl implements PluginHostApi {
 
     if (wantSeries) {
       const episodeTargets = (
-        await this.acquisitionCandidates.listEpisodeTargets(p.mediaIds)
+        await this.acquisitionCandidates.listEpisodeTargets(p.mediaIds, Boolean(p.cursor))
       ).filter((t) => !t.episode.airDate || t.episode.airDate <= p.availableOn);
       const packs =
         await this.acquisitionCandidates.groupIntoSeasonPacks(episodeTargets);
-      const packedSeasonIds = new Set(packs.map((pk) => pk.season.id));
-      const singles = episodeTargets.filter(
-        (t) => !packedSeasonIds.has(t.season.id),
-      );
       const episodeCountBySeason = await this.episodeCountsBySeasons([
-        ...new Set(singles.map((t) => t.season.id)),
+        ...new Set(episodeTargets.map((t) => t.season.id)),
       ]);
 
+      // A season with two or more wanted episodes yields BOTH its pack and every episode in it.
+      // Enumeration reports what is wanted; whether a pack beats loose episodes is only knowable
+      // once releases are scored, so the caller decides — the sort below hands it the pack first.
+      // Suppressing the episodes here also blinded the two other readers of this method: the
+      // season-grab fallback found nothing to fall back to, and an RSS match on a loose episode
+      // could not recover its episode id.
       for (const pk of packs) {
         const target = this.buildFromSeasonPackTarget(pk);
         if (target) targets.push(target);
       }
-      for (const t of singles) {
+      for (const t of episodeTargets) {
         const target = this.buildFromEpisodeTarget(
           t,
           episodeCountBySeason.get(t.season.id) ?? 1,
@@ -294,13 +319,21 @@ export class FliksHostImpl implements PluginHostApi {
         (a.episode?.id ?? 0) - (b.episode?.id ?? 0),
     );
 
-    const offset = p.cursor ? Math.max(0, parseInt(p.cursor, 10) || 0) : 0;
+    this.candidatesPage = { key: cacheKey, at: Date.now(), targets };
+    return this.pageOf(targets, p.cursor, limit);
+  }
+
+  private pageOf(
+    targets: AcquisitionTarget[],
+    cursor: string | undefined,
+    limit: number,
+  ): { items: AcquisitionTarget[]; cursor: string | null } {
+    const offset = cursor ? Math.max(0, parseInt(cursor, 10) || 0) : 0;
     const items = targets.slice(offset, offset + limit);
-    const cursor =
-      offset + items.length < targets.length
-        ? String(offset + items.length)
-        : null;
-    return { items, cursor };
+    return {
+      items,
+      cursor: offset + items.length < targets.length ? String(offset + items.length) : null,
+    };
   }
 
   // ===========================================================================


### PR DESCRIPTION
Reported: SearchMissing grabs nothing for a partially available season, while the per-episode grab modal shows results.

## The enumeration bug

A season with ≥2 wanted episodes was reduced to **one** candidate — its pack — and every episode in it was dropped:

```ts
const packedSeasonIds = new Set(packs.map((pk) => pk.season.id));
const singles = episodeTargets.filter((t) => !packedSeasonIds.has(t.season.id));
```

Three readers depended on those episodes being listed, and all three were broken:

1. **The season-grab fallback (#20 in the plugin).** `grabSeasonEpisodes` re-queries `acquisition.candidates` for the season's episodes when no pack release wins. It received an empty list and raised `no_eligible_release` — for exactly the seasons it was written to serve. It could only ever work for a season with one missing episode, which is never packed and so never needs it.
2. **RSS episode-id recovery.** `resolveSeasonEpisodeIds` looks for the candidate whose episode number matches. For a packed season there was none, so a loose-episode grab recorded `episodeId: null` and fell back to season-only — losing per-episode progress and completion matching.
3. **SearchMissing.** One pack target, searched with a season-scoped Torznab query. Per-episode releases were never asked for, which is exactly why the modal shows results the scheduler never saw.

Enumeration now reports what is wanted at **both** granularities. Whether a pack beats loose episodes is only knowable once releases are scored, so that decision stays with the caller — and the sort hands it the pack before the pack's own episodes, so a caller walking the list sees the pack first.

## The logs, which is what actually unblocked the diagnosis

```
SearchMissing[episodes]: 0/26 need a search (26 at cutoff, unprofiled, or upgrades disabled)
```

Two problems, and the second is the serious one.

**It ORs three unrelated causes.** An operator cannot tell whether to change a profile, lower a cutoff, or do nothing. `skip` now carries `skipReason` — `at-cutoff` / `upgrades-disabled` / `no-cutoff-configured` — and the counts are reported separately.

**Its denominator only ever counted rows the query returned.** Episodes the SQL itself refuses — already on disk under multi-episode coverage, unaired, or holding no air date — appear in neither the numerator nor the denominator. So "0/26 need a search" reads as "nothing is missing" when it can equally mean *the missing episodes were never offered*. Those two are the difference between a working system and this bug report, and the line could not distinguish them.

It now reads:

```
SearchMissing[episodes]: 3 need a search, 26 excluded (24 at cutoff, 2 upgrades disabled); 118 monitored episode(s) not eligible at all (already on disk, unaired, or no air date)
```

That last clause is the one that says which side of the fence a missing episode fell on.

## The repeated log lines

Five identical lines within one second were not five runs: `candidates()` re-ran the entire enumeration on **every page**, and the plugin paginates. A continuation now reuses the list its first page built, keyed on scope and date with a 60s ceiling; anything else re-enumerates.

That is also more correct than what it replaces. An offset cursor over a set re-derived per page could skip or repeat rows whenever the set shifted underneath it — the caching removes a latent consistency bug, it does not introduce one.

## Scenario coverage

| scenario | before | after |
|---|---|---|
| Movie missing / upgrade | works | unchanged |
| Season, 1 episode missing | works (never packed) | unchanged |
| Season, ≥2 missing — **auto** | pack only; nothing grabbed if no pack wins | pack tried first, then each episode |
| Season, ≥2 missing — **manual "grab season"** | fallback got 0 episodes → error | fallback gets the real episodes |
| Season, ≥2 upgradable | same hole as missing | same fix |
| Manual episode grab | works | unchanged |
| Manual URL from the modal | works | unchanged |
| RSS loose episode, packed season | `episodeId: null` | id recovered |
| Shadowed episode (multi-episode file) | excluded by coverage | unchanged |
| Unaired / no air date / unmonitored | silently excluded | still excluded, now **counted in the log** |

## Still open, deliberately not in this PR

Two things I found while tracing this and did not fold in:

- **`tryAutoGrab` does not check `pick.isFullSeason`.** If a loose-episode release wins a season-scoped search, SearchMissing grabs it and records it as the season (`seasonId` set, `episodeId` null); the next run's pending-pack check then blocks the season. `grabRelease` guards this, `tryAutoGrab` does not. It is a plugin change and needs a same-run "season already handled" set to go with it, so it wants its own PR.
- **Nothing prevents grabbing a pack and its episodes in one pass** now that both are candidates. Today's pending-check keys differ between the two, so it will not dedupe them. This is the other half of the plugin-side change above.

Those two are why this PR fixes enumeration and observability but does not yet claim SearchMissing is correct end to end for the reported case.

## Tests

Backend 1662, green. Added: a packed season offers pack + episodes with the pack first, `searchExclusionReason` names each of the four routes, a row needing a search is never counted as excluded, a paginated walk enumerates once, and a differing scope re-enumerates instead of serving another walk's page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)