### PR TITLE
fix(release): restore the iOS version markers and fail on unreadable commits

### DIFF
--- a/.github/scripts/check-commit-parse.mjs
+++ b/.github/scripts/check-commit-parse.mjs
@@ -1,0 +1,44 @@
+// release-please reads commit messages with a stricter parser than commitlint
+// (@conventional-commits/parser). A message it can't parse is dropped from the
+// release — no error, exit 0 — so a feat silently stops bumping the minor and
+// never reaches the changelog. Run the same parser here to make that loud.
+//
+// Usage: node check-commit-parse.mjs <git-range>
+import { execFileSync } from 'node:child_process';
+import { parser } from '@conventional-commits/parser';
+
+const range = process.argv[2];
+if (!range) {
+  console.error('usage: check-commit-parse.mjs <git-range>');
+  process.exit(2);
+}
+
+const git = (...args) =>
+  execFileSync('git', args, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+
+const shas = git('log', '--format=%H', range).split('\n').filter(Boolean);
+let failed = 0;
+
+for (const sha of shas) {
+  const message = git('log', '-1', '--format=%B', sha);
+  try {
+    parser(message);
+  } catch (e) {
+    failed++;
+    const reason = String(e.message).split('\n')[0];
+    console.error(
+      `::error::${sha.slice(0, 8)} ${git('log', '-1', '--format=%s', sha).trim()}\n` +
+        `release-please cannot parse this message and would drop the commit: ${reason}`,
+    );
+  }
+}
+
+if (failed) {
+  console.error(
+    `\n${failed} of ${shas.length} commit message(s) would vanish from the release.\n` +
+      'An unbalanced "(" in the body is enough — quote it or drop it, then amend.',
+  );
+  process.exit(1);
+}
+
+console.log(`${shas.length} commit message(s) parse cleanly.`);

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -17,3 +17,23 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v6
+
+  # commitlint's parser is lenient about the body; release-please's is not, and
+  # it drops what it can't parse without failing. Same parser, run loudly.
+  release-parser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - run: npm install --no-save @conventional-commits/parser@0.4.1
+      - name: Check messages against release-please's parser
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+        # On a push the range is the single new commit — which is the squash
+        # message, the one release-please will actually read.
+        run: node .github/scripts/check-commit-parse.mjs "${BASE:-$HEAD~1}..$HEAD"

--- a/client/ios/App/App.xcodeproj/project.pbxproj
+++ b/client/ios/App/App.xcodeproj/project.pbxproj
@@ -523,7 +523,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 3.2.1;
+				MARKETING_VERSION = 3.2.1; /* x-release-please-version */
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = media.fliks.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -546,7 +546,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 3.2.1;
+				MARKETING_VERSION = 3.2.1; /* x-release-please-version */
 				PRODUCT_BUNDLE_IDENTIFIER = media.fliks.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
@@ -566,7 +566,7 @@
 				INFOPLIST_FILE = FliksDownloadWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 3.2.1;
+				MARKETING_VERSION = 3.2.1; /* x-release-please-version */
 				PRODUCT_BUNDLE_IDENTIFIER = media.fliks.app.DownloadWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -587,7 +587,7 @@
 				INFOPLIST_FILE = FliksDownloadWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 3.2.1;
+				MARKETING_VERSION = 3.2.1; /* x-release-please-version */
 				PRODUCT_BUNDLE_IDENTIFIER = media.fliks.app.DownloadWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
Both symptoms on the open release PR (#1059 — conflicting, and stuck on a patch
bump that ignores the merged feature) come from #1060.

## The conflict: a lost annotation

Xcode regenerated `client/ios/App/App.xcodeproj/project.pbxproj` in #1060 and
stripped the `/* x-release-please-version */` comments off `MARKETING_VERSION`:

```
-  MARKETING_VERSION = 3.2.1; /* x-release-please-version */
+  MARKETING_VERSION = 3.2.1;
```

`git merge-tree` confirms this is the only conflicting file: the release branch
was cut before #1060 and patches those lines *with* the marker.

The conflict is the harmless half. That file is a `generic` entry in
`extra-files`, so the updater simply found no marker, said nothing, and would
have left the iOS marketing version at 3.2.1 for every future release — it was
the only file in `extra-files` that had lost its marker; every other one
(`environment.ts`, `index.html`, `project.yml`, `build.gradle`, `Info.plist`, …)
still has it.

All four `MARKETING_VERSION` occurrences now carry the marker (the app target's
Debug/Release plus the widget target's, which #1060 added), so the app and the
widget bump together rather than drifting apart. The format matches exactly what
release-please wrote for 3.2.1.

## The missing feature: a commit release-please could not read

The workflow ran on #1060's merge commit and reported **success**, while logging:

```
❯ commit could not be parsed: 9a6ba721 feat(offline): rework downloads, artwork cache and playback sync (#1060)
❯ error message: Error: unexpected token '(' at 262:9, valid tokens [)]
❯ commits: 1
✔ Considering: 1 commits
✔ PR #1059 remained the same
```

Line 262, column 9 of that commit body is the literal `(` inside a
`` `split('(')` `` reference. release-please parses messages with
`@conventional-commits/parser`, a strict PEG parser — unlike commitlint's, which
is lenient about the body and passed the same message. It threw, dropped the
commit whole, and exited 0. So the release stayed a patch (3.2.2) instead of a
minor, and the feature never reached the changelog.

Reproduced locally against the real message:

```
$ node .github/scripts/check-commit-parse.mjs 9a6ba721~1..9a6ba721
::error::9a6ba721 feat(offline): rework downloads, artwork cache and playback sync (#1060)
release-please cannot parse this message and would drop the commit: unexpected token '(' at 262:9, valid tokens [)]

1 of 1 commit message(s) would vanish from the release.
```

The new `release-parser` job in the commit-lint workflow runs that same parser
over the incoming messages. On a push to `main` the range is the single new
commit — which is the squash message release-please will actually read — so this
turns a silent shrinking of the release into a red check.

`Release-As: 3.3.0` in the commit footer recovers the minor bump the dropped
`feat` should have produced. Note this does **not** recover the changelog entry
for #1060: 3.3.0's notes will list only the commits release-please could parse.
Say the word if you want a follow-up commit to put that line back.

## What this does not fix

#1060 also committed 6112 files of Xcode DerivedData (534 MB) under
`client/ios/DerivedDataSim/` — that is what made release-please warn
`⚠ Found 3000 files. This may not include all the files.` Handled separately so
this two-line fix stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
