### PR TITLE
fix(streaming): resume a slept client on the sid it already holds

### DIFF
--- a/backend/src/modules/streaming/lifetime-constants.ts
+++ b/backend/src/modules/streaming/lifetime-constants.ts
@@ -7,6 +7,7 @@
  *
  *   STREAM_LIVE_SESSION_TTL_MS         live-session.service.ts
  *   STREAM_LIVE_SESSION_GC_INTERVAL_MS live-session.service.ts
+ *   STREAM_SESSION_REVIVE_TTL_MS       live-session.service.ts
  *   STREAM_MAX_SESSIONS_PER_USER       live-session.service.ts
  *   STREAM_JOB_GRACE_MS                transcoding/constants.ts
  *   STREAM_JOB_FALLBACK_TIMEOUT_MS     transcoding/constants.ts
@@ -17,6 +18,7 @@
 
 const DEFAULT_LIVE_SESSION_TTL_MS = 30_000;
 const DEFAULT_LIVE_SESSION_GC_INTERVAL_MS = 5_000;
+const DEFAULT_SESSION_REVIVE_TTL_MS = 15 * 60 * 1000;
 const DEFAULT_MAX_SESSIONS_PER_USER = 10;
 const DEFAULT_JOB_GRACE_MS = 60_000;
 const DEFAULT_JOB_FALLBACK_TIMEOUT_MS = 30 * 60 * 1000;
