### PR TITLE
ci: fix the entity-drift check and clear the drift behind it

### DIFF
--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -58,16 +58,11 @@ jobs:
       - run: npm ci
       - name: Run migrations on a fresh DB
         run: npm run db:migration:run
-      - name: Report entity metadata drift against the migrated schema
+      - name: Verify entity metadata matches the migrated schema
         # `migration:generate` against a DB holding the latest schema emits a
         # file only when the entities and the schema disagree. It exits
-        # non-zero in the no-diff case, so a plain exit code says nothing —
+        # non-zero in the no-diff case too, so a plain exit code says nothing —
         # the emitted file is the signal.
-        #
-        # Reported, not enforced: a known body of drift predates this check
-        # (constraint/index naming, plus 14 nullable-in-entity FK columns), so
-        # failing here would redden every PR for something it did not cause.
-        # See #1057 for the inventory and the options to clear it.
         run: |
           set -o pipefail
           shopt -s nullglob
@@ -81,12 +76,13 @@ jobs:
           # path passed above is never the path written.
           drift=(src/migrations/*__ci_drift_check.ts)
           if [ ${#drift[@]} -gt 0 ]; then
-            echo "::warning::Entity metadata differs from the migrated schema — see #1057."
-            echo "If this PR changed an entity, generate and commit the migration:"
+            echo "::error::Entity changes are not reflected in any committed migration."
+            echo "Generate and commit it:"
             echo "  npm run db:migration:generate -- src/migrations/<descriptive-name>"
             cat "${drift[@]}"
             # A leftover file is picked up as a real migration by the next run.
             rm -f "${drift[@]}"
+            exit 1
           elif [ "$emitted" = false ] &&
                ! grep -q "No changes in database schema were found" <<<"$out"; then
             echo "::error::migration:generate did not complete — this check verified nothing."

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -11,10 +11,13 @@ on:
     branches: [main]
     paths:
       - 'backend/**'
+      # A change to the check itself has to run the check.
+      - '.github/workflows/db-migrations.yml'
   push:
     branches: [main]
     paths:
       - 'backend/**'
+      - '.github/workflows/db-migrations.yml'
 
 jobs:
   apply-migrations:

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -55,18 +55,38 @@ jobs:
       - run: npm ci
       - name: Run migrations on a fresh DB
         run: npm run db:migration:run
-      - name: Verify entity metadata matches the migrated schema
-        # `migration:generate` against a DB that already has the latest
-        # schema must produce an empty diff. The CLI exits non-zero in
-        # the no-diff case ("No changes in database schema were found")
-        # — we treat that as success and only fail if a migration file
-        # was actually emitted (the developer forgot to commit one).
+      - name: Report entity metadata drift against the migrated schema
+        # `migration:generate` against a DB holding the latest schema emits a
+        # file only when the entities and the schema disagree. It exits
+        # non-zero in the no-diff case, so a plain exit code says nothing —
+        # the emitted file is the signal.
+        #
+        # Reported, not enforced: a known body of drift predates this check
+        # (constraint/index naming, plus 14 nullable-in-entity FK columns), so
+        # failing here would redden every PR for something it did not cause.
+        # See #1057 for the inventory and the options to clear it.
         run: |
-          ./node_modules/.bin/typeorm-ts-node-commonjs migration:generate \
-            -d src/data-source.ts src/migrations/__ci_drift_check || true
-          if [ -f src/migrations/__ci_drift_check.ts ]; then
-            echo "::error::Entity changes are not reflected in any committed migration."
-            echo "Run 'npm run db:migration:generate -- src/migrations/<descriptive-name>' locally and commit the file."
-            cat src/migrations/__ci_drift_check.ts
+          set -o pipefail
+          shopt -s nullglob
+          if out=$(./node_modules/.bin/typeorm-ts-node-commonjs migration:generate \
+                     -d src/data-source.ts src/migrations/__ci_drift_check 2>&1); then
+            emitted=true
+          else
+            emitted=false
+          fi
+          # TypeORM prefixes the name it is handed with a timestamp, so the
+          # path passed above is never the path written.
+          drift=(src/migrations/*__ci_drift_check.ts)
+          if [ ${#drift[@]} -gt 0 ]; then
+            echo "::warning::Entity metadata differs from the migrated schema — see #1057."
+            echo "If this PR changed an entity, generate and commit the migration:"
+            echo "  npm run db:migration:generate -- src/migrations/<descriptive-name>"
+            cat "${drift[@]}"
+            # A leftover file is picked up as a real migration by the next run.
+            rm -f "${drift[@]}"
+          elif [ "$emitted" = false ] &&
+               ! grep -q "No changes in database schema were found" <<<"$out"; then
+            echo "::error::migration:generate did not complete — this check verified nothing."
+            echo "$out"
             exit 1
           fi

--- a/backend/src/migrations/1784100000000-align-foreign-key-names.ts
+++ b/backend/src/migrations/1784100000000-align-foreign-key-names.ts
@@ -1,0 +1,106 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Renames every hand-named foreign key to the name TypeORM derives from the
+ * entity metadata, so `migration:generate` reports no drift and the CI check
+ * can be enforced instead of merely reported.
+ *
+ * A constraint rename is a catalog-only operation: no table rewrite, no index
+ * rebuild, no row touched. Guarded per row, so a schema already carrying the
+ * derived name (anything built by dev `synchronize`) is left alone.
+ */
+export class AlignForeignKeyNamesWithEntityMetadata1784100000000
+  implements MigrationInterface
+{
+  name = 'AlignForeignKeyNamesWithEntityMetadata1784100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      DECLARE r record;
+      BEGIN
+        FOR r IN SELECT * FROM (VALUES
+        ('media', 'FK_media_addedById_users', 'FK_724fe2622945e05c195981e5093'),
+        ('subtitle_files', 'FK_subtitle_files_translation_provider', 'FK_295bae34d5648dd18b16747db4a'),
+        ('user_follows', 'FK_user_follows_follower', 'FK_6300484b604263eaae8a6aab88d'),
+        ('user_follows', 'FK_user_follows_following', 'FK_7c6c27f12c4e972eab4b3aaccbf'),
+        ('likes', 'FK_likes_user', 'FK_cfd8e81fac09d7339a32e57d904'),
+        ('likes', 'FK_likes_media', 'FK_65ef9a90fa855c14dd0cd896c8b'),
+        ('likes', 'FK_likes_season', 'FK_8b1354ded3e5cd533bc0d04ce18'),
+        ('likes', 'FK_likes_episode', 'FK_67214b2270f001c5a96a3626315'),
+        ('content_recommendations', 'FK_content_recommendations_sender', 'FK_a28f439c529ee2c6540d329e544'),
+        ('content_recommendations', 'FK_content_recommendations_recipient', 'FK_ee17496f10af9bad93ad1b94f2d'),
+        ('content_recommendations', 'FK_content_recommendations_media', 'FK_2e975a73e827bc421da61575b7a'),
+        ('content_recommendations', 'FK_content_recommendations_season', 'FK_1a6417072770a4914bd315ab750'),
+        ('content_recommendations', 'FK_content_recommendations_episode', 'FK_461751303606d68d0c5666347d7'),
+        ('playlist_items', 'FK_playlist_items_playlist', 'FK_1a5c30e99b5283b5653ee29b6b5'),
+        ('playlist_items', 'FK_playlist_items_media', 'FK_16f8c7b6e4824b9ccca31b9616b'),
+        ('playlist_items', 'FK_playlist_items_episode', 'FK_9dcd364d418c539e74b7f57ad36'),
+        ('playlist_items', 'FK_playlist_items_addedBy', 'FK_0f9dbadfd3458af1e6bc49c93e3'),
+        ('playlists', 'FK_playlists_owner', 'FK_aa5d498a2f045be2fb71ef98d45'),
+        ('playlist_shares', 'FK_playlist_shares_playlist', 'FK_5d4f9a22dd268ce08eb2319d0c8'),
+        ('playlist_shares', 'FK_playlist_shares_user', 'FK_62c91d23418a7ae8115f07f64d9'),
+        ('playlist_saves', 'FK_playlist_saves_user', 'FK_fe0902ebcd7a31e03080d4bf4af'),
+        ('playlist_saves', 'FK_playlist_saves_playlist', 'FK_957d1f3537c85497076254ac1e8'),
+        ('refresh_tokens', 'FK_refresh_tokens_user', 'FK_610102b60fea1455310ccd299de')
+        ) AS t(tbl, from_name, to_name)
+        LOOP
+          IF EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = r.from_name AND conrelid = r.tbl::regclass
+          ) THEN
+            EXECUTE format(
+              'ALTER TABLE %I RENAME CONSTRAINT %I TO %I',
+              r.tbl, r.from_name, r.to_name
+            );
+          END IF;
+        END LOOP;
+      END $$;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      DECLARE r record;
+      BEGIN
+        FOR r IN SELECT * FROM (VALUES
+        ('media', 'FK_724fe2622945e05c195981e5093', 'FK_media_addedById_users'),
+        ('subtitle_files', 'FK_295bae34d5648dd18b16747db4a', 'FK_subtitle_files_translation_provider'),
+        ('user_follows', 'FK_6300484b604263eaae8a6aab88d', 'FK_user_follows_follower'),
+        ('user_follows', 'FK_7c6c27f12c4e972eab4b3aaccbf', 'FK_user_follows_following'),
+        ('likes', 'FK_cfd8e81fac09d7339a32e57d904', 'FK_likes_user'),
+        ('likes', 'FK_65ef9a90fa855c14dd0cd896c8b', 'FK_likes_media'),
+        ('likes', 'FK_8b1354ded3e5cd533bc0d04ce18', 'FK_likes_season'),
+        ('likes', 'FK_67214b2270f001c5a96a3626315', 'FK_likes_episode'),
+        ('content_recommendations', 'FK_a28f439c529ee2c6540d329e544', 'FK_content_recommendations_sender'),
+        ('content_recommendations', 'FK_ee17496f10af9bad93ad1b94f2d', 'FK_content_recommendations_recipient'),
+        ('content_recommendations', 'FK_2e975a73e827bc421da61575b7a', 'FK_content_recommendations_media'),
+        ('content_recommendations', 'FK_1a6417072770a4914bd315ab750', 'FK_content_recommendations_season'),
+        ('content_recommendations', 'FK_461751303606d68d0c5666347d7', 'FK_content_recommendations_episode'),
+        ('playlist_items', 'FK_1a5c30e99b5283b5653ee29b6b5', 'FK_playlist_items_playlist'),
+        ('playlist_items', 'FK_16f8c7b6e4824b9ccca31b9616b', 'FK_playlist_items_media'),
+        ('playlist_items', 'FK_9dcd364d418c539e74b7f57ad36', 'FK_playlist_items_episode'),
+        ('playlist_items', 'FK_0f9dbadfd3458af1e6bc49c93e3', 'FK_playlist_items_addedBy'),
+        ('playlists', 'FK_aa5d498a2f045be2fb71ef98d45', 'FK_playlists_owner'),
+        ('playlist_shares', 'FK_5d4f9a22dd268ce08eb2319d0c8', 'FK_playlist_shares_playlist'),
+        ('playlist_shares', 'FK_62c91d23418a7ae8115f07f64d9', 'FK_playlist_shares_user'),
+        ('playlist_saves', 'FK_fe0902ebcd7a31e03080d4bf4af', 'FK_playlist_saves_user'),
+        ('playlist_saves', 'FK_957d1f3537c85497076254ac1e8', 'FK_playlist_saves_playlist'),
+        ('refresh_tokens', 'FK_610102b60fea1455310ccd299de', 'FK_refresh_tokens_user')
+        ) AS t(tbl, from_name, to_name)
+        LOOP
+          IF EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = r.from_name AND conrelid = r.tbl::regclass
+          ) THEN
+            EXECUTE format(
+              'ALTER TABLE %I RENAME CONSTRAINT %I TO %I',
+              r.tbl, r.from_name, r.to_name
+            );
+          END IF;
+        END LOOP;
+      END $$;
+    `);
+  }
+}

--- a/backend/src/modules/auth/entities/refresh-token.entity.ts
+++ b/backend/src/modules/auth/entities/refresh-token.entity.ts
@@ -13,6 +13,7 @@ import { User } from '../../users/entities/user.entity';
  * (forces a full re-login on every device).
  */
 @Entity('refresh_tokens')
+@Index('IDX_refresh_tokens_userId', ['user'])
 export class RefreshToken extends BaseEntity {
   @ManyToOne(() => User, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'userId' })

--- a/backend/src/modules/media/entities/media.entity.ts
+++ b/backend/src/modules/media/entities/media.entity.ts
@@ -29,6 +29,7 @@ import { MediaCrew } from './media-crew.entity';
 @Entity('media')
 @Index('idx_media_search_vector', { synchronize: false })
 @Index('UQ_media_type_tmdbId', ['type', 'tmdbId'], { unique: true })
+@Index('IDX_media_addedById', ['addedBy'])
 export class Media extends BaseEntity {
   @Column()
   title: string;
@@ -43,7 +44,7 @@ export class Media extends BaseEntity {
    * France" — still matches if the localised form is in this list.
    * Empty array when the provider returns no aliases.
    */
-  @Column({ type: 'jsonb', default: () => "'[]'::jsonb" })
+  @Column({ type: 'jsonb', default: () => "'[]'" })
   alternativeTitles: string[];
 
   @Column({ nullable: true })

--- a/backend/src/modules/playlists/entities/playlist-item.entity.ts
+++ b/backend/src/modules/playlists/entities/playlist-item.entity.ts
@@ -25,14 +25,19 @@ import { User } from '../../users/entities/user.entity';
 // `synchronize` matches prod — a plain @Unique can't express the NULL split.
 @Index('UQ_playlist_items_movie', ['playlist', 'media'], {
   unique: true,
-  where: '"episodeId" IS NULL',
+  where: '("episodeId" IS NULL)',
 })
 @Index('UQ_playlist_items_episode', ['playlist', 'episode'], {
   unique: true,
-  where: '"episodeId" IS NOT NULL',
+  where: '("episodeId" IS NOT NULL)',
 })
+@Index('IDX_playlist_items_playlist_position', ['playlist', 'position'])
+@Index('IDX_playlist_items_mediaId', ['media'])
+@Index('IDX_playlist_items_episodeId', ['episode'])
+@Index('IDX_playlist_items_addedById', ['addedBy'])
 export class PlaylistItem extends BaseEntity {
   @ManyToOne(() => Playlist, (playlist) => playlist.items, {
+    nullable: false,
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'playlistId' })
@@ -42,7 +47,7 @@ export class PlaylistItem extends BaseEntity {
   playlistId: number;
 
   /** The movie, or the parent series when this item is an episode. */
-  @ManyToOne(() => Media, { onDelete: 'CASCADE' })
+  @ManyToOne(() => Media, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'mediaId' })
   media: Media;
 

--- a/backend/src/modules/playlists/entities/playlist-save.entity.ts
+++ b/backend/src/modules/playlists/entities/playlist-save.entity.ts
@@ -16,17 +16,17 @@ import { User } from '../../users/entities/user.entity';
  * it in the saver's own playlist list. One row per (user, playlist).
  */
 @Entity('playlist_saves')
-@Unique(['user', 'playlist'])
-@Index(['user'])
+@Unique('UQ_playlist_saves_pair', ['user', 'playlist'])
+@Index('IDX_playlist_saves_user', ['user'])
 export class PlaylistSave extends BaseEntity {
-  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @ManyToOne(() => User, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'userId' })
   user: User;
 
   @RelationId((s: PlaylistSave) => s.user)
   userId: number;
 
-  @ManyToOne(() => Playlist, { onDelete: 'CASCADE' })
+  @ManyToOne(() => Playlist, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'playlistId' })
   playlist: Playlist;
 

--- a/backend/src/modules/playlists/entities/playlist-share.entity.ts
+++ b/backend/src/modules/playlists/entities/playlist-share.entity.ts
@@ -5,6 +5,7 @@ import {
   JoinColumn,
   RelationId,
   Unique,
+  Index,
 } from 'typeorm';
 import { BaseEntity } from '../../../common/entities/base.entity';
 import { Playlist } from './playlist.entity';
@@ -17,16 +18,18 @@ import { PlaylistShareRole } from '../../../common/enums';
  * "owner can never be removed" rule structural.
  */
 @Entity('playlist_shares')
-@Unique(['playlist', 'user'])
+@Unique('UQ_playlist_shares_playlist_user', ['playlist', 'user'])
+@Index('IDX_playlist_shares_playlistId', ['playlist'])
+@Index('IDX_playlist_shares_userId', ['user'])
 export class PlaylistShare extends BaseEntity {
-  @ManyToOne(() => Playlist, { onDelete: 'CASCADE' })
+  @ManyToOne(() => Playlist, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'playlistId' })
   playlist: Playlist;
 
   @RelationId((s: PlaylistShare) => s.playlist)
   playlistId: number;
 
-  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @ManyToOne(() => User, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'userId' })
   user: User;
 

--- a/backend/src/modules/playlists/entities/playlist.entity.ts
+++ b/backend/src/modules/playlists/entities/playlist.entity.ts
@@ -5,6 +5,7 @@ import {
   OneToMany,
   JoinColumn,
   RelationId,
+  Index,
 } from 'typeorm';
 import { BaseEntity } from '../../../common/entities/base.entity';
 import { PlaylistVisibility } from '../../../common/enums';
@@ -17,11 +18,12 @@ import { PlaylistItem } from './playlist-item.entity';
  * Access for other users is granted per-user through {@link PlaylistShare}.
  */
 @Entity('playlists')
+@Index('IDX_playlists_ownerId', ['owner'])
 export class Playlist extends BaseEntity {
   @Column({ type: 'varchar', length: 255 })
   name: string;
 
-  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @ManyToOne(() => User, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'ownerId' })
   owner: User;
 

--- a/backend/src/modules/social/entities/content-recommendation.entity.ts
+++ b/backend/src/modules/social/entities/content-recommendation.entity.ts
@@ -20,16 +20,16 @@ import { Episode } from '../../media/entities/episode.entity';
  * library sections without deleting the row.
  */
 @Entity('content_recommendations')
-@Index(['recipient'])
+@Index('IDX_content_recommendations_recipient', ['recipient'])
 export class ContentRecommendation extends BaseEntity {
-  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @ManyToOne(() => User, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'senderId' })
   sender: User;
 
   @RelationId((r: ContentRecommendation) => r.sender)
   senderId: number;
 
-  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @ManyToOne(() => User, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'recipientId' })
   recipient: User;
 
@@ -37,7 +37,7 @@ export class ContentRecommendation extends BaseEntity {
   recipientId: number;
 
   /** The movie, or the parent series for a season/episode recommendation. */
-  @ManyToOne(() => Media, { onDelete: 'CASCADE' })
+  @ManyToOne(() => Media, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'mediaId' })
   media: Media;
 

--- a/backend/src/modules/social/entities/like.entity.ts
+++ b/backend/src/modules/social/entities/like.entity.ts
@@ -17,23 +17,23 @@ import { Episode } from '../../media/entities/episode.entity';
  * parent title, so likes stay scoped to a library.
  */
 @Entity('likes')
-@Index(['user'])
+@Index('IDX_likes_user', ['user'])
 // One like per granularity (movie/series, season, episode). Declared here so dev
 // `synchronize` matches the migration — a plain @Unique can't express the NULL split.
 @Index('UQ_likes_movie', ['user', 'media'], {
   unique: true,
-  where: '"seasonId" IS NULL AND "episodeId" IS NULL',
+  where: '(("seasonId" IS NULL) AND ("episodeId" IS NULL))',
 })
 @Index('UQ_likes_season', ['user', 'season'], {
   unique: true,
-  where: '"seasonId" IS NOT NULL',
+  where: '("seasonId" IS NOT NULL)',
 })
 @Index('UQ_likes_episode', ['user', 'episode'], {
   unique: true,
-  where: '"episodeId" IS NOT NULL',
+  where: '("episodeId" IS NOT NULL)',
 })
 export class Like extends BaseEntity {
-  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @ManyToOne(() => User, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'userId' })
   user: User;
 
@@ -41,7 +41,7 @@ export class Like extends BaseEntity {
   userId: number;
 
   /** The movie, or the parent series for a season/episode like. */
-  @ManyToOne(() => Media, { onDelete: 'CASCADE' })
+  @ManyToOne(() => Media, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'mediaId' })
   media: Media;
 

--- a/backend/src/modules/social/entities/user-follow.entity.ts
+++ b/backend/src/modules/social/entities/user-follow.entity.ts
@@ -18,18 +18,18 @@ import { FollowStatus } from '../../../common/enums';
  * {@link PlaylistShare} join-entity shape.
  */
 @Entity('user_follows')
-@Unique(['follower', 'following'])
-@Index(['follower'])
-@Index(['following'])
+@Unique('UQ_user_follows_pair', ['follower', 'following'])
+@Index('IDX_user_follows_follower', ['follower'])
+@Index('IDX_user_follows_following', ['following'])
 export class UserFollow extends BaseEntity {
-  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @ManyToOne(() => User, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'followerId' })
   follower: User;
 
   @RelationId((f: UserFollow) => f.follower)
   followerId: number;
 
-  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @ManyToOne(() => User, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'followingId' })
   following: User;
 


### PR DESCRIPTION
Closes #1057, both halves. The issue proposed option 1 (warn only) with 2 or 3 to follow; the drift
turned out to be clearable in the same pass, so the check ends up **enforced**.

## 1. The check could never fail

TypeORM prefixes the name it is handed with a timestamp, so `-f src/migrations/__ci_drift_check.ts`
named a path that is never written. Reproduced against a database built from the committed
migrations:

```
Migration /src/backend/src/migrations/1787841737343-__ci_drift_check.ts has been generated successfully.
=== the old test:   AUCUN DRIFT   ← what CI concluded
=== files written:  1787841737343-__ci_drift_check.ts
```

The step now globs the suffix, deletes the generated file (a leftover is executed as a real migration
by the next `migration:run` — harmless in dev where `migrationsRun: !isDev`, not in prod), and
**fails when the command never compared anything**: the CLI also exits non-zero on no-diff, so a run
with no file *and* no "No changes in database schema were found" means the check verified nothing.
That branch fired for real during this work, when a bad probe made `migration:generate` throw.

The job also now triggers on its own workflow file — otherwise a PR editing the check cannot run it.

## 2. Clearing the drift: 96 statements → 0

| Category | Before | Fix |
|---|--:|---|
| Foreign keys named by hand vs derived | 46 | rename migration |
| Index drops / creates | 29 | `@Index('IDX_…', […])` on the entity |
| `NOT NULL` relaxations | 14 | `nullable: false` on the relation |
| Unique constraint names | 6 | `@Unique('UQ_…', […])` |
| jsonb default | 1 | `default: () => \"'[]'\"` |

