### PR TITLE
refactor(settings): open row editors by clicking the name

### DIFF
--- a/client/src/app/features/settings/auto-approval/auto-approval.html
+++ b/client/src/app/features/settings/auto-approval/auto-approval.html
@@ -32,7 +32,9 @@
         <tbody>
           @for (rule of rules(); track rule.id) {
             <tr [class.opacity-50]="!rule.enabled">
-              <td class="font-medium">{{ rule.name }}</td>
+              <td>
+                <button type="button" class="link link-hover font-medium" (click)="openEdit(rule)">{{ rule.name }}</button>
+              </td>
               <td>{{ rule.priority }}</td>
               <td class="text-sm text-base-content/70">{{ rule.conditions.length }}</td>
               <td>
@@ -42,9 +44,6 @@
               </td>
               <td class="text-end">
                 <div class="flex justify-end gap-1">
-                  <button type="button" class="btn btn-ghost btn-xs" (click)="openEdit(rule)">
-                    {{ 'settings.auto_approval.edit' | translate }}
-                  </button>
                   <button type="button" class="btn btn-ghost btn-xs text-error" (click)="remove(rule)">
                     {{ 'settings.auto_approval.delete' | translate }}
                   </button>

--- a/client/src/app/features/settings/custom-formats/custom-formats.html
+++ b/client/src/app/features/settings/custom-formats/custom-formats.html
@@ -31,7 +31,9 @@
         <tbody>
           @for (cf of rows(); track cf.id) {
             <tr>
-              <td class="font-medium">{{ cf.name }}</td>
+              <td>
+                <button type="button" class="link link-hover font-medium" (click)="openEdit(cf)">{{ cf.name }}</button>
+              </td>
               <td>
                 <span
                   class="badge badge-sm"
@@ -44,9 +46,6 @@
               </td>
               <td class="text-sm text-base-content/60">{{ cf.specs.length }} spec(s)</td>
               <td class="text-end">
-                <button type="button" class="btn btn-ghost btn-xs" (click)="openEdit(cf)">
-                  {{ 'settings.custom_formats.edit' | translate }}
-                </button>
                 <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteRow(cf)">
                   {{ 'settings.custom_formats.delete' | translate }}
                 </button>

--- a/client/src/app/features/settings/language-profiles/language-profiles.html
+++ b/client/src/app/features/settings/language-profiles/language-profiles.html
@@ -31,13 +31,12 @@
         <tbody>
           @for (p of profiles(); track p.id) {
             <tr>
-              <td class="font-medium">{{ p.name }}</td>
+              <td>
+                <button type="button" class="link link-hover font-medium" (click)="openEdit(p)">{{ p.name }}</button>
+              </td>
               <td class="text-end">{{ audioCount(p) }}</td>
               <td class="text-end">{{ subtitleCount(p) }}</td>
               <td class="text-end">
-                <button type="button" class="btn btn-ghost btn-xs" (click)="openEdit(p)">
-                  {{ 'settings.language_profiles.edit' | translate }}
-                </button>
                 <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteProfile(p)">
                   {{ 'settings.language_profiles.delete' | translate }}
                 </button>

--- a/client/src/app/features/settings/media-servers/media-servers.html
+++ b/client/src/app/features/settings/media-servers/media-servers.html
@@ -33,7 +33,9 @@
         <tbody>
           @for (row of rows(); track row.id) {
             <tr>
-              <td class="font-medium">{{ row.name }}</td>
+              <td>
+                <button type="button" class="link link-hover font-medium" (click)="openEdit(row)">{{ row.name }}</button>
+              </td>
               <td><span class="badge badge-ghost badge-sm">{{ typeLabel(row.type) }}</span></td>
               <td class="text-sm text-base-content/60 truncate max-w-[12rem]">{{ row.url }}</td>
               <td class="text-sm text-base-content/60">{{ row.events.length }} event(s)</td>
@@ -45,9 +47,6 @@
                 }
               </td>
               <td class="text-end">
-                <button type="button" class="btn btn-ghost btn-xs" (click)="openEdit(row)">
-                  {{ 'settings.media_servers.edit' | translate }}
-                </button>
                 <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteRow(row)">
                   {{ 'settings.media_servers.delete' | translate }}
                 </button>

--- a/client/src/app/features/settings/notifications/notifications.html
+++ b/client/src/app/features/settings/notifications/notifications.html
@@ -32,7 +32,9 @@
         <tbody>
           @for (nc of rows(); track nc.id) {
             <tr>
-              <td class="font-medium">{{ nc.name }}</td>
+              <td>
+                <button type="button" class="link link-hover font-medium" (click)="openEdit(nc)">{{ nc.name }}</button>
+              </td>
               <td><span class="badge badge-ghost badge-sm">{{ nc.type }}</span></td>
               <td class="text-sm text-base-content/60">{{ nc.events.length }} event(s)</td>
               <td>
@@ -43,9 +45,6 @@
                 }
               </td>
               <td class="text-end">
-                <button type="button" class="btn btn-ghost btn-xs" (click)="openEdit(nc)">
-                  {{ 'settings.notifications.edit' | translate }}
-                </button>
                 <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteRow(nc)">
                   {{ 'settings.notifications.delete' | translate }}
                 </button>

--- a/client/src/app/features/settings/quality-profiles/quality-profiles.html
+++ b/client/src/app/features/settings/quality-profiles/quality-profiles.html
@@ -40,7 +40,9 @@
         <tbody>
           @for (p of profiles(); track p.id) {
             <tr>
-              <td class="font-medium">{{ p.name }}</td>
+              <td>
+                <button type="button" class="link link-hover font-medium" (click)="openEdit(p)">{{ p.name }}</button>
+              </td>
               <td class="text-sm">{{ cutoffLabel(p.cutoff) }}</td>
               <td>
                 @if (p.upgradeAllowed) {
@@ -51,9 +53,6 @@
               </td>
               <td class="text-end">{{ allowedCount(p) }}</td>
               <td class="text-end">
-                <button type="button" class="btn btn-ghost btn-xs" (click)="openEdit(p)">
-                  {{ 'settings.quality_profiles.edit' | translate }}
-                </button>
                 <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteProfile(p)">
                   {{ 'settings.quality_profiles.delete' | translate }}
                 </button>

--- a/client/src/app/features/settings/roles/roles.html
+++ b/client/src/app/features/settings/roles/roles.html
@@ -29,7 +29,9 @@
         <tbody>
           @for (role of rows(); track role.id) {
             <tr>
-              <td class="font-medium">{{ role.name }}</td>
+              <td>
+                <button type="button" class="link link-hover font-medium" (click)="openEdit(role)">{{ role.name }}</button>
+              </td>
               <td>
                 <div class="flex flex-wrap gap-1">
                   @for (perm of role.permissions; track perm) {
@@ -43,9 +45,6 @@
                 }
               </td>
               <td class="text-end">
-                <button type="button" class="btn btn-ghost btn-xs" (click)="openEdit(role)">
-                  {{ 'settings.users.edit' | translate }}
-                </button>
                 <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteRole(role)">
                   {{ 'settings.users.delete' | translate }}
                 </button>

--- a/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
+++ b/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
@@ -61,7 +61,7 @@
               @for (row of translationRows(); track row.id) {
                 <tr>
                   <td class="font-medium">
-                    <div class="whitespace-nowrap">{{ row.name }}</div>
+                    <div class="whitespace-nowrap"><button type="button" class="link link-hover" (click)="openEditTranslation(row)">{{ row.name }}</button></div>
                     @if (row.isDefault) {
                       <span class="badge badge-primary badge-sm mt-1">{{ 'settings.subtitle_providers.translation_default' | translate }}</span>
                     }
@@ -76,9 +76,6 @@
                   </td>
                   <td class="text-end">
                     <div class="flex justify-end gap-1">
-                      <button type="button" class="btn btn-ghost btn-xs" (click)="openEditTranslation(row)">
-                        {{ 'common.edit' | translate }}
-                      </button>
                       <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteTranslationProvider(row)">
                         {{ 'common.delete' | translate }}
                       </button>

--- a/client/src/app/shared/components/provider-list/provider-list.html
+++ b/client/src/app/shared/components/provider-list/provider-list.html
@@ -139,7 +139,7 @@
 
 <dialog #editorDialog class="modal">
   <div class="modal-box max-w-2xl max-h-[92vh] flex flex-col p-0 gap-0 overflow-hidden">
-    <div class="px-5 sm:px-6 pt-4 pb-3 border-b border-base-200 flex justify-between items-start gap-3 shrink-0 bg-base-100">
+    <div class="px-5 sm:px-6 pt-4 pb-3 border-b border-base-200 flex justify-between items-center gap-3 shrink-0 bg-base-100">
       <h2 class="text-lg font-bold leading-tight">
         {{ (editingId() === null ? labels().createTitleKey : labels().editTitleKey) | translate }}
       </h2>


### PR DESCRIPTION
## Why

Two inconsistencies in the settings tables, both visible on the subtitle providers page:

- The download-providers table (shared `provider-list` component) opens its editor by clicking the
  provider name, while every other settings table kept a separate **Modifier** button in the Actions
  column. Same action, two different gestures.
- The `provider-list` editor modal was the only header in the app using `items-start`. The close
  button (`btn-sm`, 32px) is taller than the `text-lg` title line (~22px), so the leftover space
  fell *below* the title and stacked onto `pb-3` — 16px above, ~22px below. It read as missing
  padding above the title.

## What

- Every settings table now opens its editor from the name (`link link-hover` + `openEdit(row)`), and
  the **Modifier** button is gone from the Actions column: `media-servers`, `roles`, `auto-approval`,
  `language-profiles`, `notifications`, `custom-formats`, `quality-profiles`, and the translation
  table on `subtitle-providers`.
- `provider-list` header switched to `items-center`, matching the six other modals that already use
  the identical markup.

`users` already had a clickable name (to the user detail page) and no edit button. `plugin-sources`
and `schedulers` have no editor, so both are untouched.

## Not done

The now-unused `*.edit` i18n keys were left in place — removing 7 keys across 6 locale files is more
churn than value. The `w-40` / `w-48` widths on the Actions columns were also left as-is.

## Test

Dev stack rebuild is clean; the editors open from the name on each page and the modal header is
now symmetric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)