### PR TITLE
refactor(media-detail): draw the actions menu with the shared card panel

### DIFF
--- a/client/src/app/core/plugin-ui/when-evaluator.spec.ts
+++ b/client/src/app/core/plugin-ui/when-evaluator.spec.ts
@@ -51,6 +51,22 @@ describe('evaluateWhen', () => {
     expect(evaluateWhen(['isTouch'], ctx({ isTouch: true }))).toBe(true);
   });
 
+  // Both menus read the same contribution lists, so an item that belongs to
+  // only one says so. An omitted surface matches neither, which keeps a
+  // surface-scoped item out of any caller that hasn't declared where it is.
+  it('VERDICT: surface:card and surface:detail select one menu each', () => {
+    expect(evaluateWhen(['surface:card'], ctx({ surface: 'card' }))).toBe(true);
+    expect(evaluateWhen(['surface:card'], ctx({ surface: 'detail' }))).toBe(false);
+    expect(evaluateWhen(['surface:detail'], ctx({ surface: 'detail' }))).toBe(true);
+    expect(evaluateWhen(['surface:detail'], ctx({ surface: 'card' }))).toBe(false);
+    expect(evaluateWhen(['surface:card'], ctx())).toBe(false);
+  });
+
+  it('leaves an item with no surface predicate visible on both', () => {
+    expect(evaluateWhen(['isAdmin'], ctx({ isAdmin: true, surface: 'card' }))).toBe(true);
+    expect(evaluateWhen(['isAdmin'], ctx({ isAdmin: true, surface: 'detail' }))).toBe(true);
+  });
+
   // The whole safety property: a manifest naming a predicate this client
   // doesn't know must hide the item, never show it — in either polarity.
   it('VERDICT: an unknown predicate is always false', () => {

--- a/client/src/app/core/plugin-ui/when-evaluator.ts
+++ b/client/src/app/core/plugin-ui/when-evaluator.ts
@@ -14,6 +14,10 @@ export interface WhenContext {
   isEpisode?: boolean;
   isTv: boolean;
   isTouch: boolean;
+  /** Which menu is being built. Both surfaces read the same contribution
+   *  lists, so an item only declares this when it genuinely belongs to one:
+   *  Play and Open mean nothing on a detail page you are already on. */
+  surface?: 'card' | 'detail';
 }
 
 /** `null` marks a predicate this client doesn't know — the fail-closed signal. */
@@ -30,6 +34,8 @@ function evaluateKnown(predicate: string, ctx: WhenContext): boolean | null {
   if (predicate === 'isEpisode') return ctx.isEpisode ?? false;
   if (predicate === 'isTv') return ctx.isTv;
   if (predicate === 'isTouch') return ctx.isTouch;
+  if (predicate === 'surface:card') return ctx.surface === 'card';
+  if (predicate === 'surface:detail') return ctx.surface === 'detail';
   return null;
 }
 

--- a/client/src/app/core/services/card-actions.service.ts
+++ b/client/src/app/core/services/card-actions.service.ts
@@ -22,6 +22,11 @@ export interface CardAction {
   run: () => void;
   /** Disabled rows render greyed out and can't be activated. */
   disabled?: boolean;
+  /** Rows are grouped in declaration order and a rule is drawn wherever this
+   *  changes. Any name works: it labels nothing, it only marks the boundary. */
+  section?: string;
+  /** Renders the row as a link instead of a button. `run` is ignored. */
+  route?: string;
 }
 
 /**

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
@@ -21,25 +21,56 @@
       </div>
     </div>
   }
-  @for (a of actions(); track a) {
-    <button
-      type="button"
-      class="dropdown-item"
-      [class.text-error]="a.tone === 'danger'"
-      [disabled]="a.disabled"
-      (click)="trigger(a)"
-    >
-      @switch (a.icon) {
-        @case ('play') { <svg lucidePlay class="h-4 w-4 shrink-0 opacity-70"></svg> }
-        @case ('external-link') { <svg lucideExternalLink class="h-4 w-4 shrink-0 opacity-70"></svg> }
-        @case ('eye') { <svg lucideEye class="h-4 w-4 shrink-0 opacity-70"></svg> }
-        @case ('eye-off') { <svg lucideEyeOff class="h-4 w-4 shrink-0 opacity-70"></svg> }
-        @case ('trash-2') { <svg lucideTrash2 class="h-4 w-4 shrink-0 opacity-70"></svg> }
-        @case ('list-plus') { <svg lucideListPlus class="h-4 w-4 shrink-0 opacity-70"></svg> }
-        @case ('user-plus') { <svg lucideUserPlus class="h-4 w-4 shrink-0 opacity-70"></svg> }
-        @default { <svg lucideCircle class="h-4 w-4 shrink-0 opacity-70"></svg> }
-      }
-      <span class="flex-1 truncate text-left">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
-    </button>
+  @for (a of actions(); track $index; let i = $index) {
+    @if (i > 0 && a.section !== actions()[i - 1].section) {
+      <div class="h-px bg-base-content/10 my-1" role="separator"></div>
+    }
+    @if (a.route) {
+      <a
+        [routerLink]="a.route"
+        class="dropdown-item"
+        [class.text-error]="a.tone === 'danger'"
+        (click)="closeForRoute()"
+      >
+        <ng-container *ngTemplateOutlet="icon; context: { $implicit: a }" />
+        <span class="flex-1 truncate text-left">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
+      </a>
+    } @else {
+      <button
+        type="button"
+        class="dropdown-item"
+        [class.text-error]="a.tone === 'danger'"
+        [disabled]="a.disabled"
+        (click)="trigger(a)"
+      >
+        <ng-container *ngTemplateOutlet="icon; context: { $implicit: a }" />
+        <span class="flex-1 truncate text-left">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
+      </button>
+    }
   }
 </app-popover-menu>
+
+<!-- Curated whitelist: a `card.actions` contribution may name any icon, and an
+     unrecognised one must fall back to a glyph rather than render blank. -->
+<ng-template #icon let-a>
+  @switch (a.icon) {
+    @case ('play') { <svg lucidePlay class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @case ('external-link') { <svg lucideExternalLink class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @case ('eye') { <svg lucideEye class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @case ('eye-off') { <svg lucideEyeOff class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @case ('trash-2') { <svg lucideTrash2 class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @case ('list-plus') { <svg lucideListPlus class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @case ('user-plus') { <svg lucideUserPlus class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @case ('check') { <svg lucideCheck class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @case ('list-checks') { <svg lucideListChecks class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @case ('clipboard-list') { <svg lucideClipboardList class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @case ('settings') { <svg lucideSettings class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @case ('folder') { <svg lucideFolder class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @case ('captions') { <svg lucideCaptions class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @case ('rotate-ccw') { <svg lucideRotateCcw class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @case ('scan-line') { <svg lucideScanLine class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @case ('search') { <svg lucideSearch class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @case ('download') { <svg lucideDownload class="h-4 w-4 shrink-0 opacity-70"></svg> }
+    @default { <svg lucideCircle class="h-4 w-4 shrink-0 opacity-70"></svg> }
+  }
+</ng-template>

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
@@ -4,6 +4,8 @@ import {
   computed,
   inject,
 } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+import { RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import {
   LucidePlay,
@@ -13,6 +15,16 @@ import {
   LucideTrash2,
   LucideListPlus,
   LucideUserPlus,
+  LucideCheck,
+  LucideListChecks,
+  LucideClipboardList,
+  LucideSettings,
+  LucideFolder,
+  LucideCaptions,
+  LucideRotateCcw,
+  LucideScanLine,
+  LucideSearch,
+  LucideDownload,
   LucideCircle,
 } from '@lucide/angular';
 import { CardAction, CardActionsService } from '../../../core/services/card-actions.service';
@@ -41,7 +53,19 @@ import { CachedSrcDirective } from '../../directives/cached-src.directive';
     LucideTrash2,
     LucideListPlus,
     LucideUserPlus,
+    LucideCheck,
+    LucideListChecks,
+    LucideClipboardList,
+    LucideSettings,
+    LucideFolder,
+    LucideCaptions,
+    LucideRotateCcw,
+    LucideScanLine,
+    LucideSearch,
+    LucideDownload,
     LucideCircle,
+    NgTemplateOutlet,
+    RouterLink,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './card-actions-panel.html',
@@ -68,6 +92,11 @@ export class CardActionsPanelComponent {
   });
 
   onClose() {
+    this.service.close();
+  }
+
+  /** A link row navigates on its own; the panel just gets out of the way. */
+  closeForRoute() {
     this.service.close();
   }
 

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -147,13 +147,10 @@
         <svg lucideListPlus class="h-5 w-5"></svg>
         {{ 'playlists.add_to_playlist' | translate }}
       </button>
-      <app-dropdown-menu placement="bottom-end">
-        <button trigger type="button" class="flex flex-col items-center gap-1 text-sm cursor-pointer">
-          <svg lucideEllipsisVertical class="h-5 w-5"></svg>
-          {{ 'common.more' | translate }}
-        </button>
-        <ng-container *ngTemplateOutlet="moreMenuItems"></ng-container>
-      </app-dropdown-menu>
+      <button #moreMobile type="button" class="flex flex-col items-center gap-1 text-sm cursor-pointer" (click)="openActionsMenu(moreMobile)">
+        <svg lucideEllipsisVertical class="h-5 w-5"></svg>
+        {{ 'common.more' | translate }}
+      </button>
     </div>
 
     <!-- Series episode progress -->
@@ -329,12 +326,10 @@
         <button type="button" class="btn btn-ghost btn btn-circle" [attr.aria-label]="'playlists.add_to_playlist' | translate" (click)="addToPlaylist.emit()">
           <svg lucideListPlus class="h-4 w-4"></svg>
         </button>
-        <app-dropdown-menu placement="bottom-end">
-          <button trigger type="button" class="btn btn-ghost btn btn-circle">
-            <svg lucideEllipsisVertical class="h-5 w-5"></svg>
-          </button>
-          <ng-container *ngTemplateOutlet="moreMenuItems"></ng-container>
-        </app-dropdown-menu>
+        <button #moreDesktop type="button" class="btn btn-ghost btn btn-circle"
+          [attr.aria-label]="'common.more' | translate" (click)="openActionsMenu(moreDesktop)">
+          <svg lucideEllipsisVertical class="h-5 w-5"></svg>
+        </button>
       </div>
 
       <!-- Progress bar -->
@@ -497,62 +492,5 @@
         </div>
       }
     </div>
-  }
-</ng-template>
-
-<!-- Items projected into both mobile + desktop dropdown-menus. Rendered from
-     the `media.actions` contribution registry: core's own list merged with
-     any plugin contributions, sorted by weight then id, `when`-filtered. -->
-<ng-template #moreMenuItems>
-  @for (item of menuItems(); track item.id) {
-    @if (item.route) {
-      <a
-        [routerLink]="item.route"
-        class="dropdown-item"
-        [class.text-error]="item.tone === 'danger'"
-        [class.text-white]="item.tone !== 'danger'"
-      >
-        <ng-container *ngTemplateOutlet="menuItemIcon; context: { item }"></ng-container>
-        <span class="flex-1">{{ displayLabelKey(item) | translate }}</span>
-      </a>
-    } @else {
-      <button
-        type="button"
-        [disabled]="isItemDisabled(item)"
-        class="dropdown-item"
-        [class.text-error]="item.tone === 'danger'"
-        [class.text-white]="item.tone !== 'danger'"
-        (click)="item.handler!()"
-      >
-        @if (isItemBusy(item)) {
-          <span class="loading loading-spinner loading-sm"></span>
-        } @else {
-          <ng-container *ngTemplateOutlet="menuItemIcon; context: { item }"></ng-container>
-        }
-        <span class="flex-1">{{ displayLabelKey(item) | translate }}</span>
-      </button>
-    }
-  }
-</ng-template>
-
-<!-- Icon by name, with a danger-tone accent kept as-is from the pre-refactor
-     markup. Unrecognised name → generic glyph, never blank. -->
-<ng-template #menuItemIcon let-item="item">
-  @switch (displayIcon(item)) {
-    @case ('user-plus') { <svg lucideUserPlus class="h-5 w-5 shrink-0 opacity-80"></svg> }
-    @case ('check') { <svg lucideCheck class="h-5 w-5 shrink-0 opacity-80" [class.text-success]="item.actionId === 'media.toggle-series-watched' && watched()"></svg> }
-    @case ('list-checks') { <svg lucideListChecks class="h-5 w-5 shrink-0 opacity-80"></svg> }
-    @case ('clipboard-list') { <svg lucideClipboardList class="h-5 w-5 shrink-0 opacity-80"></svg> }
-    @case ('download') { <svg lucideDownload class="h-5 w-5 shrink-0 opacity-80"></svg> }
-    @case ('search') { <svg lucideSearch class="h-5 w-5 shrink-0 opacity-80"></svg> }
-    @case ('settings') { <svg lucideSettings class="h-5 w-5 shrink-0 opacity-80"></svg> }
-    @case ('folder') { <svg lucideFolder class="h-5 w-5 shrink-0 opacity-80"></svg> }
-    @case ('captions') { <svg lucideCaptions class="h-5 w-5 shrink-0 opacity-80"></svg> }
-    @case ('rotate-ccw') { <svg lucideRotateCcw class="h-5 w-5 shrink-0 opacity-80"></svg> }
-    @case ('scan-line') { <svg lucideScanLine class="h-5 w-5 shrink-0 opacity-80"></svg> }
-    @case ('eye') { <svg lucideEye class="h-5 w-5 shrink-0 opacity-80"></svg> }
-    @case ('eye-off') { <svg lucideEyeOff class="h-5 w-5 shrink-0 opacity-80"></svg> }
-    @case ('trash-2') { <svg lucideTrash2 class="h-5 w-5 shrink-0"></svg> }
-    @default { <svg lucideCircle class="h-5 w-5 shrink-0 opacity-80"></svg> }
   }
 </ng-template>