Direction: **tighten the entities onto the schema**, not the reverse. The schema is the stricter of
the two and its indexes exist for a reason.

Correcting the issue's own second half — the drift was **not** naming-only. The generated `up()`
would have dropped 14 indexes without recreating them (`IDX_refresh_tokens_userId`,
`IDX_media_addedById`, `IDX_playlist_items_playlist_position`, …) and relaxed 14 FK columns from
`NOT NULL` to nullable. Running it, as option 2 suggested, would have degraded the schema.

Two TypeORM comparison quirks accounted for the rest: partial-index predicates must be written the
way Postgres normalises them (`'("episodeId" IS NOT NULL)'`, with the parentheses), and the jsonb
default matches as `'[]'` rather than `'[]'::jsonb`.

### The rename migration

23 foreign keys. No decorator can name a foreign key, so this part cannot live in an entity. Pairs
were matched on `(table, column list)` against a migrated database — 23 matched, 0 unmatched, none
hand-typed. A constraint rename is catalog-only: no table rewrite, no index rebuild, no row read.
Each rename is guarded on the old name existing, so a schema already carrying the derived name (dev
`synchronize`) is skipped.

## Verified

- `migration:generate` on a database rebuilt from the committed migrations: **CLEAN — no diff**
  (from 96 statements).
- Migration round-tripped `up → down → up`, re-run over a partially renamed schema, and re-run when
  already applied (`No migrations are pending`).
- `tsc` clean; **1689 tests / 150 suites pass**.
- Dev `synchronize` applied the tightened `NOT NULL` columns to the real dev dataset without error.
- Enforcement proven both ways: clean tree reports nothing, and an entity column added without a
  migration is caught (`ALTER TABLE "playlists" ADD "driftProbe" character varying`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)