### PR TITLE
fix(focus-ring): keep the ring visible inside scroll containers

### DIFF
--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -501,7 +501,7 @@
           <span class="font-medium">{{ 'player.queue' | translate }}</span>
         </button>
         <div class="divider my-0 before:bg-white/10 after:bg-white/10"></div>
-        <div class="max-h-[38vh] overflow-y-auto">
+        <div class="max-h-[38vh] overflow-y-auto scroll-ring-safe">
           @for (q of queueItems(); track $index; let i = $index) {
             <button
               class="w-full flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm text-white hover:bg-white/10 disabled:opacity-60 disabled:cursor-default disabled:hover:bg-transparent"

--- a/client/src/app/features/settings/language-profiles/language-profiles.html
+++ b/client/src/app/features/settings/language-profiles/language-profiles.html
@@ -59,7 +59,7 @@
           {{ 'settings.language_profiles.editor_edit_title' | translate }}
         }
       </h2>
-      <div class="py-4 flex flex-col gap-6 overflow-y-auto flex-1 min-h-0">
+      <div class="py-4 flex flex-col gap-6 overflow-y-auto flex-1 min-h-0 scroll-ring-safe">
         <label class="form-control w-full">
           <span class="label-text">{{ 'settings.language_profiles.field_name' | translate }}</span>
           <input

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
@@ -30,7 +30,7 @@
     </p>
   }
 
-  <div class="flex-1 overflow-y-auto mt-4 -mx-1 px-1">
+  <div class="flex-1 overflow-y-auto mt-4 scroll-ring-safe">
     @if (scanning()) {
       <div class="flex flex-col items-center gap-3 py-12">
         <span class="loading loading-spinner loading-lg"></span>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -411,6 +411,15 @@ body:not(.keyboard-modality):not(.tv) app-mosaic-card button:focus-visible .mosa
   position: absolute;
   z-index: 50;
 }
+/* A scroll container clips at its padding box, and as soon as one axis
+   scrolls CSS forces the other out of `visible` — so the ring above is cut
+   off the left and right edges of any full-width focusable inside one.
+   Reserve the ring's 4px and pull it straight back out of the layout, so the
+   content keeps its original alignment. Put it on the scrolling element. */
+.scroll-ring-safe {
+  @apply px-1 -mx-1;
+}
+
 /* Opt-out for focusables that paint their own focus affordance (e.g.
    round avatar with a ring-primary on the inner div). The default
    rectangle would draw a competing outer ring around the card. */


### PR DESCRIPTION
Reported on the language-profile dialog: the name field's focus ring comes out
cut flat on the left and right.

## Cause

The global ring is a 4px `box-shadow` (`styles.css`, the
`:is(a, button, select, input, …):focus-visible` rule). A scroll container clips
its content at the **padding box**, and CSS forces the second axis out of
`visible` as soon as one axis scrolls — so `overflow-y-auto` alone clips
horizontally. The dialog body is

```html
<div class="py-4 flex flex-col gap-6 overflow-y-auto flex-1 min-h-0">
```

with `py-4` but no horizontal padding, and the field is `w-full`: the ring has
literally nowhere to be drawn on either side.

## Fix

```css
.scroll-ring-safe {
  @apply px-1 -mx-1;
}
```

Reserve the ring's 4px, pull it straight back out of the layout — content keeps
its exact previous alignment. Compiles to
`margin-inline:-4px; padding-inline:4px` (verified in the built stylesheet).

Same pattern already used ad-hoc as `-mx-1 px-1` on the orphan-scan panel; that
site now uses the class, so the reason lives in one place and the next
occurrence is one word.

Applied to:

| Site | Why |
|---|---|
| `language-profiles.html` | the reported dialog |
| `player-controls.html` (queue list) | full-width buttons in a `max-h/overflow-y-auto`; its parent already reserved `px-1`, so the ring just needed the scroller to reach into it. D-pad users are the ones who need the ring |
| `orphan-scan-panel.html` | replaces the inline `-mx-1 px-1` |

## Deliberately left alone

- **`searchable-select`** popover and **`folder-picker-modal`** list clip at
  their own `rounded-* border overflow-hidden` box, one level above the
  scroller. Nothing the scrolling element does frees the ring there — it needs
  inner padding on the popover and a visual change, which is a different call.
- Rows inside the language lists (`px-3 py-2`) already have more room than the
  ring needs; their radios are fine.

Client suite green (516 tests) and a full `ng build` passes. **Not visually
confirmed on a running app** — the mechanism is the one already accepted on the
orphan-scan panel, and I checked the emitted CSS, but a look at the dialog is
worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
