### PR TITLE
fix(card-actions): swap submenus in place on the sheet instead of stacking

### DIFF
--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
@@ -5,86 +5,102 @@
   [width]="width()"
   (closed)="onClose()"
 >
-  @if (title()) {
-    <div class="flex items-start gap-3 px-2 pb-3 mb-1 border-b border-base-content/10">
-      @if (imageUrl(); as img) {
-        <img [cachedSrc]="img | resolveUrl" alt="" loading="lazy"
-          class="shrink-0 rounded object-cover bg-base-300"
-          [style.width.px]="imageAspect() === 'landscape' ? 80 : 60"
-          [style.aspect-ratio]="imageAspect() === 'landscape' ? '16 / 9' : '2 / 3'" />
-      }
-      <div class="min-w-0">
-        <div class="text-sm font-semibold line-clamp-2">{{ title() }}</div>
-        @if (subtitle()) {
-          <div class="text-xs text-base-content/60 line-clamp-2">{{ subtitle() }}</div>
+  @if (sheetSub(); as sub) {
+    <div class="panel-slide-fwd">
+    <button type="button" class="dropdown-item mb-1" (click)="backToRoot()">
+      <svg lucideArrowLeft class="h-4 w-4 shrink-0 opacity-60"></svg>
+      <span class="flex-1 truncate text-left font-medium">{{ sub.labelKey ? (sub.labelKey | translate) : sub.label }}</span>
+    </button>
+    <div class="h-px bg-base-content/10 my-1" role="separator"></div>
+    <ng-container *ngTemplateOutlet="childRows; context: { $implicit: sub.children! }" />
+    </div>
+  } @else {
+    <div [class.panel-slide-back]="slide() === 'back'">
+    @if (title()) {
+      <div class="flex items-start gap-3 px-2 pb-3 mb-1 border-b border-base-content/10">
+        @if (imageUrl(); as img) {
+          <img [cachedSrc]="img | resolveUrl" alt="" loading="lazy"
+            class="shrink-0 rounded object-cover bg-base-300"
+            [style.width.px]="imageAspect() === 'landscape' ? 80 : 60"
+            [style.aspect-ratio]="imageAspect() === 'landscape' ? '16 / 9' : '2 / 3'" />
         }
+        <div class="min-w-0">
+          <div class="text-sm font-semibold line-clamp-2">{{ title() }}</div>
+          @if (subtitle()) {
+            <div class="text-xs text-base-content/60 line-clamp-2">{{ subtitle() }}</div>
+          }
+        </div>
       </div>
+    }
+    @for (a of actions(); track $index; let i = $index) {
+      @if (i > 0 && a.section !== actions()[i - 1].section) {
+        <div class="h-px bg-base-content/10 my-1" role="separator"></div>
+      }
+      @if (a.children?.length) {
+        <button
+          #subTrigger
+          type="button"
+          class="dropdown-item"
+          [attr.aria-expanded]="isOpen(a)"
+          (click)="openSub(a, subTrigger)"
+        >
+          <ng-container *ngTemplateOutlet="icon; context: { $implicit: a }" />
+          <span class="flex-1 truncate text-left">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
+          <svg lucideChevronRight class="h-4 w-4 shrink-0 opacity-60"></svg>
+        </button>
+        <!-- Desktop only: in sheet mode the group takes over the panel above
+             instead, since a second sheet would stack on top of this one. -->
+        <app-popover-menu
+          [open]="isOpen(a)"
+          [anchor]="subAnchor()"
+          placement="right-start"
+          [submenu]="true"
+          [width]="width()"
+          (closed)="closeSub()"
+        >
+          <ng-container *ngTemplateOutlet="childRows; context: { $implicit: a.children! }" />
+        </app-popover-menu>
+      } @else if (a.route) {
+        <a
+          [routerLink]="a.route"
+          class="dropdown-item"
+          [class.text-error]="a.tone === 'danger'"
+          (click)="closeForRoute()"
+        >
+          <ng-container *ngTemplateOutlet="icon; context: { $implicit: a }" />
+          <span class="flex-1 truncate text-left">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
+        </a>
+      } @else {
+        <button
+          type="button"
+          class="dropdown-item"
+          [class.text-error]="a.tone === 'danger'"
+          [disabled]="a.disabled"
+          (click)="trigger(a)"
+        >
+          <ng-container *ngTemplateOutlet="icon; context: { $implicit: a }" />
+          <span class="flex-1 truncate text-left">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
+        </button>
+      }
+    }
     </div>
   }
-  @for (a of actions(); track $index; let i = $index) {
-    @if (i > 0 && a.section !== actions()[i - 1].section) {
-      <div class="h-px bg-base-content/10 my-1" role="separator"></div>
-    }
-    @if (a.children?.length) {
-      <button
-        #subTrigger
-        type="button"
-        class="dropdown-item"
-        [attr.aria-expanded]="isOpen(a)"
-        (click)="openSub(a, subTrigger)"
-      >
-        <ng-container *ngTemplateOutlet="icon; context: { $implicit: a }" />
-        <span class="flex-1 truncate text-left">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
-        <svg lucideChevronRight class="h-4 w-4 shrink-0 opacity-60"></svg>
-      </button>
-      <!-- Anchored beside its parent row, same mechanism the subtitle actions
-           menu uses. On touch/TV `app-popover-menu` falls back to its sheet, so
-           the group stays reachable where there is no room for a side panel. -->
-      <app-popover-menu
-        [open]="isOpen(a)"
-        [anchor]="subAnchor()"
-        placement="right-start"
-        [submenu]="true"
-        [width]="width()"
-        (closed)="closeSub()"
-      >
-        @for (child of a.children!; track $index) {
-          <button
-            type="button"
-            class="dropdown-item"
-            [class.text-error]="child.tone === 'danger'"
-            [disabled]="child.disabled"
-            (click)="trigger(child)"
-          >
-            <ng-container *ngTemplateOutlet="icon; context: { $implicit: child }" />
-            <span class="flex-1 truncate text-left">{{ child.labelKey ? (child.labelKey | translate) : child.label }}</span>
-          </button>
-        }
-      </app-popover-menu>
-    } @else if (a.route) {
-      <a
-        [routerLink]="a.route"
-        class="dropdown-item"
-        [class.text-error]="a.tone === 'danger'"
-        (click)="closeForRoute()"
-      >
-        <ng-container *ngTemplateOutlet="icon; context: { $implicit: a }" />
-        <span class="flex-1 truncate text-left">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
-      </a>
-    } @else {
-      <button
-        type="button"
-        class="dropdown-item"
-        [class.text-error]="a.tone === 'danger'"
-        [disabled]="a.disabled"
-        (click)="trigger(a)"
-      >
-        <ng-container *ngTemplateOutlet="icon; context: { $implicit: a }" />
-        <span class="flex-1 truncate text-left">{{ a.labelKey ? (a.labelKey | translate) : a.label }}</span>
-      </button>
-    }
-  }
 </app-popover-menu>
+
+<ng-template #childRows let-children>
+  @for (child of children; track $index) {
+    <button
+      type="button"
+      class="dropdown-item"
+      [class.text-error]="child.tone === 'danger'"
+      [disabled]="child.disabled"
+      (click)="trigger(child)"
+    >
+      <ng-container *ngTemplateOutlet="icon; context: { $implicit: child }" />
+      <span class="flex-1 truncate text-left">{{ child.labelKey ? (child.labelKey | translate) : child.label }}</span>
+    </button>
+  }
+</ng-template>
 
 <!-- Curated whitelist: a `card.actions` contribution may name any icon, and an
      unrecognised one must fall back to a glyph rather than render blank. -->

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
@@ -28,12 +28,15 @@ import {
   LucideSearch,
   LucideDownload,
   LucideChevronRight,
+  LucideArrowLeft,
   LucideDatabase,
   LucideSlidersHorizontal,
   LucideHeart,
   LucideCircle,
 } from '@lucide/angular';
 import { CardAction, CardActionsService } from '../../../core/services/card-actions.service';
+import { TvService } from '../../../core/services/tv.service';
+import { DeviceService } from '../../../core/services/device.service';
 import { PopoverMenuComponent } from '../popover-menu';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import { CachedSrcDirective } from '../../directives/cached-src.directive';
@@ -70,6 +73,7 @@ import { CachedSrcDirective } from '../../directives/cached-src.directive';
     LucideSearch,
     LucideDownload,
   LucideChevronRight,
+  LucideArrowLeft,
   LucideDatabase,
   LucideSlidersHorizontal,
   LucideHeart,
@@ -82,6 +86,13 @@ import { CachedSrcDirective } from '../../directives/cached-src.directive';
 })
 export class CardActionsPanelComponent {
   readonly service = inject(CardActionsService);
+  private readonly tv = inject(TvService);
+  private readonly device = inject(DeviceService);
+
+  /** Same condition `app-popover-menu` uses to render a sheet instead of an
+   *  anchored dropdown: there is no room beside the panel for a flyout, so a
+   *  submenu takes over the sheet with a back row. */
+  protected readonly sheet = computed(() => this.tv.isTv() || this.device.isTouch());
 
   readonly actions = computed(() => this.service.actions() ?? []);
   readonly title = this.service.title;
@@ -107,7 +118,10 @@ export class CardActionsPanelComponent {
     // Collapse on every open: a group left unfolded from last time would make
     // the menu a different height than the one the user reached for.
     effect(() => {
-      if (this.service.open()) this.closeSub();
+      if (this.service.open()) {
+        this.closeSub();
+        this.slide.set('');
+      }
     });
   }
 
@@ -120,6 +134,13 @@ export class CardActionsPanelComponent {
   private readonly openSubmenu = signal<CardAction | null>(null);
   protected readonly subAnchor = signal<HTMLElement | null>(null);
 
+  /** Which way the sheet panel last moved, so the incoming list slides in
+   *  from the matching side. */
+  protected readonly slide = signal<'' | 'back'>('');
+
+  /** Submenu shown in place of the root list (sheet only). */
+  protected readonly sheetSub = computed(() => (this.sheet() ? this.openSubmenu() : null));
+
   isOpen(a: CardAction): boolean {
     return this.openSubmenu() === a;
   }
@@ -128,6 +149,13 @@ export class CardActionsPanelComponent {
     if (this.isOpen(a)) return this.closeSub();
     this.subAnchor.set(anchor);
     this.openSubmenu.set(a);
+  }
+
+  /** Sheet back row: same as closing the submenu, but the root list slides
+   *  back in from the left. */
+  backToRoot() {
+    this.slide.set('back');
+    this.closeSub();
   }
 
   closeSub() {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -655,6 +655,33 @@ body.tv .to-base-100\/50 {
   }
 }
 
+/* Sheet submenu navigation: the panel swaps in place, so the incoming list
+   slides in from the side it conceptually comes from. */
+.panel-slide-fwd {
+  animation: panel-slide-fwd 0.18s ease;
+}
+@keyframes panel-slide-fwd {
+  from {
+    opacity: 0;
+    transform: translateX(30%);
+  }
+}
+.panel-slide-back {
+  animation: panel-slide-back 0.18s ease;
+}
+@keyframes panel-slide-back {
+  from {
+    opacity: 0;
+    transform: translateX(-30%);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .panel-slide-fwd,
+  .panel-slide-back {
+    animation: none;
+  }
+}
+
 /* Shared item style for app-dropdown-menu (desktop dropdown + mobile/TV
    bottom sheet). Caller adds a colour utility (`text-white`, `text-error`,
    …) and an icon — everything else (padding, hover, focus, layout) lives


### PR DESCRIPTION
## Problem

On touch and TV the card actions menu renders as a bottom sheet. Opening a group (e.g. **Métadonnées**) opened a *second* sheet on top of the first, so two panels overlapped with no clear owner — the screenshot in the issue shows the parent list still visible behind the child.

## Fix

The sheet now navigates like the player's settings panels: the group takes over the panel, with a back row (← + group label) at the top. One panel at a time, same mental model as the player's Appearance submenu.

- `sheet()` reuses the exact condition `app-popover-menu` uses to pick a sheet over an anchored dropdown, so the fix covers TV too (same stacking problem there).
- The anchored side flyout is unchanged on desktop, where there is room beside the menu.
- Child rows factored into one `#childRows` template shared by both modes.
- 180 ms slide on the swap: the incoming list enters from the right going in, from the left coming back. Disabled under `prefers-reduced-motion`.

## Not done

- The hardware/Escape back still closes the whole sheet instead of popping one level — the dismiss stack lives in `app-popover-menu` and would need a handler in the panel.
- The sheet height jumps between panels (no height morph).

## Test

`ng build` passes. Not yet exercised on a device — the swap is template-level, so a phone check of the Métadonnées group is worth a minute.