### PR TITLE
fix(acquisition): stop dropping every series candidate, and unbound the sweep's deadline

### DIFF
--- a/backend/src/common/plugin-contract/protocol.ts
+++ b/backend/src/common/plugin-contract/protocol.ts
@@ -90,10 +90,18 @@ export const PLUGIN_DEADLINES_MS = {
   healthReply: 3_000,
   /** Ceiling on one host call, unless the method appears in {@link HOST_CALL_DEADLINE_OVERRIDES_MS}. */
   hostCall: 8_000,
-  /** Ceiling on one call core makes into the plugin — a proxied `http` route or a `job`.
-   *  A route fanning out to third-party upstreams is allowed to be slow, so the plugin's
-   *  own per-upstream timeouts have to fit under this. */
+  /** Ceiling on one proxied `http` route into the plugin. A route fanning out to third-party
+   *  upstreams is allowed to be slow, so the plugin's own per-upstream timeouts have to fit
+   *  under this — and a browser behind a reverse proxy gets a 504 long before this anyway. */
   pluginCall: 180_000,
+  /**
+   * Ceiling on one `job` call. Not `pluginCall`: that value is sized for a request a browser is
+   * waiting on, and a cron sweep has neither a browser nor a proxy in front of it. Its duration
+   * scales with library size — a few hundred candidates at seconds of indexer search each passes
+   * three minutes long before it is finished — so inheriting an interactive route's ceiling made
+   * core report every real sweep as failed, and release its overlap guard while it still ran.
+   */
+  job: 60 * 60_000,
   /** After `shutdown` is answered (or not), before SIGTERM, then before SIGKILL. */
   shutdownRpc: 3_000,
   sigtermGrace: 2_000,

--- a/backend/src/modules/media/acquisition-candidates.service.ts
+++ b/backend/src/modules/media/acquisition-candidates.service.ts
@@ -69,6 +69,9 @@ export class AcquisitionCandidatesService {
   ) {}
 
   async listMovieTargets(mediaIds?: number[], quiet = false): Promise<MovieTarget[]> {
+    // Scoped to one media, this is a lookup answering a single grab, not the library-wide sweep
+    // the summary describes — the fallback and the RSS id lookup each make one per media.
+    quiet = quiet || Boolean(mediaIds?.length);
     const qb = this.mediaRepo
       .createQueryBuilder('m')
       .leftJoinAndSelect('m.qualityProfile', 'qp')
@@ -98,6 +101,7 @@ export class AcquisitionCandidatesService {
   }
 
   async listEpisodeTargets(mediaIds?: number[], quiet = false): Promise<EpisodeTarget[]> {
+    quiet = quiet || Boolean(mediaIds?.length);
     const today = new Date().toISOString().slice(0, 10);
 
     const qb = this.episodeRepo
@@ -130,6 +134,10 @@ export class AcquisitionCandidatesService {
         'ep.hasFile',
       ])
       .addSelect(['season.id', 'season.seasonNumber', 'season.mediaId'])
+      // `media.library` is joined for its id alone: `Media.libraryId` is a `@RelationId` over
+      // this relation, so an explicit column list that skips it leaves the id undefined — and a
+      // target with no library id is dropped, which is how every series candidate disappeared.
+      .leftJoin('media.library', 'medialibrary')
       .addSelect([
         'media.id',
         'media.title',
@@ -140,6 +148,7 @@ export class AcquisitionCandidatesService {
         'media.imdbId',
         'media.alternativeTitles',
       ])
+      .addSelect('medialibrary.id')
       // Profile rows are joined for the upgrade-cutoff WHERE clause AND
       // hydrated on the media entity so AutoGrabPipeline.classifyForSearch
       // doesn't read them as undefined and skip with "no profile".

--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -488,6 +488,62 @@ describe('FliksHostImpl', () => {
       expect(h.acquisitionCandidates.listMovieTargets).toHaveBeenLastCalledWith([7], true);
     });
 
+    // `Media.libraryId` is a `@RelationId`, so a query selecting an explicit column list leaves
+    // it undefined — and the builder drops a target with no library id. That is how every series
+    // candidate disappeared while movies, loaded with `leftJoinAndSelect`, came through.
+    it('VERDICT: takes the library id from the joined relation when the RelationId is absent', async () => {
+      const h = makeHarness();
+      const series = makeMedia({ id: 2, type: MediaType.SERIES });
+      const season = makeSeason({ id: 20, mediaId: 2 });
+      const ep1 = makeEpisode({ id: 201, season, episodeNumber: 1 });
+      // Exactly what the episode query hydrates: the relation, not the RelationId.
+      const withRelationOnly = { ...series, libraryId: undefined, library: { id: 9 } };
+
+      h.acquisitionCandidates.listMovieTargets.mockResolvedValue([]);
+      h.acquisitionCandidates.listEpisodeTargets.mockResolvedValue([
+        { media: withRelationOnly, season, episode: ep1, files: [] },
+      ]);
+      h.acquisitionCandidates.groupIntoSeasonPacks.mockResolvedValue([]);
+      h.autoGrab.classifyForSearch.mockReturnValue({
+        mode: 'missing',
+        minRankExclusive: 0,
+        maxRankInclusive: 10,
+      });
+
+      const { items } = await h.host['acquisition.candidates']({
+        availableOn: '2099-01-01',
+        limit: 10,
+      });
+
+      expect(items).toHaveLength(1);
+      expect(items[0].libraryId).toBe(9);
+    });
+
+    it('still drops a target with no library id either way, rather than emitting a null one', async () => {
+      const h = makeHarness();
+      const series = makeMedia({ id: 2, type: MediaType.SERIES });
+      const season = makeSeason({ id: 20, mediaId: 2 });
+      const ep1 = makeEpisode({ id: 201, season, episodeNumber: 1 });
+
+      h.acquisitionCandidates.listMovieTargets.mockResolvedValue([]);
+      h.acquisitionCandidates.listEpisodeTargets.mockResolvedValue([
+        { media: { ...series, libraryId: undefined, library: null }, season, episode: ep1, files: [] },
+      ]);
+      h.acquisitionCandidates.groupIntoSeasonPacks.mockResolvedValue([]);
+      h.autoGrab.classifyForSearch.mockReturnValue({
+        mode: 'missing',
+        minRankExclusive: 0,
+        maxRankInclusive: 10,
+      });
+
+      const { items } = await h.host['acquisition.candidates']({
+        availableOn: '2099-01-01',
+        limit: 10,
+      });
+
+      expect(items).toEqual([]);
+    });
+
     it('clamps the limit to the contract bound', async () => {
       const h = makeHarness();
       h.acquisitionCandidates.listMovieTargets.mockResolvedValue([]);

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import * as fs from 'fs';
@@ -119,6 +119,8 @@ export class FliksHostImpl implements PluginHostApi {
     private readonly sseAudience: SseAudienceService,
     private readonly countsCache: PluginCountsCacheService,
   ) {}
+
+  private readonly logger = new Logger(FliksHostImpl.name);
 
   private readonly progressGates = new Map<number, ProgressGate>();
 
@@ -1050,7 +1052,16 @@ export class FliksHostImpl implements PluginHostApi {
     decision: SearchDecision | null,
     files: { quality?: string | null }[],
   ): AcquisitionTarget | null {
-    if (media.libraryId == null) return null;
+    // `libraryId` is a `@RelationId`, so it is only populated when the relation is joined —
+    // `library.id` covers the query that selects the relation instead. Silence here is what let
+    // every series candidate vanish unreported, so a drop now says so.
+    const libraryId = media.libraryId ?? media.library?.id ?? null;
+    if (libraryId == null) {
+      this.logger.warn(
+        `candidate #${media.id} "${media.title}" dropped — no library id on the loaded media`,
+      );
+      return null;
+    }
     const { searchTitle, expectedTitles } = resolveSearchTitles(media);
     return {
       mediaId: media.id,
@@ -1063,7 +1074,7 @@ export class FliksHostImpl implements PluginHostApi {
       imdbId: media.imdbId ?? null,
       tmdbId: media.tmdbId ?? null,
       tvdbId: media.tvdbId ?? null,
-      libraryId: media.libraryId,
+      libraryId,
       want: this.buildWant(media, decision, files),
       expectedTitles,
       searchTitle,

--- a/backend/src/modules/plugins/plugin-jobs.service.ts
+++ b/backend/src/modules/plugins/plugin-jobs.service.ts
@@ -5,8 +5,8 @@ import { randomUUID } from 'crypto';
 import { PluginProcessService } from './plugin-process.service';
 import { PLUGIN_DEADLINES_MS, type PluginJob } from '../../common/plugin-contract';
 
-/** A scheduled search fans out to the same slow upstreams as its interactive counterpart. */
-const JOB_CALL_DEADLINE_MS = PLUGIN_DEADLINES_MS.pluginCall;
+/** A sweep's duration scales with library size, not with a request someone is waiting on. */
+const JOB_CALL_DEADLINE_MS = PLUGIN_DEADLINES_MS.job;
 
 function cronKey(pluginId: string, name: string): string {
   return `plugin:${pluginId}:${name}`;

--- a/backend/src/modules/plugins/supervisor/published-deadlines.spec.ts
+++ b/backend/src/modules/plugins/supervisor/published-deadlines.spec.ts
@@ -23,4 +23,11 @@ describe('published plugin deadlines', () => {
   it('carry the one host method allowed longer than the common ceiling', () => {
     expect(HOST_CALL_DEADLINE_OVERRIDES_MS['library.ingest']).toBeGreaterThan(PLUGIN_DEADLINES_MS.hostCall);
   });
+
+  // A sweep over a few hundred candidates at seconds of indexer search each passes three minutes
+  // long before it finishes, so a job bounded by the interactive route's ceiling is reported as
+  // failed on every real library — and its overlap guard released while it is still running.
+  it('VERDICT: a job is allowed far longer than a request someone is waiting on', () => {
+    expect(PLUGIN_DEADLINES_MS.job).toBeGreaterThan(PLUGIN_DEADLINES_MS.pluginCall * 10);
+  });
 });


### PR DESCRIPTION
Reported: SearchMissing finishes the movie phase and the episode phase never appears to run.

## The root cause

`Media.libraryId` is a `@RelationId` over `media.library`, so it is populated **only when that relation is joined**. `listEpisodeTargets` selects an explicit column list and never joined it:

```ts
.addSelect(['media.id', 'media.title', 'media.originalTitle', /* … */])
// no media.library anywhere
```

So every series media arrived with `libraryId` undefined, and:

```ts
if (media.libraryId == null) return null;   // buildAcquisitionTarget
```

dropped it. Silently.

**No episode and no season pack has ever left `acquisition.candidates`.** Movies were unaffected because `listMovieTargets` uses `leftJoinAndSelect`, which hydrates the relation.

That is exactly the reported symptom, and the logs say it outright once you line them up:

```
SearchMissing[episodes]: 103 need a search, 1679 excluded (…)
SearchMissing: 26 candidate(s) checked          ← the 26 movies, and nothing else
job "SearchMissing" for plugin "fliks.download" completed
```

The job completed normally. Nothing timed out. 103 episodes were enumerated, classified as needing a search, and then discarded one layer later.

This sat underneath every other fault found in this area — the pack suppression, the missing per-episode fallback, the lost RSS episode id. Those were all real, and all downstream of a candidate list that contained no series at all.

## The fix

The episode query joins `media.library` for its id, and the builder accepts either source:

```ts
const libraryId = media.libraryId ?? media.library?.id ?? null;
```

so neither loading style can lose it again. **A drop is now logged**, which is what would have found this in one run instead of four.

## Also here: the log spam

`RssSync` calls `acquisition.candidates` once per matched release, and the season-grab fallback once per season. Each was emitting a library-wide summary line — a dozen identical `SearchMissing[episodes]: 0 need a search` inside 100ms, describing a sweep nobody asked for:

```
16:30:55.207  SearchMissing[episodes]: 0 need a search
16:30:55.218  SearchMissing[episodes]: 0 need a search
16:30:55.226  SearchMissing[episodes]: 0 need a search
…
16:30:55.292  job "RssSync" for plugin "fliks.download" completed
```

A call scoped to one media is a lookup, not a sweep, so it is now quiet. This subsumes the earlier per-page condition: pagination and per-media lookups were two faces of the same wrong assumption, that every enumeration is worth narrating.

## Also here: the job deadline

A `job` call inherited `pluginCall`, 180s — a figure sized for a proxied HTTP route where a browser is waiting and a reverse proxy cuts at 60s anyway. A cron sweep has neither, and its duration scales with library size, so core reported every real sweep as failed while it ran on regardless (an RPC timeout rejects core-side; the child is never signalled).

Worse, `inFlight` was released at the same moment, so a later cron tick could start a second sweep alongside the first — two of them grabbing at once with only the per-target pending checks between them and a duplicate.

Jobs now carry their own published deadline of one hour, well inside SearchMissing's six-hour cron so an overrun cannot lap itself.

This one is not the reported bug — with 26 targets the sweep finished in 111s — but it would have become one as soon as the 103 episodes started being processed.

## Tests

Backend 1665, green. Added: the library id is taken from the joined relation when the RelationId is absent, a target with neither is still dropped rather than emitted with a null, and a job is allowed far longer than a request someone is waiting on.

## What to expect after deploying

`SearchMissing: N candidate(s) checked` should jump from 26 to roughly 129 on the reported library, and the repeated per-media lines disappear. If episodes still do not grab, the next thing to read is whether the indexers have gone into the throttle's progressive cooldown during the movie phase — a separate question this does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)