### PR TITLE
test(libraries): pin that a new library's grants leave other libraries alone

### DIFF
--- a/backend/src/modules/libraries/libraries.service.user-access.spec.ts
+++ b/backend/src/modules/libraries/libraries.service.user-access.spec.ts
@@ -1,0 +1,63 @@
+import { LibrariesService } from './libraries.service';
+import { LibraryUserAccess } from './entities/library-user-access.entity';
+
+/**
+ * Access is a row per (library, user) and a non-admin sees exactly the
+ * libraries they hold a row for. Granting access to a new library therefore
+ * must not touch the rows that carry the other libraries: widening the delete
+ * to the users being granted would silently take every library they had.
+ */
+describe('LibrariesService.create — user access', () => {
+  function harness() {
+    const deletes: unknown[] = [];
+    const saved: unknown[] = [];
+
+    const m = {
+      create: (_entity: unknown, row: Record<string, unknown>) => row,
+      save: async (row: unknown) => {
+        if (Array.isArray(row)) saved.push(...row);
+        else if ((row as { name?: string }).name) return { ...(row as object), id: 42 };
+        return row;
+      },
+      delete: async (entity: unknown, criteria: unknown) => {
+        deletes.push({ entity, criteria });
+        return { affected: 0 };
+      },
+      update: async () => ({ affected: 1 }),
+      findOne: async () => null,
+      count: async () => 0,
+    };
+
+    const service = new LibrariesService(
+      { findOne: async () => ({ id: 42, name: 'Docs', path: null }) } as never,
+      { find: async () => [] } as never,
+      {} as never,
+      { transaction: async (fn: (mm: unknown) => unknown) => fn(m) } as never,
+      {} as never,
+    );
+    return { service, deletes, saved };
+  }
+
+  it('VERDICT: clears access for the new library only, never for the users granted it', async () => {
+    const { service, deletes, saved } = harness();
+
+    await service.create({ name: 'Docs', userIds: [7, 9] } as never);
+
+    expect(deletes).toEqual([
+      { entity: LibraryUserAccess, criteria: { library: { id: 42 } } },
+    ]);
+    expect(saved).toEqual([
+      { library: { id: 42 }, user: { id: 7 } },
+      { library: { id: 42 }, user: { id: 9 } },
+    ]);
+  });
+
+  it('touches no access row at all when the library is created with nobody', async () => {
+    const { service, deletes, saved } = harness();
+
+    await service.create({ name: 'Docs', userIds: [] } as never);
+
+    expect(deletes).toEqual([]);
+    expect(saved).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Question

When a new library is created with users assigned to it, do those users lose access to the libraries they already had?

## Answer: no

Access is one row per `(library, user)` in `LibraryUserAccess`, and `getAccessibleLibraryIds` gives a non-admin exactly the libraries they hold a row for — there is no "no rows means everything" fallback. So what a grant does hinges entirely on the delete that precedes the insert, and there are two writers with two different scopes:

| Writer | Delete scope | Replaces |
|---|---|---|
| `LibrariesService.replaceUserAccess` (library create/update, `POST/PATCH /api/libraries`) | `{ library: { id } }` | the user set of **one library** |
| `UsersService.update` with `dto.libraryIds` (`PATCH /api/users/:id`) | `{ user: { id } }` | the library set of **one user** |

The library form — including creation, which posts `userIds` in the create DTO — goes through the first. Its delete is keyed on the library being created, which is brand new and matches nothing, then it inserts one row per assigned user for that library alone. Rows carrying those users' other libraries are never in scope.

## Change

No production change: the behaviour is already correct. This adds the test that says so, because the property is invisible in the code — `replaceUserAccess` reads as "replace access", and rewriting its delete to key on the users being granted is a one-word edit that no existing test rejects, with no symptom until someone opens the app and finds their libraries gone.

Two cases: a create granting two users clears only the new library's rows and inserts exactly those two pairs; a create granting nobody touches the access table at all.

Verified the first fails against a user-scoped delete. Suites green — 10 tests across the libraries and users modules.

## Noted, not changed

A library created with an empty `userIds` gets no access rows, so no non-admin can see it until someone is assigned. That is consistent with the opt-in model, but it does mean the default state of a new library is "invisible to everyone but admins".

🤖 Generated with [Claude Code](https://claude.com/claude-code)