### PR TITLE
fix(media-menu): stop doubling Download and Edit subtitles on an episode

### DIFF
--- a/client/src/app/shared/components/media-info-header/core-media-actions.ts
+++ b/client/src/app/shared/components/media-info-header/core-media-actions.ts
@@ -43,12 +43,14 @@ export const CORE_MEDIA_ACTIONS: readonly UiContribution[] = [
     action: { kind: 'action', actionId: 'media.download' },
   },
   {
+    // A card reports an episode as `series` + `isEpisode`; the detail header
+    // reports it as `movie`, so this twin covers the card surface only.
     id: 'core.download_episode',
     slot: 'media.actions',
     weight: 140,
     labelKey: 'downloads.download',
     icon: 'download',
-    when: ['!isTv', 'isEpisode'],
+    when: ['!isTv', 'isEpisode', 'surface:card'],
     action: { kind: 'action', actionId: 'media.download' },
   },
   // ── Rows a card owns ────────────────────────────────────────────────────
@@ -241,15 +243,6 @@ export const CORE_MEDIA_ACTIONS: readonly UiContribution[] = [
     labelKey: 'media_detail.edit_subtitles',
     icon: 'captions',
     when: ['mediaType:movie', 'surface:detail'],
-    action: { kind: 'action', actionId: 'media.edit-subtitles' },
-  },
-  {
-    id: 'core.edit_subtitles_episode',
-    slot: 'media.actions',
-    weight: 700,
-    labelKey: 'media_detail.edit_subtitles',
-    icon: 'captions',
-    when: ['isEpisode', 'surface:detail'],
     action: { kind: 'action', actionId: 'media.edit-subtitles' },
   },
   {

--- a/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
@@ -449,6 +449,18 @@ describe('MediaInfoHeaderComponent — destructive-item styling and ephemeral gu
     expect(shown).toContain('media_detail.delete_from_library');
   });
 
+  it('an episode-level header lists Download and Edit subtitles once, not twice', async () => {
+    const fixture = await createFixture(OWNER, {
+      mediaType: 'movie',
+      ...MOVIE,
+      episodeId: 999,
+      episodeInstance: true,
+    });
+    const shown = labels(fixture);
+    expect(shown.filter((l) => l === 'downloads.download').length).toBe(1);
+    expect(shown.filter((l) => l === 'media_detail.edit_subtitles').length).toBe(1);
+  });
+
   it('the series-watched toggle swaps its label with the live watched state', async () => {
     const unwatched = await createFixture(OWNER, { mediaType: 'series', ...SERIES, watched: false });
     expect(labels(unwatched)).toContain('media_detail.mark_series_watched');


### PR DESCRIPTION
## Problem

On an episode detail page the kebab menu shows **Télécharger** twice and **Modifier les sous-titres** twice.

An episode reaches the two menu surfaces under two different identities:

| | `mediaType` | `isEpisode` | `surface` |
|---|---|---|---|
| episode **card** (`media-card.ts`) | `series` | `true` | `card` |
| episode **detail header** (`media-info-header.ts`) | `movie` (the input default — the detail page never binds it in episode mode) | `true` | `detail` |

`core.download_episode` (`['!isTv', 'isEpisode']`) and `core.edit_subtitles_episode` (`['isEpisode', 'surface:detail']`) exist to cover the card identity, where `mediaType:movie` cannot match. But on the detail header both identities hold at once — `mediaType` *is* `movie` there and `isEpisode` is true — so the movie row and its episode twin both pass and the row renders twice.

## Change

- `core.download_episode` gains `surface:card`, the only surface where the movie row cannot already match.
- `core.edit_subtitles_episode` is deleted: it was gated `surface:detail`, and on that surface `core.edit_subtitles` already covers an episode.

Behaviour per case, after the change — each is exactly one row: movie detail and movie card via `core.download` / `core.edit_subtitles`; episode card via the download twin (subtitles stays detail-only, as before); episode detail via the movie rows; a series with no episode shows neither, as before.

Binding the real `m.type` on the episode header was the other candidate, and it is the wrong one — the component treats `mediaType` as the *displayed item's* type throughout its template (`mediaType() === 'movie' || episodeId()` appears in seven places, and `mediaType() === 'series' && episodeStats()` gates the season blocks). Changing it there would move far more than this menu.

## Test

New case in `media-info-header.spec.ts` asserting an episode-level header lists each label once. Verified it fails on the old gate (`expected 2 to be 1`) and passes on the new one; full client suite green (519 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)