### PR TITLE
ci(commit-lint): scope the parser check to what a PR actually adds

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -32,8 +32,17 @@ jobs:
       - run: npm install --no-save @conventional-commits/parser@0.4.1
       - name: Check messages against release-please's parser
         env:
-          BASE: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.base_ref }}
           HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
-        # On a push the range is the single new commit — which is the squash
-        # message, the one release-please will actually read.
-        run: node .github/scripts/check-commit-parse.mjs "${BASE:-$HEAD~1}..$HEAD"
+        # Judge a PR only on what it adds: the event's `base.sha` is frozen at
+        # PR creation, so on a long-lived branch it drags in everything already
+        # on main and re-reports history nobody can amend. On a push the range
+        # is the single new commit — the squash message release-please reads.
+        run: |
+          if [ -n "$BASE_REF" ]; then
+            git fetch -q --depth=1000 origin "$BASE_REF"
+            range="origin/$BASE_REF..$HEAD"
+          else
+            range="$HEAD~1..$HEAD"
+          fi
+          node .github/scripts/check-commit-parse.mjs "$range"


### PR DESCRIPTION
Follow-up to #1061. The new `release-parser` job used the pull-request event's
`base.sha`, which is frozen at PR creation. On a long-lived branch that reaches
much further back than the PR's own commits — on the release PR it goes back to
the previous release tag, so it re-scanned `9a6ba721` (the commit whose body
release-please can't parse) and failed:

```
::error::9a6ba721 feat(offline): rework downloads, artwork cache and playback sync (#1060)
1 of 3 commit message(s) would vanish from the release.
```

That commit is already on `main` and can't be amended, so the check would have
stayed red on every release PR from now on — which is exactly how a useful check
gets tuned out.

Scoping to `origin/<base branch>..<head>` judges a PR only on the commits it
brings. Verified against the live release branch:

```
$ node .github/scripts/check-commit-parse.mjs origin/main..origin/release-please--branches--main--components--fliks
1 commit message(s) parse cleanly.

$ node .github/scripts/check-commit-parse.mjs 77043018..origin/release-please--branches--main--components--fliks
1 of 4 commit message(s) would vanish from the release.
```

The push-to-`main` path is unchanged (`$HEAD~1..$HEAD` — the squash message
release-please will actually read), which is the run that matters for catching a
message before it costs a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
