### PR TITLE
fix(focus-ring): keep the ring visible in three more scrollers

### DIFF
--- a/client/src/app/features/playlists/playlist-detail/playlist-detail.html
+++ b/client/src/app/features/playlists/playlist-detail/playlist-detail.html
@@ -456,7 +456,7 @@
       (ngModelChange)="onMemberQuery($event)"
     />
     @if (memberResults().length) {
-      <ul class="flex flex-col gap-1 mt-2 max-h-52 overflow-y-auto">
+      <ul class="flex flex-col gap-1 mt-2 max-h-52 overflow-y-auto scroll-ring-safe">
         @for (u of memberResults(); track u.id) {
           <li>
             <button type="button" class="w-full flex items-center gap-3 p-2 rounded-lg hover:bg-base-200 text-left" [disabled]="memberBusy()" (click)="addMember(u)">

--- a/client/src/app/features/settings/quality-profiles/quality-profiles.html
+++ b/client/src/app/features/settings/quality-profiles/quality-profiles.html
@@ -74,7 +74,7 @@
           {{ 'settings.quality_profiles.editor_edit_title' | translate }}
         }
       </h2>
-      <div class="py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0">
+      <div class="py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 scroll-ring-safe">
         <label class="form-control w-full">
           <span class="label-text">{{ 'settings.quality_profiles.field_name' | translate }}</span>
           <input

--- a/client/src/app/shared/components/recommend-modal/recommend-modal.component.html
+++ b/client/src/app/shared/components/recommend-modal/recommend-modal.component.html
@@ -21,7 +21,7 @@
       (ngModelChange)="onQuery($event)"
     />
     @if (results().length) {
-      <ul class="flex flex-col gap-1 mt-2 max-h-60 overflow-y-auto">
+      <ul class="flex flex-col gap-1 mt-2 max-h-60 overflow-y-auto scroll-ring-safe">
         @for (u of results(); track u.id) {
           <li>
             <button


### PR DESCRIPTION
## Why

Follow-up to #1064. The focus ring was still clipped on the profile-name input of the quality
profiles editor, and on two member/user pickers with the same shape: a scroll container with **no
horizontal padding** cuts the ring off a full-width focusable sitting flush against its edge.

## What

`scroll-ring-safe` (already in `styles.css`) applied to three containers:

| File | Focusable |
|---|---|
| `quality-profiles.html:77` | the editor's form fields — same `modal-box` as `language-profiles`, where the fix is already proven |
| `recommend-modal.component.html:24` | `button w-full` rows |
| `playlist-detail.html:459` | `button w-full` rows |

## Scope

Swept all 30 `overflow-y-auto` containers in the client. The rest need nothing: those with
`px-5` / `p-3` / `p-4` already reserve far more than the ring's 4px (including the seven
`provider-list`-shaped modals), daisyUI's `.menu` contributes 8px (`folder-picker`,
`settings-drawer` — checked in `daisyui.css`), and `subtitle-providers.html:182` hand-rolls the same
trick with `p-2 -m-2`.

## Left out on purpose

`searchable-select.html:34` is genuinely clipped, but its popover parent has `overflow-hidden`, so the
class's `-mx-1` would push the list outside the popover and get clipped there instead. Fixing it means
either `px-1` without the negative margin (options shift 4px) or dropping `overflow-hidden` from the
popover — a shared-component trade-off worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)