### PR TITLE
feat(requests): act on a pending request from the title preview

### DIFF
--- a/backend/src/modules/requests/dto/list-requests.dto.ts
+++ b/backend/src/modules/requests/dto/list-requests.dto.ts
@@ -1,6 +1,6 @@
 import { IsEnum, IsInt, IsOptional, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
-import { RequestStatus, RequestKind } from '../../../common/enums';
+import { RequestStatus, RequestKind, MediaType } from '../../../common/enums';
 
 export class ListRequestsDto {
   @IsOptional()
@@ -15,6 +15,17 @@ export class ListRequestsDto {
   @Type(() => Number)
   @IsInt()
   userId?: number;
+
+  // Narrows the list to one title. `mediaType` must accompany it: TMDB numbers
+  // movies and series in separate namespaces, so an id alone can match both.
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  tmdbId?: number;
+
+  @IsOptional()
+  @IsEnum(MediaType)
+  mediaType?: MediaType;
 
   @IsOptional()
   @Type(() => Number)

--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -637,6 +637,12 @@ export class RequestsService {
     if (query.kind) {
       qb.andWhere('r.kind = :kind', { kind: query.kind });
     }
+    if (query.tmdbId) {
+      qb.andWhere('r."tmdbId" = :tmdbId', { tmdbId: query.tmdbId });
+    }
+    if (query.mediaType) {
+      qb.andWhere('r."mediaType" = :mediaType', { mediaType: query.mediaType });
+    }
 
     const [data, total] = await qb
       .skip((page - 1) * limit)

--- a/client/src/app/core/services/api/requests.service.ts
+++ b/client/src/app/core/services/api/requests.service.ts
@@ -105,6 +105,10 @@ export interface ListRequestsParams {
   status?: FliksRequestStatus;
   kind?: RequestKind;
   userId?: number;
+  /** Narrow to one title. Pass `mediaType` alongside it — TMDB ids are only
+   *  unique within a namespace, so a movie and a series can share a number. */
+  tmdbId?: number;
+  mediaType?: MediaType;
   page?: number;
   limit?: number;
 }

--- a/client/src/app/features/tmdb-preview/tmdb-preview.html
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.html
@@ -1,3 +1,48 @@
+<ng-template #pendingRequestsPanel>
+  @if (canManageRequests() && pendingRequests().length) {
+    <div class="mt-4 rounded-lg border border-warning/40 bg-warning/5 p-3 flex flex-col gap-3">
+      @for (r of pendingRequests(); track r.id) {
+        <div class="flex flex-col gap-1.5">
+          <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+            <span class="badge badge-warning badge-sm">{{ 'requests.status.pending' | translate }}</span>
+            <span class="text-sm">
+              <span class="text-base-content/50">{{ 'requests.requested_by' | translate }}</span>
+              <span class="font-medium">{{ r.user.username }}</span>
+            </span>
+            <span class="flex flex-wrap items-center gap-1 ms-auto">
+              <button type="button" class="btn btn-primary btn-sm"
+                      [disabled]="actionBusyId() === r.id" (click)="approveRequest(r.id)">
+                {{ 'requests.approve' | translate }}
+              </button>
+              <button type="button" class="btn btn-ghost btn-sm"
+                      [disabled]="actionBusyId() === r.id" (click)="openEdit(r)">
+                {{ 'requests.edit' | translate }}
+              </button>
+              <button type="button" class="btn btn-ghost btn-sm text-error"
+                      [disabled]="actionBusyId() === r.id" (click)="openDecline(r.id)">
+                {{ 'requests.decline' | translate }}
+              </button>
+            </span>
+          </div>
+          @if (seasonScope(r) || qualityProfileName(r) || languageProfileName(r)) {
+            <div class="flex flex-col gap-0.5 text-sm text-base-content/60">
+              @if (seasonScope(r)) {
+                <span>{{ 'requests.seasons_label' | translate }} {{ seasonScope(r) }}</span>
+              }
+              @if (qualityProfileName(r)) {
+                <span>{{ 'discover.quality_profile' | translate }}: {{ qualityProfileName(r) }}</span>
+              }
+              @if (languageProfileName(r)) {
+                <span>{{ 'discover.language_profile' | translate }}: {{ languageProfileName(r) }}</span>
+              }
+            </div>
+          }
+        </div>
+      }
+    </div>
+  }
+</ng-template>
+
 @if (loading()) {
   <div class="flex justify-center py-16">
     <span class="loading loading-spinner loading-lg"></span>
@@ -44,7 +89,7 @@
 
       <!-- Action buttons -->
       <div class="flex flex-wrap items-center gap-3 mt-4">
-        @if (canImport()) {
+        @if (showImportButton()) {
           <button type="button" class="btn btn-primary flex-1 gap-2" (click)="openImportModal()">
             <svg lucidePlus class="h-4 w-4"></svg>{{ 'discover.add_to_library' | translate }}
           </button>
@@ -69,6 +114,7 @@
           {{ 'discover.seasons_already_requested' | translate:{ seasons: requestedSeasons().join(', ') } }}
         </p>
       }
+      <ng-container *ngTemplateOutlet="pendingRequestsPanel" />
 
       @if (m.overview) {
         <p [appClampToggle]="m.overview" #syn="clampToggle"
@@ -174,7 +220,7 @@
 
         <!-- Action buttons — order + sizing matching media-detail's row. -->
         <div class="flex flex-wrap items-center gap-2 mt-6">
-          @if (canImport()) {
+          @if (showImportButton()) {
             <button type="button" class="btn btn-primary gap-2" (click)="openImportModal()">
               <svg lucidePlus class="h-4 w-4"></svg>{{ 'discover.add_to_library' | translate }}
             </button>
@@ -199,6 +245,7 @@
             {{ 'discover.seasons_already_requested' | translate:{ seasons: requestedSeasons().join(', ') } }}
           </p>
         }
+        <ng-container *ngTemplateOutlet="pendingRequestsPanel" />
 
         @if (m.overview) {
           <p class="mt-4 text-base-content/90 leading-relaxed whitespace-pre-line">{{ m.overview }}</p>
@@ -349,3 +396,28 @@
 />
 
 <app-import-modal />
+<app-request-decline-modal
+  [requestId]="declineForId()"
+  [reasonText]="declineReasonText()"
+  [submitBusy]="actionBusyId() !== null"
+  (reasonTextChange)="declineReasonText.set($event)"
+  (dismissed)="closeDecline()"
+  (submitted)="submitDecline()"
+/>
+
+<app-request-edit-modal
+  [row]="editingRequest()"
+  [qualityProfiles]="qualityProfiles()"
+  [languageProfiles]="languageProfiles()"
+  [libraries]="compatibleLibraries()"
+  [qualityProfileId]="editQualityProfileId()"
+  [languageProfileId]="editLanguageProfileId()"
+  [libraryId]="editLibraryId()"
+  [saving]="editSaving()"
+  (qualityProfileIdChange)="editQualityProfileId.set($event)"
+  (languageProfileIdChange)="editLanguageProfileId.set($event)"
+  (libraryIdChange)="editLibraryId.set($event)"
+  (dismissed)="closeEdit()"
+  (save)="saveEdit()"
+/>
+

--- a/client/src/app/features/tmdb-preview/tmdb-preview.ts
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.ts
@@ -11,7 +11,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { CurrencyPipe, DecimalPipe } from '@angular/common';
+import { CurrencyPipe, DecimalPipe, NgTemplateOutlet } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -23,9 +23,16 @@ import {
 } from '../../core/services/api/metadata.service';
 import { ProfilesService } from '../../core/services/api/profiles.service';
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
+import { ToastService } from '../../core/services/toast.service';
 import { NavbarService } from '../../core/services/navbar.service';
 import { BackgroundService } from '../../core/services/background.service';
-import { RequestsService, TitleRequestState } from '../../core/services/api/requests.service';
+import {
+  RequestsService,
+  TitleRequestState,
+  FliksRequestRow,
+} from '../../core/services/api/requests.service';
+import { RequestDeclineModalComponent } from '../requests/request-decline-modal/request-decline-modal.component';
+import { RequestEditModalComponent } from '../requests/request-edit-modal/request-edit-modal.component';
 import { RequestModalComponent } from './components/request-modal/request-modal.component';
 import { ImportModalComponent } from './components/import-modal/import-modal.component';
 import { MediaType } from '../../core/enums/media-type.enum';
@@ -41,7 +48,7 @@ import { PreviewSeasonsComponent } from './components/preview-seasons/preview-se
 
 @Component({
   selector: 'app-tmdb-preview',
-  imports: [FormsModule, CurrencyPipe, DecimalPipe, TranslateModule, ResolveUrlPipe, LocaleDatePipe, RequestModalComponent, ImportModalComponent, MobileFanartHeroComponent, HorizontalScrollerComponent, ClampToggleDirective, CollapsibleSectionComponent, PreviewSeasonsComponent, LucideFilm, LucideUser, LucidePlay, LucidePlus],
+  imports: [FormsModule, CurrencyPipe, DecimalPipe, NgTemplateOutlet, TranslateModule, ResolveUrlPipe, LocaleDatePipe, RequestModalComponent, ImportModalComponent, MobileFanartHeroComponent, HorizontalScrollerComponent, ClampToggleDirective, CollapsibleSectionComponent, PreviewSeasonsComponent, RequestDeclineModalComponent, RequestEditModalComponent, LucideFilm, LucideUser, LucidePlay, LucidePlus],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './tmdb-preview.html',
 })
@@ -52,6 +59,7 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
   private readonly profilesApi = inject(ProfilesService);
   private readonly librariesApi = inject(LibrariesApiService);
   private readonly requestsApi = inject(RequestsService);
+  private readonly toast = inject(ToastService);
   private readonly translate = inject(TranslateService);
   protected readonly navbar = inject(NavbarService);
   private readonly backgroundService = inject(BackgroundService);
@@ -115,8 +123,53 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
     () => this.titleState()?.requestedSeasons ?? [],
   );
 
+  readonly canManageRequests = computed(() =>
+    this.auth.hasPermission('requests.manage'),
+  );
+
+  /** Pending requests on this title, for a manager. Importing while one is
+   *  open can leave it stranded: the lifecycle only adopts a request whose
+   *  profiles the imported envelope covers, so a narrower import leaves it
+   *  PENDING with the media already in the library. */
+  readonly pendingRequests = signal<FliksRequestRow[]>([]);
+
+  /** Whether a pending request makes a raw import the wrong move — the scope
+   *  rule `hasBlockingRequest` already applies to requesters: any pending
+   *  request for a movie, only a whole-series one for a series. */
+  readonly pendingBlocksImport = computed(() => {
+    const pending = this.pendingRequests();
+    if (!pending.length) return false;
+    return this.type() === 'series'
+      ? pending.some((r) => !r.seasons?.length)
+      : true;
+  });
+
+  /** The import button stands down while a pending request would be bypassed —
+   *  kept apart from `canImport`, which `canRequest` negates as a role test. */
+  readonly showImportButton = computed(
+    () => this.canImport() && !this.pendingBlocksImport(),
+  );
+
+  readonly declineForId = signal<number | null>(null);
+  readonly declineReasonText = signal('');
+  readonly actionBusyId = signal<number | null>(null);
+
+  readonly editingRequest = signal<FliksRequestRow | null>(null);
+  readonly editQualityProfileId = signal<number | null>(null);
+  readonly editLanguageProfileId = signal<number | null>(null);
+  readonly editLibraryId = signal<number | null>(null);
+  readonly editSaving = signal(false);
+
+  readonly compatibleLibraries = computed(() => {
+    const row = this.editingRequest();
+    if (!row) return [];
+    return this.libraries().filter((l) => l.mediaTypes.includes(row.mediaType));
+  });
+
   private readonly requestModal = viewChild(RequestModalComponent);
   private readonly importModal = viewChild(ImportModalComponent);
+  private readonly declineModal = viewChild(RequestDeclineModalComponent);
+  private readonly editModal = viewChild(RequestEditModalComponent);
   private readonly trailerDialog =
     viewChild<ElementRef<HTMLDialogElement>>('trailerDialog');
   private readonly sanitizer = inject(DomSanitizer);
@@ -205,9 +258,9 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
     const provider = this.provider();
     const externalId = this.externalId();
 
-    // Only the request flow needs profiles+libraries pre-loaded on the page
-    // (the import modal loads its own data on open).
-    if (this.canRequest()) {
+    // Feeds the request form and the manager's edit modal; the import modal
+    // loads its own data on open.
+    if (this.canRequest() || this.canManageRequests()) {
       const [qp, lp, libs] = await Promise.all([
         this.profilesApi.getQualityProfiles(),
         this.profilesApi.getLanguageProfiles(),
@@ -226,6 +279,9 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
       // import never see the "déjà demandé" badge anyway.
       if (this.canRequest()) {
         await this.loadTitleState(details.tmdbId);
+      }
+      if (this.canManageRequests()) {
+        await this.loadPendingRequests(details.tmdbId);
       }
     } catch {
       this.error.set(this.translate.instant('discover.preview_error'));
@@ -261,6 +317,123 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
       provider: this.provider(),
       externalId: this.externalId(),
     });
+  }
+
+  /** Pending requests on this title, so a manager acts on the request instead
+   *  of importing past it. Bypasses the cache: an approve/decline here has to
+   *  be reflected on the next visit. */
+  private async loadPendingRequests(tmdbId: number) {
+    try {
+      const page = await this.requestsApi.list(
+        {
+          tmdbId,
+          mediaType: this.type() as MediaType,
+          status: 'pending',
+          kind: 'add',
+          limit: 50,
+        },
+        { force: true },
+      );
+      this.pendingRequests.set(page.data);
+    } catch {
+      /* a failed lookup must not block the page — the Add button stays */
+    }
+  }
+
+  private refreshPendingRequests() {
+    const m = this.media();
+    if (m) void this.loadPendingRequests(m.tmdbId);
+  }
+
+  async approveRequest(id: number) {
+    this.actionBusyId.set(id);
+    try {
+      await this.requestsApi.approve(id);
+      this.refreshPendingRequests();
+    } finally {
+      this.actionBusyId.set(null);
+    }
+  }
+
+  openDecline(id: number) {
+    this.declineForId.set(id);
+    this.declineReasonText.set('');
+    this.declineModal()?.showModal();
+  }
+
+  closeDecline() {
+    this.declineModal()?.close();
+    this.declineForId.set(null);
+  }
+
+  async submitDecline() {
+    const id = this.declineForId();
+    if (id == null) return;
+    this.actionBusyId.set(id);
+    try {
+      await this.requestsApi.decline(id, this.declineReasonText());
+      this.closeDecline();
+      this.refreshPendingRequests();
+    } finally {
+      this.actionBusyId.set(null);
+    }
+  }
+
+  openEdit(row: FliksRequestRow) {
+    this.editingRequest.set(row);
+    this.editQualityProfileId.set(row.qualityProfileId);
+    this.editLanguageProfileId.set(row.languageProfileId);
+    this.editLibraryId.set(row.libraryId);
+    this.editModal()?.showModal();
+  }
+
+  closeEdit() {
+    this.editModal()?.close();
+    this.editingRequest.set(null);
+  }
+
+  async saveEdit() {
+    const row = this.editingRequest();
+    if (!row) return;
+    this.editSaving.set(true);
+    try {
+      // Only send libraryId when it actually changed: re-sending an unchanged
+      // value would re-run the backend access check on a plain profile edit.
+      const libraryChanged = this.editLibraryId() !== row.libraryId;
+      await this.requestsApi.update(row.id, {
+        qualityProfileId: this.editQualityProfileId() ?? undefined,
+        languageProfileId: this.editLanguageProfileId() ?? undefined,
+        ...(libraryChanged ? { libraryId: this.editLibraryId() } : {}),
+      });
+      this.toast.success(this.translate.instant('requests.edit_success'));
+      this.closeEdit();
+      this.refreshPendingRequests();
+    } finally {
+      this.editSaving.set(false);
+    }
+  }
+
+  /** Season scope of a per-season request; empty for a whole-title one. */
+  seasonScope(row: FliksRequestRow): string {
+    return (row.seasons ?? []).join(', ');
+  }
+
+  /** Quality profile the requester picked. `#id` when the profile is gone —
+   *  losing the value entirely would hide what the request actually asks for. */
+  qualityProfileName(row: FliksRequestRow): string {
+    return this.profileName(this.qualityProfiles(), row.qualityProfileId);
+  }
+
+  languageProfileName(row: FliksRequestRow): string {
+    return this.profileName(this.languageProfiles(), row.languageProfileId);
+  }
+
+  private profileName(
+    profiles: { id: number; name: string }[],
+    id: number | null,
+  ): string {
+    if (id == null) return '';
+    return profiles.find((p) => p.id === id)?.name ?? `#${id}`;
   }
 
   openRequestModal() {


### PR DESCRIPTION
## Why

A manager opening a title that someone had requested saw only **Add to library** — no sign a request
existed, no way to act on it. The preview loaded the request state under `if (this.canRequest())`,
and `canRequest` is defined as `!canImport() && …`, so the pending request was invisible to exactly
the people who can approve it.

Importing past it is not always harmless. `onMediaImported` adopts a pending request **only when the
imported profile envelope covers what the request asked for**
([request-lifecycle.service.ts:154](backend/src/modules/requests/request-lifecycle.service.ts#L154)).
A narrower import takes the `if (!covers) continue;` branch and leaves the request `PENDING` forever
with the media already in the library.

## What

The preview now lists the title's pending requests for anyone with `requests.manage`:

```
[Pending]  Requested by test            [Approve] [Edit] [Decline]
Quality profile: HD - 1080p
Language profile: French
```

- **Add to library stands down** through a separate `showImportButton`, leaving `canImport` intact as
  the role test `canRequest` negates — otherwise the admin would start seeing the *Request* button.
- **Blocking scope reuses the rule requesters already get** from `hasBlockingRequest`: any pending
  request for a movie, only a whole-series one for a series. A per-season request shows the panel
  *and* keeps Add, so a manager can still bring in the other seasons.
- **A declined request leaves no pending row**, so Add comes back with no code for that case.
- `request-decline-modal` and `request-edit-modal` are reused as-is (both are presentational).
- **Zero i18n keys added** — `requests.status.pending`, `requested_by`, `approve`, `edit`, `decline`,
  `seasons_label`, `discover.quality_profile` and `discover.language_profile` all already exist in
  the six locales.

### Backend

Listing by title reuses `findAll` instead of a new endpoint: `tmdbId` and `mediaType` join the
existing filters and inherit its ownership + library scoping untouched. `mediaType` is required
alongside `tmdbId` because TMDB numbers movies and series in separate namespaces, so an id alone can
match both.

## Verified

- `tsc` clean on the backend, Angular build clean.
- Live against the dev stack: `GET /api/requests?tmdbId=1288445&mediaType=movie&status=pending&kind=add`
  returns the pending request with its requester identity; a non-manager still sees only their own row.

**Not verified:** the panel's visual rendering — this repo has no browser automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)