### PR TITLE
perf(notifications): dispatch download.complete before the episode lookup

### DIFF
--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -1423,6 +1423,46 @@ describe('FliksHostImpl', () => {
         }),
       ).rejects.toThrow(/outside every configured ingest root/);
     });
+
+    it('dispatches download.complete before resolving the episode it does not carry', async () => {
+      const h = makeHarness();
+      h.pluginRegistrationRepo.findOne.mockResolvedValue({
+        ingestRoots: [tmpRoot],
+      });
+      h.mediaRepo.findOne.mockResolvedValue(makeMedia());
+      h.libraryIngestService.ingest.mockResolvedValue({
+        imported: [
+          {
+            file: { id: 55, relativePath: 'Show/S01E02.mkv', quality: '1080p' },
+            episodeId: 7,
+          },
+        ],
+        alreadyPresent: [],
+      });
+
+      const order: string[] = [];
+      h.notifications.dispatch.mockImplementation(() => {
+        order.push('dispatch');
+        return Promise.resolve();
+      });
+      h.episodeRepo.findOne.mockImplementation(() => {
+        order.push('episodeLookup');
+        return Promise.resolve({ episodeNumber: 2, season: { seasonNumber: 1 } });
+      });
+
+      const result = await h.host['library.ingest']({
+        idempotencyKey: 'k1',
+        mediaId: 1,
+        paths: [sourceFile],
+        transfer: 'copy',
+        sourceLabel: 'Release.Name',
+      });
+
+      expect(order).toEqual(['dispatch', 'episodeLookup']);
+      // The lookup still has to happen — the return value carries the numbers.
+      expect(result.seasonNumber).toBe(1);
+      expect(result.episodeNumber).toBe(2);
+    });
   });
 
   // ===========================================================================

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -807,19 +807,8 @@ export class FliksHostImpl implements PluginHostApi {
       quality: x.file.quality,
     }));
 
-    let seasonNumber: number | undefined;
-    let episodeNumber: number | undefined;
-    if (result.imported.length === 1 && result.imported[0].episodeId != null) {
-      const episode = await this.episodeRepo.findOne({
-        where: { id: result.imported[0].episodeId },
-        relations: ['season'],
-      });
-      if (episode) {
-        episodeNumber = episode.episodeNumber;
-        seasonNumber = episode.season?.seasonNumber;
-      }
-    }
-
+    // Dispatched before the episode lookup below: neither payload carries the
+    // season or episode number, so resolving them first only delays the alert.
     if (imported.length) {
       const media = await this.mediaRepo.findOne({ where: { id: p.mediaId } });
       if (media) {
@@ -832,6 +821,19 @@ export class FliksHostImpl implements PluginHostApi {
           title: media.title,
           path: media.path,
         });
+      }
+    }
+
+    let seasonNumber: number | undefined;
+    let episodeNumber: number | undefined;
+    if (result.imported.length === 1 && result.imported[0].episodeId != null) {
+      const episode = await this.episodeRepo.findOne({
+        where: { id: result.imported[0].episodeId },
+        relations: ['season'],
+      });
+      if (episode) {
+        episodeNumber = episode.episodeNumber;
+        seasonNumber = episode.season?.seasonNumber;
       }
     }
 


### PR DESCRIPTION
Closes #893.

## Still relevant, and cheaper to fix than when it was written

The drift the issue recorded is still in the tree, though the code moved: `processOne` and the
acquisition publisher are both gone (the download queue became a plugin), and the ordering now lives
in `FliksHostService.libraryIngest`.

```
history row update
  → episodeRepo.findOne({ relations: ['season'] })   ← 1 SELECT
  → mediaRepo.findOne()                              ← 1 SELECT
  → notifications.dispatch('download.complete', …)
```

Neither `download.complete` payload carries the season or episode number — only `libraryIngest`'s
return value does, and nothing between the lookup and the `return` reads it. So the lookup can simply
move below the dispatch.

The issue judged this not worth fixing because "restoring the exact old ordering would mean splitting
the fan-out back up across the caller and the publisher". That publisher no longer exists, so the
duplication it would have reintroduced is not on the table: the block is linear now and the fix is a
move, not a split.

`mediaRepo.findOne` stays ahead of the dispatch — the payload needs `media.title`.

## The other path was already fine

`publishOne` (`acquisition.imported`) receives the numbers on the event and does only the one
`findOne` its payload requires. Untouched.

## Test

Added to the existing `library.ingest` describe: records call order across mocked
`notifications.dispatch` and `episodeRepo.findOne` and asserts `['dispatch', 'episodeLookup']`, plus
that the return value still carries both numbers.

Checked it is not vacuous — with the two blocks swapped back to the pre-fix order the test fails with
`["episodeLookup", "dispatch"]`, then passes again once restored.

`tsc` clean, 1690 tests / 150 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)