### PR TITLE
test(requests): cover the acquisition announcement on both approval paths

### DIFF
--- a/backend/src/modules/requests/request-lifecycle.service.spec.ts
+++ b/backend/src/modules/requests/request-lifecycle.service.spec.ts
@@ -17,7 +17,6 @@ describe('RequestLifecycleService onMediaRemoved (kind-aware)', () => {
       {} as never,
       { subscribe: jest.fn() } as never,
       {} as never,
-      {} as never,
     );
   });
 
@@ -70,5 +69,63 @@ describe('RequestLifecycleService onMediaRemoved (kind-aware)', () => {
     expect(first.status).toBe(RequestStatus.APPROVED);
     expect(duplicate.status).toBe(RequestStatus.APPROVED);
     expect(duplicate.media).toBeNull();
+  });
+});
+
+// The announcement is what makes an import satisfy a request: whoever owns acquisition acts on it
+// instead of waiting for its own tick. Nothing asserted it, and a lost announcement is silent —
+// the request flips to APPROVED and then sits there.
+describe('RequestLifecycleService onMediaImported — acquisition announcement', () => {
+  const media = { id: 91, tmdbId: 555, type: 'movie', qualityProfile: null, languageProfile: null };
+
+  function makeService(opts: { covers: boolean; open: unknown[] }) {
+    const requestRepo = {
+      find: jest.fn(async () => opts.open),
+      save: jest.fn(async (rows: unknown) => rows),
+    };
+    const events = { emitDomain: jest.fn(), subscribe: jest.fn() };
+    const service = new RequestLifecycleService(
+      requestRepo as never,
+      { applyMonitoredForRequestScope: jest.fn() } as never,
+      { envelopeCovers: jest.fn(async () => opts.covers) } as never,
+      events as never,
+      {} as never,
+    );
+    return { service, events, requestRepo };
+  }
+
+  const pending = () => ({
+    id: 1,
+    kind: RequestKind.ADD,
+    status: RequestStatus.PENDING,
+    seasons: null,
+  });
+
+  it('VERDICT: announces once the import adopted a request', async () => {
+    const { service, events } = makeService({ covers: true, open: [pending()] });
+
+    await service.onMediaImported(media as never, 3);
+
+    expect(events.emitDomain).toHaveBeenCalledWith({
+      type: 'media.acquisition.requested',
+      mediaIds: [91],
+      reason: 'media-imported',
+    });
+  });
+
+  it('says nothing when the imported profiles cover no open request', async () => {
+    const { service, events } = makeService({ covers: false, open: [pending()] });
+
+    await service.onMediaImported(media as never, 3);
+
+    expect(events.emitDomain).not.toHaveBeenCalled();
+  });
+
+  it('says nothing when there was no open request at all', async () => {
+    const { service, events } = makeService({ covers: true, open: [] });
+
+    await service.onMediaImported(media as never, 3);
+
+    expect(events.emitDomain).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/requests/request-lifecycle.service.ts
+++ b/backend/src/modules/requests/request-lifecycle.service.ts
@@ -17,7 +17,6 @@ import { onDiskEpisodeNumbers } from '../media/episode-coverage.util';
 import { ProfilesService } from '../profiles/profiles.service';
 import { EventsService } from '../scheduler/events.service';
 import { NotificationsService } from '../notifications/notifications.service';
-import { SettingsService } from '../settings/settings.service';
 import { User } from '../users/entities/user.entity';
 import {
   IN_FLIGHT_REQUEST_STATUSES,
@@ -65,18 +64,8 @@ export class RequestLifecycleService
     private readonly profiles: ProfilesService,
     private readonly events: EventsService,
     private readonly notifications: NotificationsService,
-    private readonly settings: SettingsService,
   ) {}
 
-  /**
-   * Whether an import driven by a request approval should kick off a
-   * targeted search immediately, or wait for the next scheduled
-   * SearchMissing tick. Default is "yes" — users expect the download
-   * to start right after the green check.
-   *
-   * Admin-toggleable from the General settings page; defaults to `true`
-   * (an unset key reads as enabled) to preserve behaviour on existing installs.
-   */
   onModuleInit(): void {
     // Files landing on disk is the canonical "request might be
     // available now" trigger. Subscribing here keeps the recompute

--- a/backend/src/modules/requests/requests.service.spec.ts
+++ b/backend/src/modules/requests/requests.service.spec.ts
@@ -43,7 +43,11 @@ describe('RequestsService delete requests', () => {
     findByTmdbId: jest.Mock;
     remove: jest.Mock;
     deleteMediaFolder: jest.Mock;
+    assertImportTarget: jest.Mock;
+    importFromTmdb: jest.Mock;
+    applyMonitoredForRequestScope: jest.Mock;
   };
+  let events: { emitDomain: jest.Mock };
   let casl: { createForUser: jest.Mock };
   let libraries: { getAccessibleLibraryIds: jest.Mock };
   let service: RequestsService;
@@ -54,16 +58,36 @@ describe('RequestsService delete requests', () => {
       findOne: jest.fn(),
       create: jest.fn((p: unknown) => p),
       save: jest.fn(async (r: any) => ({ id: r.id ?? 42, ...r })),
-      createQueryBuilder: jest.fn(),
+      // `approve` reads the row back through a builder before returning it.
+      createQueryBuilder: jest.fn(() => {
+        const qb: Record<string, unknown> = {};
+        for (const m of [
+          'leftJoin',
+          'addSelect',
+          'leftJoinAndMapOne',
+          'where',
+          'andWhere',
+          'orderBy',
+        ]) {
+          qb[m] = () => qb;
+        }
+        qb.getOne = () => Promise.resolve({ id: 7, user: null, approvedBy: null });
+        return qb;
+      }),
     };
     notifications = { dispatch: jest.fn().mockResolvedValue(undefined) };
     mediaService = {
       findByTmdbId: jest.fn(),
       remove: jest.fn(),
       deleteMediaFolder: jest.fn().mockResolvedValue(undefined),
+      assertImportTarget: jest.fn().mockResolvedValue(undefined),
+      importFromTmdb: jest.fn(),
+      applyMonitoredForRequestScope: jest.fn().mockResolvedValue(undefined),
     };
     casl = { createForUser: jest.fn(() => ({ can: () => true })) };
     libraries = { getAccessibleLibraryIds: jest.fn().mockResolvedValue([]) };
+
+    events = { emitDomain: jest.fn() };
 
     service = new RequestsService(
       requestRepo as never,
@@ -72,12 +96,11 @@ describe('RequestsService delete requests', () => {
       notifications as never,
       mediaService as never,
       {} as never,
-      {} as never,
       casl as never,
       {} as never,
       {} as never,
       libraries as never,
-      { emitDomain: jest.fn() } as never,
+      events as never,
     );
   });
 
@@ -290,6 +313,53 @@ describe('RequestsService delete requests', () => {
         'request.delete.declined',
         expect.objectContaining({ title: 'A Placeholder Title' }),
       );
+    });
+  });
+
+  // #886 gated the announcement behind `requests_auto_grab_on_approval` and #1015 removed both
+  // the key and the gate: core states the fact and the acquisition owner decides. Untested either
+  // way until now, and the failure is silent — an approval that announces nothing downloads
+  // nothing, with a green check to say it worked.
+  describe('approve (add) — acquisition announcement', () => {
+    const addRow = {
+      id: 7,
+      kind: RequestKind.ADD,
+      status: RequestStatus.PENDING,
+      mediaType: MediaType.MOVIE,
+      tmdbId: 555,
+      userId: 3,
+      libraryId: null,
+      qualityProfileId: null,
+      languageProfileId: null,
+      seasons: null,
+    };
+
+    const announcements = () =>
+      events.emitDomain.mock.calls
+        .map(([e]) => e as { type: string; mediaIds?: number[]; reason?: string })
+        .filter((e) => e.type === 'media.acquisition.requested');
+
+    it('VERDICT: announces the acquisition once the media is linked', async () => {
+      requestRepo.findOne.mockResolvedValue({ ...addRow });
+      mediaService.findByTmdbId.mockResolvedValue(null);
+      mediaService.importFromTmdb.mockResolvedValue({ id: 91 });
+
+      await service.approve(7, makeUser());
+
+      expect(announcements()).toEqual([
+        { type: 'media.acquisition.requested', mediaIds: [91], reason: 'request-approved' },
+      ]);
+    });
+
+    it('says nothing when the approval produced no media', async () => {
+      requestRepo.findOne.mockResolvedValue({ ...addRow });
+      mediaService.findByTmdbId.mockResolvedValue(null);
+      // The 409 branch: the title exists elsewhere, and no row comes back for it.
+      mediaService.importFromTmdb.mockRejectedValue({ status: 409 });
+
+      await service.approve(7, makeUser());
+
+      expect(announcements()).toEqual([]);
     });
   });
 });

--- a/backend/src/modules/requests/requests.service.ts
+++ b/backend/src/modules/requests/requests.service.ts
@@ -28,7 +28,6 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { MediaService } from '../media/media.service';
 import { Media } from '../media/entities/media.entity';
 import { ProfilesService } from '../profiles/profiles.service';
-import { SettingsService } from '../settings/settings.service';
 import { EventsService } from '../scheduler/events.service';
 import { CaslAbilityFactory } from '../auth/casl/casl-ability.factory';
 import { Action } from '../auth/casl/actions.enum';
@@ -64,7 +63,6 @@ export class RequestsService {
     private readonly notifications: NotificationsService,
     private readonly mediaService: MediaService,
     private readonly profilesService: ProfilesService,
-    private readonly settings: SettingsService,
     private readonly caslAbilityFactory: CaslAbilityFactory,
     private readonly imageService: ImageService,
     private readonly tmdb: TmdbProvider,


### PR DESCRIPTION
Closes #887 — partly by writing what it asked for, partly because the rest no longer applies.

## Two of the four asks are moot

The issue wanted assertions that `emitDomain` fires when `requests_auto_grab_on_approval` is unset
and stays quiet when it is `'false'`. That key and its gate were deleted by #1015 ("announce an
approved acquisition instead of deciding for its owner") — the same finding that closed #892. Core
now states the fact unconditionally and whichever plugin owns acquisition decides.

```
$ grep -rn "requests_auto_grab_on_approval" backend/src   → no match
```

## The other two are still worth having

The announcement itself was asserted nowhere. `requests.service.spec.ts` mocked `emitDomain` and
never looked at it; `request-lifecycle.service.spec.ts` did not construct it at all.

The failure mode survived #1015, inverted: a lost announcement no longer grabs something the
operator forbade — it fails to grab something they asked for, with the request flipped to APPROVED
and a green check to say it worked.

- **Admin path** (`requests.service.ts:818`): announces `[mediaId]` / `request-approved` once the
  media is linked; says nothing when the approval produced no media (the 409-with-no-existing-row
  branch).
- **Import-driven path** (`request-lifecycle.service.ts:177`): announces when the import adopted a
  request; says nothing when the imported profiles cover no open request, and nothing when there was
  no open request at all.

Checked **non-vacuous**: neutering both `emitDomain` calls fails exactly two tests, one per path.

The issue deferred this over harness size ("needs `ensureMediaForApprovedRequest` and its
dependencies mocked"). Post-#1015 it needs `importFromTmdb` and `assertImportTarget`, plus a
chainable stub for the builder `approve` closes with.

## Leftovers from #1015, in the same files

- `SettingsService` was injected into **both** request services with no reader anywhere — dead
  dependency.
- The docblock describing the deleted toggle ("Admin-toggleable from the General settings page")
  stayed attached to `onModuleInit`, which only wires event subscriptions.

## Verified

`tsc` clean, **1700 tests / 150 suites pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)