### PR TITLE
fix(identify): make re-identification work on a TVDB library

### DIFF
--- a/backend/src/modules/media/dto/identify-media.dto.ts
+++ b/backend/src/modules/media/dto/identify-media.dto.ts
@@ -1,8 +1,8 @@
 import { IsInt, IsOptional, IsString, Min } from 'class-validator';
 import { Type } from 'class-transformer';
 
-/** At least one id is required; the service refuses an empty target. An omitted
- *  field leaves the media's current value alone. */
+/** At least one id is required; the service refuses an empty target. The ids
+ *  sent are the media's new identity — an omitted one is cleared, not kept. */
 export class IdentifyMediaDto {
   @IsOptional()
   @Type(() => Number)

--- a/backend/src/modules/media/media-service/media-metadata.identify.spec.ts
+++ b/backend/src/modules/media/media-service/media-metadata.identify.spec.ts
@@ -81,12 +81,24 @@ describe('MediaMetadataService.identify', () => {
     expect(updates).toEqual([]); // the ids were never written
   });
 
-  it('writes only the ids the caller supplied', async () => {
+  it('VERDICT: clears the ids the caller did not supply — they belong to the old work', async () => {
+    const { service, updates } = harness({
+      media: { ...movie, tvdbId: 4242, imdbId: 'tt-old' },
+    });
+
+    await service.identify(1, { tvdbId: 99 });
+
+    // Keeping tmdbId=10 would let `resolveProviderForMedia` fall back to the
+    // previous work the moment TVDB is unavailable.
+    expect(updates).toEqual([{ tmdbId: null, tvdbId: 99, imdbId: null }]);
+  });
+
+  it('writes the full identity when the caller supplies every id', async () => {
     const { service, updates } = harness({ media: movie });
 
-    await service.identify(1, { tmdbId: 77, imdbId: 'tt7' });
+    await service.identify(1, { tmdbId: 77, tvdbId: 88, imdbId: 'tt7' });
 
-    expect(updates).toEqual([{ tmdbId: 77, imdbId: 'tt7' }]);
+    expect(updates).toEqual([{ tmdbId: 77, tvdbId: 88, imdbId: 'tt7' }]);
   });
 
   it('leaves a movie alone past the refresh — no season work', async () => {

--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -28,6 +28,7 @@ import { ImageService } from '../../images/image.service';
 import { EventsService } from '../../scheduler/events.service';
 import { mapWithConcurrency } from '../../../common/utils/concurrency';
 import { buildMediaFieldsFromTmdb } from './tmdb-mapping.util';
+import type { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 
 @Injectable()
 export class MediaMetadataService {
@@ -83,7 +84,8 @@ export class MediaMetadataService {
    */
   async identify(
     id: number,
-    // Identification only ever sets ids; an omitted field is left untouched.
+    // The supplied ids ARE the new identity: what the caller omits is cleared,
+    // never carried over from the work this media used to point at.
     target: {
       tmdbId?: number;
       tvdbId?: number;
@@ -115,14 +117,20 @@ export class MediaMetadataService {
 
     const before = `"${media.title}" tmdb=${media.tmdbId ?? '-'} tvdb=${media.tvdbId ?? '-'}`;
 
+    // Keeping an id the caller did not supply would leave this media pointing at
+    // the previous work on that provider, and `resolveProviderForMedia` falls
+    // back to whichever id is set — the old identity would silently return.
+    // Cross-referencing during the refresh below repopulates the rest.
+    // The cast clears the three ids: the columns are nullable, the entity types
+    // them as non-null.
     await this.mediaRepo.update(id, {
-      ...(target.tmdbId !== undefined ? { tmdbId: target.tmdbId } : {}),
-      ...(target.tvdbId !== undefined ? { tvdbId: target.tvdbId } : {}),
-      ...(target.imdbId !== undefined ? { imdbId: target.imdbId } : {}),
+      tmdbId: target.tmdbId ?? null,
+      tvdbId: target.tvdbId ?? null,
+      imdbId: target.imdbId ?? null,
       ...(target.preferredProvider !== undefined
         ? { preferredProvider: target.preferredProvider }
         : {}),
-    });
+    } as QueryDeepPartialEntity<Media>);
 
     const refreshed = await this.refreshMetadata(id);
 

--- a/backend/src/modules/metadata-providers/metadata-providers.controller.ts
+++ b/backend/src/modules/metadata-providers/metadata-providers.controller.ts
@@ -31,11 +31,13 @@ export class MetadataProvidersController {
     @Query('q') q: string,
     @Query('year') year?: string,
     @Query('provider') providerName?: string,
+    @Query('mediaId') mediaId?: string,
   ) {
     const query = q?.trim();
     if (!query) return [];
-    const results = await this.searchWithFallback(providerName, (p) =>
-      p.searchMovie(query, year ? +year : undefined),
+    const results = await this.searchWithFallback(
+      providerName ?? (await this.providerPreferredFor(mediaId)),
+      (p) => p.searchMovie(query, year ? +year : undefined),
     );
     return this.enrichWithExisting(results, 'movie');
   }
@@ -45,11 +47,13 @@ export class MetadataProvidersController {
     @Query('q') q: string,
     @Query('year') year?: string,
     @Query('provider') providerName?: string,
+    @Query('mediaId') mediaId?: string,
   ) {
     const query = q?.trim();
     if (!query) return [];
-    const results = await this.searchWithFallback(providerName, (p) =>
-      p.searchTvShow(query, year ? +year : undefined),
+    const results = await this.searchWithFallback(
+      providerName ?? (await this.providerPreferredFor(mediaId)),
+      (p) => p.searchTvShow(query, year ? +year : undefined),
     );
     return this.enrichWithExisting(results, 'series');
   }
@@ -209,6 +213,26 @@ export class MetadataProvidersController {
       yearGte: yearGte ? parseInt(yearGte, 10) : undefined,
       yearLte: yearLte ? parseInt(yearLte, 10) : undefined,
     };
+  }
+
+  /**
+   * Re-identifying a media searches the provider that media is refreshed from,
+   * not the global default — same precedence as the metadata service: the
+   * media's own override, then its library's. Unknown media resolves to
+   * undefined, which `resolve` reads as "no preference".
+   */
+  private async providerPreferredFor(
+    mediaId?: string,
+  ): Promise<string | undefined> {
+    const id = mediaId ? parseInt(mediaId, 10) : NaN;
+    if (!Number.isInteger(id) || id < 1) return undefined;
+    const media = await this.mediaRepo.findOne({
+      where: { id },
+      relations: ['library'],
+    });
+    return (
+      media?.preferredProvider ?? media?.library?.preferredProvider ?? undefined
+    );
   }
 
   private async searchWithFallback(

--- a/backend/src/modules/metadata-providers/metadata-providers.search-provider.spec.ts
+++ b/backend/src/modules/metadata-providers/metadata-providers.search-provider.spec.ts
@@ -1,0 +1,70 @@
+import { MetadataProvidersController } from './metadata-providers.controller';
+
+/**
+ * Re-identifying a media searches the provider that media is refreshed from.
+ * Searching the global default instead returns works the library's provider has
+ * never heard of, and the ids on them cannot identify anything.
+ */
+describe('MetadataProvidersController — which provider a search uses', () => {
+  function harness(media: Record<string, unknown> | null) {
+    const searched: (string | undefined)[] = [];
+    const controller = Object.create(
+      MetadataProvidersController.prototype,
+    ) as MetadataProvidersController;
+    Object.assign(controller, {
+      mediaRepo: { findOne: jest.fn(() => Promise.resolve(media)) },
+      searchWithFallback: jest.fn((name?: string) => {
+        searched.push(name);
+        return Promise.resolve([]);
+      }),
+      enrichWithExisting: jest.fn((r: unknown[]) => Promise.resolve(r)),
+    });
+    return { controller, searched };
+  }
+
+  it("VERDICT: falls back to the library's provider when the media has no override", async () => {
+    const { controller, searched } = harness({
+      id: 795,
+      preferredProvider: null,
+      library: { preferredProvider: 'tvdb' },
+    });
+
+    await controller.searchTv('a series', undefined, undefined, '795');
+
+    expect(searched).toEqual(['tvdb']);
+  });
+
+  it("prefers the media's own override over its library's", async () => {
+    const { controller, searched } = harness({
+      id: 795,
+      preferredProvider: 'tmdb',
+      library: { preferredProvider: 'tvdb' },
+    });
+
+    await controller.searchTv('a series', undefined, undefined, '795');
+
+    expect(searched).toEqual(['tmdb']);
+  });
+
+  it('lets an explicit provider win over both', async () => {
+    const { controller, searched } = harness({
+      id: 795,
+      preferredProvider: 'tmdb',
+      library: { preferredProvider: 'tvdb' },
+    });
+
+    await controller.searchTv('a series', undefined, 'tvdb', '795');
+
+    expect(searched).toEqual(['tvdb']);
+  });
+
+  it('expresses no preference without a media id, or for one that is gone', async () => {
+    const { controller, searched } = harness(null);
+
+    await controller.searchMovie('a film');
+    await controller.searchMovie('a film', undefined, undefined, '795');
+    await controller.searchMovie('a film', undefined, undefined, 'not-a-number');
+
+    expect(searched).toEqual([undefined, undefined, undefined]);
+  });
+});

--- a/client/src/app/core/services/api/metadata.service.ts
+++ b/client/src/app/core/services/api/metadata.service.ts
@@ -22,6 +22,27 @@ export interface MetadataSearchResult {
   existingMediaType: MediaType | null;
 }
 
+/**
+ * A result's identity for the UI: TVDB reports `tmdbId: 0` for a work
+ * TheMovieDB does not know, so every one of its rows would share that key.
+ */
+export function searchResultKey(r: MetadataSearchResult): string {
+  return `${r.provider}:${r.tmdbId || 0}:${r.tvdbId || 0}`;
+}
+
+/** The ids worth sending to the API — the 0 above is not an id. */
+export function searchResultIds(r: MetadataSearchResult): {
+  tmdbId?: number;
+  tvdbId?: number;
+  imdbId?: string;
+} {
+  return {
+    ...(r.tmdbId > 0 ? { tmdbId: r.tmdbId } : {}),
+    ...(r.tvdbId ? { tvdbId: r.tvdbId } : {}),
+    ...(r.imdbId ? { imdbId: r.imdbId } : {}),
+  };
+}
+
 /** A cast/crew credit from the provider. */
 export interface MetadataCredit {
   externalId: number;

--- a/client/src/app/core/services/api/metadata.service.ts
+++ b/client/src/app/core/services/api/metadata.service.ts
@@ -109,10 +109,13 @@ export interface DiscoverFilters {
 export class MetadataService {
   private readonly http = inject(HttpClient);
 
-  searchMovie(q: string, year?: number, provider?: string) {
+  /** `mediaId` lets the server search the provider that media is refreshed
+   *  from; an explicit `provider` still wins. */
+  searchMovie(q: string, year?: number, provider?: string, mediaId?: number) {
     let params = new HttpParams().set('q', q);
     if (year != null) params = params.set('year', String(year));
     if (provider) params = params.set('provider', provider);
+    if (mediaId != null) params = params.set('mediaId', String(mediaId));
     return firstValueFrom(
       this.http.get<MetadataSearchResult[]>('/api/metadata/search/movie', {
         params,
@@ -120,10 +123,13 @@ export class MetadataService {
     );
   }
 
-  searchTv(q: string, year?: number, provider?: string) {
+  /** `mediaId` lets the server search the provider that media is refreshed
+   *  from; an explicit `provider` still wins. */
+  searchTv(q: string, year?: number, provider?: string, mediaId?: number) {
     let params = new HttpParams().set('q', q);
     if (year != null) params = params.set('year', String(year));
     if (provider) params = params.set('provider', provider);
+    if (mediaId != null) params = params.set('mediaId', String(mediaId));
     return firstValueFrom(
       this.http.get<MetadataSearchResult[]>('/api/metadata/search/tv', {
         params,

--- a/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.html
@@ -73,18 +73,18 @@
             <p class="text-sm text-base-content/50 py-4">{{ 'media_detail.identify_no_results' | translate }}</p>
           } @else {
             <div class="grid gap-3 grid-cols-2 sm:grid-cols-4 lg:grid-cols-5">
-              @for (r of results(); track r.tmdbId) {
+              @for (r of results(); track $index) {
                 <button type="button"
                   class="flex flex-col gap-1 text-left rounded-lg p-1 hover:bg-base-200 disabled:opacity-40"
                   [disabled]="applyingId() !== null || isTaken(r)"
                   [attr.title]="isTaken(r) ? ('media_detail.identify_already_in_library' | translate) : r.title"
-                  (click)="apply(r)">
+                  (click)="apply(r, $index)">
                   <div class="relative aspect-[2/3] w-full rounded bg-base-300 overflow-hidden">
                     @if (r.posterUrl) {
                       <img [src]="r.posterUrl | resolveUrl" [alt]="r.title"
                         class="h-full w-full object-cover" loading="lazy" />
                     }
-                    @if (applyingId() === r.tmdbId) {
+                    @if (applyingId() === $index) {
                       <span class="absolute inset-0 flex items-center justify-center bg-base-100/70">
                         <span class="loading loading-spinner loading-sm"></span>
                       </span>

--- a/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.html
@@ -60,8 +60,8 @@
           {{ 'media_detail.identify_search' | translate }}
         </button>
         <button type="button" class="btn btn-outline btn-sm"
-          [disabled]="applyingId() !== null" (click)="applyIds()">
-          @if (applyingId() === -1) { <span class="loading loading-spinner loading-xs"></span> }
+          [disabled]="applyingKey() !== null" (click)="applyIds()">
+          @if (applyingKey() === 'ids') { <span class="loading loading-spinner loading-xs"></span> }
           {{ 'media_detail.identify_apply_ids' | translate }}
         </button>
       </div>
@@ -73,18 +73,18 @@
             <p class="text-sm text-base-content/50 py-4">{{ 'media_detail.identify_no_results' | translate }}</p>
           } @else {
             <div class="grid gap-3 grid-cols-2 sm:grid-cols-4 lg:grid-cols-5">
-              @for (r of results(); track $index) {
+              @for (r of results(); track key(r)) {
                 <button type="button"
                   class="flex flex-col gap-1 text-left rounded-lg p-1 hover:bg-base-200 disabled:opacity-40"
-                  [disabled]="applyingId() !== null || isTaken(r)"
+                  [disabled]="applyingKey() !== null || isTaken(r)"
                   [attr.title]="isTaken(r) ? ('media_detail.identify_already_in_library' | translate) : r.title"
-                  (click)="apply(r, $index)">
+                  (click)="apply(r)">
                   <div class="relative aspect-[2/3] w-full rounded bg-base-300 overflow-hidden">
                     @if (r.posterUrl) {
                       <img [src]="r.posterUrl | resolveUrl" [alt]="r.title"
                         class="h-full w-full object-cover" loading="lazy" />
                     }
-                    @if (applyingId() === $index) {
+                    @if (applyingKey() === key(r)) {
                       <span class="absolute inset-0 flex items-center justify-center bg-base-100/70">
                         <span class="loading loading-spinner loading-sm"></span>
                       </span>

--- a/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.spec.ts
+++ b/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.spec.ts
@@ -33,12 +33,13 @@ describe('MediaDetailIdentifyModalComponent — a TVDB-only result', () => {
 
   function setup() {
     const identify = vi.fn(() => Promise.resolve({} as never));
+    const searchTv = vi.fn(() => Promise.resolve([]));
     TestBed.configureTestingModule({
       imports: [MediaDetailIdentifyModalComponent],
       providers: [
         provideZonelessChangeDetection(),
         provideTranslateService(),
-        { provide: MetadataService, useValue: { searchTv: vi.fn(), searchMovie: vi.fn() } },
+        { provide: MetadataService, useValue: { searchTv, searchMovie: vi.fn() } },
         { provide: MediaService, useValue: { identify } },
         { provide: ToastService, useValue: { success: vi.fn(), error: vi.fn() } },
       ],
@@ -55,7 +56,7 @@ describe('MediaDetailIdentifyModalComponent — a TVDB-only result', () => {
       tvdbId: null,
       imdbId: null,
     });
-    return { cmp, identify };
+    return { cmp, identify, searchTv };
   }
 
   it('VERDICT: sends no tmdbId when the provider has none, so the API accepts it', async () => {
@@ -72,6 +73,15 @@ describe('MediaDetailIdentifyModalComponent — a TVDB-only result', () => {
     await cmp.apply({ ...tvdbOnly, tmdbId: 77 }, 0);
 
     expect(identify).toHaveBeenCalledWith(795, { tmdbId: 77, tvdbId: 4242, imdbId: 'tt0499308' });
+  });
+
+  it('searches with the media id so the server picks its library provider', async () => {
+    const { cmp, searchTv } = setup();
+    cmp.formTitle.set('A Series');
+
+    await cmp.search();
+
+    expect(searchTv).toHaveBeenCalledWith('A Series', undefined, undefined, 795);
   });
 
   it('keys the in-flight spinner by row, not by the shared 0 id', async () => {

--- a/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.spec.ts
+++ b/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.spec.ts
@@ -62,7 +62,7 @@ describe('MediaDetailIdentifyModalComponent — a TVDB-only result', () => {
   it('VERDICT: sends no tmdbId when the provider has none, so the API accepts it', async () => {
     const { cmp, identify } = setup();
 
-    await cmp.apply(tvdbOnly, 0);
+    await cmp.apply(tvdbOnly);
 
     expect(identify).toHaveBeenCalledWith(795, { tvdbId: 4242, imdbId: 'tt0499308' });
   });
@@ -70,7 +70,7 @@ describe('MediaDetailIdentifyModalComponent — a TVDB-only result', () => {
   it('still sends a real tmdbId', async () => {
     const { cmp, identify } = setup();
 
-    await cmp.apply({ ...tvdbOnly, tmdbId: 77 }, 0);
+    await cmp.apply({ ...tvdbOnly, tmdbId: 77 });
 
     expect(identify).toHaveBeenCalledWith(795, { tmdbId: 77, tvdbId: 4242, imdbId: 'tt0499308' });
   });
@@ -84,11 +84,13 @@ describe('MediaDetailIdentifyModalComponent — a TVDB-only result', () => {
     expect(searchTv).toHaveBeenCalledWith('A Series', undefined, undefined, 795);
   });
 
-  it('keys the in-flight spinner by row, not by the shared 0 id', async () => {
+  it('keys the in-flight spinner by result, not by the shared 0 id', async () => {
     const { cmp } = setup();
-    const pending = cmp.apply(tvdbOnly, 2);
+    const other = { ...tvdbOnly, tvdbId: 5150 };
+    const pending = cmp.apply(tvdbOnly);
 
-    expect(cmp.applyingId()).toBe(2);
+    expect(cmp.applyingKey()).toBe(cmp.key(tvdbOnly));
+    expect(cmp.applyingKey()).not.toBe(cmp.key(other));
     await pending;
   });
 });

--- a/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.spec.ts
+++ b/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.spec.ts
@@ -1,0 +1,84 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { vi, describe, it, expect } from 'vitest';
+import { provideTranslateService } from '@ngx-translate/core';
+import { MediaDetailIdentifyModalComponent } from './media-detail-identify-modal.component';
+import { MetadataService, MetadataSearchResult } from '../../../../core/services/api/metadata.service';
+import { MediaService } from '../../../../core/services/api/media.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import type { MediaType } from '../../../../core/enums/media-type.enum';
+
+/**
+ * A work TVDB knows but TheMovieDB does not is reported with `tmdbId: 0` — the
+ * provider's "no cross-reference" sentinel. Forwarding it identifies the media
+ * against nothing and the API rejects it, so the whole re-identification fails.
+ */
+describe('MediaDetailIdentifyModalComponent — a TVDB-only result', () => {
+  const tvdbOnly: MetadataSearchResult = {
+    tmdbId: 0,
+    tvdbId: 4242,
+    imdbId: 'tt0499308',
+    provider: 'tvdb',
+    title: 'A Series',
+    originalTitle: 'A Series',
+    overview: '',
+    year: 2007,
+    posterUrl: null,
+    rating: 0,
+    genres: [],
+    mediaType: ('series' satisfies MediaType),
+    existingMediaId: null,
+    existingMediaType: null,
+  };
+
+  function setup() {
+    const identify = vi.fn(() => Promise.resolve({} as never));
+    TestBed.configureTestingModule({
+      imports: [MediaDetailIdentifyModalComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideTranslateService(),
+        { provide: MetadataService, useValue: { searchTv: vi.fn(), searchMovie: vi.fn() } },
+        { provide: MediaService, useValue: { identify } },
+        { provide: ToastService, useValue: { success: vi.fn(), error: vi.fn() } },
+      ],
+    });
+    const fixture = TestBed.createComponent(MediaDetailIdentifyModalComponent);
+    const cmp = fixture.componentInstance;
+    cmp.config.set({
+      mediaId: 795,
+      mediaType: ('series' satisfies MediaType),
+      title: 'Old',
+      year: null,
+      path: null,
+      tmdbId: 10,
+      tvdbId: null,
+      imdbId: null,
+    });
+    return { cmp, identify };
+  }
+
+  it('VERDICT: sends no tmdbId when the provider has none, so the API accepts it', async () => {
+    const { cmp, identify } = setup();
+
+    await cmp.apply(tvdbOnly, 0);
+
+    expect(identify).toHaveBeenCalledWith(795, { tvdbId: 4242, imdbId: 'tt0499308' });
+  });
+
+  it('still sends a real tmdbId', async () => {
+    const { cmp, identify } = setup();
+
+    await cmp.apply({ ...tvdbOnly, tmdbId: 77 }, 0);
+
+    expect(identify).toHaveBeenCalledWith(795, { tmdbId: 77, tvdbId: 4242, imdbId: 'tt0499308' });
+  });
+
+  it('keys the in-flight spinner by row, not by the shared 0 id', async () => {
+    const { cmp } = setup();
+    const pending = cmp.apply(tvdbOnly, 2);
+
+    expect(cmp.applyingId()).toBe(2);
+    await pending;
+  });
+});

--- a/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.ts
@@ -89,8 +89,8 @@ export class MediaDetailIdentifyModalComponent {
       const year = this.formYear();
       const found = title
         ? isSeries
-          ? await this.metadata.searchTv(title, year ?? undefined)
-          : await this.metadata.searchMovie(title, year ?? undefined)
+          ? await this.metadata.searchTv(title, year ?? undefined, undefined, cfg.mediaId)
+          : await this.metadata.searchMovie(title, year ?? undefined, undefined, cfg.mediaId)
         : [];
       this.results.set(found);
       this.searched.set(true);

--- a/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.ts
@@ -13,6 +13,8 @@ import { ResolveUrlPipe } from '../../../../core/pipes/resolve-url.pipe';
 import {
   MetadataService,
   MetadataSearchResult,
+  searchResultIds,
+  searchResultKey,
 } from '../../../../core/services/api/metadata.service';
 import { MediaService } from '../../../../core/services/api/media.service';
 import { ToastService } from '../../../../core/services/toast.service';
@@ -57,9 +59,10 @@ export class MediaDetailIdentifyModalComponent {
   readonly searching = signal(false);
   readonly searched = signal(false);
   readonly results = signal<MetadataSearchResult[]>([]);
-  /** Index of the result being applied, or -1 for the typed-ids button. Not the
-   *  tmdbId: a TVDB result reports 0 and every card would answer to it. */
-  readonly applyingId = signal<number | null>(null);
+  /** Key of the result being applied, or 'ids' for the typed-ids button. */
+  readonly applyingKey = signal<string | null>(null);
+
+  readonly key = searchResultKey;
 
   open(config: IdentifyModalConfig) {
     this.config.set(config);
@@ -106,25 +109,19 @@ export class MediaDetailIdentifyModalComponent {
     return result.existingMediaId != null && result.existingMediaId !== cfg?.mediaId;
   }
 
-  async apply(result: MetadataSearchResult, index: number) {
+  async apply(result: MetadataSearchResult) {
     const cfg = this.config();
     if (!cfg || this.isTaken(result)) return;
-    this.applyingId.set(index);
+    this.applyingKey.set(searchResultKey(result));
     try {
-      // A TVDB work with no TheMovieDB cross-reference reports tmdbId 0, which
-      // the API rejects — send an id only when the provider really has one.
-      await this.media.identify(cfg.mediaId, {
-        ...(result.tmdbId > 0 ? { tmdbId: result.tmdbId } : {}),
-        ...(result.tvdbId != null ? { tvdbId: result.tvdbId } : {}),
-        ...(result.imdbId ? { imdbId: result.imdbId } : {}),
-      });
+      await this.media.identify(cfg.mediaId, searchResultIds(result));
       this.toast.success(this.translate.instant('media_detail.identify_success'));
       this.close();
       this.identified.emit();
     } catch {
       // the global interceptor surfaces the 409 / provider error
     } finally {
-      this.applyingId.set(null);
+      this.applyingKey.set(null);
     }
   }
 
@@ -138,7 +135,7 @@ export class MediaDetailIdentifyModalComponent {
       ...(this.formImdbId().trim() ? { imdbId: this.formImdbId().trim() } : {}),
     };
     if (!Object.keys(target).length) return;
-    this.applyingId.set(-1);
+    this.applyingKey.set('ids');
     try {
       await this.media.identify(cfg.mediaId, target);
       this.toast.success(this.translate.instant('media_detail.identify_success'));
@@ -147,7 +144,7 @@ export class MediaDetailIdentifyModalComponent {
     } catch {
       // handled by the global interceptor
     } finally {
-      this.applyingId.set(null);
+      this.applyingKey.set(null);
     }
   }
 }

--- a/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.ts
@@ -57,6 +57,8 @@ export class MediaDetailIdentifyModalComponent {
   readonly searching = signal(false);
   readonly searched = signal(false);
   readonly results = signal<MetadataSearchResult[]>([]);
+  /** Index of the result being applied, or -1 for the typed-ids button. Not the
+   *  tmdbId: a TVDB result reports 0 and every card would answer to it. */
   readonly applyingId = signal<number | null>(null);
 
   open(config: IdentifyModalConfig) {
@@ -104,13 +106,15 @@ export class MediaDetailIdentifyModalComponent {
     return result.existingMediaId != null && result.existingMediaId !== cfg?.mediaId;
   }
 
-  async apply(result: MetadataSearchResult) {
+  async apply(result: MetadataSearchResult, index: number) {
     const cfg = this.config();
     if (!cfg || this.isTaken(result)) return;
-    this.applyingId.set(result.tmdbId);
+    this.applyingId.set(index);
     try {
+      // A TVDB work with no TheMovieDB cross-reference reports tmdbId 0, which
+      // the API rejects — send an id only when the provider really has one.
       await this.media.identify(cfg.mediaId, {
-        tmdbId: result.tmdbId,
+        ...(result.tmdbId > 0 ? { tmdbId: result.tmdbId } : {}),
         ...(result.tvdbId != null ? { tvdbId: result.tvdbId } : {}),
         ...(result.imdbId ? { imdbId: result.imdbId } : {}),
       });
@@ -129,7 +133,7 @@ export class MediaDetailIdentifyModalComponent {
     const cfg = this.config();
     if (!cfg) return;
     const target = {
-      ...(this.formTmdbId() != null ? { tmdbId: this.formTmdbId()! } : {}),
+      ...((this.formTmdbId() ?? 0) > 0 ? { tmdbId: this.formTmdbId()! } : {}),
       ...(this.formTvdbId() != null ? { tvdbId: this.formTvdbId()! } : {}),
       ...(this.formImdbId().trim() ? { imdbId: this.formImdbId().trim() } : {}),
     };

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
@@ -99,10 +99,10 @@
                   }
 
                   <div class="flex flex-col gap-1 max-h-60 overflow-auto">
-                    @for (r of vm.results; track r.tmdbId) {
+                    @for (r of vm.results; track key(r)) {
                       <button type="button"
                         class="flex items-center gap-3 p-2 rounded text-left hover:bg-base-300/50"
-                        [class.bg-base-300]="vm.pick?.tmdbId === r.tmdbId"
+                        [class.bg-base-300]="isPicked(vm.pick, r)"
                         (click)="pick(i, r)">
                         @if (r.posterUrl) {
                           <img [src]="r.posterUrl | resolveUrl: 'thumb'" alt="" loading="lazy"
@@ -113,7 +113,7 @@
                         <div class="min-w-0">
                           <div class="flex items-center gap-2">
                             <span class="font-medium truncate">{{ r.title }}</span>
-                            @if (vm.fromNfo && vm.pick?.tmdbId === r.tmdbId) {
+                            @if (vm.fromNfo && isPicked(vm.pick, r)) {
                               <span class="badge badge-ghost badge-xs">{{ 'settings.libraries.scan_from_nfo' | translate }}</span>
                             }
                           </div>

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
@@ -45,7 +45,7 @@
         @for (item of pagedGroups(); track item.vm.group.groupKey) {
         @let vm = item.vm;
         @let i = item.i;
-          <div class="collapse collapse-arrow bg-base-200/40 border border-base-200"
+          <div class="collapse collapse-arrow bg-base-200 border border-base-300"
             [class.collapse-open]="!vm.collapsed" [class.collapse-close]="vm.collapsed">
             <div class="collapse-title cursor-pointer flex items-center justify-between gap-2 flex-wrap pr-12"
               (click)="toggleCollapse(i)">
@@ -101,7 +101,7 @@
                   <div class="flex flex-col gap-1 max-h-60 overflow-auto">
                     @for (r of vm.results; track key(r)) {
                       <button type="button"
-                        class="relative flex items-center gap-3 p-2 rounded-lg text-left border hover:bg-base-300/50"
+                        class="relative flex items-center gap-3 p-2 rounded-lg text-left border-2 hover:bg-base-300/50"
                         [class.bg-base-300]="isPicked(vm.pick, r)"
                         [class.border-primary]="isPicked(vm.pick, r)"
                         [class.border-transparent]="!isPicked(vm.pick, r)"

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
@@ -101,9 +101,15 @@
                   <div class="flex flex-col gap-1 max-h-60 overflow-auto">
                     @for (r of vm.results; track key(r)) {
                       <button type="button"
-                        class="flex items-center gap-3 p-2 rounded text-left hover:bg-base-300/50"
+                        class="relative flex items-center gap-3 p-2 rounded text-left border border-transparent hover:bg-base-300/50"
                         [class.bg-base-300]="isPicked(vm.pick, r)"
+                        [class.border-primary]="isPicked(vm.pick, r)"
                         (click)="pick(i, r)">
+                        @if (isPicked(vm.pick, r)) {
+                          <span class="absolute top-1 right-1 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-primary-content">
+                            <svg lucideCheck class="h-3 w-3"></svg>
+                          </span>
+                        }
                         @if (r.posterUrl) {
                           <img [src]="r.posterUrl | resolveUrl: 'thumb'" alt="" loading="lazy"
                             class="h-14 w-auto rounded shrink-0" />

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
@@ -101,9 +101,10 @@
                   <div class="flex flex-col gap-1 max-h-60 overflow-auto">
                     @for (r of vm.results; track key(r)) {
                       <button type="button"
-                        class="relative flex items-center gap-3 p-2 rounded text-left border border-transparent hover:bg-base-300/50"
+                        class="relative flex items-center gap-3 p-2 rounded-lg text-left border hover:bg-base-300/50"
                         [class.bg-base-300]="isPicked(vm.pick, r)"
                         [class.border-primary]="isPicked(vm.pick, r)"
+                        [class.border-transparent]="!isPicked(vm.pick, r)"
                         (click)="pick(i, r)">
                         @if (isPicked(vm.pick, r)) {
                           <span class="absolute top-1 right-1 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-primary-content">

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.spec.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.spec.ts
@@ -14,7 +14,11 @@ import {
 } from '../../../../../core/services/api/metadata.service';
 import { ToastService } from '../../../../../core/services/toast.service';
 
-const result = (tmdbId: number, title: string): MetadataSearchResult => ({
+const result = (
+  tmdbId: number,
+  title: string,
+  extra: Partial<MetadataSearchResult> = {},
+): MetadataSearchResult => ({
   tmdbId,
   provider: 'tmdb',
   title,
@@ -27,6 +31,7 @@ const result = (tmdbId: number, title: string): MetadataSearchResult => ({
   mediaType: 'movie',
   existingMediaId: null,
   existingMediaType: null,
+  ...extra,
 });
 
 const scanResult = (folders: string[]): OrphanScanResult => ({
@@ -106,6 +111,45 @@ describe('OrphanScanPanelComponent.importAll', () => {
 
     await panel.importAll(7);
     expect(relinked[0].externalId).toBe('22');
+  });
+});
+
+/** A TVDB work TheMovieDB does not know is reported with `tmdbId: 0`, so every
+ *  such row would answer to the same identity. */
+describe('OrphanScanPanelComponent — picking among TVDB-only results', () => {
+  const tvdb = (tvdbId: number, title: string) =>
+    result(0, title, { provider: 'tvdb', tvdbId });
+
+  it('VERDICT: switches the pick between two results that share tmdbId 0', async () => {
+    const { panel } = setup(['Alpha']);
+    await panel.scanPath('/medias', ['movie'], 'tvdb');
+    const first = tvdb(101, 'First');
+    const second = tvdb(202, 'Second');
+
+    panel.pick(0, first);
+    panel.pick(0, second);
+
+    expect(panel.groups()[0].pick).toBe(second);
+  });
+
+  it('still deselects when the same result is clicked twice', async () => {
+    const { panel } = setup(['Alpha']);
+    await panel.scanPath('/medias', ['movie'], 'tvdb');
+    const first = tvdb(101, 'First');
+
+    panel.pick(0, first);
+    panel.pick(0, { ...first });
+
+    expect(panel.groups()[0].pick).toBeNull();
+  });
+
+  it('marks only the picked row as selected', () => {
+    const { panel } = setup(['Alpha']);
+    const first = tvdb(101, 'First');
+    const second = tvdb(202, 'Second');
+
+    expect(panel.isPicked(first, first)).toBe(true);
+    expect(panel.isPicked(first, second)).toBe(false);
   });
 });
 

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.spec.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.spec.ts
@@ -104,6 +104,23 @@ describe('OrphanScanPanelComponent.importAll', () => {
     ]);
   });
 
+  it('skips a group whose default pick was deselected', async () => {
+    const { panel, relinked } = setup(['Alpha', 'Beta']);
+    await panel.scanPath('/medias', ['movie'], 'tmdb');
+    panel.pick(0, panel.groups()[0].pick!); // clicking the selected row clears it
+
+    expect(await panel.importAll(7)).toBe(1);
+    expect(relinked.map((b) => b.folderName)).toEqual(['Beta']);
+  });
+
+  it('selects the first result as soon as a group is searched', async () => {
+    const { panel } = setup(['Alpha']);
+    await panel.scanPath('/medias', ['movie'], 'tmdb');
+
+    expect(panel.groups()[0].pick?.title).toBe('First');
+    expect(panel.groups()[0].fromNfo).toBe(false);
+  });
+
   it('keeps an explicit pick over the first result', async () => {
     const { panel, relinked } = setup(['Alpha']);
     await panel.scanPath('/medias', ['movie'], 'tmdb');

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
@@ -17,6 +17,7 @@ import { ToastService } from '../../../../../core/services/toast.service';
 import {
   MetadataService,
   MetadataSearchResult,
+  searchResultKey,
 } from '../../../../../core/services/api/metadata.service';
 import {
   ImportsApiService,
@@ -286,9 +287,15 @@ export class OrphanScanPanelComponent {
     }
   }
 
+  readonly key = searchResultKey;
+
+  isPicked(pick: MetadataSearchResult | null, result: MetadataSearchResult): boolean {
+    return !!pick && searchResultKey(pick) === searchResultKey(result);
+  }
+
   pick(index: number, result: MetadataSearchResult) {
-    const current = this.groups()[index]?.pick;
-    const same = current?.provider === result.provider && current?.tmdbId === result.tmdbId;
+    const current = this.groups()[index]?.pick ?? null;
+    const same = this.isPicked(current, result);
     this.patch(index, { pick: same ? null : result, fromNfo: false });
   }
 

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
@@ -9,7 +9,7 @@ import {
 import { FormsModule } from '@angular/forms';
 import { UpperCasePipe } from '@angular/common';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { LucideChevronsDownUp, LucideChevronsUpDown } from '@lucide/angular';
+import { LucideCheck, LucideChevronsDownUp, LucideChevronsUpDown } from '@lucide/angular';
 import { MediaType } from '../../../../../core/enums/media-type.enum';
 import { PaginationComponent } from '../../../../../shared/components/pagination/pagination';
 import { ResolveUrlPipe } from '../../../../../core/pipes/resolve-url.pipe';
@@ -50,6 +50,7 @@ interface GroupVM {
     UpperCasePipe,
     TranslateModule,
     ResolveUrlPipe,
+    LucideCheck,
     LucideChevronsDownUp,
     LucideChevronsUpDown,
     PaginationComponent,

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
@@ -206,11 +206,11 @@ export class OrphanScanPanelComponent {
     for (let i = 0; i < this.groups().length; i++) {
       if (this.groups()[i].done) continue;
       if (!this.groups()[i].searched) await this.search(i);
+      // The search selects the first result, so an empty pick is a deselection:
+      // the group is skipped rather than imported against a row nobody chose.
       const vm = this.groups()[i];
-      const pick = vm.pick ?? vm.results[0] ?? null;
-      if (pick) {
-        this.patch(i, { pick });
-        items.push(this.relinkBody(libraryId, vm.group, pick));
+      if (vm.pick) {
+        items.push(this.relinkBody(libraryId, vm.group, vm.pick));
       }
       this.imported.update((n) => n + 1);
     }
@@ -271,11 +271,13 @@ export class OrphanScanPanelComponent {
               (nfo.tvdbId != null && r.tvdbId === nfo.tvdbId),
           )
         : undefined;
+      // Import-all takes the first result when nothing is picked, so pick it
+      // here: the row the import will use is the row the user sees selected.
       this.patch(index, {
         results,
         searching: false,
         searched: true,
-        pick: auto ?? null,
+        pick: auto ?? results[0] ?? null,
         fromNfo: !!auto,
       });
     } catch {


### PR DESCRIPTION
Seven commits on one bug: re-identifying a series in a library whose default provider is TVDB could not work, and the same defect sat in the library import panel.

## 1. `fix(identify)` — accept a TVDB-only work, and replace the identity it matched

The symptom: a toast reading `tmdbId must not be less than 1`, and the media still pointing at the show it was wrongly matched to.

`tvdb.provider.ts` maps a work with no TheMovieDB cross-reference to `tmdbId: parseInt(… ?? '0')` — `0` means "no TMDB id" but is still a number. `apply()` forwarded it, `IdentifyMediaDto.tmdbId` is `@Min(1)`, so the request 400'd and nothing was identified.

Underneath, `identify()` merged the supplied ids into the existing ones ("an omitted field leaves the media's current value alone"). Even once the request went through, a media identified by `tvdbId` alone kept the **tmdbId of the previous work**, and `resolveProviderForMedia` falls back to whichever id is set — the day TVDB is unavailable, the refresh would resolve the stale tmdbId and silently restore the old identity.

Replacing rather than merging is safe here: `tmdbId` is nullable and Postgres allows several NULLs under `UQ_media_type_tmdbId`; the manual "I only know the IMDb id" path still resolves because `resolveExternalIdForProvider` already cross-references imdb→tvdb and imdb→tmdb, and if it cannot, the caller gets an explicit `BadRequest` instead of a silent refresh of the wrong work. `POST /api/media/:id/identify` has two callers, both in this dialog.

## 2. `feat(identify)` — search the provider the media is refreshed from

The dialog called `searchTv`/`searchMovie` with no `provider`, so `MetadataProviderRegistry.resolve(null)` returned its hardcoded default (TMDB) and only fell back to TVDB when TMDB came back empty. A library set to TVDB was searched against TMDB, and the empty-result fallback then mixed one provider's results into the other's search — which is how a TVDB row carrying `tmdbId: 0` reached a dialog that had queried TMDB.

The search endpoints now accept a `mediaId` and resolve the same precedence the metadata service already uses to refresh that media: its own override, then its library's. An explicit `provider` still wins — that is what the orphan-scan panel passes.

## 3. `refactor(metadata)` — one identity for a search result, shared

The `0` was read as an identity in two grids, not one. The orphan-scan panel — the library import surface — had the same three symptoms: `track r.tmdbId` collapsed every TVDB row onto one key, `vm.pick?.tmdbId === r.tmdbId` highlighted all of them when one was picked, and `pick()` compared the same way, so clicking a second result **deselected** instead of switching. On a TVDB library that panel was unusable for any work TMDB does not know.

`searchResultKey` and `searchResultIds` now sit next to `MetadataSearchResult`, so "0 is not an id" is stated once and both surfaces read it. The dialog also keys its in-flight spinner by result instead of index.

## 4. `fix(library-import)` — show the match import-all would use

Import-all already fell back to `results[0]` for any group with no explicit pick, and wrote that pick back to the group *after* queueing it. So the choice existed, it was just invisible until the import had been made: the grid showed no selection and the badge stayed empty, and a whole library could be linked against rows nobody had looked at.

The search now selects the first result, so the row the import will use is the row on screen — the existing badge and row highlight had nothing to show before. That in turn gives an empty pick a meaning, so import-all skips those groups rather than re-defaulting over a deselection the user just made.

## 5. `style(library-import)` — make the selection unmistakable

The picked row was distinguished by a background tint alone, which reads as the hover state of whatever row the cursor is over — poor for the one row import-all will link against. It now carries a primary `border-2` and a check badge in its corner. The border colour is bound exclusively (`border-primary` / `border-transparent`) because both applied at once resolve by stylesheet order, not by the selection, and the width stays on every row so picking one does not shift the layout. Group cards move to `bg-base-200 border border-base-300`.

## Scope checked, found sound

The rest of the import path already does this right and needed no change: the scan resolves the provider from the library (and from the wizard's DTO for a library that does not exist yet) and ships it to the UI as `suggestedProvider`; `relinkBody` sends the tvdbId for a TVDB pick; `buildMediaFieldsFromTmdb` writes `tmdbId: details.tmdbId || undefined`, so the sentinel never lands in the column and cannot collide on `UQ_media_type_tmdbId`; `importMedia` cross-references tvdb→tmdb when no tmdbId is set. There is no server-side auto-match — every match is user-chosen.

## Tests

- Backend: the ids the caller omits are cleared; a full id set is written verbatim; the search provider falls back to the library's, prefers the media's own override, yields to an explicit `provider`, and expresses no preference for a missing or malformed media id.
- Client: a `tmdbId: 0` result is sent without a tmdbId, a real one is still sent, the spinner is keyed by result, the search carries the media id; and in the panel, picking switches between two results sharing `tmdbId: 0`, still deselects on a second click of the same one, and marks only the picked row; the first result is selected on search, and a deselected group is skipped by import-all.

Every new assertion was verified to fail on the code it replaces. Full suites green — 528 client tests, 57 backend tests across the two modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