@@ -38,6 +40,11 @@ export const StreamLifetime = {
     readEnvPositiveInt(
       'STREAM_LIVE_SESSION_GC_INTERVAL_MS',
       DEFAULT_LIVE_SESSION_GC_INTERVAL_MS,
+    ),
+  sessionReviveTtlMs: (): number =>
+    readEnvPositiveInt(
+      'STREAM_SESSION_REVIVE_TTL_MS',
+      DEFAULT_SESSION_REVIVE_TTL_MS,
     ),
   maxSessionsPerUser: (): number =>
     readEnvPositiveInt(

--- a/backend/src/modules/streaming/live-session.service.spec.ts
+++ b/backend/src/modules/streaming/live-session.service.spec.ts
@@ -240,6 +240,48 @@ describe('LiveSessionRegistry GC', () => {
     expect(svc.size()).toBe(1);
   });
 
+  it('revives a GC\'d session on the sid it already holds', async () => {
+    // Laptop sleep: heartbeats stop, GC drops the session, then the client
+    // comes back with the same sid. It must resume, not 410.
+    process.env.STREAM_LIVE_SESSION_TTL_MS = '50';
+    process.env.STREAM_LIVE_SESSION_GC_INTERVAL_MS = '20';
+    svc = new LiveSessionRegistry();
+    svc.onModuleInit();
+    const session = svc.create({ ...BASE, position: 640 });
+    await new Promise((r) => setTimeout(r, 100));
+    expect(svc.size()).toBe(0);
+    expect(svc.touch(session.sessionId)).toBe(true);
+    expect(svc.size()).toBe(1);
+    // Revived with its context intact — that is what lets the segment route
+    // respawn ffmpeg instead of demanding a fresh playback-info.
+    expect(svc.get(session.sessionId)!.position).toBe(640);
+    expect(svc.get(session.sessionId)!.profileHash).toBe('aaaaaaaaaa');
+    // And the heartbeat no longer reports the session as lost.
+    expect(svc.heartbeat(session.sessionId, { position: 650 })).not.toBeNull();
+  });
+
+  it('does not revive past the revive window', async () => {
+    process.env.STREAM_LIVE_SESSION_TTL_MS = '20';
+    process.env.STREAM_LIVE_SESSION_GC_INTERVAL_MS = '10';
+    process.env.STREAM_SESSION_REVIVE_TTL_MS = '60';
+    svc = new LiveSessionRegistry();
+    svc.onModuleInit();
+    const session = svc.create(BASE);
+    await new Promise((r) => setTimeout(r, 150));
+    expect(svc.touch(session.sessionId)).toBe(false);
+    expect(svc.heartbeat(session.sessionId, {})).toBeNull();
+  });
+
+  it('an explicit stop is not revivable', async () => {
+    process.env.STREAM_LIVE_SESSION_TTL_MS = '50';
+    process.env.STREAM_LIVE_SESSION_GC_INTERVAL_MS = '20';
+    svc = new LiveSessionRegistry();
+    svc.onModuleInit();
+    const session = svc.create(BASE);
+    expect(svc.stop(session.sessionId)).toBe(true);
+    expect(svc.touch(session.sessionId)).toBe(false);
+  });
+
   it('keeps sessions kept alive by segment-fetch touches alone', async () => {
     // No client heartbeat at all — the receiver pulling segments must be
     // enough to survive the ttl (the Cast crash repro).

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -196,6 +196,13 @@ export type LiveSessionPatch = Partial<
  * to absorb transient network hiccups without dragging the ffmpeg
  * keep-alive window).
  *
+ * A GC'd entry isn't forgotten: it is kept as a tombstone for
+ * `STREAM_SESSION_REVIVE_TTL_MS` (15 min default, measured from its last
+ * beat), and any request presenting that sid again revives it. The stream
+ * URL therefore stays replayable across a laptop sleep or a network drop —
+ * the client resumes on its existing sid instead of re-minting one and
+ * reloading the engine (which tears the picture down to black).
+ *
  * Drives the admin "now watching" dashboard and the ffmpeg job grace
  * window — `listForJob` reports whether a given encoder still has any
  * live consumer.
@@ -204,6 +211,11 @@ export type LiveSessionPatch = Partial<
 export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
   private readonly log = new Logger(LiveSessionRegistry.name);
   private readonly sessions = new Map<string, LiveSession>();
+  /** GC'd sessions still inside the revive window, keyed by sid. Consulted
+   *  only by {@link resolve} — they are invisible to the dashboard, the
+   *  per-user cap and the ffmpeg keep-alive, so a tombstone never holds an
+   *  encoder alive. */
+  private readonly tombstones = new Map<string, LiveSession>();
   private gcTimer: ReturnType<typeof setInterval> | null = null;
 
   private readonly ttlMs = StreamLifetime.liveSessionTtlMs();
@@ -213,6 +225,10 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
    *  them warm; this only bounds how long a paused or finished download holds
    *  its session before GC reclaims it. */
   private readonly pinnedTtlMs = 60 * 60 * 1000;
+  private readonly reviveTtlMs = StreamLifetime.sessionReviveTtlMs();
+  /** Hard ceiling on tombstones so a client looping playback-info can't grow
+   *  the map without bound; the oldest are dropped first. */
+  private static readonly MAX_TOMBSTONES = 500;
 
   onModuleInit(): void {
     this.gcTimer = setInterval(() => this.runGc(), this.gcIntervalMs);
@@ -221,6 +237,7 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
   onModuleDestroy(): void {
     if (this.gcTimer) clearInterval(this.gcTimer);
     this.sessions.clear();
+    this.tombstones.clear();
   }
 
   /**
@@ -338,7 +355,7 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
       sseConnectionId?: string | null;
     },
   ): LiveSession | null {
-    const session = this.sessions.get(sessionId);
+    const session = this.resolve(sessionId);
     if (!session) return null;
     session.lastBeat = Date.now();
     if (payload.position !== undefined) session.position = payload.position;
@@ -366,7 +383,7 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
    * beat, gets GC'd mid-playback and 410s on its next segment.
    */
   touch(sessionId: string): boolean {
-    const session = this.sessions.get(sessionId);
+    const session = this.resolve(sessionId);
     if (!session) return false;
     session.lastBeat = Date.now();
     return true;
@@ -378,20 +395,46 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
    * fall through to defaults).
    */
   update(sessionId: string, patch: LiveSessionPatch): LiveSession | null {
-    const session = this.sessions.get(sessionId);
+    const session = this.resolve(sessionId);
     if (!session) return null;
     Object.assign(session, patch);
     return session;
   }
 
-  /** Drop a session explicitly. Returns whether the id was known. */
+  /** Drop a session explicitly — an intentional stop is not revivable, so the
+   *  tombstone goes too. Returns whether the id was known. */
   stop(sessionId: string): boolean {
+    this.tombstones.delete(sessionId);
     return this.sessions.delete(sessionId);
   }
 
-  /** Lookup by id without mutating lastBeat. */
+  /** Lookup by id without mutating lastBeat. Revives a tombstoned sid. */
   get(sessionId: string): LiveSession | null {
-    return this.sessions.get(sessionId) ?? null;
+    return this.resolve(sessionId);
+  }
+
+  /**
+   * Resolve a sid the caller presented: a live session, else a tombstone
+   * inside the revive window — which is moved back into the live map. Anyone
+   * still holding the sid (a heartbeat, a segment fetch) is proof the viewer
+   * is back, and reviving keeps their stream URL valid: no 410, no fresh sid,
+   * no engine reload. The encoder is gone by then; the next segment request
+   * respawns it at the requested segment through the usual slow path.
+   */
+  private resolve(sessionId: string): LiveSession | null {
+    const live = this.sessions.get(sessionId);
+    if (live) return live;
+    const buried = this.tombstones.get(sessionId);
+    if (!buried) return null;
+    this.tombstones.delete(sessionId);
+    if (buried.lastBeat < Date.now() - this.reviveTtlMs) return null;
+    this.sessions.set(sessionId, buried);
+    this.log.log(
+      `revived session ${sessionId} after ${Math.round(
+        (Date.now() - buried.lastBeat) / 1000,
+      )}s idle (file ${buried.mediaFileId}, user ${buried.userId})`,
+    );
+    return buried;
   }
 
   /**
@@ -450,11 +493,23 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
       if (session.lastBeat < now - ttl) expired.push(id);
     }
     for (const id of expired) {
+      const session = this.sessions.get(id)!;
       this.sessions.delete(id);
+      // Insertion order is beat order, which is what the size trim below
+      // walks — oldest first.
+      this.tombstones.set(id, session);
+    }
+    for (const [id, session] of this.tombstones) {
+      if (session.lastBeat < now - this.reviveTtlMs) this.tombstones.delete(id);
+    }
+    for (const id of this.tombstones.keys()) {
+      if (this.tombstones.size <= LiveSessionRegistry.MAX_TOMBSTONES) break;
+      this.tombstones.delete(id);
     }
     if (expired.length) {
       this.log.log(
-        `gc: dropped ${expired.length} session(s) past ${Math.round(this.ttlMs / 1000)}s ttl`,
+        `gc: dropped ${expired.length} session(s) past ${Math.round(this.ttlMs / 1000)}s ttl` +
+          `, revivable for ${Math.round(this.reviveTtlMs / 60000)}min`,
       );
     }
   }

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -119,7 +119,8 @@
       "SubtitleBurnIn": "Eingebrannte Untertitel",
       "AudioCodecNotSupported": "Audio-Codec nicht unterstützt",
       "AudioChannelsNotSupported": "Zu viele Audiokanäle"
-    }
+    },
+    "preparing": "Stream wird vorbereitet…"
   },
   "sse": {
     "subtitle_synced": "Untertitel erfolgreich synchronisiert.",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -124,7 +124,8 @@
       "SubtitleBurnIn": "Burned-in subtitles",
       "AudioCodecNotSupported": "Audio codec not supported",
       "AudioChannelsNotSupported": "Too many audio channels"
-    }
+    },
+    "preparing": "Preparing the stream…"
   },
   "sse": {
     "subtitle_synced": "Subtitle synced successfully.",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -119,7 +119,8 @@
       "SubtitleBurnIn": "Subtítulos incrustados",
       "AudioCodecNotSupported": "Códec de audio no compatible",
       "AudioChannelsNotSupported": "Demasiados canales de audio"
-    }
+    },
+    "preparing": "Preparando la transmisión…"
   },
   "sse": {
     "subtitle_synced": "Subtítulo sincronizado correctamente.",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -124,7 +124,8 @@
       "SubtitleBurnIn": "Sous-titres incrustés",
       "AudioCodecNotSupported": "Codec audio non supporté",
       "AudioChannelsNotSupported": "Trop de canaux audio"
-    }
+    },
+    "preparing": "Préparation du flux…"
   },
   "sse": {
     "subtitle_synced": "Sous-titre synchronisé avec succès.",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -119,7 +119,8 @@
       "SubtitleBurnIn": "Sottotitoli incorporati",
       "AudioCodecNotSupported": "Codec audio non supportato",
       "AudioChannelsNotSupported": "Troppi canali audio"
-    }
+    },
+    "preparing": "Preparazione del flusso…"
   },
   "sse": {
     "subtitle_synced": "Sottotitolo sincronizzato con successo.",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -119,7 +119,8 @@
       "SubtitleBurnIn": "Legendas incrustadas",
       "AudioCodecNotSupported": "Codec de áudio não suportado",
       "AudioChannelsNotSupported": "Demasiados canais de áudio"
-    }
+    },
+    "preparing": "A preparar a transmissão…"
   },
   "sse": {
     "subtitle_synced": "Legenda sincronizada com sucesso.",

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -83,8 +83,13 @@
   }
 
   @if (loading() || buffering() || (!videoStarted() && !error())) {
-    <div class="loading-overlay absolute inset-0 flex items-center justify-center z-50 pointer-events-none">
+    <div class="loading-overlay absolute inset-0 flex flex-col items-center justify-center gap-3 z-50 pointer-events-none">
       <span class="loading loading-spinner loading-lg text-white"></span>
+      <!-- A long buffer is almost always a cold transcode start; say so rather
+           than leaving a mute spinner over a black frame. -->
+      @if (preparing()) {
+        <p class="text-sm text-white/70">{{ 'player.preparing' | translate }}</p>
+      }
     </div>
   }
 

--- a/client/src/app/features/player/player.spec.ts
+++ b/client/src/app/features/player/player.spec.ts
@@ -125,7 +125,10 @@ function createHarness(opts: {
   const stopSessions = vi.fn(async () => ({}));
   const updatePlaybackState = vi.fn(async () => ({}));
   const getStreamUrl = vi.fn((id: number, sid?: string) => `stream://${id}?sid=${sid}`);
-  const getHlsUrl = vi.fn((id: number) => `hls://${id}`);
+  const getHlsUrl = vi.fn(
+    (id: number, quality?: string, startAt?: number, sid?: string) =>
+      `hls://${id}?q=${quality}&startAt=${startAt}&sid=${sid}`,
+  );
 
   const streamingApi = {
     getPlaybackInfo,
@@ -404,4 +407,114 @@ describe('PlayerComponent pre-roll', () => {
     expect(h.navigated).toBe(true);
   });
 
+});
+
+describe('PlayerComponent wake / resume', () => {
+  afterEach(() => {
+    TestBed.resetTestingModule();
+    vi.unstubAllGlobals();
+  });
+
+  /** A clock gap the 1s tick can't explain = the process was frozen. */
+  function sleep(component: any, ms: number) {
+    component.lastTickAt = Date.now() - ms;
+  }
+
+  it('a clock gap warms the existing session instead of reloading the engine', async () => {
+    const h = createHarness();
+    const fetchMock = vi.fn(async (_url: string) => ({}) as any);
+    vi.stubGlobal('fetch', fetchMock);
+    h.state.playbackMode.set('transcode');
+    h.engine.currentTime = 640;
+
+    sleep(h.component, 10 * 60 * 1000);
+    h.component.tickClockWatch();
+    await flush();
+
+    // Prewarm rides the live sid at the playhead: this is what revives the
+    // backend session and respawns ffmpeg while the user is still paused.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = fetchMock.mock.calls[0]![0];
+    expect(url).toContain(`sid=sid-${MAIN_FILE_ID}`);
+    expect(url).toContain('startAt=640');
+    // And a beat goes out now rather than up to 10s later.
+    expect(h.streamingApi.updatePlaybackState).toHaveBeenCalled();
+    // The whole point: no fresh sid, no engine.load(), so no black frame.
+    expect(h.streamingApi.getPlaybackInfo).not.toHaveBeenCalled();
+    expect(h.engine.loadCalls.length).toBe(0);
+  });
+
+  it('the frozen interval does not read as a stalled playhead', async () => {
+    const h = createHarness();
+    vi.stubGlobal('fetch', vi.fn(async () => ({}) as any));
+    h.state.loading.set(false);
+    h.state.paused.set(false);
+    h.component.lastProgressPos = 640;
+    h.component.lastProgressAt = Date.now() - 60_000;
+    h.engine.currentTime = 640;
+    h.engine.duration = 3600;
+
+    sleep(h.component, 60_000);
+    h.component.tickClockWatch();
+    h.component.checkStall();
+    await flush();
+
+    // A stall recovery here would re-mint the sid and reload the engine.
+    expect(h.streamingApi.getPlaybackInfo).not.toHaveBeenCalled();
+    expect(h.engine.loadCalls.length).toBe(0);
+  });
+
+  it('direct play has no encoder to warm', async () => {
+    const h = createHarness();
+    const fetchMock = vi.fn(async () => ({}) as any);
+    vi.stubGlobal('fetch', fetchMock);
+    h.state.playbackMode.set('direct');
+
+    sleep(h.component, 60_000);
+    h.component.tickClockWatch();
+    await flush();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(h.streamingApi.updatePlaybackState).toHaveBeenCalled();
+  });
+
+  it('a heartbeat lost to the network is retried, not swallowed', async () => {
+    const h = createHarness();
+    vi.stubGlobal('fetch', vi.fn(async () => ({}) as any));
+    h.streamingApi.updatePlaybackState.mockRejectedValueOnce(
+      new Error('offline'),
+    );
+
+    await h.component.savePosition();
+    expect(h.component.resumeDue).toBe(true);
+
+    // Next tick, still online: the resume path runs again on its own.
+    h.component.lastTickAt = Date.now();
+    h.component.lastResumeAt = 0;
+    h.component.lastSaveAt = 0;
+    h.component.tickClockWatch();
+    await flush();
+    expect(h.component.resumeDue).toBe(false);
+    expect(h.streamingApi.updatePlaybackState).toHaveBeenCalledTimes(2);
+  });
+
+  it('a long buffer explains itself, a short one stays mute', async () => {
+    const h = createHarness();
+    h.state.loading.set(false);
+    h.state.buffering.set(true);
+
+    h.component.lastTickAt = Date.now();
+    h.component.tickClockWatch();
+    expect(h.component.preparing()).toBe(false);
+
+    h.component.stalledSince = Date.now() - 6_000;
+    h.component.lastTickAt = Date.now();
+    h.component.tickClockWatch();
+    expect(h.component.preparing()).toBe(true);
+
+    h.state.buffering.set(false);
+    h.component.lastTickAt = Date.now();
+    h.component.tickClockWatch();
+    expect(h.component.preparing()).toBe(false);
+  });
 });

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -330,6 +330,24 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   // outside this band reloads at the offset instead of seeking in place.
   private readonly desktopSeekCacheSlackS = 1;
   private readonly desktopSeekBackWindowS = 15;
+  /** A 1 s tick that comes back this late means the process was frozen — the
+   *  machine slept, or the tab was throttled — not that time passed normally.
+   *  Nothing else in the app notices a wake: `visibilitychange` doesn't fire
+   *  for a sleep, so the clock gap is the signal. */
+  private static readonly wakeGapMs = 5_000;
+  private lastTickAt = 0;
+  /** A heartbeat that died on the network — typically the seconds right after
+   *  a wake, before Wi-Fi is back — leaves us blind to whether the session
+   *  survived. Retry the resume path once we're online instead of swallowing
+   *  the answer we never received. */
+  private resumeDue = false;
+  private lastResumeAt = 0;
+  private readonly resumeRetryMs = 5_000;
+  /** How long buffering has to hold before the overlay explains itself: a
+   *  cold ffmpeg respawn (after a sleep, or a far seek) takes seconds, and a
+   *  bare spinner over a black frame reads as a broken player. */
+  private static readonly preparingAfterMs = 5_000;
+  private stalledSince = 0;
 
   // ── Template-facing signal aliases (delegate to services) ──
   readonly loading = this.state.loading;
@@ -337,6 +355,8 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   readonly error = this.state.error;
   /** Transient "copied ✓" feedback for the error card's copy button. */
   readonly errorCopied = signal(false);
+  /** Buffering has lasted long enough to be worth a word on screen. */
+  readonly preparing = signal(false);
   readonly paused = this.state.paused;
   readonly currentTime = this.state.currentTime;
   readonly duration = this.state.duration;
@@ -1450,7 +1470,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       this.loadSpriteMetadata();
 
       // Update stats every second
+      this.lastTickAt = Date.now();
       this.statsInterval = setInterval(() => {
+        this.tickClockWatch();
         this.checkStall();
         const stats = this.engine?.getStats();
         const variant = stats?.activeVariant;
@@ -3175,6 +3197,100 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     return (v?.dvProfile ?? 0) > 0;
   }
 
+  /**
+   * Ticked once a second from the stats interval, before {@link checkStall}.
+   * Two jobs, both keyed off the wall clock rather than off playback: notice
+   * that the process was frozen and came back, and decide when a long buffer
+   * deserves an explanation on screen.
+   */
+  private tickClockWatch(): void {
+    const now = Date.now();
+    const gap = now - this.lastTickAt;
+    this.lastTickAt = now;
+    if (gap > PlayerComponent.wakeGapMs) {
+      // The frozen interval is not a frozen playhead: without this the stall
+      // watchdog fires on the same tick and reloads the engine — the very
+      // black-screen reload the resume path exists to avoid.
+      this.resetStallWatchdog();
+      void this.resumeAfterGap(gap);
+    } else if (
+      this.resumeDue &&
+      this.network.isOnline() &&
+      now - this.lastResumeAt >= this.resumeRetryMs
+    ) {
+      void this.resumeAfterGap(0);
+    }
+    if (!this.loading() && !this.buffering()) {
+      this.stalledSince = 0;
+      this.preparing.set(false);
+      return;
+    }
+    if (!this.stalledSince) this.stalledSince = now;
+    this.preparing.set(
+      now - this.stalledSince >= PlayerComponent.preparingAfterMs,
+    );
+  }
+
+  /**
+   * The player was frozen (laptop sleep) or cut off from the server, and is
+   * back. The backend killed our encoder while we were away but still answers
+   * on the same sid for a while, so the cheap path is: refresh the stream
+   * token, re-fetch the manifest at the playhead — which revives the session
+   * and respawns ffmpeg at the resume segment while the user is still paused —
+   * then beat once, so a session that is genuinely gone is caught now instead
+   * of up to 10 s later. No engine reload: the picture and the sid survive.
+   */
+  private async resumeAfterGap(gapMs: number): Promise<void> {
+    if (this.destroyed || !this.mediaFileId) return;
+    if (this.castService.isConnected()) return;
+    if (!this.network.isOnline()) {
+      this.resumeDue = true;
+      return;
+    }
+    this.resumeDue = false;
+    this.lastResumeAt = Date.now();
+    if (gapMs) {
+      console.log(
+        `[Player] resuming after a ${Math.round(gapMs / 1000)}s clock gap`,
+      );
+    }
+    try {
+      await this.authService.ensureStreamToken();
+      await this.prewarmCurrentStream();
+    } catch {
+      // Best effort: the heartbeat below is what actually drives recovery.
+    }
+    await this.savePosition();
+  }
+
+  /** GET the HLS manifest on the live sid, anchored at the playhead. The
+   *  backend reads it as a keep-alive plus a prewarm, so it revives a GC'd
+   *  session and starts ffmpeg at the resume segment; it is a no-op when an
+   *  encoder is already running. Skipped off the HLS path (direct play has no
+   *  encoder to warm) and offline. */
+  private async prewarmCurrentStream(): Promise<void> {
+    const sid = this.playbackInfo?.sessionId;
+    if (!sid || this.isOfflinePlayback || this.playbackMode() === 'direct') {
+      return;
+    }
+    // A hidden tab hits the same clock gap from timer throttling, and nobody
+    // is waiting on a warm encoder there — reviving via the heartbeat is
+    // enough. Only a visible player earns the respawn.
+    if (typeof document !== 'undefined' && document.hidden) return;
+    const pos = Math.floor(
+      this.engine?.currentTime || this.state.currentTime() || 0,
+    );
+    await fetch(
+      this.streamingApi.getHlsUrl(
+        this.mediaFileId!,
+        this.resolveStartQuality(),
+        pos,
+        sid,
+      ),
+      { cache: 'no-store' },
+    );
+  }
+
   /** Ticked once a second from the stats interval. Detects a frozen playhead
    *  during intended playback and routes it through the same recovery as a
    *  lost session (re-mint sid + reload at position). */
@@ -4219,9 +4335,14 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         }
       } catch {
         this.offlineSync.queue(offlinePayload);
+        // The beat never landed, so we never learned whether the session
+        // survived. Re-run the resume path once we're back online rather than
+        // waiting for a 410 on the next segment.
+        this.resumeDue = true;
       }
     } else {
       this.offlineSync.queue(offlinePayload);
+      this.resumeDue = true;
     }
   }
 


