### PR TITLE
fix(identify): finish the job — relink the files, refresh off the request, bust the image cache

### DIFF
--- a/backend/src/modules/images/image.service.ts
+++ b/backend/src/modules/images/image.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import axios from 'axios';
+import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import sharp from 'sharp';
@@ -149,7 +150,10 @@ export class ImageService {
       }),
     );
 
-    return this.getApiPath(type, id, variant);
+    // The path is stable across re-downloads, so a client that cached the old
+    // bytes for `max-age` would keep showing them after a re-identification.
+    // Stamping the content makes the URL move exactly when the image does.
+    return `${this.getApiPath(type, id, variant)}?v=${createHash('sha1').update(buffer).digest('hex').slice(0, 8)}`;
   }
 
   /**

--- a/backend/src/modules/media/media-service/media-metadata.identify.spec.ts
+++ b/backend/src/modules/media/media-service/media-metadata.identify.spec.ts
@@ -8,7 +8,7 @@ import { MediaType } from '../../../common/enums';
  * with it the files, playback states, markers, likes and playlist entries that
  * reference it. Only the surplus is dropped.
  */
-describe('MediaMetadataService.identify', () => {
+describe('MediaMetadataService identification', () => {
   function harness(opts: {
     media: Record<string, unknown>;
     clash?: Record<string, unknown> | null;
@@ -16,6 +16,11 @@ describe('MediaMetadataService.identify', () => {
     providerSeasons?: { seasonNumber: number; episodes: { episodeNumber: number }[] }[];
   }) {
     const updates: Record<string, unknown>[] = [];
+    const refreshOpts: unknown[] = [];
+    const refreshMetadata = jest.fn((_id: number, o?: unknown) => {
+      refreshOpts.push(o);
+      return Promise.resolve(opts.media);
+    });
     const removedSeasons: number[] = [];
     const removedEpisodes: number[] = [];
 
@@ -49,7 +54,7 @@ describe('MediaMetadataService.identify', () => {
       episodeRepo,
       log: { log: jest.fn(), warn: jest.fn() },
       // the refresh itself is covered elsewhere; identify only orchestrates it
-      refreshMetadata: jest.fn(() => Promise.resolve(opts.media)),
+      refreshMetadata: refreshMetadata,
       resolveProviderForMedia: jest.fn(() =>
         Promise.resolve({
           provider: {
@@ -60,7 +65,7 @@ describe('MediaMetadataService.identify', () => {
       ),
       loadLibraryOverride: jest.fn(() => Promise.resolve(undefined)),
     });
-    return { service, updates, removedSeasons, removedEpisodes, mediaRepo };
+    return { service, updates, removedSeasons, removedEpisodes, mediaRepo, refreshOpts };
   }
 
   const movie = { id: 1, type: MediaType.MOVIE, title: 'Old', tmdbId: 10 };
@@ -68,7 +73,7 @@ describe('MediaMetadataService.identify', () => {
   it('refuses an empty target rather than refreshing against nothing', async () => {
     const { service } = harness({ media: movie });
 
-    await expect(service.identify(1, {})).rejects.toBeInstanceOf(BadRequestException);
+    await expect(service.applyIdentity(1, {})).rejects.toBeInstanceOf(BadRequestException);
   });
 
   it('VERDICT: refuses a TMDB id another title already holds, before touching the row', async () => {
@@ -77,7 +82,7 @@ describe('MediaMetadataService.identify', () => {
       clash: { id: 99, title: 'Taken', tmdbId: 55 },
     });
 
-    await expect(service.identify(1, { tmdbId: 55 })).rejects.toBeInstanceOf(ConflictException);
+    await expect(service.applyIdentity(1, { tmdbId: 55 })).rejects.toBeInstanceOf(ConflictException);
     expect(updates).toEqual([]); // the ids were never written
   });
 
@@ -86,7 +91,7 @@ describe('MediaMetadataService.identify', () => {
       media: { ...movie, tvdbId: 4242, imdbId: 'tt-old' },
     });
 
-    await service.identify(1, { tvdbId: 99 });
+    await service.applyIdentity(1, { tvdbId: 99 });
 
     // Keeping tmdbId=10 would let `resolveProviderForMedia` fall back to the
     // previous work the moment TVDB is unavailable.
@@ -96,7 +101,7 @@ describe('MediaMetadataService.identify', () => {
   it('writes the full identity when the caller supplies every id', async () => {
     const { service, updates } = harness({ media: movie });
 
-    await service.identify(1, { tmdbId: 77, tvdbId: 88, imdbId: 'tt7' });
+    await service.applyIdentity(1, { tmdbId: 77, tvdbId: 88, imdbId: 'tt7' });
 
     expect(updates).toEqual([{ tmdbId: 77, tvdbId: 88, imdbId: 'tt7' }]);
   });
@@ -104,10 +109,18 @@ describe('MediaMetadataService.identify', () => {
   it('leaves a movie alone past the refresh — no season work', async () => {
     const { service, removedSeasons, removedEpisodes } = harness({ media: movie });
 
-    await service.identify(1, { tmdbId: 77 });
+    await service.completeIdentify(1);
 
     expect(removedSeasons).toEqual([]);
     expect(removedEpisodes).toEqual([]);
+  });
+
+  it('VERDICT: holds back the refresh\'s grab kick — the files are not relinked yet', async () => {
+    const { service, refreshOpts } = harness({ media: movie });
+
+    await service.completeIdentify(1);
+
+    expect(refreshOpts).toEqual([{ deferAcquisitionKick: true }]);
   });
 
   it('VERDICT: drops the surplus of the old work and keeps what the new one has', async () => {
@@ -126,7 +139,7 @@ describe('MediaMetadataService.identify', () => {
       ],
     });
 
-    await service.identify(2, { tmdbId: 77 });
+    await service.completeIdentify(2);
 
     expect(removedSeasons).toEqual([3]);
     expect(removedEpisodes).toEqual([12]); // S01E02 has no counterpart

--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -117,6 +117,13 @@ export class MediaMetadataService {
 
     const before = `"${media.title}" tmdb=${media.tmdbId ?? '-'} tvdb=${media.tvdbId ?? '-'}`;
 
+    // The refresh below re-reads the whole work — every season, episode and
+    // image — so without this line a long identify looks like nothing happened.
+    this.log.log(
+      `identify: media#${id} ${before} -> tmdb=${target.tmdbId ?? '-'} ` +
+        `tvdb=${target.tvdbId ?? '-'} imdb=${target.imdbId ?? '-'}, refreshing`,
+    );
+
     // Keeping an id the caller did not supply would leave this media pointing at
     // the previous work on that provider, and `resolveProviderForMedia` falls
     // back to whichever id is set — the old identity would silently return.
@@ -139,7 +146,8 @@ export class MediaMetadataService {
     }
 
     this.log.log(
-      `identify: ${before} -> "${refreshed.title}" tmdb=${refreshed.tmdbId ?? '-'} tvdb=${refreshed.tvdbId ?? '-'}`,
+      `identify: media#${id} done — "${refreshed.title}" tmdb=${refreshed.tmdbId ?? '-'} ` +
+        `tvdb=${refreshed.tvdbId ?? '-'} imdb=${refreshed.imdbId ?? '-'}`,
     );
     return (await this.mediaRepo.findOne({ where: { id } })) ?? refreshed;
   }

--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -69,6 +69,10 @@ export class MediaMetadataService {
   }
 
   /**
+   * Write the external ids the caller picked. Validation and the id clash live
+   * here, so they reach the admin as an HTTP error; {@link completeIdentify}
+   * carries the long half.
+   *
    * Point a media at a different work: write the external ids the caller
    * picked, re-pull everything from the provider, then drop the seasons and
    * episodes the new work does not have.
@@ -82,7 +86,7 @@ export class MediaMetadataService {
    * and markers on those episodes do go — they described content this title no
    * longer contains.
    */
-  async identify(
+  async applyIdentity(
     id: number,
     // The supplied ids ARE the new identity: what the caller omits is cleared,
     // never carried over from the work this media used to point at.
@@ -139,14 +143,30 @@ export class MediaMetadataService {
         : {}),
     } as QueryDeepPartialEntity<Media>);
 
-    const refreshed = await this.refreshMetadata(id);
+    return (await this.mediaRepo.findOne({ where: { id } })) ?? media;
+  }
+
+  /**
+   * The half that talks to the provider: re-pull the work and drop what the new
+   * one does not have. Runs after {@link applyIdentity} has committed the ids,
+   * off the request, because it walks every season, episode and image.
+   *
+   * The acquisition kick `refreshMetadata` normally fires is deferred: the
+   * episodes it just inserted have no files yet — the files of the work this
+   * media used to be are sitting unmatched until the caller relinks them, and
+   * grabbing against that state re-downloads what is already on disk.
+   */
+  async completeIdentify(id: number): Promise<Media> {
+    const refreshed = await this.refreshMetadata(id, {
+      deferAcquisitionKick: true,
+    });
 
     if (refreshed.type === MediaType.SERIES) {
       await this.dropSeasonsAbsentFromProvider(refreshed);
     }
 
     this.log.log(
-      `identify: media#${id} done — "${refreshed.title}" tmdb=${refreshed.tmdbId ?? '-'} ` +
+      `identify: media#${id} refreshed — "${refreshed.title}" tmdb=${refreshed.tmdbId ?? '-'} ` +
         `tvdb=${refreshed.tvdbId ?? '-'} imdb=${refreshed.imdbId ?? '-'}`,
     );
     return (await this.mediaRepo.findOne({ where: { id } })) ?? refreshed;
@@ -193,7 +213,10 @@ export class MediaMetadataService {
     }
   }
 
-  async refreshMetadata(id: number): Promise<Media> {
+  async refreshMetadata(
+    id: number,
+    opts?: { deferAcquisitionKick?: boolean },
+  ): Promise<Media> {
     const media = await this.mediaRepo.findOne({ where: { id } });
     if (!media) throw new NotFoundException(`Media #${id} not found`);
 
@@ -237,7 +260,7 @@ export class MediaMetadataService {
       // New episodes appeared on the provider (typically a fresh season
       // drop): kick the auto-grab pipeline now instead of waiting up to 6 h
       // for the next scheduler tick. Mirrors the post-approval kick.
-      if (insertedCount > 0) {
+      if (insertedCount > 0 && !opts?.deferAcquisitionKick) {
         this.events.emitDomain({
           type: 'media.acquisition.requested',
           mediaIds: [media.id],

--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -242,9 +242,10 @@ export class MediaController {
     return this.mediaService.updateProfiles(id, dto);
   }
 
-  /** Re-point a media at a different work. Synchronous, unlike `:id/refresh`:
-   *  the client replaces the whole page from the result, and an id clash has to
-   *  reach the admin as an error rather than a silent SSE failure. */
+  /** Re-point a media at a different work. The ids are written on the request,
+   *  so a bad target or an id clash still reaches the admin as an HTTP error;
+   *  re-pulling the work walks every season, episode and image, so it runs off
+   *  the request like `:id/refresh` and reports through the same SSE events. */
   @Post(':id/identify')
   @CheckPolicies((ability) => ability.can(Action.Update, Media))
   async identify(
@@ -254,11 +255,31 @@ export class MediaController {
   ) {
     await this.assertMediaAccessible(id, user);
     const media = await this.mediaService.identify(id, dto);
-    this.eventsService.emit({
-      type: 'metadata.refreshed',
-      mediaId: id,
-      title: media.title,
-    });
+    const title = media.title;
+
+    this.eventsService.emit({ type: 'metadata.started', mediaId: id, title });
+    void this.mediaService.finishIdentify(id).then(
+      (refreshed) => {
+        this.eventsService.emit({
+          type: 'metadata.refreshed',
+          mediaId: id,
+          title: refreshed.title,
+        });
+      },
+      (err) => {
+        const message = (err as Error).message;
+        this.logger.error(
+          `Identification failed after the ids were written — id=${id} error=${message}`,
+          err instanceof Error ? err.stack : err,
+        );
+        this.eventsService.emit({
+          type: 'metadata.failed',
+          mediaId: id,
+          title,
+          error: message,
+        });
+      },
+    );
     return media;
   }
 

--- a/backend/src/modules/media/media.service.identify.spec.ts
+++ b/backend/src/modules/media/media.service.identify.spec.ts
@@ -1,0 +1,56 @@
+import { MediaService } from './media.service';
+
+/**
+ * Dropping the old work's episodes leaves their files with no episode
+ * (`ON DELETE SET NULL`), so until they are relinked the new work's episodes
+ * read as missing while the files sit on disk. Letting the auto-grab pipeline
+ * see that state re-downloads what is already there.
+ */
+describe('MediaService.finishIdentify', () => {
+  function harness(opts: { rescanFails?: boolean } = {}) {
+    const calls: string[] = [];
+    const service = Object.create(MediaService.prototype) as MediaService;
+    Object.assign(service, {
+      metadata: {
+        completeIdentify: async () => {
+          calls.push('refresh');
+          return { id: 1, title: 'New Work' };
+        },
+      },
+      rescan: {
+        rescanFiles: async () => {
+          calls.push('rescan');
+          if (opts.rescanFails) throw new Error('no root path configured');
+          return {};
+        },
+      },
+      events: { emitDomain: () => calls.push('acquisition') },
+      logger: { warn: () => undefined },
+    });
+    return { service, calls };
+  }
+
+  it('VERDICT: relinks the files before letting the grab pipeline look at them', async () => {
+    const { service, calls } = harness();
+
+    await service.finishIdentify(1);
+
+    expect(calls).toEqual(['refresh', 'rescan', 'acquisition']);
+  });
+
+  it('returns the refreshed media', async () => {
+    const { service } = harness();
+
+    await expect(service.finishIdentify(1)).resolves.toMatchObject({
+      title: 'New Work',
+    });
+  });
+
+  it('finishes the identification even when nothing can be relinked', async () => {
+    const { service, calls } = harness({ rescanFails: true });
+
+    await service.finishIdentify(1);
+
+    expect(calls).toEqual(['refresh', 'rescan', 'acquisition']);
+  });
+});

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Media } from './entities/media.entity';
@@ -22,6 +22,7 @@ import { MediaQueryService } from './media-service/media-query.service';
 import { MediaRelatedService } from './media-service/media-related.service';
 import { MediaMutationService } from './media-service/media-mutation.service';
 import { MediaRescanService } from './media-service/media-rescan.service';
+import { EventsService } from '../scheduler/events.service';
 
 /**
  * Façade in front of the media sub-services. External callers
@@ -31,6 +32,8 @@ import { MediaRescanService } from './media-service/media-rescan.service';
  */
 @Injectable()
 export class MediaService {
+  private readonly logger = new Logger(MediaService.name);
+
   constructor(
     @InjectRepository(Media)
     private readonly mediaRepo: Repository<Media>,
@@ -40,6 +43,7 @@ export class MediaService {
     private readonly related: MediaRelatedService,
     private readonly mutation: MediaMutationService,
     private readonly rescan: MediaRescanService,
+    private readonly events: EventsService,
   ) {}
 
   // -- Imports ----------------------------------------------------------------
@@ -204,7 +208,33 @@ export class MediaService {
       preferredProvider?: string;
     },
   ) {
-    return this.metadata.identify(id, target);
+    return this.metadata.applyIdentity(id, target);
+  }
+
+  /**
+   * The provider half of an identification, plus the relink it needs: dropping
+   * the old work's episodes leaves their files with no episode (`ON DELETE SET
+   * NULL`), so the new work's episodes read as missing while the files sit on
+   * disk. The rescan re-parses those filenames against the new numbering, and
+   * only then is it safe to let the auto-grab pipeline look at this media.
+   */
+  async finishIdentify(id: number) {
+    const media = await this.metadata.completeIdentify(id);
+    try {
+      await this.rescan.rescanFiles(id);
+    } catch (err) {
+      // A media with no root path has nothing to relink; anything else is worth
+      // seeing, but neither is a reason to leave the identification unfinished.
+      this.logger.warn(
+        `identify: media#${id} relink skipped — ${(err as Error).message}`,
+      );
+    }
+    this.events.emitDomain({
+      type: 'media.acquisition.requested',
+      mediaIds: [id],
+      reason: 'metadata-refresh',
+    });
+    return media;
   }
 
   refreshMetadata(id: number) {

--- a/client/src/app/core/pipes/resolve-url.pipe.spec.ts
+++ b/client/src/app/core/pipes/resolve-url.pipe.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { imageUrlWithSize } from './resolve-url.pipe';
+
+/**
+ * Stored artwork URLs carry a `?v=<content hash>` so a re-identified media does
+ * not keep serving the old bytes out of the HTTP cache, the service worker or
+ * the native image cache — all three key on the URL.
+ */
+describe('imageUrlWithSize', () => {
+  it('VERDICT: keeps the version and adds the size as a second parameter', () => {
+    expect(imageUrlWithSize('/api/images/media/795/poster?v=1a2b3c4d', 'thumb')).toBe(
+      '/api/images/media/795/poster?v=1a2b3c4d&size=thumb',
+    );
+  });
+
+  it('starts the query string when the URL has none', () => {
+    expect(imageUrlWithSize('/api/images/media/795/poster', 'medium')).toBe(
+      '/api/images/media/795/poster?size=medium',
+    );
+  });
+
+  it('leaves a remote URL alone', () => {
+    const remote = 'https://image.tmdb.org/t/p/w500/x.jpg';
+    expect(imageUrlWithSize(remote, 'thumb')).toBe(remote);
+  });
+});


### PR DESCRIPTION
## Stale artwork after a re-identification

A media's artwork lives at a path that does not move — `/api/images/media/795/poster` — and `downloadAndStore` overwrites the file in place. So after a re-identification the database, the API and the page are all correct, and the poster on screen is still the previous work's.

Three caches hold it, and every one of them keys on the URL:

| Cache | Where | How long |
|---|---|---|
| HTTP cache | `image.controller.ts` sets `Cache-Control: public, max-age=86400`, no validator | 24 h |
| Angular service worker | `ngsw-config.json`: `/api/images/**`, `strategy: performance`, `maxAge: 30d` | **30 days**, never revalidated while fresh |
| `ImageCacheService` | native, keyed on a hash of the full URL | until LRU eviction |

The service worker is the one that hurts: a *performance* strategy serves from cache without touching the network, so on web a re-identified series could show the wrong poster for a month.

## Change

`downloadAndStore` returns `…/poster?v=<sha1 of the bytes, 8 chars>`. The value is already in hand — it hashes the buffer it just wrote — and it lands in the column the API serves, so all three caches see a different resource exactly when the image differs. An unchanged image keeps its URL, so an ordinary metadata refresh does not re-download a library's worth of artwork.

Nothing had to change on the read side: `imageUrlWithSize` already appends `size=` with the right separator, and the controller reads only `size` off the query string. Rows stored before this keep their unversioned URL and still resolve.

## Logging

`identify` now logs before the refresh as well as after. The refresh re-reads every season, episode and image of the new work, so on a long series the operation was silent for as long as it ran — the only line came out at the end.

```
identify: media#795 "Holmes and Holmes" tmdb=68427 tvdb=311521 -> tmdb=- tvdb=81188 imdb=tt0499308, refreshing
identify: media#795 done — "Fais pas ci, fais pas ça" tmdb=- tvdb=81188 imdb=tt0499308
```

## Tests

`imageUrlWithSize` keeps the version and appends the size as a second parameter, still opens the query string when there is none, and still leaves a remote URL alone. 531 client tests green; backend typecheck and the identify suite green.

## Relinking the files, and moving the long half off the request

Re-identifying a series drops the seasons the new work does not have. `media_files.episodeId` is `ON DELETE SET NULL`, so those files survive with no episode — the doc comment even says they "go back to unmatched" — and nothing ever matched them again. The new work's episodes therefore read as missing while the files sit on disk, and `refreshMetadata` kicks the auto-grab pipeline as soon as it inserts episodes, so a re-identified series could start downloading what was already there.

The identification now ends with `rescanFiles`, which already handles exactly this case (a series file with a null `episodeId` gets its filename re-parsed against the current numbering, linked, and its episode marked `hasFile`). The grab kick is held back until that has run, which is why `refreshMetadata` takes a `deferAcquisitionKick`.

That adds a disk walk to an operation that was already long, so the split the endpoint's own comment was protecting had to be made properly rather than abandoned:

- **On the request**: validation, the `UQ_media_type_tmdbId` clash check, and the id write. The comment asked that "an id clash has to reach the admin as an error rather than a silent SSE failure" — it still does, because all of it happens before anything slow.
- **Off the request**: re-pulling the work, dropping the surplus, relinking, then the grab kick — reported through `metadata.started` / `metadata.refreshed` / `metadata.failed`, which the detail page already listens to (reload, reload + toast, error toast). A provider failure now surfaces as a toast instead of an opaque 500.

No client change was needed: the dialog ignores the endpoint's return value, and the page reloads on `metadata.refreshed` the same way it does after a manual refresh.

## Tests

`imageUrlWithSize` keeps the version and appends the size as a second parameter, still opens the query string when there is none, and still leaves a remote URL alone. `finishIdentify` runs refresh → rescan → grab kick in that order, returns the refreshed media, and completes even when there is nothing to relink; `completeIdentify` holds back the refresh's own kick. Verified the ordering test fails when the kick is removed.

531 client tests and 54 backend media tests green.

## Not in this PR

Identify is fully synchronous: it writes the ids, then awaits the whole refresh — details, every season, every episode, every image — before the request returns. On a long series that is a very long request. Two things are worth doing about it and both are a separate change: `refreshSeriesEpisodes` enumerates the provider's seasons, and `dropSeasonsAbsentFromProvider` immediately enumerates them **again**, so an identify pays for two full walks of the series; and the episode/image half could run in the background with the page reloading on the event, which is the pattern the import path already uses (`downloadMediaImagesInBackground`, `persistMediaMetadataInBackground`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
