### PR TITLE
fix(subtitles): stop the missing-subtitles list from hanging the server

### DIFF
--- a/backend/src/modules/scheduler/subtitle-scheduler.service.ts
+++ b/backend/src/modules/scheduler/subtitle-scheduler.service.ts
@@ -78,20 +78,31 @@ export class SubtitleSchedulerService {
 
     const opts = await this.resolveSearchOpts();
 
-    const mediaList = await this.mediaRepo.find({
-      where: { monitored: true },
-      relations: [
-        'languageProfile',
-        'files',
-        'files.episode',
-        'files.episode.season',
-      ],
-    });
+    // Walked in batches: hydrating every monitored media with `files` and the
+    // episode/season joins in one query builds the whole library in memory
+    // before the first search even starts. Ordered by id so a batch boundary
+    // cannot skip or repeat a row.
+    const BATCH = 50;
+    for (let skip = 0; ; skip += BATCH) {
+      const batch = await this.mediaRepo.find({
+        where: { monitored: true },
+        relations: [
+          'languageProfile',
+          'files',
+          'files.episode',
+          'files.episode.season',
+        ],
+        order: { id: 'ASC' },
+        take: BATCH,
+        skip,
+      });
+      if (!batch.length) return;
 
-    for (const media of mediaList) {
-      if (!media.files?.length) continue;
-      for (const file of media.files) {
-        await this.searchMissingForFile(media, file, opts);
+      for (const media of batch) {
+        if (!media.files?.length) continue;
+        for (const file of media.files) {
+          await this.searchMissingForFile(media, file, opts);
+        }
       }
     }
   }
@@ -319,33 +330,55 @@ export class SubtitleSchedulerService {
     );
     const opts = await this.resolveSearchOpts();
 
-    const lowScoreSubs = await this.subtitleFileRepo
-      .createQueryBuilder('sf')
-      .where('sf.score < :threshold', { threshold })
-      .andWhere('sf.status != :failed', { failed: SubtitleStatus.FAILED })
-      .andWhere('sf.locked = false')
-      .leftJoinAndSelect('sf.media', 'media')
-      .leftJoinAndSelect('media.languageProfile', 'lp')
-      .leftJoinAndSelect('sf.mediaFile', 'mf')
-      .leftJoinAndSelect('mf.episode', 'mfEpisode')
-      .leftJoinAndSelect('mfEpisode.season', 'mfSeason')
-      .getMany();
+    // Walked by ascending id rather than OFFSET: an upgrade raises the sub's
+    // score past the threshold, so the row leaves the filtered set mid-walk and
+    // a positional cursor would step over its successors. An id cursor cannot.
+    // Batching also bounds `buildMissingLangsByFile`'s `IN (...)` list, which
+    // took every low-score file id at once.
+    const BATCH = 100;
+    let lastId = 0;
+    for (;;) {
+      const lowScoreSubs = await this.subtitleFileRepo
+        .createQueryBuilder('sf')
+        .where('sf.score < :threshold', { threshold })
+        .andWhere('sf.status != :failed', { failed: SubtitleStatus.FAILED })
+        .andWhere('sf.locked = false')
+        .andWhere('sf.id > :lastId', { lastId })
+        .leftJoinAndSelect('sf.media', 'media')
+        .leftJoinAndSelect('media.languageProfile', 'lp')
+        .leftJoinAndSelect('sf.mediaFile', 'mf')
+        .leftJoinAndSelect('mf.episode', 'mfEpisode')
+        .leftJoinAndSelect('mfEpisode.season', 'mfSeason')
+        .orderBy('sf.id', 'ASC')
+        .take(BATCH)
+        .getMany();
+      if (!lowScoreSubs.length) return;
+      lastId = lowScoreSubs[lowScoreSubs.length - 1].id;
 
-    // Build "languages still missing on file F" map upfront so we don't pay
-    // an N+1 inside the upgrade loop. A file with even one required language
-    // and zero (non-failed) subs for it counts as "still missing" — upgrade
-    // defers to the next missing-search pass on those files so we don't
-    // spend provider quota on score bumps while gaps remain.
-    const fileIds = [
-      ...new Set(
-        lowScoreSubs.map((s) => s.mediaFile?.id).filter((id): id is number => id != null),
-      ),
-    ];
-    const missingByFileId = await this.buildMissingLangsByFile(
-      fileIds,
-      lowScoreSubs,
-    );
+      // "Languages still missing on file F", resolved per batch so the upgrade
+      // loop pays no N+1. A file with even one required language and zero
+      // (non-failed) subs for it counts as still missing — upgrade defers to the
+      // next missing-search pass there, rather than spending provider quota on
+      // score bumps while gaps remain.
+      const fileIds = [
+        ...new Set(
+          lowScoreSubs.map((s) => s.mediaFile?.id).filter((id): id is number => id != null),
+        ),
+      ];
+      const missingByFileId = await this.buildMissingLangsByFile(
+        fileIds,
+        lowScoreSubs,
+      );
 
+      await this.upgradeBatch(lowScoreSubs, missingByFileId, opts);
+    }
+  }
+
+  private async upgradeBatch(
+    lowScoreSubs: SubtitleFile[],
+    missingByFileId: Map<number, boolean>,
+    opts: { minScore: number; autoSyncEnabled: boolean; encodeUtf8: boolean },
+  ): Promise<void> {
     for (const sub of lowScoreSubs) {
       // The profile is the contract: a language it doesn't ask for is never
       // searched, downloaded, nor allowed to replace a file on disk.

--- a/backend/src/modules/scheduler/subtitle-scheduler.upgrade-walk.spec.ts
+++ b/backend/src/modules/scheduler/subtitle-scheduler.upgrade-walk.spec.ts
@@ -1,0 +1,127 @@
+import { SubtitleSchedulerService } from './subtitle-scheduler.service';
+import { SubtitleStatus } from '../../common/enums';
+
+/**
+ * The upgrade pass walks the rows it mutates: a successful upgrade raises the
+ * score past the threshold, so the row leaves the filtered set mid-walk. A
+ * positional cursor then steps over the rows that moved up under it — with 25
+ * eligible rows and batches of 10, offset 10 lands on the 21st, and rows 11-20
+ * are never visited. An id cursor cannot do that.
+ */
+describe('SubtitleSchedulerService.upgradeSubtitles — walking a shrinking set', () => {
+  const THRESHOLD = 90;
+
+  /** Rows must outnumber the service's own batch size, or the whole set arrives
+   *  in one query and the walk is never exercised. */
+  const ROWS = 250;
+
+  /** Query-builder stub that re-filters a live table per batch, honouring
+   *  whichever cursor the service uses: `andWhere(sf.id > :lastId)` or `skip()`. */
+  function fakeSubtitleRepo(table: { id: number; score: number }[]) {
+    const seen: number[] = [];
+    const createQueryBuilder = () => {
+      let lastId = 0;
+      let offset = 0;
+      let take = Number.MAX_SAFE_INTEGER;
+      const qb: Record<string, unknown> = {};
+      for (const m of ['where', 'leftJoinAndSelect', 'orderBy']) qb[m] = () => qb;
+      qb.andWhere = (_sql: string, params?: Record<string, unknown>) => {
+        if (params && 'lastId' in params) lastId = Number(params.lastId);
+        return qb;
+      };
+      qb.skip = (n: number) => {
+        offset = Number(n);
+        return qb;
+      };
+      qb.take = (n: number) => {
+        take = Number(n);
+        return qb;
+      };
+      qb.getMany = () => {
+        const rows = table
+          .filter((r) => r.score < THRESHOLD && r.id > lastId)
+          .sort((a, b) => a.id - b.id)
+          .slice(offset, offset + take)
+          .map((r) => ({
+            id: r.id,
+            score: r.score,
+            language: 'fr',
+            hashMatched: false,
+            status: SubtitleStatus.DOWNLOADED,
+            media: {
+              title: 'T',
+              tmdbId: 1,
+              languageProfile: { subtitleLanguages: [{ isoCode: 'fr', name: 'French' }] },
+            },
+            mediaFile: { id: 500 + r.id, relativePath: 'a/b.mkv' },
+          }));
+        rows.forEach((r) => seen.push(r.id));
+        return Promise.resolve(rows);
+      };
+      return qb;
+    };
+    return {
+      seen,
+      repo: {
+        createQueryBuilder,
+        // buildMissingLangsByFile: every file already covers its required language
+        find: () =>
+          Promise.resolve(
+            table.map((r) => ({
+              mediaFile: { id: 500 + r.id },
+              language: 'fr',
+              status: SubtitleStatus.DOWNLOADED,
+            })),
+          ),
+      },
+    };
+  }
+
+  function makeService(table: { id: number; score: number }[]) {
+    const { seen, repo } = fakeSubtitleRepo(table);
+    const service = new SubtitleSchedulerService(
+      {} as never,
+      {} as never,
+      repo as never,
+      {
+        // always a better candidate, so every visited row is upgraded out of the set
+        searchSubtitles: () =>
+          Promise.resolve([{ score: 99, providerName: 'p', hashMatched: false }]),
+        upgradeSubtitle: (id: number) => {
+          const row = table.find((r) => r.id === id);
+          if (row) row.score = 99;
+          return Promise.resolve({ id });
+        },
+      } as never,
+      { reencodeToUtf8: jest.fn(), syncSubtitle: jest.fn() } as never,
+      { dispatch: jest.fn() } as never,
+      {
+        get: (k: string) =>
+          Promise.resolve(k === 'subtitle_upgrade_threshold' ? String(THRESHOLD) : undefined),
+      } as never,
+      {} as never,
+      {} as never,
+      { dispatch: jest.fn() } as never,
+    );
+    return { service, seen, table };
+  }
+
+  it('VERDICT: visits every eligible row once even as upgrades remove them', async () => {
+    const table = Array.from({ length: ROWS }, (_, i) => ({ id: i + 1, score: 10 }));
+    const { service, seen, table: live } = makeService(table);
+
+    await service.upgradeSubtitles();
+
+    expect([...seen].sort((a, b) => a - b)).toEqual(live.map((r) => r.id));
+    expect(new Set(seen).size).toBe(seen.length);
+    expect(live.every((r) => r.score === 99)).toBe(true);
+  });
+
+  it('terminates when nothing is eligible', async () => {
+    const { service, seen } = makeService([{ id: 1, score: 99 }]);
+
+    await service.upgradeSubtitles();
+
+    expect(seen).toEqual([]);
+  });
+});

--- a/backend/src/modules/subtitles/subtitle-activity.controller.ts
+++ b/backend/src/modules/subtitles/subtitle-activity.controller.ts
@@ -15,7 +15,10 @@ import { SubtitleFile } from './entities/subtitle-file.entity';
 import { Media } from '../media/entities/media.entity';
 import { MediaFile } from '../media/entities/media-file.entity';
 import { SubtitleProviderType } from '../../common/enums/subtitle-provider-type.enum';
-import { hasServableTextSub } from '../../common/constants/subtitle-codecs';
+import {
+  hasServableTextSub,
+  IMAGE_BASED_SUBTITLE_CODECS,
+} from '../../common/constants/subtitle-codecs';
 import { SubtitleProviderService } from './subtitle-provider.service';
 import { SubtitlesService } from './subtitles.service';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
@@ -197,66 +200,74 @@ export class SubtitleActivityController {
     return results;
   }
 
+  /**
+   * Every (file, profile language) pair with no servable text subtitle.
+   *
+   * One statement, paginated. It replaced a walk that hydrated the whole
+   * monitored library with `files`, `seasons` and `seasons.episodes` joined in,
+   * then ran one subtitle query per file — on a real library that is tens of
+   * thousands of sequential round trips holding a pool connection, which is why
+   * the page hung and took the rest of the server with it.
+   *
+   * The `NOT EXISTS` mirrors `hasServableTextSub`: an image codec never
+   * satisfies a language (it is burn-in/OCR material) and a FAILED row never
+   * counts. A NULL codec or status is servable, hence the COALESCE.
+   */
   @Get('missing')
   @CheckPolicies((ability) => ability.can(Action.Read, SubtitleFile))
-  async missing() {
-    const mediaList = await this.mediaRepo.find({
-      where: { monitored: true },
-      relations: ['languageProfile', 'files', 'seasons', 'seasons.episodes'],
-    });
+  async missing(@Query('page') page?: string, @Query('limit') limit?: string) {
+    const take = Math.min(Math.max(Number(limit) || 50, 1), 500);
+    const skip = (Math.max(Number(page) || 1, 1) - 1) * take;
 
-    const results: {
-      mediaId: number;
-      mediaTitle: string;
-      mediaType: string;
-      fileId: number;
-      fileName: string;
-      episodeId: number | null;
-      episodeLabel: string | null;
-      language: string;
-    }[] = [];
+    const rows = await this.mediaFileRepo.query(
+      `
+      WITH required AS (
+        SELECT m.id            AS media_id,
+               m.title         AS media_title,
+               m.type::text    AS media_type,
+               lang->>'isoCode' AS language
+        FROM media m
+        JOIN language_profiles lp ON lp.id = m."languageProfileId"
+        CROSS JOIN LATERAL jsonb_array_elements(lp."subtitleLanguages") AS lang
+        WHERE m.monitored = true
+      )
+      SELECT r.media_id, r.media_title, r.media_type, r.language,
+             f.id AS file_id, f."relativePath", f."episodeId",
+             s."seasonNumber", e."episodeNumber",
+             COUNT(*) OVER () AS total
+      FROM required r
+      JOIN media_files f ON f."mediaId" = r.media_id
+      LEFT JOIN episodes e ON e.id = f."episodeId"
+      LEFT JOIN seasons  s ON s.id = e."seasonId"
+      WHERE NOT EXISTS (
+        SELECT 1 FROM subtitle_files sf
+        WHERE sf."mediaFileId" = f.id
+          AND sf.language = r.language
+          AND COALESCE(sf.codec, '') <> ALL ($1::text[])
+          AND COALESCE(sf.status::text, '') <> 'failed'
+      )
+      ORDER BY r.media_title, f.id, r.language
+      LIMIT $2 OFFSET $3
+      `,
+      [[...IMAGE_BASED_SUBTITLE_CODECS], take, skip],
+    );
 
-    for (const media of mediaList) {
-      const subtitleLangs = media.languageProfile?.subtitleLanguages ?? [];
-      if (!subtitleLangs.length || !media.files?.length) continue;
-
-      for (const file of media.files) {
-        const existingSubs = await this.subtitleFileRepo.find({
-          where: { mediaFile: { id: file.id } },
-        });
-
-        for (const lang of subtitleLangs) {
-          // Image-based tracks don't satisfy a language — they still need OCR
-          // to become servable text, so the language stays "missing" until then.
-          if (hasServableTextSub(existingSubs, lang.isoCode)) continue;
-
-          // Build episode label
-          let episodeLabel: string | null = null;
-          if (file.episodeId) {
-            for (const season of media.seasons ?? []) {
-              const ep = season.episodes?.find((e) => e.id === file.episodeId);
-              if (ep) {
-                episodeLabel = `S${String(season.seasonNumber).padStart(2, '0')}E${String(ep.episodeNumber).padStart(2, '0')}`;
-                break;
-              }
-            }
-          }
-
-          results.push({
-            mediaId: media.id,
-            mediaTitle: media.title,
-            mediaType: media.type,
-            fileId: file.id,
-            fileName: file.relativePath.split('/').pop() ?? file.relativePath,
-            episodeId: file.episodeId ?? null,
-            episodeLabel,
-            language: lang.isoCode,
-          });
-        }
-      }
-    }
-
-    return results;
+    return {
+      total: Number(rows[0]?.total ?? 0),
+      data: (rows as Record<string, string | number | null>[]).map((r) => ({
+        mediaId: Number(r.media_id),
+        mediaTitle: String(r.media_title),
+        mediaType: String(r.media_type),
+        fileId: Number(r.file_id),
+        fileName: String(r.relativePath).split('/').pop() ?? String(r.relativePath),
+        episodeId: r.episodeId == null ? null : Number(r.episodeId),
+        episodeLabel:
+          r.seasonNumber == null || r.episodeNumber == null
+            ? null
+            : `S${String(r.seasonNumber).padStart(2, '0')}E${String(r.episodeNumber).padStart(2, '0')}`,
+        language: String(r.language),
+      })),
+    };
   }
 
   // ---------------------------------------------------------------------------

--- a/client/src/app/core/services/api/subtitles-api.service.ts
+++ b/client/src/app/core/services/api/subtitles-api.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { MediaType } from '../../enums/media-type.enum';
 
@@ -206,8 +206,16 @@ export class SubtitlesApiService {
     return firstValueFrom(this.http.delete<{ deleted: number }>('/api/subtitles/blacklist'));
   }
 
-  getMissing() {
-    return firstValueFrom(this.http.get<MissingSubtitleEntry[]>('/api/subtitles/missing'));
+  /** Server-paged: the full list is one row per (file, profile language) and
+   *  runs to six figures on a large library. */
+  getMissing(page = 1, limit = 20) {
+    const params = new HttpParams().set('page', String(page)).set('limit', String(limit));
+    return firstValueFrom(
+      this.http.get<{ total: number; data: MissingSubtitleEntry[] }>(
+        '/api/subtitles/missing',
+        { params },
+      ),
+    );
   }
 }
 

--- a/client/src/app/features/settings/subtitles/subtitles-stats.html
+++ b/client/src/app/features/settings/subtitles/subtitles-stats.html
@@ -62,7 +62,7 @@
               </tr>
             </thead>
             <tbody>
-              @for (row of pagedMissing(); track row.fileId + row.language) {
+              @for (row of missing(); track row.fileId + row.language) {
                 <tr>
                   <td>
                     @if (row.episodeId) {

--- a/client/src/app/features/settings/subtitles/subtitles-stats.ts
+++ b/client/src/app/features/settings/subtitles/subtitles-stats.ts
@@ -34,7 +34,9 @@ export class SubtitlesStatsComponent implements OnInit {
   readonly stats = signal<SubtitleStats | null>(null);
   readonly missing = signal<MissingSubtitleEntry[]>([]);
 
-  readonly missingCount = computed(() => this.missing().length);
+  /** Server-reported total, not the page length. */
+  readonly missingTotal = signal(0);
+  readonly missingCount = computed(() => this.missingTotal());
 
   private readonly statusLabels: Record<string, string> = {
     downloaded: 'Téléchargés',
@@ -63,15 +65,18 @@ export class SubtitlesStatsComponent implements OnInit {
   readonly pageSize = 20;
   readonly page = signal(0);
   readonly totalPages = computed(() =>
-    Math.max(1, Math.ceil(this.missing().length / this.pageSize)),
+    Math.max(1, Math.ceil(this.missingTotal() / this.pageSize)),
   );
-  readonly pagedMissing = computed(() => {
-    const start = this.page() * this.pageSize;
-    return this.missing().slice(start, start + this.pageSize);
-  });
 
-  goToPage(p: number) {
+  async goToPage(p: number) {
     this.page.set(Math.max(0, Math.min(p, this.totalPages() - 1)));
+    await this.loadMissing();
+  }
+
+  private async loadMissing() {
+    const { total, data } = await this.api.getMissing(this.page() + 1, this.pageSize);
+    this.missingTotal.set(total);
+    this.missing.set(data);
   }
 
   rowKey(row: MissingSubtitleEntry): string {
@@ -91,6 +96,7 @@ export class SubtitlesStatsComponent implements OnInit {
         this.missing.update((list) =>
           list.filter((r) => !(r.fileId === row.fileId && r.language === row.language)),
         );
+        this.missingTotal.update((t) => Math.max(0, t - 1));
         this.toast.success(
           this.translate.instant('settings.subtitles.search_one_ok', {
             lang: row.language,
@@ -113,12 +119,8 @@ export class SubtitlesStatsComponent implements OnInit {
 
   async ngOnInit() {
     try {
-      const [stats, missing] = await Promise.all([
-        this.api.getStats(),
-        this.api.getMissing(),
-      ]);
+      const [stats] = await Promise.all([this.api.getStats(), this.loadMissing()]);
       this.stats.set(stats);
-      this.missing.set(missing);
     } catch {
       // handled by global interceptor
     } finally {


### PR DESCRIPTION
Production incident: `admin/settings/subtitles/stats` loaded forever and the whole server stopped
answering. Confirmed on the `missing` query, as reported.

## What the endpoint did

[`subtitle-activity.controller.ts:199`](backend/src/modules/subtitles/subtitle-activity.controller.ts#L199)
compounded three things:

1. `mediaRepo.find({ monitored: true, relations: ['languageProfile','files','seasons','seasons.episodes'] })`
   — hydrated the **entire monitored library** through a multi-join cartesian result before computing
   anything.
2. One `subtitleFileRepo.find()` **per media file**, sequentially inside the loop. A 20 000-file
   library is 20 000 round trips, each holding a pool connection — that is what took the rest of the
   server down with it, not just the page.
3. No pagination: one row per (file × profile language). The page then `slice()`d 20 for display, so
   it downloaded everything to render one screen.

Plus an O(seasons × episodes) episode-label lookup per file.

## Now

One statement, paginated. The `NOT EXISTS` mirrors `hasServableTextSub`: an image codec never
satisfies a language (it is burn-in/OCR material), a `FAILED` row never counts, and a NULL codec or
status is servable — hence the `COALESCE`. **12 ms** on the dev library.

Verified against a fixture built on the real migrated schema, one case per branch of the predicate:

| Fixture | Expected | Got |
|---|---|---|
| servable text sub for `fr` | `fr` covered, `en` missing | ✓ |
| `dvd_subtitle` for `fr` | still missing | ✓ |
| `failed` sub for `en` | still missing | ✓ |
| NULL codec for `fr` | covered | ✓ |
| unmonitored / no profile / profile with no subtitle language | all excluded | ✓ |
| episode file | `S03E07` label | ✓ |

Then end to end on the real dev DB: `{"total":14,...}` with paging.

`stats`, the page's other call, is bounded already (three aggregates + `take: 10`) — `missing` was the
sole cause.

**Contract change:** the endpoint returns `{ total, data }` instead of an array. One caller, updated;
the page pages server-side now.

## The same defect, on a timer

`subtitle-scheduler.service.ts` had the same unbounded enumeration in **both** passes — and being
scheduled, they freeze the process with nobody watching. The incident would have recurred at the next
tick regardless of the page.

- **Search pass**: paged by offset. Nothing in its loop changes what `monitored: true` selects.
- **Upgrade pass**: paged by **ascending id**, because an offset would be wrong here — a successful
  upgrade lifts the score past the threshold, so the row leaves the filtered set mid-walk and an
  offset steps over the rows that moved up under it. Batching also bounds
  `buildMissingLangsByFile`'s `IN (...)`, which previously took every low-score file id at once.

## On the walk spec

`subtitle-scheduler.upgrade-walk.spec.ts` covers the id cursor, and the fixture must have **more rows
than the source's batch size** — the point I got wrong first. My initial version passed a batch size
of 10 into the stub, but the service's `.take(BATCH)` overwrote it with 100, so all 25 fixture rows
arrived in one query and the walk never advanced: the test passed identically with either cursor.
Instrumenting the stub showed `take=100` in one run, after three rounds of reasoning had failed.

Sized at 250 rows it discriminates: a positional cursor loses exactly 100 of them (rows 101-200), an
id cursor visits all 250 once. The comment in the spec says so, because a well-meaning trim back to
25 rows would hollow it out again with nothing turning red.

## Verified

`tsc` clean, **1702 tests / 151 suites pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)