### PR DESCRIPTION
## The bug

Pause a film on a laptop, let the machine sleep, wake it: the player is black and
the spinner runs for a very long time.

A paused player keeps its `LiveSession` alive only through the 10 s heartbeat
(`savePosition`). Sleep freezes that timer, so:

1. the 30 s TTL (`STREAM_LIVE_SESSION_TTL_MS`) drops the session,
2. the 60 s job grace kills ffmpeg — the encoder is dead within ~90 s of sleep,
3. on wake nothing detects the wake (`visibilitychange` does not fire for a
   sleep), so the loss surfaces up to 10 s later via the heartbeat, or as a 410
   on the first segment,
4. recovery re-mints a sid and calls `engine.load()`: the media source is torn
   down (black), and the segment route can block in `getSegmentPath` for up to
   60 s while a cold ffmpeg respawns — with a mute spinner as the only feedback.

If Wi-Fi wasn't back yet, the heartbeat `PUT` threw, the `catch` queued the
payload offline and **swallowed the `sessionLost` answer**, so no recovery ran
that tick at all.

## Backend — a revivable sid

`LiveSessionRegistry` no longer forgets a GC'd session: it keeps it as a
tombstone for `STREAM_SESSION_REVIVE_TTL_MS` (15 min default, measured from its
last beat) and revives it for anyone presenting that sid, through a single
`resolve()` wired into `get` / `touch` / `heartbeat` / `update`. An explicit
`stop()` clears the tombstone too — an intentional stop is not revivable.