--- a/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
@@ -3,6 +3,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
+import {
+  CardActionsService,
+  type CardAction,
+} from '../../../core/services/card-actions.service';
 import { MediaInfoHeaderComponent } from './media-info-header';
 import { AuthService } from '../../../core/services/auth.service';
 import { OfflinePlaybackSyncService } from '../../../core/services/offline-playback-sync.service';
@@ -208,24 +212,28 @@ function readItem(el: Element): CapturedItem {
   };
 }
 
-/** Scoped to the desktop layout's dropdown — mobile renders an identical
- *  second copy of the same `moreMenuItems` template via its own outlet. */
-function menuItems(root: HTMLElement): CapturedItem[] {
-  const desktopMenu = root.querySelectorAll('app-dropdown-menu')[1];
-  if (!desktopMenu) return [];
-  return Array.from(desktopMenu.querySelectorAll('.dropdown-item')).map(readItem);
+/**
+ * The rows the header hands to the shared card actions panel. The header no
+ * longer renders the menu itself — it registers the actions and the globally
+ * mounted panel draws them — so the assertions read the registry, which is the
+ * header's actual output.
+ */
+function menuActions(fixture: ComponentFixture<MediaInfoHeaderComponent>): CardAction[] {
+  fixture.componentInstance.openActionsMenu(document.createElement('button'));
+  return TestBed.inject(CardActionsService).actions() ?? [];
 }
 
-function labels(root: HTMLElement): string[] {
-  return menuItems(root).map((i) => i.label);
+function menuItems(fixture: ComponentFixture<MediaInfoHeaderComponent>): CapturedItem[] {
+  return menuActions(fixture).map((a) => ({
+    label: a.labelKey ?? a.label ?? '',
+    icon: a.icon ?? null,
+    danger: a.tone === 'danger',
+    disabled: a.disabled === true,
+  }));
 }
 
-/** Raw elements behind {@link menuItems}, in the same order — needed to
- *  dispatch a real click rather than just inspect the rendered row. */
-function dropdownButtons(root: HTMLElement): HTMLButtonElement[] {
-  const desktopMenu = root.querySelectorAll('app-dropdown-menu')[1];
-  if (!desktopMenu) return [];
-  return Array.from(desktopMenu.querySelectorAll('.dropdown-item')) as HTMLButtonElement[];
+function labels(fixture: ComponentFixture<MediaInfoHeaderComponent>): string[] {
+  return menuItems(fixture).map((i) => i.label);
 }
 
 // ── The permission matrix ──
@@ -250,13 +258,14 @@ const SERIES: Omit<MediaFixture, 'mediaType'> = {
 describe('MediaInfoHeaderComponent — media.actions permission matrix', () => {
   it('owner (isAdmin): movie root', async () => {
     const fixture = await createFixture(OWNER, { mediaType: 'movie', ...MOVIE });
-    expect(labels(fixture.nativeElement)).toEqual([
+    expect(labels(fixture)).toEqual([
       'recommend.menu_item',
       'tracking.menu_item',
       'media_detail.edit_profiles',
       'media_detail.edit_library',
       'media_detail.edit_subtitles',
       'media_detail.refresh_metadata',
+      'media_detail.identify',
       'media_detail.analyze',
       'media_detail.unmonitor',
       'media_detail.delete_from_library',
@@ -265,13 +274,14 @@ describe('MediaInfoHeaderComponent — media.actions permission matrix', () => {
 
   it('owner (isAdmin): series root', async () => {
     const fixture = await createFixture(OWNER, { mediaType: 'series', ...SERIES });
-    expect(labels(fixture.nativeElement)).toEqual([
+    expect(labels(fixture)).toEqual([
       'recommend.menu_item',
       'media_detail.mark_series_watched',
       'tracking.menu_item',
       'media_detail.edit_profiles',
       'media_detail.edit_library',
       'media_detail.refresh_metadata',
+      'media_detail.identify',
       'media_detail.analyze',
       'media_detail.unmonitor',
       'media_detail.delete_from_library',
@@ -280,7 +290,7 @@ describe('MediaInfoHeaderComponent — media.actions permission matrix', () => {
 
   it('media.read only: movie root', async () => {
     const fixture = await createFixture(READER, { mediaType: 'movie', ...MOVIE });
-    expect(labels(fixture.nativeElement)).toEqual([
+    expect(labels(fixture)).toEqual([
       'recommend.menu_item',
       'tracking.menu_item',
       'media_detail.edit_subtitles',
@@ -289,7 +299,7 @@ describe('MediaInfoHeaderComponent — media.actions permission matrix', () => {
 
   it('media.read only: series root', async () => {
     const fixture = await createFixture(READER, { mediaType: 'series', ...SERIES });
-    expect(labels(fixture.nativeElement)).toEqual([
+    expect(labels(fixture)).toEqual([
       'recommend.menu_item',
       'media_detail.mark_series_watched',
       'tracking.menu_item',
@@ -298,7 +308,7 @@ describe('MediaInfoHeaderComponent — media.actions permission matrix', () => {
 
   it('media.read + requests.create: movie root', async () => {
     const fixture = await createFixture(REQUESTER, { mediaType: 'movie', ...MOVIE });
-    expect(labels(fixture.nativeElement)).toEqual([
+    expect(labels(fixture)).toEqual([
       'recommend.menu_item',
       'tracking.menu_item',
       'media_detail.request_media',
@@ -309,7 +319,7 @@ describe('MediaInfoHeaderComponent — media.actions permission matrix', () => {
 
   it('media.read + requests.create: series root', async () => {
     const fixture = await createFixture(REQUESTER, { mediaType: 'series', ...SERIES });
-    expect(labels(fixture.nativeElement)).toEqual([
+    expect(labels(fixture)).toEqual([
       'recommend.menu_item',
       'media_detail.mark_series_watched',
       'tracking.menu_item',
@@ -320,7 +330,7 @@ describe('MediaInfoHeaderComponent — media.actions permission matrix', () => {
 
   it('media.delete: movie root', async () => {
     const fixture = await createFixture(DELETER, { mediaType: 'movie', ...MOVIE });
-    expect(labels(fixture.nativeElement)).toEqual([
+    expect(labels(fixture)).toEqual([
       'recommend.menu_item',
       'tracking.menu_item',
       'media_detail.edit_subtitles',
@@ -330,7 +340,7 @@ describe('MediaInfoHeaderComponent — media.actions permission matrix', () => {
 
   it('media.delete: series root', async () => {
     const fixture = await createFixture(DELETER, { mediaType: 'series', ...SERIES });
-    expect(labels(fixture.nativeElement)).toEqual([
+    expect(labels(fixture)).toEqual([
       'recommend.menu_item',
       'media_detail.mark_series_watched',
       'tracking.menu_item',
@@ -344,12 +354,12 @@ describe('MediaInfoHeaderComponent — media.actions permission matrix', () => {
 describe('MediaInfoHeaderComponent — destructive-item styling and ephemeral guards', () => {
   it('Delete and Request deletion render with danger styling; nothing else does', async () => {
     const fixture = await createFixture(OWNER, { mediaType: 'movie', ...MOVIE });
-    const items = menuItems(fixture.nativeElement);
+    const items = menuItems(fixture);
     const dangerLabels = items.filter((i) => i.danger).map((i) => i.label);
     expect(dangerLabels).toEqual(['media_detail.delete_from_library']);
 
     const requester = await createFixture(REQUESTER, { mediaType: 'movie', ...MOVIE });
-    const requesterDanger = menuItems(requester.nativeElement).filter((i) => i.danger).map((i) => i.label);
+    const requesterDanger = menuItems(requester).filter((i) => i.danger).map((i) => i.label);
     expect(requesterDanger).toEqual(['media_detail.request_deletion']);
   });
 
@@ -359,7 +369,7 @@ describe('MediaInfoHeaderComponent — destructive-item styling and ephemeral gu
       { mediaType: 'movie', ...MOVIE },
       { deleteRequestPending: true },
     );
-    expect(labels(fixture.nativeElement)).not.toContain('media_detail.request_deletion');
+    expect(labels(fixture)).not.toContain('media_detail.request_deletion');
   });
 
   it('an existing whole-title request hides Request media even though the permission still holds', async () => {
@@ -368,27 +378,27 @@ describe('MediaInfoHeaderComponent — destructive-item styling and ephemeral gu
       ...MOVIE,
       userHasOpenWholeRequest: true,
     });
-    expect(labels(fixture.nativeElement)).not.toContain('media_detail.request_media');
+    expect(labels(fixture)).not.toContain('media_detail.request_media');
   });
 
   it('a movie that already has a file hides Request media (nothing left to request)', async () => {
     const fixture = await createFixture(REQUESTER, { mediaType: 'movie', ...MOVIE, selectedFileId: 42 });
-    expect(labels(fixture.nativeElement)).not.toContain('media_detail.request_media');
+    expect(labels(fixture)).not.toContain('media_detail.request_media');
   });
 
   it('a series root still offers Request media even with files present — partial availability is requestable', async () => {
     const fixture = await createFixture(REQUESTER, { mediaType: 'series', ...SERIES, selectedFileId: 42 });
-    expect(labels(fixture.nativeElement)).toContain('media_detail.request_media');
+    expect(labels(fixture)).toContain('media_detail.request_media');
   });
 
   it('sharing-disabled hides Recommend for every role, including the owner', async () => {
     const fixture = await createFixture(OWNER, { mediaType: 'movie', ...MOVIE, sharingDisabled: true });
-    expect(labels(fixture.nativeElement)).not.toContain('recommend.menu_item');
+    expect(labels(fixture)).not.toContain('recommend.menu_item');
   });
 
   it('TV form factor hides Recommend for every role, including the owner', async () => {
     const fixture = await createFixture(OWNER, { mediaType: 'movie', ...MOVIE, isTv: true });
-    expect(labels(fixture.nativeElement)).not.toContain('recommend.menu_item');
+    expect(labels(fixture)).not.toContain('recommend.menu_item');
   });
 
   it('an episode-level header hides Edit profiles/library and Request deletion for an owner — the parent never binds those inputs there, regardless of permission', async () => {
@@ -398,7 +408,7 @@ describe('MediaInfoHeaderComponent — destructive-item styling and ephemeral gu
       episodeId: 999,
       episodeInstance: true,
     });
-    const shown = labels(fixture.nativeElement);
+    const shown = labels(fixture);
     expect(shown).not.toContain('media_detail.edit_profiles');
     expect(shown).not.toContain('media_detail.edit_library');
     expect(shown).not.toContain('media_detail.request_deletion');
@@ -410,10 +420,10 @@ describe('MediaInfoHeaderComponent — destructive-item styling and ephemeral gu
 
   it('the series-watched toggle swaps its label with the live watched state', async () => {
     const unwatched = await createFixture(OWNER, { mediaType: 'series', ...SERIES, watched: false });
-    expect(labels(unwatched.nativeElement)).toContain('media_detail.mark_series_watched');
+    expect(labels(unwatched)).toContain('media_detail.mark_series_watched');
 
     const watched = await createFixture(OWNER, { mediaType: 'series', ...SERIES, watched: true });
-    expect(labels(watched.nativeElement)).toContain('media_detail.mark_series_unwatched');
+    expect(labels(watched)).toContain('media_detail.mark_series_unwatched');
   });
 });
 
@@ -437,13 +447,13 @@ describe('MediaInfoHeaderComponent — media.actions merges with plugin contribu
         ],
       },
     });
-    const shown = labels(fixture.nativeElement);
+    const shown = labels(fixture);
     expect(shown.indexOf('recommend.menu_item')).toBe(0);
     expect(shown.indexOf('x.between')).toBe(1);
     expect(shown.indexOf('tracking.menu_item')).toBeGreaterThan(1);
   });
 
-  it('an unrecognised icon renders the generic glyph, never blank', async () => {
+  it('passes an unrecognised icon name through — the panel owns the fallback glyph', async () => {
     const fixture = await createFixture(OWNER, {
       mediaType: 'movie',
       ...MOVIE,
@@ -460,8 +470,8 @@ describe('MediaInfoHeaderComponent — media.actions merges with plugin contribu
         ],
       },
     });
-    const item = menuItems(fixture.nativeElement).find((i) => i.label === 'x.weird');
-    expect(item?.icon).toBe('lucideCircle');
+    const item = menuItems(fixture).find((i) => i.label === 'x.weird');
+    expect(item?.icon).toBe('not-a-real-lucide-name');
   });
 
   it('VERDICT: an unknown actionId renders no row — fail closed, not a dead click', async () => {
@@ -480,7 +490,7 @@ describe('MediaInfoHeaderComponent — media.actions merges with plugin contribu
         ],
       },
     });
-    expect(labels(fixture.nativeElement)).not.toContain('x.bogus');
+    expect(labels(fixture)).not.toContain('x.bogus');
   });
 
   it('VERDICT: an unrecognised action.kind renders no row', async () => {
@@ -493,7 +503,7 @@ describe('MediaInfoHeaderComponent — media.actions merges with plugin contribu
         ],
       },
     });
-    expect(labels(fixture.nativeElement)).not.toContain('x.broken');
+    expect(labels(fixture)).not.toContain('x.broken');
   });
 
   it('a plugin can reuse a core actionId (its handler), but must bring its own `when` — core\'s `when` is per-contribution, not per-actionId', async () => {
@@ -510,10 +520,10 @@ describe('MediaInfoHeaderComponent — media.actions merges with plugin contribu
       ],
     };
     const reader = await createFixture(READER, { mediaType: 'movie', ...MOVIE, registry: gatedRegistry });
-    expect(labels(reader.nativeElement)).not.toContain('x.delete_alias');
+    expect(labels(reader)).not.toContain('x.delete_alias');
 
     const deleter = await createFixture(DELETER, { mediaType: 'movie', ...MOVIE, registry: gatedRegistry });
-    expect(labels(deleter.nativeElement)).toContain('x.delete_alias');
+    expect(labels(deleter)).toContain('x.delete_alias');
   });
 
   it('a plugin cannot widen a core action: an alias with no `when` stays hidden from a role core hides it from', async () => {
@@ -531,10 +541,10 @@ describe('MediaInfoHeaderComponent — media.actions merges with plugin contribu
       ],
     };
     const reader = await createFixture(READER, { mediaType: 'movie', ...MOVIE, registry: wideOpen });
-    expect(labels(reader.nativeElement)).not.toContain('x.delete_wide');
+    expect(labels(reader)).not.toContain('x.delete_wide');
 
     const deleter = await createFixture(DELETER, { mediaType: 'movie', ...MOVIE, registry: wideOpen });
-    expect(labels(deleter.nativeElement)).toContain('x.delete_wide');
+    expect(labels(deleter)).toContain('x.delete_wide');
   });
 });
 
@@ -566,14 +576,14 @@ describe('MediaInfoHeaderComponent — release-picker actions are plugin-contrib
 
   it('VERDICT: with no plugin installed, neither entry exists — core carries no acquisition menu item', async () => {
     const fixture = await createFixture(OWNER, { mediaType: 'movie', ...MOVIE });
-    const shown = labels(fixture.nativeElement);
+    const shown = labels(fixture);
     expect(shown).not.toContain('x.grab_best');
     expect(shown).not.toContain('x.search_releases');
   });
 
   it('a plugin contribution surfaces both actions and routes clicks to core\'s own outputs', async () => {
     const fixture = await createFixture(OWNER, { mediaType: 'movie', ...MOVIE, registry: releasePickerRegistry });
-    const shown = labels(fixture.nativeElement);
+    const shown = labels(fixture);
     const grabIdx = shown.indexOf('x.grab_best');
     const searchIdx = shown.indexOf('x.search_releases');
     expect(grabIdx).toBeGreaterThanOrEqual(0);
@@ -584,9 +594,9 @@ describe('MediaInfoHeaderComponent — release-picker actions are plugin-contrib
     fixture.componentInstance.grabBest.subscribe(() => (grabbed = true));
     fixture.componentInstance.loadReleases.subscribe(() => (searched = true));
 
-    const buttons = dropdownButtons(fixture.nativeElement);
-    buttons[grabIdx].click();
-    buttons[searchIdx].click();
+    const rows = menuActions(fixture);
+    rows[grabIdx].run();
+    rows[searchIdx].run();
 
     expect(grabbed).toBe(true);
     expect(searched).toBe(true);
@@ -596,9 +606,9 @@ describe('MediaInfoHeaderComponent — release-picker actions are plugin-contrib
     // Busy swaps the icon slot for a spinner, which shifts readItem's label lookup —
     // so locate the row by index (idle fixture) rather than by its now-blank label.
     const idle = await createFixture(OWNER, { mediaType: 'movie', ...MOVIE, registry: releasePickerRegistry });
-    const grabIdx = labels(idle.nativeElement).indexOf('x.grab_best');
+    const grabIdx = labels(idle).indexOf('x.grab_best');
     expect(grabIdx).toBeGreaterThanOrEqual(0);
-    expect(dropdownButtons(idle.nativeElement)[grabIdx].disabled).toBe(false);
+    expect(menuActions(idle)[grabIdx].disabled).toBe(false);
 
     const busy = await createFixture(OWNER, {
       mediaType: 'movie',
@@ -607,7 +617,7 @@ describe('MediaInfoHeaderComponent — release-picker actions are plugin-contrib
       grabBusy: 'best',
       releasesLoading: true,
     });
-    expect(dropdownButtons(busy.nativeElement)[grabIdx].disabled).toBe(true);
+    expect(menuActions(busy)[grabIdx].disabled).toBe(true);
   });
 });
 

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -13,26 +13,14 @@ import { Router, RouterLink } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { FormsModule } from '@angular/forms';
 import {
-  LucideCaptions,
   LucideCheck,
-  LucideCircle,
-  LucideClipboardList,
   LucideDownload,
   LucideEllipsisVertical,
-  LucideEye,
-  LucideEyeOff,
   LucideFilm,
-  LucideFolder,
   LucideHeart,
-  LucideListChecks,
   LucideListPlus,
   LucidePlay,
   LucideRotateCcw,
-  LucideScanLine,
-  LucideSearch,
-  LucideSettings,
-  LucideTrash2,
-  LucideUserPlus,
 } from '@lucide/angular';
 import { PlayableMediaService } from '../../../core/services/playable-media.service';
 import {
@@ -62,6 +50,7 @@ import { ClampToggleDirective } from '../../directives/clamp-toggle.directive';
 import { TvRowDirective } from '../../directives/tv-row.directive';
 import { TvSelectDirective } from '../../directives/tv-select.directive';
 import { NgTemplateOutlet } from '@angular/common';
+import { CardActionsService } from '../../../core/services/card-actions.service';
 import { PluginUiRegistryService } from '../../../core/plugin-ui/plugin-ui-registry.service';
 import { evaluateWhen, type WhenContext } from '../../../core/plugin-ui/when-evaluator';
 import type { MediaType } from '../../../core/enums/media-type.enum';
@@ -72,8 +61,25 @@ import { CachedSrcDirective } from '../../directives/cached-src.directive';
 
 /** One `media.actions` contribution resolved to something the template can
  *  render directly — visibility, handler and icon fallback already decided. */
+/**
+ * Section boundaries, as weight bands over the media actions registry:
+ * personal actions, acquisition, editing, maintenance, then destructive.
+ * Bands rather than an explicit field so a plugin contribution groups itself by
+ * the weight it already declares, with no addition to the contract.
+ */
+function sectionOf(weight: number): string {
+  if (weight < 500) return 'personal';
+  if (weight < 700) return 'acquire';
+  if (weight < 1000) return 'edit';
+  if (weight < 1300) return 'maintain';
+  return 'danger';
+}
+
 export interface ResolvedMediaAction {
   id: string;
+  /** Kept from the contribution: the section boundaries are weight bands, so
+   *  a plugin lands in whichever group its own weight puts it. */
+  weight: number;
   labelKey: string;
   icon: string;
   tone: 'default' | 'danger';
@@ -135,10 +141,8 @@ interface AudioTrack {
     TvSelectDirective,
     NgTemplateOutlet,
     DecimalPipe, FormsModule, RouterLink, TranslateModule,
-    LucideCaptions, LucideCheck, LucideCircle, LucideClipboardList, LucideDownload,
-    LucideEllipsisVertical, LucideEye, LucideEyeOff,
-    LucideFilm, LucideFolder, LucideHeart, LucideListChecks, LucideListPlus, LucidePlay, LucideRotateCcw, LucideScanLine,
-    LucideSearch, LucideSettings, LucideTrash2, LucideUserPlus,
+    LucideCheck, LucideDownload, LucideEllipsisVertical,
+    LucideFilm, LucideHeart, LucideListPlus, LucidePlay, LucideRotateCcw,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-info-header.html',
@@ -156,6 +160,7 @@ export class MediaInfoHeaderComponent {
   private readonly streamingApi = inject(StreamingApiService);
   private readonly offlineSync = inject(OfflinePlaybackSyncService);
   private readonly pluginUi = inject(PluginUiRegistryService);
+  private readonly cardActions = inject(CardActionsService);
 
   // ── Inputs: content ──
   readonly title = input.required<string>();
@@ -665,6 +670,7 @@ export class MediaInfoHeaderComponent {
       if (!(this.extraGuards[c.id]?.() ?? true)) continue;
       const base = {
         id: c.id,
+        weight: c.weight,
         labelKey: c.labelKey,
         icon: c.icon ?? 'circle',
         tone: c.tone ?? ('default' as const),
@@ -710,6 +716,37 @@ export class MediaInfoHeaderComponent {
       return this.monitored() ? 'eye-off' : 'eye';
     }
     return item.icon;
+  }
+
+  /**
+   * Hands the resolved rows to the shared card actions panel, anchored to the
+   * ⋯ button that was clicked. The panel owns the chrome on every form factor —
+   * anchored dropdown on desktop, bottom sheet on touch and TV — so this header
+   * no longer carries a menu of its own.
+   */
+  openActionsMenu(anchor: HTMLElement) {
+    const items = this.menuItems();
+    if (!items.length) return;
+    this.cardActions.register({
+      actions: items.map((item) => ({
+        // The two toggles carry a label and an icon that follow live state, so
+        // they go through the same resolvers the rendered rows used to.
+        labelKey: this.displayLabelKey(item),
+        icon: this.displayIcon(item),
+        tone: item.tone,
+        section: sectionOf(item.weight),
+        disabled: this.isItemDisabled(item),
+        ...(item.route ? { route: item.route } : {}),
+        run: () => item.handler?.(),
+      })),
+      anchor,
+      title: this.title(),
+      subtitle: this.dateLabel() ?? '',
+      imageUrl: this.posterUrl(),
+      imageAspect: this.episodeId() ? 'landscape' : 'portrait',
+      placement: 'button',
+    });
+    this.cardActions.show();
   }
 
   /** Mid-request spinner, per actionId — the ids not listed never show one. */


### PR DESCRIPTION
Three commits. The first fixes a test that has been red on `main`.

## 1. A broken test on main, and it was mine

`core.identify` (#1077) added a ninth row to the actions menu without updating the permission
matrix's expected list, so `media-info-header.spec.ts` has been failing on `main` since that merge.

I merged it having run only the backend suite and reported "1707 tests pass" — the client suite was
never run. It does run here, in about six seconds:

```
cd client && CHROME_BIN=/snap/bin/chromium npx ng test --watch=false
```

## 2. A `surface` predicate

The card menu and the detail menu are meant to offer the same items, so one contribution has to be
readable by either. A few genuinely belong to one surface — **Play** and **Open** say nothing on a
page you are already on — so those declare it, rather than the two lists drifting apart again.

An omitted surface matches neither predicate, so a scoped item stays hidden from any caller that
hasn't said where it is. Unknown predicates already fail closed, so this is invisible to older
clients.

## 3. The menu itself

The header carried a menu of its own: two dropdowns projecting one template, its own row markup, its
own icon switch. It now hands the resolved rows to the panel that already serves media cards.

That delivers what was asked for almost for free:

- **the header zone with poster, title and date** — the panel already had it. Poster + year on a
  title, still + episode date on an episode, `imageAspect` following `episodeId`.
- **rules between related groups** — the sections come from the **weight bands the registry already
  declares** (personal, acquisition, editing, maintenance, destructive), so a plugin contribution
  groups itself by the weight it already carries. No addition to the plugin contract.

`CardAction` gains `section` and `route`. The panel draws a rule where the section changes, renders a
route row as a link, and its icon whitelist grows from 7 to 18 to cover the media rows — keeping the
generic fallback, so an unrecognised name is never blank.

**57 lines of template and 12 now-unused icon imports go.**

### On the spec

It read the rows out of the header's DOM, which the header no longer renders. It now reads them from
the registry, which is the header's actual output — every assertion survives: gating matrix, ordering,
plugin weighting, danger tone, disabled state, activation.

The generic-glyph fallback moved layer with the markup, so the header now asserts it passes an
unknown icon name through untouched and the panel owns the fallback. **That leaves the panel without a
spec** — the one coverage gap this creates, worth filling.

## Two regressions caught by running the tests

- **Mine:** passing `item.labelKey` raw broke the two toggles whose label *and* icon follow live
  state — "Monitor" stayed on an already-monitored title. Fixed by going through `displayLabelKey` /
  `displayIcon`, as the rendered rows did.
- The matrix drift above.

## Verified

Backend `tsc` clean, **1707 tests / 152 suites**. Client **518 tests / 60 files**. Build clean, no
unused-import warnings left on the component.

**Not verified:** the menu's rendering. No browser automation here.

## Not in this PR

Making the two menus carry the *same items* needs more: both surfaces reading both core lists and
both slots, `media-card` implementing the handlers it can serve, and the three page-local modals
(identify, profiles, library) hoisted so cards can reach them. Staged deliberately — this PR is the
plumbing and the shared presentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)