Everything downstream falls out of that, with no other change: `assertFresh`
stops 410ing, `SessionContextBuilder` finds its `videoVariant` again, and the
segment slow path (`getOrCreateSession`) respawns ffmpeg at the requested
segment. The stream URL stays replayable, so **the client keeps its sid and never
reloads the engine — no black frame.**

Tombstones stay invisible to the admin dashboard, the per-user cap and the ffmpeg
keep-alive (`listForJob`), so a tombstone never holds an encoder alive. Bounded
at 500 entries, purged in the same GC pass, and every revive is logged.

## Client — notice the wake, and warm the encoder before the user presses play

- `tickClockWatch()` on the existing 1 s stats interval: a tick returning >5 s
  late means the process was frozen. It **rebaselines the stall watchdog first** —
  without that, `checkStall` reads an hour-old `lastProgressAt` on the same tick
  and triggers exactly the black-screen reload this PR removes.
- `resumeAfterGap()`: refresh the stream token, GET the master playlist on the
  live sid with `startAt=<playhead>` (the backend reads it as a keep-alive plus a
  prewarm, so it revives the session and starts ffmpeg at the resume segment
  while the user is still paused), then beat immediately instead of waiting up to
  10 s. Skipped for direct play, offline, and hidden tabs (timer throttling
  produces the same clock gap and nobody there is waiting on a warm encoder).
- A heartbeat lost to the network sets `resumeDue` and re-runs the resume path
  once back online, instead of discarding the answer it never received.
- Buffering that holds past 5 s shows `player.preparing` ("Preparing the
  stream…", 6 locales) under the spinner — a long buffer is almost always a cold
  transcode start.

## Deliberately not done

- **A separate paused-session TTL**: redundant with the tombstone, which covers
  the same case. One mechanism, one knob.
- **Electron `powerMonitor`**: the clock gap works in the desktop renderer too,
  with no IPC plumbing.
- **Re-showing the backdrop during a mid-playback buffer**: the backdrop is
  `z-1` and `.player-video` is `z-auto`, so it would paint *over* a frame that is
  still valid. Hiding a working picture is worse than the blank surface macOS
  leaves behind, which we can't control anyway.
- **Shortening the 60 s `getSegmentPath` deadline**: a CPU AV1 transcode
  legitimately needs more than 20 s for its first segment. The server already
  warns with ffmpeg's state and last stderr on timeout, and the client now
  explains the wait.

## Tests

- `live-session.service.spec.ts`: a GC'd session revives on its own sid with its
  context intact and stops reporting `sessionLost`; no revive past the window;
  an explicit stop is not revivable.
- `player.spec.ts`: a clock gap warms the existing session (prewarm carries the
  sid + playhead) and issues no `playback-info` and no `engine.load()`; direct
  play warms nothing; a heartbeat lost to the network is retried; the frozen
  interval does not read as a stalled playhead (this one fails if the watchdog
  rebaseline is removed); a long buffer explains itself, a short one stays mute.

Backend 1683 tests green, client 511 green.

Manual validation still pending on the reporter's Mac: pause → sleep → wake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
