### PR TITLE
refactor(modals): unify dialog headers and footers on the bordered look

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -982,6 +982,8 @@
     "subtitles_section": "Untertitel",
     "search_subtitles": "Untertitel suchen",
     "upload_subtitle": "Untertitel hochladen",
+    "subtitles_import": "Importieren",
+    "subtitles_search": "Suchen",
     "upload_subtitle_hint": "Wählen Sie die Sprache der hochzuladenden Datei.",
     "upload_subtitle_success": "Untertitel hochgeladen",
     "auto_subtitle": "Auto",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -987,6 +987,8 @@
     "subtitles_section": "Subtitles",
     "search_subtitles": "Search subtitles",
     "upload_subtitle": "Upload a subtitle",
+    "subtitles_import": "Import",
+    "subtitles_search": "Search",
     "upload_subtitle_hint": "Pick the language of the file to upload.",
     "upload_subtitle_success": "Subtitle uploaded",
     "auto_subtitle": "Auto",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -982,6 +982,8 @@
     "subtitles_section": "Subtítulos",
     "search_subtitles": "Buscar subtítulos",
     "upload_subtitle": "Subir un subtítulo",
+    "subtitles_import": "Importar",
+    "subtitles_search": "Buscar",
     "upload_subtitle_hint": "Elige el idioma del archivo que vas a subir.",
     "upload_subtitle_success": "Subtítulo subido",
     "auto_subtitle": "Auto",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -987,6 +987,8 @@
     "subtitles_section": "Sous-titres",
     "search_subtitles": "Chercher des sous-titres",
     "upload_subtitle": "Importer un sous-titre",
+    "subtitles_import": "Importer",
+    "subtitles_search": "Rechercher",
     "upload_subtitle_hint": "Choisissez la langue du fichier à importer.",
     "upload_subtitle_success": "Sous-titre importé",
     "auto_subtitle": "Auto",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -982,6 +982,8 @@
     "subtitles_section": "Sottotitoli",
     "search_subtitles": "Cerca sottotitoli",
     "upload_subtitle": "Carica un sottotitolo",
+    "subtitles_import": "Importa",
+    "subtitles_search": "Cerca",
     "upload_subtitle_hint": "Scegli la lingua del file da caricare.",
     "upload_subtitle_success": "Sottotitolo caricato",
     "auto_subtitle": "Auto",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -982,6 +982,8 @@
     "subtitles_section": "Legendas",
     "search_subtitles": "Procurar legendas",
     "upload_subtitle": "Carregar uma legenda",
+    "subtitles_import": "Importar",
+    "subtitles_search": "Pesquisar",
     "upload_subtitle_hint": "Escolha o idioma do ficheiro a carregar.",
     "upload_subtitle_success": "Legenda carregada",
     "auto_subtitle": "Auto",

--- a/client/src/app/features/app-settings/home-settings/home-settings.html
+++ b/client/src/app/features/app-settings/home-settings/home-settings.html
@@ -14,48 +14,71 @@
 
     <div cdkDropList (cdkDropListDropped)="drop($event)" class="flex flex-col gap-2">
       @for (section of rows(); track section.key; let i = $index) {
-        <div cdkDrag [cdkDragDisabled]="tv.isTv()" class="flex items-center gap-2 rounded-lg border border-base-200 bg-base-200/40 px-3 py-2">
+        <div
+          cdkDrag
+          [cdkDragDisabled]="tv.isTv()"
+          class="flex items-center gap-2 rounded-lg border border-base-200 bg-base-200/40 px-3 py-2"
+        >
           @if (!tv.isTv()) {
-            <button type="button" cdkDragHandle
-                    class="cursor-grab text-base-content/40 hover:text-base-content/70"
-                    [attr.aria-label]="'home_settings.drag' | translate">
+            <button
+              type="button"
+              cdkDragHandle
+              class="cursor-grab text-base-content/40 hover:text-base-content/70"
+              [attr.aria-label]="'home_settings.drag' | translate"
+            >
               <svg lucideGripVertical class="h-4 w-4"></svg>
             </button>
           }
 
           <span class="flex-1 font-medium">
             @if (section.type === 'library-recent') {
-              {{ 'home_settings.section_library_recent' | translate: { library: section.libraryName } }}
+              {{
+                'home_settings.section_library_recent' | translate: { library: section.libraryName }
+              }}
             } @else {
               {{ builtinLabel(section) | translate }}
             }
           </span>
 
           @if (section.type === 'libraries') {
-            <button type="button" class="btn btn-ghost btn-xs btn-square"
-                    (click)="openLibraryReorder()"
-                    [attr.aria-label]="'home_settings.libraries_settings' | translate">
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-square"
+              (click)="openLibraryReorder()"
+              [attr.aria-label]="'home_settings.libraries_settings' | translate"
+            >
               <svg lucideSettings class="h-4 w-4"></svg>
             </button>
           }
 
           @if (tv.isTv()) {
-            <button type="button" class="btn btn-ghost btn-xs btn-square"
-                    [disabled]="i === 0" (click)="move(i, -1)"
-                    [attr.aria-label]="'home_settings.move_up' | translate">
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-square"
+              [disabled]="i === 0"
+              (click)="move(i, -1)"
+              [attr.aria-label]="'home_settings.move_up' | translate"
+            >
               <svg lucideArrowUp class="h-4 w-4"></svg>
             </button>
-            <button type="button" class="btn btn-ghost btn-xs btn-square"
-                    [disabled]="i === rows().length - 1" (click)="move(i, 1)"
-                    [attr.aria-label]="'home_settings.move_down' | translate">
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-square"
+              [disabled]="i === rows().length - 1"
+              (click)="move(i, 1)"
+              [attr.aria-label]="'home_settings.move_down' | translate"
+            >
               <svg lucideArrowDown class="h-4 w-4"></svg>
             </button>
           }
 
-          <input type="checkbox" class="toggle toggle-primary toggle-sm ml-1"
-                 [checked]="section.visible"
-                 (change)="setVisible(i, $any($event.target).checked)"
-                 [attr.aria-label]="'home_settings.toggle_visible' | translate" />
+          <input
+            type="checkbox"
+            class="toggle toggle-primary toggle-sm ml-1"
+            [checked]="section.visible"
+            (change)="setVisible(i, $any($event.target).checked)"
+            [attr.aria-label]="'home_settings.toggle_visible' | translate"
+          />
         </div>
       }
     </div>
@@ -91,20 +114,28 @@
     <app-modal-header>
       <div>
         <h3 class="text-lg font-bold">{{ 'home_settings.libraries_modal_title' | translate }}</h3>
-        <p class="text-sm text-base-content/60 mt-1">{{ 'home_settings.libraries_modal_hint' | translate }}</p>
+        <p class="text-sm text-base-content/60 mt-1">
+          {{ 'home_settings.libraries_modal_hint' | translate }}
+        </p>
       </div>
     </app-modal-header>
 
     @if (libraryRows().length) {
       <div cdkDropList (cdkDropListDropped)="dropLibrary($event)" class="flex flex-col gap-2 mt-4">
         @for (lib of libraryRows(); track lib.id; let i = $index) {
-          <div cdkDrag [cdkDragDisabled]="tv.isTv()"
-               class="flex items-center gap-2 rounded-lg border border-base-200 bg-base-200/40 px-3 py-2"
-               [class.opacity-50]="lib.hidden">
+          <div
+            cdkDrag
+            [cdkDragDisabled]="tv.isTv()"
+            class="flex items-center gap-2 rounded-lg border border-base-200 bg-base-200/40 px-3 py-2"
+            [class.opacity-50]="lib.hidden"
+          >
             @if (!tv.isTv()) {
-              <button type="button" cdkDragHandle
-                      class="cursor-grab text-base-content/40 hover:text-base-content/70"
-                      [attr.aria-label]="'home_settings.drag' | translate">
+              <button
+                type="button"
+                cdkDragHandle
+                class="cursor-grab text-base-content/40 hover:text-base-content/70"
+                [attr.aria-label]="'home_settings.drag' | translate"
+              >
                 <svg lucideGripVertical class="h-4 w-4"></svg>
               </button>
             }
@@ -112,21 +143,32 @@
             <span class="flex-1 font-medium truncate">{{ lib.name }}</span>
 
             @if (tv.isTv()) {
-              <button type="button" class="btn btn-ghost btn-xs btn-square"
-                      [disabled]="i === 0" (click)="moveLibrary(i, -1)"
-                      [attr.aria-label]="'home_settings.move_up' | translate">
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs btn-square"
+                [disabled]="i === 0"
+                (click)="moveLibrary(i, -1)"
+                [attr.aria-label]="'home_settings.move_up' | translate"
+              >
                 <svg lucideArrowUp class="h-4 w-4"></svg>
               </button>
-              <button type="button" class="btn btn-ghost btn-xs btn-square"
-                      [disabled]="i === libraryRows().length - 1" (click)="moveLibrary(i, 1)"
-                      [attr.aria-label]="'home_settings.move_down' | translate">
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs btn-square"
+                [disabled]="i === libraryRows().length - 1"
+                (click)="moveLibrary(i, 1)"
+                [attr.aria-label]="'home_settings.move_down' | translate"
+              >
                 <svg lucideArrowDown class="h-4 w-4"></svg>
               </button>
             }
 
-            <button type="button" class="btn btn-ghost btn-xs btn-square"
-                    (click)="toggleLibraryHidden(i)"
-                    [attr.aria-label]="'home_settings.toggle_library_visible' | translate">
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-square"
+              (click)="toggleLibraryHidden(i)"
+              [attr.aria-label]="'home_settings.toggle_library_visible' | translate"
+            >
               @if (lib.hidden) {
                 <svg lucideEyeOff class="h-4 w-4 text-base-content/40"></svg>
               } @else {
@@ -137,20 +179,40 @@
         }
       </div>
     } @else {
-      <p class="text-center py-8 text-base-content/50">{{ 'settings.libraries.empty' | translate }}</p>
+      <p class="text-center py-8 text-base-content/50">
+        {{ 'settings.libraries.empty' | translate }}
+      </p>
     }
 
-    <div class="modal-action mt-6">
-      <button type="button" class="btn btn-ghost" (click)="closeLibraryReorder()" [disabled]="librarySaving()">
+    <app-modal-footer>
+      <button
+        type="button"
+        class="btn btn-ghost"
+        (click)="closeLibraryReorder()"
+        [disabled]="librarySaving()"
+      >
         {{ 'common.cancel' | translate }}
       </button>
-      <button type="button" class="btn btn-primary" (click)="saveLibraryOrder()" [disabled]="librarySaving()">
-        @if (librarySaving()) { <span class="loading loading-spinner loading-sm"></span> }
+      <button
+        type="button"
+        class="btn btn-primary"
+        (click)="saveLibraryOrder()"
+        [disabled]="librarySaving()"
+      >
+        @if (librarySaving()) {
+          <span class="loading loading-spinner loading-sm"></span>
+        }
         {{ 'common.save' | translate }}
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
-    <button type="button" (click)="closeLibraryReorder()" [attr.aria-label]="'common.close' | translate">close</button>
+    <button
+      type="button"
+      (click)="closeLibraryReorder()"
+      [attr.aria-label]="'common.close' | translate"
+    >
+      close
+    </button>
   </form>
 </dialog>

--- a/client/src/app/features/app-settings/home-settings/home-settings.html
+++ b/client/src/app/features/app-settings/home-settings/home-settings.html
@@ -88,8 +88,12 @@
 
 <dialog #libraryDialog class="modal">
   <div class="modal-box max-w-md">
-    <h2 class="text-lg font-bold">{{ 'home_settings.libraries_modal_title' | translate }}</h2>
-    <p class="text-sm text-base-content/60 mt-1">{{ 'home_settings.libraries_modal_hint' | translate }}</p>
+    <app-modal-header>
+      <div>
+        <h3 class="text-lg font-bold">{{ 'home_settings.libraries_modal_title' | translate }}</h3>
+        <p class="text-sm text-base-content/60 mt-1">{{ 'home_settings.libraries_modal_hint' | translate }}</p>
+      </div>
+    </app-modal-header>
 
     @if (libraryRows().length) {
       <div cdkDropList (cdkDropListDropped)="dropLibrary($event)" class="flex flex-col gap-2 mt-4">

--- a/client/src/app/features/app-settings/home-settings/home-settings.ts
+++ b/client/src/app/features/app-settings/home-settings/home-settings.ts
@@ -38,10 +38,12 @@ import { DisplaySettingsService } from '../../../core/services/display-settings.
 import { SelectFieldComponent } from '../../../shared/components/forms/select-field/select-field';
 import { ToggleFieldComponent } from '../../../shared/components/forms/toggle-field/toggle-field';
 import { ModalHeaderComponent } from '../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-home-settings',
   imports: [
+    ModalFooterComponent,
     ModalHeaderComponent,
     TranslateModule,
     FormsModule,
@@ -79,13 +81,10 @@ export class HomeSettingsPageComponent implements OnInit {
   private libs: { id: number; name: string }[] = [];
 
   // --- Library order + visibility modal ---
-  private readonly libraryDialog =
-    viewChild<ElementRef<HTMLDialogElement>>('libraryDialog');
+  private readonly libraryDialog = viewChild<ElementRef<HTMLDialogElement>>('libraryDialog');
   /** Working copy edited in the modal: every accessible library in the user's
    *  order, each flagged hidden. Persisted only on save. */
-  readonly libraryRows = signal<
-    { id: number; name: string; hidden: boolean }[]
-  >([]);
+  readonly libraryRows = signal<{ id: number; name: string; hidden: boolean }[]>([]);
   readonly librarySaving = signal(false);
 
   private readonly BUILTIN_LABELS: Record<string, string> = {
@@ -115,17 +114,12 @@ export class HomeSettingsPageComponent implements OnInit {
   }
 
   private get requestsAllowed(): boolean {
-    return (
-      this.auth.hasPermission('requests.create') ||
-      this.auth.hasPermission('requests.manage')
-    );
+    return this.auth.hasPermission('requests.create') || this.auth.hasPermission('requests.manage');
   }
 
   /** Re-derive the rendered rows from the persisted settings + current libs. */
   private rebuild() {
-    this.rows.set(
-      this.home.resolve(this.libs, { requests: this.requestsAllowed }),
-    );
+    this.rows.set(this.home.resolve(this.libs, { requests: this.requestsAllowed }));
   }
 
   /** Reset zone order + visibility to defaults, after confirmation. */
@@ -147,9 +141,7 @@ export class HomeSettingsPageComponent implements OnInit {
   }
 
   private persist() {
-    this.home.setOrder(
-      this.rows().map((r) => ({ key: r.key, visible: r.visible })),
-    );
+    this.home.setOrder(this.rows().map((r) => ({ key: r.key, visible: r.visible })));
   }
 
   drop(event: CdkDragDrop<ResolvedHomeSection[]>) {

--- a/client/src/app/features/app-settings/home-settings/home-settings.ts
+++ b/client/src/app/features/app-settings/home-settings/home-settings.ts
@@ -37,10 +37,12 @@ import { ConfirmationService } from '../../../core/services/confirmation.service
 import { DisplaySettingsService } from '../../../core/services/display-settings.service';
 import { SelectFieldComponent } from '../../../shared/components/forms/select-field/select-field';
 import { ToggleFieldComponent } from '../../../shared/components/forms/toggle-field/toggle-field';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 
 @Component({
   selector: 'app-home-settings',
   imports: [
+    ModalHeaderComponent,
     TranslateModule,
     FormsModule,
     CdkDropList,

--- a/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.html
@@ -1,23 +1,15 @@
 <dialog #dialog class="modal">
   <div class="modal-box max-w-3xl max-h-[90vh] flex flex-col p-0 gap-0 overflow-hidden">
-    <div class="px-5 sm:px-6 pt-4 pb-3 border-b border-base-200 flex justify-between items-center gap-3 shrink-0 bg-base-100">
-      <h2 class="text-lg font-bold leading-tight">{{ 'media_detail.identify_title' | translate }}</h2>
-      <button
-        type="button"
-        class="btn btn-sm btn-circle btn-ghost shrink-0"
-        (click)="close()"
-        [attr.aria-label]="'common.close' | translate"
-      >
-        ✕
-      </button>
-    </div>
+    <app-modal-header flush [title]="'media_detail.identify_title' | translate" />
 
     <div class="px-5 sm:px-6 py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 bg-base-100">
       <p class="text-sm text-base-content/60">{{ 'media_detail.identify_hint' | translate }}</p>
 
       @if (config()?.path) {
         <div>
-          <span class="text-sm text-base-content/50">{{ 'media_detail.identify_path' | translate }}</span>
+          <span class="text-sm text-base-content/50">{{
+            'media_detail.identify_path' | translate
+          }}</span>
           <p class="text-sm font-mono break-all m-0">{{ config()!.path }}</p>
         </div>
       }
@@ -25,67 +17,113 @@
       <div class="grid gap-4 sm:grid-cols-2">
         <label class="form-control w-full">
           <span class="label-text">{{ 'media_detail.identify_field_title' | translate }}</span>
-          <input type="text" class="input input-bordered input-sm w-full"
-            [ngModel]="formTitle()" (ngModelChange)="formTitle.set($event)"
-            (keydown.enter)="search()" />
+          <input
+            type="text"
+            class="input input-bordered input-sm w-full"
+            [ngModel]="formTitle()"
+            (ngModelChange)="formTitle.set($event)"
+            (keydown.enter)="search()"
+          />
         </label>
         <label class="form-control w-full">
           <span class="label-text">{{ 'media_detail.identify_field_year' | translate }}</span>
-          <input type="number" class="input input-bordered input-sm w-full"
-            [ngModel]="formYear()" (ngModelChange)="formYear.set($event === null ? null : +$event)"
-            (keydown.enter)="search()" />
+          <input
+            type="number"
+            class="input input-bordered input-sm w-full"
+            [ngModel]="formYear()"
+            (ngModelChange)="formYear.set($event === null ? null : +$event)"
+            (keydown.enter)="search()"
+          />
         </label>
         <label class="form-control w-full">
           <span class="label-text">{{ 'media_detail.identify_field_imdb' | translate }}</span>
-          <input type="text" class="input input-bordered input-sm w-full font-mono"
+          <input
+            type="text"
+            class="input input-bordered input-sm w-full font-mono"
             placeholder="tt1234567"
-            [ngModel]="formImdbId()" (ngModelChange)="formImdbId.set($event)" />
+            [ngModel]="formImdbId()"
+            (ngModelChange)="formImdbId.set($event)"
+          />
         </label>
         <label class="form-control w-full">
           <span class="label-text">{{ 'media_detail.identify_field_tmdb' | translate }}</span>
-          <input type="number" class="input input-bordered input-sm w-full font-mono"
-            [ngModel]="formTmdbId()" (ngModelChange)="formTmdbId.set($event === null ? null : +$event)" />
+          <input
+            type="number"
+            class="input input-bordered input-sm w-full font-mono"
+            [ngModel]="formTmdbId()"
+            (ngModelChange)="formTmdbId.set($event === null ? null : +$event)"
+          />
         </label>
         <label class="form-control w-full">
           <span class="label-text">{{ 'media_detail.identify_field_tvdb' | translate }}</span>
-          <input type="number" class="input input-bordered input-sm w-full font-mono"
-            [ngModel]="formTvdbId()" (ngModelChange)="formTvdbId.set($event === null ? null : +$event)" />
+          <input
+            type="number"
+            class="input input-bordered input-sm w-full font-mono"
+            [ngModel]="formTvdbId()"
+            (ngModelChange)="formTvdbId.set($event === null ? null : +$event)"
+          />
         </label>
       </div>
 
       <div class="flex flex-wrap gap-2">
-        <button type="button" class="btn btn-primary btn-sm"
-          [disabled]="searching() || !formTitle().trim()" (click)="search()">
-          @if (searching()) { <span class="loading loading-spinner loading-xs"></span> }
+        <button
+          type="button"
+          class="btn btn-primary btn-sm"
+          [disabled]="searching() || !formTitle().trim()"
+          (click)="search()"
+        >
+          @if (searching()) {
+            <span class="loading loading-spinner loading-xs"></span>
+          }
           {{ 'media_detail.identify_search' | translate }}
         </button>
-        <button type="button" class="btn btn-outline btn-sm"
-          [disabled]="applyingKey() !== null" (click)="applyIds()">
-          @if (applyingKey() === 'ids') { <span class="loading loading-spinner loading-xs"></span> }
+        <button
+          type="button"
+          class="btn btn-outline btn-sm"
+          [disabled]="applyingKey() !== null"
+          (click)="applyIds()"
+        >
+          @if (applyingKey() === 'ids') {
+            <span class="loading loading-spinner loading-xs"></span>
+          }
           {{ 'media_detail.identify_apply_ids' | translate }}
         </button>
       </div>
 
       @if (searched()) {
         <div class="border-t border-base-200 pt-4">
-          <h3 class="text-base font-semibold m-0 mb-3">{{ 'media_detail.identify_results' | translate }}</h3>
+          <h3 class="text-base font-semibold m-0 mb-3">
+            {{ 'media_detail.identify_results' | translate }}
+          </h3>
           @if (!results().length) {
-            <p class="text-sm text-base-content/50 py-4">{{ 'media_detail.identify_no_results' | translate }}</p>
+            <p class="text-sm text-base-content/50 py-4">
+              {{ 'media_detail.identify_no_results' | translate }}
+            </p>
           } @else {
             <div class="grid gap-3 grid-cols-2 sm:grid-cols-4 lg:grid-cols-5">
               @for (r of results(); track key(r)) {
-                <button type="button"
+                <button
+                  type="button"
                   class="flex flex-col gap-1 text-left rounded-lg p-1 hover:bg-base-200 disabled:opacity-40"
                   [disabled]="applyingKey() !== null || isTaken(r)"
-                  [attr.title]="isTaken(r) ? ('media_detail.identify_already_in_library' | translate) : r.title"
-                  (click)="apply(r)">
+                  [attr.title]="
+                    isTaken(r) ? ('media_detail.identify_already_in_library' | translate) : r.title
+                  "
+                  (click)="apply(r)"
+                >
                   <div class="relative aspect-[2/3] w-full rounded bg-base-300 overflow-hidden">
                     @if (r.posterUrl) {
-                      <img [src]="r.posterUrl | resolveUrl" [alt]="r.title"
-                        class="h-full w-full object-cover" loading="lazy" />
+                      <img
+                        [src]="r.posterUrl | resolveUrl"
+                        [alt]="r.title"
+                        class="h-full w-full object-cover"
+                        loading="lazy"
+                      />
                     }
                     @if (applyingKey() === key(r)) {
-                      <span class="absolute inset-0 flex items-center justify-center bg-base-100/70">
+                      <span
+                        class="absolute inset-0 flex items-center justify-center bg-base-100/70"
+                      >
                         <span class="loading loading-spinner loading-sm"></span>
                       </span>
                     }
@@ -93,7 +131,9 @@
                   <span class="text-sm leading-tight line-clamp-2">{{ r.title }}</span>
                   <span class="text-xs text-base-content/50">
                     {{ r.year ?? '—' }}
-                    @if (isTaken(r)) { · {{ 'media_detail.identify_already_in_library' | translate }} }
+                    @if (isTaken(r)) {
+                      · {{ 'media_detail.identify_already_in_library' | translate }}
+                    }
                   </span>
                 </button>
               }
@@ -103,9 +143,9 @@
       }
     </div>
 
-    <div class="modal-action modal-action-sticky">
+    <app-modal-footer flush>
       <button type="button" class="btn" (click)="close()">{{ 'common.close' | translate }}</button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.html
@@ -103,8 +103,8 @@
       }
     </div>
 
-    <div class="modal-action mt-0 shrink-0 px-5 sm:px-6 py-3 border-t border-base-200 bg-base-100">
-      <button type="button" class="btn btn-sm" (click)="close()">{{ 'common.close' | translate }}</button>
+    <div class="modal-action modal-action-sticky">
+      <button type="button" class="btn" (click)="close()">{{ 'common.close' | translate }}</button>
     </div>
   </div>
   <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>

--- a/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.ts
@@ -19,6 +19,8 @@ import {
 import { MediaService } from '../../../../core/services/api/media.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import type { MediaType } from '../../../../core/enums/media-type.enum';
+import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../../shared/components/modal-footer';
 
 /** What the caller knows about the media, used to prefill the criteria. */
 export interface IdentifyModalConfig {
@@ -34,7 +36,13 @@ export interface IdentifyModalConfig {
 
 @Component({
   selector: 'app-media-detail-identify-modal',
-  imports: [TranslateModule, FormsModule, ResolveUrlPipe],
+  imports: [
+    ModalFooterComponent,
+    ModalHeaderComponent,
+    TranslateModule,
+    FormsModule,
+    ResolveUrlPipe,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-identify-modal.component.html',
 })

--- a/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.html
@@ -32,12 +32,16 @@
             </option>
           }
         </select>
-        <span class="label-text-alt opacity-60">{{ 'media_detail.provider_override_hint' | translate }}</span>
+        <span class="label-text-alt opacity-60">{{
+          'media_detail.provider_override_hint' | translate
+        }}</span>
       </label>
       @if (saved()) {
-        <div role="alert" class="alert alert-success text-sm py-2">{{ 'media_detail.library_saved' | translate }}</div>
+        <div role="alert" class="alert alert-success text-sm py-2">
+          {{ 'media_detail.library_saved' | translate }}
+        </div>
       }
-      <div class="modal-action">
+      <app-modal-footer>
         <button type="button" class="btn btn-ghost" (click)="close()">
           {{ 'common.close' | translate }}
         </button>
@@ -51,7 +55,7 @@
           }
           {{ 'common.save' | translate }}
         </button>
-      </div>
+      </app-modal-footer>
     </form>
   </div>
   <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>

--- a/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.html
@@ -38,18 +38,18 @@
         <div role="alert" class="alert alert-success text-sm py-2">{{ 'media_detail.library_saved' | translate }}</div>
       }
       <div class="modal-action">
+        <button type="button" class="btn btn-ghost" (click)="close()">
+          {{ 'common.close' | translate }}
+        </button>
         <button
           type="submit"
-          class="btn btn-primary btn-sm"
+          class="btn btn-primary"
           [disabled]="saving() || selectedLibraryId() === null"
         >
           @if (saving()) {
             <span class="loading loading-spinner loading-xs"></span>
           }
           {{ 'common.save' | translate }}
-        </button>
-        <button type="button" class="btn btn-sm" onclick="this.closest('dialog').close()">
-          {{ 'common.close' | translate }}
         </button>
       </div>
     </form>

--- a/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.ts
@@ -37,4 +37,8 @@ export class MediaDetailLibraryModalComponent {
   showModal() {
     this.dialogEl()?.nativeElement.showModal();
   }
+
+  close() {
+    this.dialogEl()?.nativeElement.close();
+  }
 }

--- a/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.ts
@@ -12,10 +12,17 @@ import { LibrarySummary } from '../../../../core/services/api/libraries-api.serv
 import { METADATA_PROVIDER_OPTIONS_OVERRIDE } from '../../../../core/constants/metadata-providers';
 import { TvSelectDirective } from '../../../../shared/directives/tv-select.directive';
 import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-media-detail-library-modal',
-  imports: [TranslateModule, FormsModule, TvSelectDirective, ModalHeaderComponent],
+  imports: [
+    ModalFooterComponent,
+    TranslateModule,
+    FormsModule,
+    TvSelectDirective,
+    ModalHeaderComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-library-modal.component.html',
 })

--- a/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.html
@@ -44,14 +44,14 @@
           <div role="alert" class="alert alert-error text-sm py-2">{{ profilesErr() }}</div>
         }
         <div class="modal-action">
-          <button type="submit" class="btn btn-primary btn-sm" [disabled]="profilesSaveLoading()">
+          <button type="button" class="btn btn-ghost" (click)="close()">
+            {{ 'common.close' | translate }}
+          </button>
+          <button type="submit" class="btn btn-primary" [disabled]="profilesSaveLoading()">
             @if (profilesSaveLoading()) {
               <span class="loading loading-spinner loading-xs"></span>
             }
             {{ 'media_detail.save_profiles' | translate }}
-          </button>
-          <button type="button" class="btn btn-sm" onclick="this.closest('dialog').close()">
-            {{ 'common.close' | translate }}
           </button>
         </div>
       </form>

--- a/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.html
@@ -43,7 +43,7 @@
         @if (profilesErr()) {
           <div role="alert" class="alert alert-error text-sm py-2">{{ profilesErr() }}</div>
         }
-        <div class="modal-action">
+        <app-modal-footer>
           <button type="button" class="btn btn-ghost" (click)="close()">
             {{ 'common.close' | translate }}
           </button>
@@ -53,7 +53,7 @@
             }
             {{ 'media_detail.save_profiles' | translate }}
           </button>
-        </div>
+        </app-modal-footer>
       </form>
     }
   </div>

--- a/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.ts
@@ -10,10 +10,17 @@ import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { TvSelectDirective } from '../../../../shared/directives/tv-select.directive';
 import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-media-detail-profiles-modal',
-  imports: [TranslateModule, FormsModule, TvSelectDirective, ModalHeaderComponent],
+  imports: [
+    ModalFooterComponent,
+    TranslateModule,
+    FormsModule,
+    TvSelectDirective,
+    ModalHeaderComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-profiles-modal.component.html',
 })

--- a/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.ts
@@ -36,4 +36,8 @@ export class MediaDetailProfilesModalComponent {
   showModal() {
     this.dialogEl()?.nativeElement.showModal();
   }
+
+  close() {
+    this.dialogEl()?.nativeElement.close();
+  }
 }

--- a/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
@@ -12,7 +12,12 @@
           <option [value]="code">{{ code | localizeLanguage }}</option>
         }
       </select>
-      <button type="button" class="btn btn-primary btn-sm" (click)="search.emit()" [disabled]="subSearchLoading()">
+      <button
+        type="button"
+        class="btn btn-primary btn-sm"
+        (click)="search.emit()"
+        [disabled]="subSearchLoading()"
+      >
         @if (subSearchLoading()) {
           <span class="loading loading-spinner loading-xs"></span>
         }
@@ -25,8 +30,12 @@
           <thead>
             <tr>
               <th>{{ 'media_detail.col_sub_title' | translate }}</th>
-              <th class="text-center hidden sm:table-cell">{{ 'media_detail.col_sub_score' | translate }}</th>
-              <th class="text-center hidden sm:table-cell">{{ 'media_detail.col_sub_flags' | translate }}</th>
+              <th class="text-center hidden sm:table-cell">
+                {{ 'media_detail.col_sub_score' | translate }}
+              </th>
+              <th class="text-center hidden sm:table-cell">
+                {{ 'media_detail.col_sub_flags' | translate }}
+              </th>
               <th>{{ 'media_detail.col_sub_provider' | translate }}</th>
               <th class="w-32"></th>
             </tr>
@@ -35,7 +44,9 @@
             @for (r of subSearchResults(); track r.providerFileId) {
               <tr>
                 <td class="text-sm">
-                  <div class="max-w-[13rem] sm:max-w-[20rem] truncate" [title]="r.title">{{ r.title }}</div>
+                  <div class="max-w-[13rem] sm:max-w-[20rem] truncate" [title]="r.title">
+                    {{ r.title }}
+                  </div>
                   <div class="sm:hidden mt-1 flex items-center gap-2 text-sm">
                     <progress
                       class="progress w-14 h-1.5"
@@ -78,7 +89,9 @@
                 <td class="text-sm">
                   {{ r.providerName }}
                   @if (r.downloadCount) {
-                    <span class="block text-sm text-base-content/50 whitespace-nowrap">{{ 'media_detail.subtitle_downloads' | translate: { count: r.downloadCount } }}</span>
+                    <span class="block text-sm text-base-content/50 whitespace-nowrap">{{
+                      'media_detail.subtitle_downloads' | translate: { count: r.downloadCount }
+                    }}</span>
                   }
                 </td>
                 <td>
@@ -97,11 +110,15 @@
         </table>
       </div>
     } @else if (subSearchSearched() && !subSearchLoading()) {
-      <p class="text-sm text-base-content/50 py-4 text-center">{{ 'media_detail.no_subtitle_results' | translate }}</p>
+      <p class="text-sm text-base-content/50 py-4 text-center">
+        {{ 'media_detail.no_subtitle_results' | translate }}
+      </p>
     }
-    <div class="modal-action">
-      <form method="dialog"><button class="btn btn-ghost">{{ 'common.close' | translate }}</button></form>
-    </div>
+    <app-modal-footer>
+      <form method="dialog">
+        <button class="btn btn-ghost">{{ 'common.close' | translate }}</button>
+      </form>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.html
@@ -1,6 +1,6 @@
 <dialog #dialog class="modal">
   <div class="modal-box max-w-5xl max-h-[85vh] flex flex-col">
-    <h3 class="text-lg font-bold mb-4">{{ 'media_detail.search_subtitles' | translate }}</h3>
+    <app-modal-header [title]="'media_detail.search_subtitles' | translate" />
     <div class="flex gap-2 mb-4">
       <select
         class="select select-bordered select-sm"

--- a/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.ts
@@ -11,10 +11,12 @@ import { TranslateModule } from '@ngx-translate/core';
 import { LocalizeLanguagePipe } from '../../../../core/pipes/localize-language.pipe';
 import { SubtitleSearchResult } from '../../../../core/services/api/subtitles-api.service';
 import { TvSelectDirective } from '../../../../shared/directives/tv-select.directive';
+import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
 
 @Component({
   selector: 'app-media-detail-subtitle-search-modal',
-  imports: [TranslateModule, FormsModule, LocalizeLanguagePipe, TvSelectDirective],
+  imports: [
+    ModalHeaderComponent,TranslateModule, FormsModule, LocalizeLanguagePipe, TvSelectDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-subtitle-search-modal.component.html',
 })

--- a/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.ts
@@ -12,11 +12,18 @@ import { LocalizeLanguagePipe } from '../../../../core/pipes/localize-language.p
 import { SubtitleSearchResult } from '../../../../core/services/api/subtitles-api.service';
 import { TvSelectDirective } from '../../../../shared/directives/tv-select.directive';
 import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-media-detail-subtitle-search-modal',
   imports: [
-    ModalHeaderComponent,TranslateModule, FormsModule, LocalizeLanguagePipe, TvSelectDirective],
+    ModalFooterComponent,
+    ModalHeaderComponent,
+    TranslateModule,
+    FormsModule,
+    LocalizeLanguagePipe,
+    TvSelectDirective,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-subtitle-search-modal.component.html',
 })
@@ -35,8 +42,24 @@ export class MediaDetailSubtitleSearchModalComponent {
   // resolved via the localizeLanguage pipe so it matches what the player
   // shows on its audio/subtitle tracks.
   readonly languageCodes: readonly string[] = [
-    'en', 'fr', 'de', 'es', 'it', 'pt', 'ja', 'ko', 'zh', 'ru',
-    'ar', 'nl', 'pl', 'tr', 'sv', 'da', 'no', 'fi',
+    'en',
+    'fr',
+    'de',
+    'es',
+    'it',
+    'pt',
+    'ja',
+    'ko',
+    'zh',
+    'ru',
+    'ar',
+    'nl',
+    'pl',
+    'tr',
+    'sv',
+    'da',
+    'no',
+    'fi',
   ];
 
   private readonly dialogEl = viewChild<ElementRef<HTMLDialogElement>>('dialog');

--- a/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.html
+++ b/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.html
@@ -75,9 +75,9 @@
       }
     </div>
 
-    <div class="modal-action px-4 pb-4 sm:px-6 shrink-0">
+    <div class="modal-action modal-action-sticky">
       <form method="dialog">
-        <button class="btn btn-sm">{{ 'common.close' | translate }}</button>
+        <button class="btn">{{ 'common.close' | translate }}</button>
       </form>
     </div>
   </div>

--- a/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.html
+++ b/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.html
@@ -1,15 +1,15 @@
 <dialog #dialog class="modal">
-  <div class="modal-box w-[95%] max-w-7xl my-8 max-h-[calc(100vh-4rem)] flex flex-col overflow-hidden p-0">
-    <div class="px-4 pt-4 sm:px-6 sm:pt-6 shrink-0">
-      <div class="flex items-center justify-between mb-3">
-        <h3 class="text-lg font-bold">{{ title() }}</h3>
-        <form method="dialog">
-          <button class="btn btn-sm btn-circle btn-ghost">✕</button>
-        </form>
-      </div>
+  <div
+    class="modal-box w-[95%] max-w-7xl my-8 max-h-[calc(100vh-4rem)] flex flex-col overflow-hidden p-0"
+  >
+    <app-modal-header flush [title]="title()" />
 
+    <div class="px-4 pt-4 sm:px-6 shrink-0">
       @if (tabs().length) {
-        <div role="tablist" class="tabs tabs-bordered flex-nowrap overflow-x-auto overflow-y-hidden">
+        <div
+          role="tablist"
+          class="tabs tabs-bordered flex-nowrap overflow-x-auto overflow-y-hidden"
+        >
           @for (t of tabs(); track t.id) {
             <button
               type="button"
@@ -17,19 +17,33 @@
               class="tab shrink-0 whitespace-nowrap"
               [class.tab-active]="activeTab() === t.id"
               [attr.aria-selected]="activeTab() === t.id"
-              (click)="activeTab.set(t.id)">
+              (click)="activeTab.set(t.id)"
+            >
               <span class="inline-flex flex-nowrap items-center gap-1.5">
                 @if (t.state === 'failed') {
-                  <span class="h-2 w-2 rounded-full bg-error shrink-0" [attr.title]="'media_detail.indexer_failed' | translate"></span>
+                  <span
+                    class="h-2 w-2 rounded-full bg-error shrink-0"
+                    [attr.title]="'media_detail.indexer_failed' | translate"
+                  ></span>
                 } @else if (t.state === 'skipped') {
-                  <span class="h-2 w-2 rounded-full bg-base-content/30 shrink-0" [attr.title]="'media_detail.indexer_cooldown' | translate"></span>
+                  <span
+                    class="h-2 w-2 rounded-full bg-base-content/30 shrink-0"
+                    [attr.title]="'media_detail.indexer_cooldown' | translate"
+                  ></span>
                 }
-                <span class="tab-label">{{ t.id === null ? ('media_detail.releases_tab_all' | translate) : t.label }}</span>
-                <span class="tab-count inline-flex h-5 min-w-5 shrink-0 items-center justify-center">
+                <span class="tab-label">{{
+                  t.id === null ? ('media_detail.releases_tab_all' | translate) : t.label
+                }}</span>
+                <span
+                  class="tab-count inline-flex h-5 min-w-5 shrink-0 items-center justify-center"
+                >
                   @if (t.count === null) {
                     <span class="loading loading-spinner loading-xs text-warning"></span>
                   } @else {
-                    <span class="badge badge-sm badge-ghost h-5 min-w-5 rounded-full px-1 tabular-nums">{{ t.count }}</span>
+                    <span
+                      class="badge badge-sm badge-ghost h-5 min-w-5 rounded-full px-1 tabular-nums"
+                      >{{ t.count }}</span
+                    >
                   }
                 </span>
               </span>
@@ -43,9 +57,13 @@
       @if (error()) {
         <div role="alert" class="alert alert-error text-sm">{{ error() }}</div>
       } @else if (showSpinnerPanel()) {
-        <div class="flex min-h-64 flex-col items-center justify-center gap-3 pt-16 pb-10 text-center">
+        <div
+          class="flex min-h-64 flex-col items-center justify-center gap-3 pt-16 pb-10 text-center"
+        >
           <span class="loading loading-spinner loading-lg text-base-content/40"></span>
-          <p class="max-w-sm text-sm text-base-content/60">{{ 'media_detail.releases_searching' | translate }}</p>
+          <p class="max-w-sm text-sm text-base-content/60">
+            {{ 'media_detail.releases_searching' | translate }}
+          </p>
         </div>
       } @else if (visibleReleases().length) {
         <app-releases-table
@@ -58,7 +76,9 @@
           (grab)="grab.emit($event)"
         />
       } @else if (activeTab() !== null || searched() || !loading()) {
-        <div class="flex min-h-64 flex-col items-center justify-center gap-3 pt-16 pb-10 text-center">
+        <div
+          class="flex min-h-64 flex-col items-center justify-center gap-3 pt-16 pb-10 text-center"
+        >
           @switch (emptyPanel().icon) {
             @case ('failed') {
               <svg lucideTriangleAlert class="h-10 w-10 text-warning/60"></svg>
@@ -75,11 +95,11 @@
       }
     </div>
 
-    <div class="modal-action modal-action-sticky">
+    <app-modal-footer flush>
       <form method="dialog">
         <button class="btn">{{ 'common.close' | translate }}</button>
       </form>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.ts
+++ b/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.ts
@@ -17,6 +17,8 @@ import { MovieRelease } from '../../media-detail-release-picker.service';
 import { IndexerRosterEntry } from '../../release-search-stream.service';
 import { ReleasesTableComponent } from '../releases-table/releases-table.component';
 import { DismissableStackService } from '../../../../core/services/dismissable-stack.service';
+import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../../shared/components/modal-footer';
 
 /** `null` is the "Tous" tab; anything else is one indexer id. */
 export type ReleaseTab = number | null;
@@ -32,7 +34,16 @@ type IndexerSearchStateOrAll = IndexerRosterEntry['state'] | 'all';
 
 @Component({
   selector: 'app-releases-modal',
-  imports: [FormsModule, TranslateModule, ReleasesTableComponent, LucideSearchX, LucideTriangleAlert, LucideCirclePause],
+  imports: [
+    ModalFooterComponent,
+    ModalHeaderComponent,
+    FormsModule,
+    TranslateModule,
+    ReleasesTableComponent,
+    LucideSearchX,
+    LucideTriangleAlert,
+    LucideCirclePause,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './releases-modal.component.html',
 })
@@ -76,7 +87,12 @@ export class ReleasesModalComponent {
     // `count: null` is the spinner slot — a tab still working. Tous spins for as long as any
     // indexer does, so the whole strip follows one rule instead of the header carrying its own.
     return [
-      { id: null, label: '', count: this.loading() ? null : this.releases().length, state: 'all' as const },
+      {
+        id: null,
+        label: '',
+        count: this.loading() ? null : this.releases().length,
+        state: 'all' as const,
+      },
       ...roster.map((ix) => ({
         id: ix.id,
         label: ix.name,
@@ -124,6 +140,8 @@ export class ReleasesModalComponent {
     if (!el || el.open) return;
     el.showModal();
     this.dismissStack.push(this.closeCallback);
-    el.addEventListener('close', () => this.dismissStack.remove(this.closeCallback), { once: true });
+    el.addEventListener('close', () => this.dismissStack.remove(this.closeCallback), {
+      once: true,
+    });
   }
 }

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -465,8 +465,12 @@
      superset) and disables the granular options when ticked. -->
 <dialog #analyzeDialog class="modal" role="dialog" aria-modal="true" aria-labelledby="analyze-title">
   <div class="modal-box">
-    <h3 id="analyze-title" class="text-lg font-bold mb-2">{{ 'media_detail.analyze_title' | translate }}</h3>
-    <p class="text-sm text-base-content/70 mb-4">{{ 'media_detail.analyze_hint' | translate }}</p>
+    <app-modal-header>
+      <div>
+        <h3 id="analyze-title" class="text-lg font-bold">{{ 'media_detail.analyze_title' | translate }}</h3>
+        <p class="text-sm text-base-content/70 mt-1">{{ 'media_detail.analyze_hint' | translate }}</p>
+      </div>
+    </app-modal-header>
     <div class="space-y-2">
       <label class="flex items-start gap-3 cursor-pointer">
         <input

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -1,5 +1,4 @@
 <div appTvSection appDefaultFocus="[autofocus]" class="flex flex-col gap-4">
-
   @if (loading()) {
     <!-- Skeleton: same vertical rhythm as the loaded layout so the page
          doesn't reflow when data arrives. -->
@@ -31,7 +30,6 @@
       <p class="text-lg">{{ 'media_detail.not_found' | translate }}</p>
     </div>
   } @else if (media(); as m) {
-
     <!-- ===== EPISODE MODE ===== -->
     @if (episodeMode() && focusedEpisode(); as ep) {
       @let s = focusedSeason()!;
@@ -89,7 +87,7 @@
             [watchedEpisodeIds]="watchedEpisodeIds()"
             [episodeProgress]="episodeProgress()"
             [hideControls]="true"
-            [sectionTitle]="'media_detail.more_from_season' | translate:{ season: s.seasonNumber }"
+            [sectionTitle]="'media_detail.more_from_season' | translate: { season: s.seasonNumber }"
             (toggleEpisodeWatched)="onToggleEpisodeWatched(m.id, $event.episode, $event.watched)"
           />
         }
@@ -97,25 +95,25 @@
         @if (otherSeasons().length) {
           <div class="divider my-6"></div>
           <app-collapsible-section
-            [heading]="'media_detail.other_seasons_of' | translate:{ title: m.title }"
+            [heading]="'media_detail.other_seasons_of' | translate: { title: m.title }"
             persistKey="otherSeasons"
           >
-          <app-horizontal-scroller>
-            @for (other of otherSeasons(); track other.id) {
-              <app-media-card
-                class="shrink-0 w-28 sm:w-32 lg:w-40"
-                [aspect]="'portrait'"
-                [imageUrl]="other.posterUrl ?? m.posterUrl"
-                [title]="('media_detail.season' | translate) + ' ' + other.seasonNumber"
-                [subtitle]="other.episodes.length + ' ' + ('media_detail.episodes' | translate)"
-                [link]="seasonLink(m, other)"
-                [replaceUrl]="true"
-                [interactiveWatched]="true"
-                [status]="seasonFullyWatched(other) ? 'watched' : null"
-                (watchedToggled)="onToggleSeasonWatched(m.id, other, $event)"
-              />
-            }
-          </app-horizontal-scroller>
+            <app-horizontal-scroller>
+              @for (other of otherSeasons(); track other.id) {
+                <app-media-card
+                  class="shrink-0 w-28 sm:w-32 lg:w-40"
+                  [aspect]="'portrait'"
+                  [imageUrl]="other.posterUrl ?? m.posterUrl"
+                  [title]="('media_detail.season' | translate) + ' ' + other.seasonNumber"
+                  [subtitle]="other.episodes.length + ' ' + ('media_detail.episodes' | translate)"
+                  [link]="seasonLink(m, other)"
+                  [replaceUrl]="true"
+                  [interactiveWatched]="true"
+                  [status]="seasonFullyWatched(other) ? 'watched' : null"
+                  (watchedToggled)="onToggleSeasonWatched(m.id, other, $event)"
+                />
+              }
+            </app-horizontal-scroller>
           </app-collapsible-section>
         }
 
@@ -146,7 +144,7 @@
         }
       </div>
 
-    <!-- ===== NORMAL MODE (movie / series) ===== -->
+      <!-- ===== NORMAL MODE (movie / series) ===== -->
     } @else {
       <div class="flex flex-col">
         <app-media-info-header
@@ -217,7 +215,7 @@
         @if (m.type === 'movie' && collection(); as coll) {
           <div class="divider my-6"></div>
           <app-collapsible-section
-            [heading]="'media_detail.part_of' | translate:{ name: coll.name }"
+            [heading]="'media_detail.part_of' | translate: { name: coll.name }"
             persistKey="collection"
           >
             @if (coll.items.length > 1) {
@@ -230,7 +228,7 @@
                 @if (only.posterUrl) {
                   <img
                     appImgFadeIn
-                    [cachedSrc]="only.posterUrl | resolveUrl:'thumb'"
+                    [cachedSrc]="only.posterUrl | resolveUrl: 'thumb'"
                     [alt]="only.title"
                     class="w-16 rounded-md shrink-0"
                     loading="lazy"
@@ -243,7 +241,9 @@
                     <p class="text-sm text-base-content/60">{{ only.year }}</p>
                   }
                   @if (!only.hasFile) {
-                    <span class="badge badge-sm badge-warning mt-1">{{ 'media_card.missing_files' | translate }}</span>
+                    <span class="badge badge-sm badge-warning mt-1">{{
+                      'media_card.missing_files' | translate
+                    }}</span>
                   }
                 </div>
               </a>
@@ -328,14 +328,13 @@
           <div class="divider my-6"></div>
           <ng-container *ngTemplateOutlet="castCrewBlock" />
         }
-
-
       </div>
     }
 
     <!-- Modals (shared between modes) -->
     <div>
-      <app-releases-modal #movieReleasesModal
+      <app-releases-modal
+        #movieReleasesModal
         [title]="'media_detail.releases_title' | translate"
         [releases]="releases()"
         [indexers]="releasesIndexers()"
@@ -350,7 +349,8 @@
         (grab)="grabRelease($event.release, $event.key)"
       />
 
-      <app-releases-modal #episodeReleasesModal
+      <app-releases-modal
+        #episodeReleasesModal
         [title]="'media_detail.ep_releases_title' | translate"
         [releases]="epReleases()"
         [indexers]="epReleasesIndexers()"
@@ -365,7 +365,8 @@
         (grab)="grabEpisodeRelease(m.id, selectedEpisodeId()!, $event.release, $event.key)"
       />
 
-      <app-releases-modal #seasonReleasesModal
+      <app-releases-modal
+        #seasonReleasesModal
         [title]="'media_detail.season_packs_title' | translate"
         [releases]="seasonReleases()"
         [indexers]="seasonReleasesIndexers()"
@@ -407,7 +408,6 @@
       <app-download-quality-modal #downloadModal (download)="onDownload($event)" />
       <app-download-detail-modal #downloadDetailModal [progress]="activeDownload()" />
     </div>
-
   }
 </div>
 
@@ -419,7 +419,7 @@
         [aspect]="'portrait'"
         [imageUrl]="item.posterUrl"
         [title]="item.title"
-        [subtitle]="item.year ? ('' + item.year) : ''"
+        [subtitle]="item.year ? '' + item.year : ''"
         [rating]="item.rating ?? 0"
         [status]="item.hasFile ? null : 'missing'"
         [link]="['/movies', '' + item.id]"
@@ -431,29 +431,49 @@
 <ng-template #castCrewBlock>
   @if (cast().length) {
     <div class="cv-auto py-5 -my-5 px-4 -mx-4" style="contain-intrinsic-size: auto 12rem">
-    <app-collapsible-section [heading]="'media_detail.cast' | translate" persistKey="cast">
-    <app-horizontal-scroller>
-      @for (c of cast(); track c.id) {
-        <a [routerLink]="['/persons', c.person.id]" data-no-focus-ring class="shrink-0 w-20 sm:w-24 flex flex-col items-center gap-1.5 group">
-          <div class="avatar">
-            <div class="w-16 h-16 sm:w-20 sm:h-20 rounded-full ring ring-base-200 group-hover:ring-primary group-focus:ring-primary group-focus-visible:ring-primary group-focus:ring-4 group-focus-visible:ring-4 group-focus:ring-offset-2 group-focus-visible:ring-offset-2 group-focus:ring-offset-base-100 group-focus-visible:ring-offset-base-100 transition-colors">
-              @if (c.person.avatarUrl) {
-                <img appImgFadeIn [cachedSrc]="c.person.avatarUrl | resolveUrl:'thumb'" [alt]="c.person.name" loading="lazy" decoding="async" fetchpriority="low" />
-              } @else {
-                <div class="bg-base-300 flex items-center justify-center w-full h-full text-lg font-bold text-base-content/30">
-                  {{ c.person.name.charAt(0) }}
+      <app-collapsible-section [heading]="'media_detail.cast' | translate" persistKey="cast">
+        <app-horizontal-scroller>
+          @for (c of cast(); track c.id) {
+            <a
+              [routerLink]="['/persons', c.person.id]"
+              data-no-focus-ring
+              class="shrink-0 w-20 sm:w-24 flex flex-col items-center gap-1.5 group"
+            >
+              <div class="avatar">
+                <div
+                  class="w-16 h-16 sm:w-20 sm:h-20 rounded-full ring ring-base-200 group-hover:ring-primary group-focus:ring-primary group-focus-visible:ring-primary group-focus:ring-4 group-focus-visible:ring-4 group-focus:ring-offset-2 group-focus-visible:ring-offset-2 group-focus:ring-offset-base-100 group-focus-visible:ring-offset-base-100 transition-colors"
+                >
+                  @if (c.person.avatarUrl) {
+                    <img
+                      appImgFadeIn
+                      [cachedSrc]="c.person.avatarUrl | resolveUrl: 'thumb'"
+                      [alt]="c.person.name"
+                      loading="lazy"
+                      decoding="async"
+                      fetchpriority="low"
+                    />
+                  } @else {
+                    <div
+                      class="bg-base-300 flex items-center justify-center w-full h-full text-lg font-bold text-base-content/30"
+                    >
+                      {{ c.person.name.charAt(0) }}
+                    </div>
+                  }
                 </div>
+              </div>
+              <span class="text-xs text-center font-medium line-clamp-1 w-full">{{
+                c.person.name
+              }}</span>
+              @if (c.character) {
+                <span
+                  class="text-[10px] text-base-content/50 text-center line-clamp-1 w-full -mt-1"
+                  >{{ c.character }}</span
+                >
               }
-            </div>
-          </div>
-          <span class="text-xs text-center font-medium line-clamp-1 w-full">{{ c.person.name }}</span>
-          @if (c.character) {
-            <span class="text-[10px] text-base-content/50 text-center line-clamp-1 w-full -mt-1">{{ c.character }}</span>
+            </a>
           }
-        </a>
-      }
-    </app-horizontal-scroller>
-    </app-collapsible-section>
+        </app-horizontal-scroller>
+      </app-collapsible-section>
     </div>
   }
 </ng-template>
@@ -463,87 +483,133 @@
      Escape-to-close for free; the <form method="dialog"> backdrop
      dismisses on outside click. Rescan stays on /rescan (full-disk
      superset) and disables the granular options when ticked. -->
-<dialog #analyzeDialog class="modal" role="dialog" aria-modal="true" aria-labelledby="analyze-title">
+<dialog
+  #analyzeDialog
+  class="modal"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="analyze-title"
+>
   <div class="modal-box">
     <app-modal-header>
       <div>
-        <h3 id="analyze-title" class="text-lg font-bold">{{ 'media_detail.analyze_title' | translate }}</h3>
-        <p class="text-sm text-base-content/70 mt-1">{{ 'media_detail.analyze_hint' | translate }}</p>
+        <h3 id="analyze-title" class="text-lg font-bold">
+          {{ 'media_detail.analyze_title' | translate }}
+        </h3>
+        <p class="text-sm text-base-content/70 mt-1">
+          {{ 'media_detail.analyze_hint' | translate }}
+        </p>
       </div>
     </app-modal-header>
     <div class="space-y-2">
       <label class="flex items-start gap-3 cursor-pointer">
         <input
           #firstAnalyzeOption
-          type="checkbox" class="checkbox checkbox-primary mt-0.5"
+          type="checkbox"
+          class="checkbox checkbox-primary mt-0.5"
           [checked]="analyzeOpts().rescan"
           (change)="setAnalyzeOpt('rescan', $any($event.target).checked)"
         />
         <span>
           <span class="font-medium block">{{ 'media_detail.analyze_rescan' | translate }}</span>
-          <span class="text-xs text-base-content/60">{{ 'media_detail.analyze_rescan_hint' | translate }}</span>
+          <span class="text-xs text-base-content/60">{{
+            'media_detail.analyze_rescan_hint' | translate
+          }}</span>
         </span>
       </label>
-      <label class="flex items-start gap-3 cursor-pointer" [class.opacity-50]="analyzeOpts().rescan">
+      <label
+        class="flex items-start gap-3 cursor-pointer"
+        [class.opacity-50]="analyzeOpts().rescan"
+      >
         <input
-          type="checkbox" class="checkbox checkbox-primary mt-0.5"
-          [checked]="analyzeOpts().sprites" [disabled]="analyzeOpts().rescan"
+          type="checkbox"
+          class="checkbox checkbox-primary mt-0.5"
+          [checked]="analyzeOpts().sprites"
+          [disabled]="analyzeOpts().rescan"
           (change)="setAnalyzeOpt('sprites', $any($event.target).checked)"
         />
         <span>
           <span class="font-medium block">{{ 'media_detail.analyze_sprites' | translate }}</span>
-          <span class="text-xs text-base-content/60">{{ 'media_detail.analyze_sprites_hint' | translate }}</span>
+          <span class="text-xs text-base-content/60">{{
+            'media_detail.analyze_sprites_hint' | translate
+          }}</span>
         </span>
       </label>
-      <label class="flex items-start gap-3 cursor-pointer" [class.opacity-50]="analyzeOpts().rescan">
+      <label
+        class="flex items-start gap-3 cursor-pointer"
+        [class.opacity-50]="analyzeOpts().rescan"
+      >
         <input
-          type="checkbox" class="checkbox checkbox-primary mt-0.5"
-          [checked]="analyzeOpts().crop" [disabled]="analyzeOpts().rescan"
+          type="checkbox"
+          class="checkbox checkbox-primary mt-0.5"
+          [checked]="analyzeOpts().crop"
+          [disabled]="analyzeOpts().rescan"
           (change)="setAnalyzeOpt('crop', $any($event.target).checked)"
         />
         <span>
           <span class="font-medium block">{{ 'media_detail.analyze_crop' | translate }}</span>
-          <span class="text-xs text-base-content/60">{{ 'media_detail.analyze_crop_hint' | translate }}</span>
+          <span class="text-xs text-base-content/60">{{
+            'media_detail.analyze_crop_hint' | translate
+          }}</span>
         </span>
       </label>
-      <label class="flex items-start gap-3 cursor-pointer" [class.opacity-50]="analyzeOpts().rescan">
+      <label
+        class="flex items-start gap-3 cursor-pointer"
+        [class.opacity-50]="analyzeOpts().rescan"
+      >
         <input
-          type="checkbox" class="checkbox checkbox-primary mt-0.5"
-          [checked]="analyzeOpts().subtitleCache" [disabled]="analyzeOpts().rescan"
+          type="checkbox"
+          class="checkbox checkbox-primary mt-0.5"
+          [checked]="analyzeOpts().subtitleCache"
+          [disabled]="analyzeOpts().rescan"
           (change)="setAnalyzeOpt('subtitleCache', $any($event.target).checked)"
         />
         <span>
-          <span class="font-medium block">{{ 'media_detail.analyze_subtitle_cache' | translate }}</span>
-          <span class="text-xs text-base-content/60">{{ 'media_detail.analyze_subtitle_cache_hint' | translate }}</span>
+          <span class="font-medium block">{{
+            'media_detail.analyze_subtitle_cache' | translate
+          }}</span>
+          <span class="text-xs text-base-content/60">{{
+            'media_detail.analyze_subtitle_cache_hint' | translate
+          }}</span>
         </span>
       </label>
       @if (analyzeShowMarkers()) {
-        <label class="flex items-start gap-3 cursor-pointer" [class.opacity-50]="analyzeOpts().rescan">
+        <label
+          class="flex items-start gap-3 cursor-pointer"
+          [class.opacity-50]="analyzeOpts().rescan"
+        >
           <input
-            type="checkbox" class="checkbox checkbox-primary mt-0.5"
-            [checked]="analyzeOpts().markers" [disabled]="analyzeOpts().rescan"
+            type="checkbox"
+            class="checkbox checkbox-primary mt-0.5"
+            [checked]="analyzeOpts().markers"
+            [disabled]="analyzeOpts().rescan"
             (change)="setAnalyzeOpt('markers', $any($event.target).checked)"
           />
           <span>
             <span class="font-medium block">{{ 'media_detail.analyze_markers' | translate }}</span>
-            <span class="text-xs text-base-content/60">{{ 'media_detail.analyze_markers_hint' | translate }}</span>
+            <span class="text-xs text-base-content/60">{{
+              'media_detail.analyze_markers_hint' | translate
+            }}</span>
           </span>
         </label>
       }
     </div>
-    <div class="modal-action">
+    <app-modal-footer>
       <button type="button" class="btn btn-ghost" (click)="closeAnalyzeModal()">
         {{ 'common.cancel' | translate }}
       </button>
       <button
-        type="button" class="btn btn-primary"
+        type="button"
+        class="btn btn-primary"
         [disabled]="analyzeRunning() || !analyzeHasSelection()"
         (click)="runAnalyze()"
       >
-        @if (analyzeRunning()) { <span class="loading loading-spinner loading-sm"></span> }
+        @if (analyzeRunning()) {
+          <span class="loading loading-spinner loading-sm"></span>
+        }
         {{ 'media_detail.analyze_apply' | translate }}
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <!-- Backdrop close: clicking outside submits the dialog-method form,
        which the browser handles natively. The button is removed from the

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -87,6 +87,7 @@ import { TvSectionDirective } from '../../shared/directives/tv-section.directive
 import { ImgFadeInDirective } from '../../shared/directives/img-fade-in.directive';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
 import { CachedSrcDirective } from '../../shared/directives/cached-src.directive';
+import { ModalHeaderComponent } from '../../shared/components/modal-header';
 
 const LS_EPISODES_HAS_FILE_ONLY = 'fliks.mediaDetail.episodesHasFileOnly';
 
@@ -102,6 +103,7 @@ function readEpisodesHasFileOnlyFromStorage(): boolean {
 @Component({
   selector: 'app-media-detail',
   imports: [
+    ModalHeaderComponent,
     CachedSrcDirective,
     TranslateModule,
     DefaultFocusDirective,

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -28,17 +28,23 @@ import {
   RelatedMedia,
   MediaCollection,
 } from '../../core/services/api/media.service';
-import { MediaDetailReleasePickerService, MovieRelease } from './media-detail-release-picker.service';
-import { ReleaseSearchStreamService, type IndexerRosterEntry } from './release-search-stream.service';
+import {
+  MediaDetailReleasePickerService,
+  MovieRelease,
+} from './media-detail-release-picker.service';
+import {
+  ReleaseSearchStreamService,
+  type IndexerRosterEntry,
+} from './release-search-stream.service';
 import { AuthService } from '../../core/services/auth.service';
 import { ProfilesService, LanguageProfile } from '../../core/services/api/profiles.service';
-import {
-  LibrariesApiService,
-  LibrarySummary,
-} from '../../core/services/api/libraries-api.service';
+import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
 import { NavbarService } from '../../core/services/navbar.service';
 import { BackgroundService } from '../../core/services/background.service';
-import { StreamingApiService, MediaResumeInfo } from '../../core/services/api/streaming-api.service';
+import {
+  StreamingApiService,
+  MediaResumeInfo,
+} from '../../core/services/api/streaming-api.service';
 import { MarkersApiService } from '../../core/services/api/markers-api.service';
 import { RequestsService, TitleRequestState } from '../../core/services/api/requests.service';
 import {
@@ -51,9 +57,7 @@ import { MediaFileInfoComponent } from '../../shared/components/media-file-info'
 import { DefaultFocusDirective } from '../../shared/directives/default-focus.directive';
 import { MediaDetailSeasonsComponent } from './components/media-detail-seasons/media-detail-seasons.component';
 import { ReleasesModalComponent } from './components/releases-modal/releases-modal.component';
-import {
-  TrackingScope,
-} from '../../shared/components/tracking-status-modal/tracking-status-modal';
+import { TrackingScope } from '../../shared/components/tracking-status-modal/tracking-status-modal';
 import { MediaDetailProfilesModalComponent } from './components/media-detail-profiles-modal/media-detail-profiles-modal.component';
 import { MediaDetailLibraryModalComponent } from './components/media-detail-library-modal/media-detail-library-modal.component';
 import { RequestModalComponent } from '../tmdb-preview/components/request-modal/request-modal.component';
@@ -88,6 +92,7 @@ import { ImgFadeInDirective } from '../../shared/directives/img-fade-in.directiv
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
 import { CachedSrcDirective } from '../../shared/directives/cached-src.directive';
 import { ModalHeaderComponent } from '../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../shared/components/modal-footer';
 
 const LS_EPISODES_HAS_FILE_ONLY = 'fliks.mediaDetail.episodesHasFileOnly';
 
@@ -103,6 +108,7 @@ function readEpisodesHasFileOnlyFromStorage(): boolean {
 @Component({
   selector: 'app-media-detail',
   imports: [
+    ModalFooterComponent,
     ModalHeaderComponent,
     CachedSrcDirective,
     TranslateModule,
@@ -247,9 +253,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       this.backgroundService.clear();
       return;
     }
-    const pool = [m.fanartUrl, ...(m.additionalFanartUrls ?? [])].filter(
-      (u): u is string => !!u,
-    );
+    const pool = [m.fanartUrl, ...(m.additionalFanartUrls ?? [])].filter((u): u is string => !!u);
     if (pool.length === 0) {
       this.backgroundService.clear();
       return;
@@ -269,13 +273,10 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       void this.reloadAfterRescan(m.id);
     } else if (event.type === 'metadata.refreshed') {
       void this.reloadAfterRescan(m.id);
-      this.toast.success(
-        this.translate.instant('media_detail.refresh_ok'),
-      );
+      this.toast.success(this.translate.instant('media_detail.refresh_ok'));
     } else if (event.type === 'metadata.failed') {
       this.toast.error(
-        (event as { error?: string }).error ??
-          this.translate.instant('media_detail.refresh_error'),
+        (event as { error?: string }).error ?? this.translate.instant('media_detail.refresh_error'),
       );
     }
   });
@@ -335,7 +336,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     }
   });
 
-
   // ── Episode full-page mode (when navigating to series/:id/episode/:episodeId) ──
   readonly episodeMode = signal(false);
   readonly focusedEpisode = signal<Episode | null>(null);
@@ -363,7 +363,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
 
   readonly episodeActiveFile = computed(() => {
     const id = this.episodeActiveFileId();
-    return this.episodeFiles().find(f => f.id === id) ?? null;
+    return this.episodeFiles().find((f) => f.id === id) ?? null;
   });
 
   readonly episodeLabel = computed(() => {
@@ -382,7 +382,12 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   readonly episodeDateLabel = computed(() => {
     const ep = this.focusedEpisode();
     if (!ep?.airDate) return null;
-    return new Date(ep.airDate).toLocaleDateString(this.translate.currentLang || undefined, { day: 'numeric', month: 'short', year: 'numeric', timeZone: 'UTC' });
+    return new Date(ep.airDate).toLocaleDateString(this.translate.currentLang || undefined, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+      timeZone: 'UTC',
+    });
   });
 
   /**
@@ -475,7 +480,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     return total > 0;
   }
 
-
   /**
    * When the focused episode changes on the episode detail page, bring the
    * "Plus de saison X" scroller to the episode AFTER the active one — the
@@ -488,11 +492,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   private readonly scrollToFocusedEpisodeEffect = effect(() => {
     const active = this.focusedEpisode();
     const eps = this.currentSeasonEpisodes();
-    if (
-      !active ||
-      !this.episodeMode() ||
-      this.moreFromSeasonEpisodes().length === 0
-    ) {
+    if (!active || !this.episodeMode() || this.moreFromSeasonEpisodes().length === 0) {
       return;
     }
     const idx = eps.findIndex((e) => e.id === active.id);
@@ -511,8 +511,10 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     const elRect = el.getBoundingClientRect();
     const scrollerRect = scroller.getBoundingClientRect();
     const target =
-      scroller.scrollLeft + (elRect.left - scrollerRect.left)
-      - scroller.clientWidth / 2 + el.offsetWidth / 2;
+      scroller.scrollLeft +
+      (elRect.left - scrollerRect.left) -
+      scroller.clientWidth / 2 +
+      el.offsetWidth / 2;
     scroller.scrollTo({ left: Math.max(0, target), behavior: 'smooth' });
   }
 
@@ -569,9 +571,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       for (const s of seasons) {
         const ep = s.episodes?.find((e) => e.id === info.episodeId);
         if (ep) {
-          const file = info.mediaFileId
-            ? { id: info.mediaFileId }
-            : resolveFile(ep.id);
+          const file = info.mediaFileId ? { id: info.mediaFileId } : resolveFile(ep.id);
           if (file) return { episode: ep, season: s, file };
         }
       }
@@ -615,18 +615,14 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     return `S${sn}:E${en} - ${ctx.episode.title ?? ''}`;
   });
 
-  readonly nextPlayEpisodeId = computed(
-    () => this.nextPlayEpisode()?.episode.id,
-  );
-  readonly nextPlayMediaFileId = computed(
-    () => this.nextPlayEpisode()?.file.id,
-  );
+  readonly nextPlayEpisodeId = computed(() => this.nextPlayEpisode()?.episode.id);
+  readonly nextPlayMediaFileId = computed(() => this.nextPlayEpisode()?.file.id);
 
   /** Directors for shared header */
   readonly directors = computed(() =>
     this.crew()
-      .filter(c => c.job?.toLowerCase() === 'director')
-      .map(c => c.person.name),
+      .filter((c) => c.job?.toLowerCase() === 'director')
+      .map((c) => c.person.name),
   );
 
   readonly loading = signal(true);
@@ -676,17 +672,13 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   /** Regular requester (no `media.create` permission). The Demander
    *  actions are only surfaced for them — admins use Grab/Search. */
   readonly canRequest = computed(
-    () =>
-      !this.auth.hasPermission('media.create') &&
-      this.auth.hasPermission('requests.create'),
+    () => !this.auth.hasPermission('media.create') && this.auth.hasPermission('requests.create'),
   );
 
   /** Requester (no `media.delete`) can ask an admin to delete this library
    *  title. Admins with `media.delete` delete directly and never see it. */
   readonly canRequestDeletion = computed(
-    () =>
-      this.auth.hasPermission('requests.create') &&
-      !this.auth.hasPermission('media.delete'),
+    () => this.auth.hasPermission('requests.create') && !this.auth.hasPermission('media.delete'),
   );
 
   /** A deletion request on this title is already pending (submitted by the
@@ -708,15 +700,11 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
    *  user) — a movie request (no seasons concept) or a whole-series request
    *  covering everything. Blocks the Demander entry in the header for the
    *  corresponding case. */
-  readonly hasBlockingRequest = computed(
-    () => this.titleState()?.requested ?? false,
-  );
+  readonly hasBlockingRequest = computed(() => this.titleState()?.requested ?? false);
 
   /** Season numbers already covered by an active per-season request (any
    *  user). Gates the season-level Demander entry and pre-fed to the modal. */
-  readonly requestedSeasons = computed<number[]>(
-    () => this.titleState()?.requestedSeasons ?? [],
-  );
+  readonly requestedSeasons = computed<number[]>(() => this.titleState()?.requestedSeasons ?? []);
   readonly deleteLoading = signal(false);
   readonly monitoredLoading = signal(false);
   /** Active season tab (series) — first season selected after load */
@@ -808,10 +796,8 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     // Admins edit profiles inline; regular requesters need the same
     // options surfaced to fill the request modal. Either permission
     // is enough to justify the round-trip.
-    if (
-      !this.auth.hasPermission('media.edit') &&
-      !this.auth.hasPermission('requests.create')
-    ) return;
+    if (!this.auth.hasPermission('media.edit') && !this.auth.hasPermission('requests.create'))
+      return;
     this.profilesOptionsLoading.set(true);
     try {
       const [q, l, libs] = await Promise.all([
@@ -836,8 +822,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     // anywhere else — a home card, a similar-movies card that swaps the page
     // under itself — starts at the top, whether or not it was read before.
     const nav =
-      this.router.getCurrentNavigation() ??
-      untracked(this.router.lastSuccessfulNavigation);
+      this.router.getCurrentNavigation() ?? untracked(this.router.lastSuccessfulNavigation);
     const wentBack = nav?.trigger === 'popstate';
     this.scrollMemory.activate(this.scrollKey());
     if (!Number.isFinite(id) || id < 1) {
@@ -875,11 +860,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     try {
       const m = await this.mediaService.getOne(id);
       if (m.type !== kind) {
-        void this.router.navigate([
-          '/',
-          m.type === 'movie' ? 'movies' : 'series',
-          m.id,
-        ]);
+        void this.router.navigate(['/', m.type === 'movie' ? 'movies' : 'series', m.id]);
         return;
       }
       this.media.set(m);
@@ -902,7 +883,9 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
           .then((fresh) => {
             if (fresh.type === kind) this.media.set(fresh);
           })
-          .catch(() => { /* network failure — cached body keeps showing */ });
+          .catch(() => {
+            /* network failure — cached body keeps showing */
+          });
       });
 
       // Episode focus (series/:id/episode/:episodeId) is applied reactively
@@ -910,11 +893,23 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       // call is needed here.
 
       // Load cast/crew async — doesn't block page render
-      this.mediaService.getCast(m.id).then((c) => this.cast.set(c)).catch(() => {});
-      this.mediaService.getCrew(m.id).then((c) => this.crew.set(c)).catch(() => {});
+      this.mediaService
+        .getCast(m.id)
+        .then((c) => this.cast.set(c))
+        .catch(() => {});
+      this.mediaService
+        .getCrew(m.id)
+        .then((c) => this.crew.set(c))
+        .catch(() => {});
       if (m.type === 'movie') {
-        this.mediaService.getSimilar(m.id).then((s) => this.similar.set(s)).catch(() => {});
-        this.mediaService.getCollection(m.id).then((c) => this.collection.set(c)).catch(() => {});
+        this.mediaService
+          .getSimilar(m.id)
+          .then((s) => this.similar.set(s))
+          .catch(() => {});
+        this.mediaService
+          .getCollection(m.id)
+          .then((c) => this.collection.set(c))
+          .catch(() => {});
       }
       // Active requests (only for users who would ever see the Demander
       // button — admins skip the round-trip).
@@ -933,9 +928,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
             ? this.streamingApi.getWatchedEpisodeIds(m.id).catch(() => [] as number[])
             : Promise.resolve([] as number[]),
           m.type === 'series'
-            ? this.streamingApi
-                .getEpisodeProgress(m.id)
-                .catch(() => ({}) as Record<number, number>)
+            ? this.streamingApi.getEpisodeProgress(m.id).catch(() => ({}) as Record<number, number>)
             : Promise.resolve({} as Record<number, number>),
         ]);
         this.resumeInfo.set(resumeInfo);
@@ -961,17 +954,13 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
           let targetSeasonId: number | null = null;
           if (resumeInfo?.episodeId) {
             targetSeasonId =
-              m.seasons.find((s) =>
-                s.episodes?.some((e) => e.id === resumeInfo.episodeId),
-              )?.id ?? null;
+              m.seasons.find((s) => s.episodes?.some((e) => e.id === resumeInfo.episodeId))?.id ??
+              null;
           }
           if (targetSeasonId == null) {
             targetSeasonId =
-              m.seasons.find((s) =>
-                s.episodes?.some(
-                  (e) => e.hasFile && !watchedSet.has(e.id),
-                ),
-              )?.id ?? null;
+              m.seasons.find((s) => s.episodes?.some((e) => e.hasFile && !watchedSet.has(e.id)))
+                ?.id ?? null;
           }
           if (targetSeasonId != null) {
             this.activeSeasonId.set(targetSeasonId);
@@ -986,7 +975,9 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
           const seasonId = this.activeSeasonId();
           const activeSeason = m.seasons.find((s) => s.id === seasonId);
           if (activeSeason?.episodes?.length) {
-            const firstUnwatched = activeSeason.episodes.find((e) => e.hasFile && !watchedSet.has(e.id));
+            const firstUnwatched = activeSeason.episodes.find(
+              (e) => e.hasFile && !watchedSet.has(e.id),
+            );
             if (firstUnwatched) {
               requestAnimationFrame(() => {
                 const el = document.getElementById(`episode-${firstUnwatched.id}`);
@@ -995,7 +986,12 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
                 if (scroller && scroller.scrollWidth > scroller.clientWidth) {
                   const elRect = el.getBoundingClientRect();
                   const scrollerRect = scroller.getBoundingClientRect();
-                  const offset = elRect.left - scrollerRect.left + scroller.scrollLeft - scroller.clientWidth / 2 + el.offsetWidth / 2;
+                  const offset =
+                    elRect.left -
+                    scrollerRect.left +
+                    scroller.scrollLeft -
+                    scroller.clientWidth / 2 +
+                    el.offsetWidth / 2;
                   scroller.scrollTo({ left: offset, behavior: 'smooth' });
                 }
               });
@@ -1070,10 +1066,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     this.libraryPatchSaving.set(true);
     this.libraryPatchSaved.set(false);
     try {
-      let updated =
-        libId !== m.libraryId
-          ? await this.mediaService.patchLibrary(m.id, libId)
-          : m;
+      let updated = libId !== m.libraryId ? await this.mediaService.patchLibrary(m.id, libId) : m;
       if (providerChanged) {
         updated = await this.mediaService.update(m.id, {
           preferredProvider: provider,
@@ -1210,7 +1203,14 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   async deleteMedia() {
     const m = this.media();
     if (!m) return;
-    if (!await this.confirmation.confirm({ title: this.translate.instant('common.confirm'), message: this.translate.instant('media_detail.confirm_delete', { title: m.title }), variant: 'danger' })) return;
+    if (
+      !(await this.confirmation.confirm({
+        title: this.translate.instant('common.confirm'),
+        message: this.translate.instant('media_detail.confirm_delete', { title: m.title }),
+        variant: 'danger',
+      }))
+    )
+      return;
     this.deleteLoading.set(true);
     try {
       await this.mediaService.delete(m.id);
@@ -1238,9 +1238,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       } else {
         await this.mediaService.refreshMetadata(m.id);
       }
-      this.toast.success(
-        this.translate.instant('media_detail.refresh_launched'),
-      );
+      this.toast.success(this.translate.instant('media_detail.refresh_launched'));
     } catch (err: unknown) {
       this.toast.error(serverMessage(err, this.translate, 'media_detail.refresh_error'));
     }
@@ -1271,7 +1269,10 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
         if (ep.title) episode += ` ${ep.title}`;
       }
       await this.downloadManager.createDownload(ev.mediaFileId, ev.quality, title, episode, {
-        mediaId: m?.id, posterUrl: m?.posterUrl, type: m?.type, episodeId: ep?.id,
+        mediaId: m?.id,
+        posterUrl: m?.posterUrl,
+        type: m?.type,
+        episodeId: ep?.id,
       });
       this.toast.success(this.translate.instant('downloads.started'));
     } catch {
@@ -1301,15 +1302,12 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
 
   /** Intro/outro detection is episode-based, so the analyze option only
    *  applies to series. */
-  readonly analyzeShowMarkers = computed(
-    () => this.media()?.type === 'series',
-  );
+  readonly analyzeShowMarkers = computed(() => this.media()?.type === 'series');
 
   /** Refs to the native <dialog>. `showModal()` gives us focus trapping,
    *  Tab cycling and Escape-to-close for free — no manual keydown
    *  handling required. */
-  private readonly analyzeDialog =
-    viewChild<ElementRef<HTMLDialogElement>>('analyzeDialog');
+  private readonly analyzeDialog = viewChild<ElementRef<HTMLDialogElement>>('analyzeDialog');
   private readonly firstAnalyzeOption =
     viewChild<ElementRef<HTMLInputElement>>('firstAnalyzeOption');
 
@@ -1402,10 +1400,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     this.analyzeDialog()?.nativeElement.close();
   }
 
-  setAnalyzeOpt(
-    key: 'rescan' | 'sprites' | 'crop' | 'subtitleCache' | 'markers',
-    value: boolean,
-  ) {
+  setAnalyzeOpt(key: 'rescan' | 'sprites' | 'crop' | 'subtitleCache' | 'markers', value: boolean) {
     this.analyzeOpts.update((o) => ({ ...o, [key]: value }));
   }
 
@@ -1433,14 +1428,10 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
           await this.markersApi.detectSeries(m.id);
         }
       }
-      this.toast.success(
-        this.translate.instant('media_detail.analyze_launched'),
-      );
+      this.toast.success(this.translate.instant('media_detail.analyze_launched'));
       this.closeAnalyzeModal();
     } catch {
-      this.toast.error(
-        this.translate.instant('media_detail.analyze_launch_error'),
-      );
+      this.toast.error(this.translate.instant('media_detail.analyze_launch_error'));
     } finally {
       this.analyzeRunning.set(false);
     }
@@ -1455,11 +1446,17 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       const ep = this.focusedEpisode();
       if (ep) {
         for (const s of updated.seasons ?? []) {
-          const fresh = s.episodes?.find(e => e.id === ep.id);
-          if (fresh) { this.focusedSeason.set(s); this.focusedEpisode.set(fresh); break; }
+          const fresh = s.episodes?.find((e) => e.id === ep.id);
+          if (fresh) {
+            this.focusedSeason.set(s);
+            this.focusedEpisode.set(fresh);
+            break;
+          }
         }
       }
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
   selectSeason(seasonId: number) {
@@ -1476,7 +1473,9 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       } else {
         sessionStorage.removeItem(`fliks.season.${m.id}`);
       }
-    } catch { /* private mode */ }
+    } catch {
+      /* private mode */
+    }
   }
 
   private restoreActiveSeason(): number | null {
@@ -1485,7 +1484,9 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     try {
       const v = sessionStorage.getItem(`fliks.season.${m.id}`);
       return v ? Number(v) : null;
-    } catch { return null; }
+    } catch {
+      return null;
+    }
   }
 
   setEpisodesHasFileOnly(value: boolean) {
@@ -1607,7 +1608,10 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     if (!this.isAdmin()) return;
     this.episodeBusy.set(episode.id);
     try {
-      const updated = await this.mediaService.updateEpisodeMonitored(episode.id, !episode.monitored);
+      const updated = await this.mediaService.updateEpisodeMonitored(
+        episode.id,
+        !episode.monitored,
+      );
       const m = this.media();
       if (!m?.seasons) return;
       const nextSeasons = m.seasons.map((s) =>
@@ -1646,7 +1650,8 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     this.episodeReleasesModal()?.showModal();
     try {
       const rows = await this.releaseStream.run(
-        (searchId) => this.releasePickerApi.getEpisodeReleases(mediaId, episodeId, undefined, searchId),
+        (searchId) =>
+          this.releasePickerApi.getEpisodeReleases(mediaId, episodeId, undefined, searchId),
         { releases: this.epReleases, indexers: this.epReleasesIndexers },
       );
       this.epReleases.set(rows);
@@ -1693,7 +1698,8 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     this.seasonReleasesModal()?.showModal();
     try {
       const rows = await this.releaseStream.run(
-        (searchId) => this.releasePickerApi.getSeasonReleases(mediaId, season.id, undefined, searchId),
+        (searchId) =>
+          this.releasePickerApi.getSeasonReleases(mediaId, season.id, undefined, searchId),
         { releases: this.seasonReleases, indexers: this.seasonReleasesIndexers },
       );
       this.seasonReleases.set(rows);
@@ -1701,7 +1707,9 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       if (isUnprofiledReleaseError(err)) {
         this.seasonReleasesEmptyMessage.set('media_detail.no_quality_profile');
       } else {
-        this.seasonReleasesError.set(serverMessage(err, this.translate, 'media_detail.releases_error'));
+        this.seasonReleasesError.set(
+          serverMessage(err, this.translate, 'media_detail.releases_error'),
+        );
       }
     } finally {
       this.seasonReleasesLoading.set(false);
@@ -1746,7 +1754,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       // ignore
     }
   }
-
 
   /**
    * Handler for the series root watched toggle. The header has already
@@ -1971,9 +1978,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
    *  profile lock flip without a manual reload. */
   private async loadTitleState(tmdbId: number, mediaType: MediaType) {
     try {
-      this.titleState.set(
-        await this.requestsApi.getTitleState(tmdbId, mediaType),
-      );
+      this.titleState.set(await this.requestsApi.getTitleState(tmdbId, mediaType));
     } catch {
       /* swallowed; global interceptor surfaces it */
     }
@@ -2016,9 +2021,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
         title: m.title,
       });
       this.deleteRequestPending.set(true);
-      this.toast.success(
-        this.translate.instant('media_detail.request_deletion_success'),
-      );
+      this.toast.success(this.translate.instant('media_detail.request_deletion_success'));
     } catch {
       /* error toast surfaced by the global interceptor */
     }

--- a/client/src/app/features/playlists/playlist-detail/playlist-detail.html
+++ b/client/src/app/features/playlists/playlist-detail/playlist-detail.html
@@ -331,12 +331,12 @@
         autofocus
       />
       <div class="modal-action mt-0">
-        <button type="button" class="btn btn-sm" (click)="closeRename()">
+        <button type="button" class="btn" (click)="closeRename()">
           {{ 'common.cancel' | translate }}
         </button>
         <button
           type="submit"
-          class="btn btn-primary btn-sm"
+          class="btn btn-primary"
           [disabled]="renaming() || !renameValue().trim()"
         >
           @if (renaming()) {
@@ -390,12 +390,12 @@
       }
     </div>
     <div class="modal-action">
-      <button type="button" class="btn btn-sm" (click)="closeSettings()">
+      <button type="button" class="btn" (click)="closeSettings()">
         {{ 'common.cancel' | translate }}
       </button>
       <button
         type="button"
-        class="btn btn-primary btn-sm"
+        class="btn btn-primary"
         [disabled]="savingSettings()"
         (click)="saveSettings()"
       >

--- a/client/src/app/features/playlists/playlist-detail/playlist-detail.html
+++ b/client/src/app/features/playlists/playlist-detail/playlist-detail.html
@@ -4,104 +4,128 @@
   </div>
 } @else if (playlist(); as pl) {
   <div class="flex items-start gap-4 mb-6">
-      <!-- Playlist icon: the auto cover mosaic (2×2 / single / fallback). -->
-      <div class="w-16 h-16 sm:w-20 sm:h-20 shrink-0 overflow-hidden rounded-lg bg-base-300">
-        @if (pl.posters.length >= 4) {
-          <div class="grid grid-cols-2 grid-rows-2 h-full w-full">
-            @for (p of pl.posters.slice(0, 4); track p) {
-              <img [cachedSrc]="p | resolveUrl: 'thumb'" alt="" class="h-full w-full object-cover" />
-            }
-          </div>
-        } @else if (pl.posters.length > 0) {
-          <img [cachedSrc]="pl.posters[0] | resolveUrl: 'thumb'" alt="" class="h-full w-full object-cover" />
-        } @else {
-          <div class="flex h-full w-full items-center justify-center text-base-content/40">
-            <svg lucideListVideo class="h-8 w-8" [strokeWidth]="1.5"></svg>
-          </div>
+    <!-- Playlist icon: the auto cover mosaic (2×2 / single / fallback). -->
+    <div class="w-16 h-16 sm:w-20 sm:h-20 shrink-0 overflow-hidden rounded-lg bg-base-300">
+      @if (pl.posters.length >= 4) {
+        <div class="grid grid-cols-2 grid-rows-2 h-full w-full">
+          @for (p of pl.posters.slice(0, 4); track p) {
+            <img [cachedSrc]="p | resolveUrl: 'thumb'" alt="" class="h-full w-full object-cover" />
+          }
+        </div>
+      } @else if (pl.posters.length > 0) {
+        <img
+          [cachedSrc]="pl.posters[0] | resolveUrl: 'thumb'"
+          alt=""
+          class="h-full w-full object-cover"
+        />
+      } @else {
+        <div class="flex h-full w-full items-center justify-center text-base-content/40">
+          <svg lucideListVideo class="h-8 w-8" [strokeWidth]="1.5"></svg>
+        </div>
+      }
+    </div>
+
+    <div class="min-w-0 flex-1">
+      <h1 class="text-2xl font-bold truncate">{{ pl.name }}</h1>
+      <p class="text-sm text-base-content/60 mt-1">
+        {{
+          (items().length <= 1 ? 'common.item_count_one' : 'common.item_count_other')
+            | translate: { count: items().length }
+        }}
+      </p>
+    </div>
+    <div class="flex items-center gap-2 shrink-0">
+      @if (items().length) {
+        <button type="button" class="btn btn-primary btn-sm gap-2" (click)="playAll()">
+          <svg lucidePlay class="h-4 w-4"></svg>
+          {{ 'player.play' | translate }}
+        </button>
+      }
+      @if (!isOwner() && !sharingDisabled()) {
+        <button
+          type="button"
+          class="btn btn-sm gap-2"
+          [class.btn-ghost]="!pl.saved"
+          [class.btn-outline]="pl.saved"
+          [disabled]="savingBookmark()"
+          (click)="toggleSave()"
+        >
+          @if (pl.saved) {
+            <svg lucideBookmarkCheck class="h-4 w-4"></svg>
+            {{ 'playlists.saved_label' | translate }}
+          } @else {
+            <svg lucideBookmark class="h-4 w-4"></svg>
+            {{ 'playlists.save' | translate }}
+          }
+        </button>
+      }
+      <!-- md+ : inline buttons -->
+      <div class="hidden md:flex items-center gap-2">
+        @if (canManage()) {
+          @if (!sharingDisabled()) {
+            <button type="button" class="btn btn-ghost btn-sm gap-2" (click)="openMembers()">
+              <svg lucideUsers class="h-4 w-4"></svg>
+              {{ 'playlists.members' | translate }}
+            </button>
+          }
+          <button type="button" class="btn btn-ghost btn-sm gap-2" (click)="openSettings()">
+            <svg lucideSettings class="h-4 w-4"></svg>
+            {{ 'playlists.settings' | translate }}
+          </button>
+          <button type="button" class="btn btn-ghost btn-sm gap-2" (click)="openRename()">
+            <svg lucidePencil class="h-4 w-4"></svg>
+            {{ 'playlists.rename' | translate }}
+          </button>
+        }
+        @if (isOwner()) {
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm text-error gap-2"
+            (click)="deletePlaylist()"
+          >
+            <svg lucideTrash2 class="h-4 w-4"></svg>
+            {{ 'common.delete' | translate }}
+          </button>
         }
       </div>
 
-      <div class="min-w-0 flex-1">
-        <h1 class="text-2xl font-bold truncate">{{ pl.name }}</h1>
-        <p class="text-sm text-base-content/60 mt-1">
-          {{ (items().length <= 1 ? 'common.item_count_one' : 'common.item_count_other') | translate: { count: items().length } }}
-        </p>
-      </div>
-      <div class="flex items-center gap-2 shrink-0">
-        @if (items().length) {
-          <button type="button" class="btn btn-primary btn-sm gap-2" (click)="playAll()">
-            <svg lucidePlay class="h-4 w-4"></svg>
-            {{ 'player.play' | translate }}
-          </button>
-        }
-        @if (!isOwner() && !sharingDisabled()) {
-          <button type="button" class="btn btn-sm gap-2" [class.btn-ghost]="!pl.saved" [class.btn-outline]="pl.saved" [disabled]="savingBookmark()" (click)="toggleSave()">
-            @if (pl.saved) {
-              <svg lucideBookmarkCheck class="h-4 w-4"></svg>
-              {{ 'playlists.saved_label' | translate }}
-            } @else {
-              <svg lucideBookmark class="h-4 w-4"></svg>
-              {{ 'playlists.save' | translate }}
-            }
-          </button>
-        }
-        <!-- md+ : inline buttons -->
-        <div class="hidden md:flex items-center gap-2">
+      <!-- small screens : dropdown (desktop) / bottom sheet (native) -->
+      @if (canManage() || isOwner()) {
+        <app-dropdown-menu placement="bottom-end" class="md:hidden">
+          <div
+            trigger
+            tabindex="0"
+            role="button"
+            class="btn btn-ghost btn-sm btn-circle"
+            [attr.aria-label]="'common.more' | translate"
+          >
+            <svg lucideEllipsisVertical class="h-5 w-5"></svg>
+          </div>
           @if (canManage()) {
             @if (!sharingDisabled()) {
-              <button type="button" class="btn btn-ghost btn-sm gap-2" (click)="openMembers()">
+              <button type="button" class="dropdown-item text-white" (click)="openMembers()">
                 <svg lucideUsers class="h-4 w-4"></svg>
                 {{ 'playlists.members' | translate }}
               </button>
             }
-            <button type="button" class="btn btn-ghost btn-sm gap-2" (click)="openSettings()">
+            <button type="button" class="dropdown-item text-white" (click)="openSettings()">
               <svg lucideSettings class="h-4 w-4"></svg>
               {{ 'playlists.settings' | translate }}
             </button>
-            <button type="button" class="btn btn-ghost btn-sm gap-2" (click)="openRename()">
+            <button type="button" class="dropdown-item text-white" (click)="openRename()">
               <svg lucidePencil class="h-4 w-4"></svg>
               {{ 'playlists.rename' | translate }}
             </button>
           }
           @if (isOwner()) {
-            <button type="button" class="btn btn-ghost btn-sm text-error gap-2" (click)="deletePlaylist()">
+            <button type="button" class="dropdown-item text-error" (click)="deletePlaylist()">
               <svg lucideTrash2 class="h-4 w-4"></svg>
               {{ 'common.delete' | translate }}
             </button>
           }
-        </div>
-
-        <!-- small screens : dropdown (desktop) / bottom sheet (native) -->
-        @if (canManage() || isOwner()) {
-          <app-dropdown-menu placement="bottom-end" class="md:hidden">
-            <div trigger tabindex="0" role="button" class="btn btn-ghost btn-sm btn-circle" [attr.aria-label]="'common.more' | translate">
-              <svg lucideEllipsisVertical class="h-5 w-5"></svg>
-            </div>
-            @if (canManage()) {
-              @if (!sharingDisabled()) {
-                <button type="button" class="dropdown-item text-white" (click)="openMembers()">
-                  <svg lucideUsers class="h-4 w-4"></svg>
-                  {{ 'playlists.members' | translate }}
-                </button>
-              }
-              <button type="button" class="dropdown-item text-white" (click)="openSettings()">
-                <svg lucideSettings class="h-4 w-4"></svg>
-                {{ 'playlists.settings' | translate }}
-              </button>
-              <button type="button" class="dropdown-item text-white" (click)="openRename()">
-                <svg lucidePencil class="h-4 w-4"></svg>
-                {{ 'playlists.rename' | translate }}
-              </button>
-            }
-            @if (isOwner()) {
-              <button type="button" class="dropdown-item text-error" (click)="deletePlaylist()">
-                <svg lucideTrash2 class="h-4 w-4"></svg>
-                {{ 'common.delete' | translate }}
-              </button>
-            }
-          </app-dropdown-menu>
-        }
-      </div>
+        </app-dropdown-menu>
+      }
+    </div>
   </div>
 
   @if (!items().length) {
@@ -110,20 +134,68 @@
     </div>
   } @else {
     <div cdkDropList (cdkDropListDropped)="dropGroup($event)" class="flex flex-col gap-1">
-        @for (
-          entry of groupedEntries();
-          track entry.kind === 'movie' ? 'm' + entry.item.itemId : 's' + entry.group.seriesId;
-          let i = $index
-        ) {
-          <div cdkDrag [cdkDragDisabled]="!canEditItems() || tv.isTv()">
-            @if (entry.kind === 'movie') {
-              <div class="flex items-center gap-2 rounded-lg p-1.5 hover:bg-base-200">
+      @for (
+        entry of groupedEntries();
+        track entry.kind === 'movie' ? 'm' + entry.item.itemId : 's' + entry.group.seriesId;
+        let i = $index
+      ) {
+        <div cdkDrag [cdkDragDisabled]="!canEditItems() || tv.isTv()">
+          @if (entry.kind === 'movie') {
+            <div class="flex items-center gap-2 rounded-lg p-1.5 hover:bg-base-200">
+              @if (canEditItems()) {
+                @if (!tv.isTv()) {
+                  <button
+                    type="button"
+                    cdkDragHandle
+                    class="btn btn-ghost btn-xs btn-square cursor-grab shrink-0"
+                    [attr.aria-label]="'playlists.drag' | translate"
+                  >
+                    <svg lucideGripVertical class="h-4 w-4"></svg>
+                  </button>
+                } @else {
+                  <div class="flex flex-col shrink-0">
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs btn-square"
+                      [disabled]="i === 0"
+                      (click)="moveGroup(i, -1)"
+                      [attr.aria-label]="'playlists.move_up' | translate"
+                    >
+                      <svg lucideArrowUp class="h-4 w-4"></svg>
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs btn-square"
+                      [disabled]="i === groupedEntries().length - 1"
+                      (click)="moveGroup(i, 1)"
+                      [attr.aria-label]="'playlists.move_down' | translate"
+                    >
+                      <svg lucideArrowDown class="h-4 w-4"></svg>
+                    </button>
+                  </div>
+                }
+              }
+              <ng-container
+                [ngTemplateOutlet]="itemRow"
+                [ngTemplateOutletContext]="{ $implicit: entry.item }"
+              ></ng-container>
+            </div>
+          } @else {
+            <div
+              class="collapse collapse-arrow rounded-lg"
+              [class.collapse-open]="expandedSeries().has(entry.group.seriesId)"
+            >
+              <div
+                class="collapse-title flex items-center gap-2 min-h-0 p-1.5 pr-10 cursor-pointer hover:bg-base-200"
+                (click)="toggleSeries(entry.group.seriesId)"
+              >
                 @if (canEditItems()) {
                   @if (!tv.isTv()) {
                     <button
                       type="button"
                       cdkDragHandle
                       class="btn btn-ghost btn-xs btn-square cursor-grab shrink-0"
+                      (click)="$event.stopPropagation()"
                       [attr.aria-label]="'playlists.drag' | translate"
                     >
                       <svg lucideGripVertical class="h-4 w-4"></svg>
@@ -134,7 +206,7 @@
                         type="button"
                         class="btn btn-ghost btn-xs btn-square"
                         [disabled]="i === 0"
-                        (click)="moveGroup(i, -1)"
+                        (click)="$event.stopPropagation(); moveGroup(i, -1)"
                         [attr.aria-label]="'playlists.move_up' | translate"
                       >
                         <svg lucideArrowUp class="h-4 w-4"></svg>
@@ -143,7 +215,7 @@
                         type="button"
                         class="btn btn-ghost btn-xs btn-square"
                         [disabled]="i === groupedEntries().length - 1"
-                        (click)="moveGroup(i, 1)"
+                        (click)="$event.stopPropagation(); moveGroup(i, 1)"
                         [attr.aria-label]="'playlists.move_down' | translate"
                       >
                         <svg lucideArrowDown class="h-4 w-4"></svg>
@@ -151,102 +223,59 @@
                     </div>
                   }
                 }
-                <ng-container
-                  [ngTemplateOutlet]="itemRow"
-                  [ngTemplateOutletContext]="{ $implicit: entry.item }"
-                ></ng-container>
-              </div>
-            } @else {
-              <div
-                class="collapse collapse-arrow rounded-lg"
-                [class.collapse-open]="expandedSeries().has(entry.group.seriesId)"
-              >
                 <div
-                  class="collapse-title flex items-center gap-2 min-h-0 p-1.5 pr-10 cursor-pointer hover:bg-base-200"
-                  (click)="toggleSeries(entry.group.seriesId)"
+                  class="relative w-24 sm:w-44 aspect-video shrink-0 overflow-hidden rounded bg-base-300"
                 >
-                  @if (canEditItems()) {
-                    @if (!tv.isTv()) {
-                      <button
-                        type="button"
-                        cdkDragHandle
-                        class="btn btn-ghost btn-xs btn-square cursor-grab shrink-0"
-                        (click)="$event.stopPropagation()"
-                        [attr.aria-label]="'playlists.drag' | translate"
-                      >
-                        <svg lucideGripVertical class="h-4 w-4"></svg>
-                      </button>
-                    } @else {
-                      <div class="flex flex-col shrink-0">
-                        <button
-                          type="button"
-                          class="btn btn-ghost btn-xs btn-square"
-                          [disabled]="i === 0"
-                          (click)="$event.stopPropagation(); moveGroup(i, -1)"
-                          [attr.aria-label]="'playlists.move_up' | translate"
-                        >
-                          <svg lucideArrowUp class="h-4 w-4"></svg>
-                        </button>
-                        <button
-                          type="button"
-                          class="btn btn-ghost btn-xs btn-square"
-                          [disabled]="i === groupedEntries().length - 1"
-                          (click)="$event.stopPropagation(); moveGroup(i, 1)"
-                          [attr.aria-label]="'playlists.move_down' | translate"
-                        >
-                          <svg lucideArrowDown class="h-4 w-4"></svg>
-                        </button>
-                      </div>
-                    }
-                  }
-                  <div
-                    class="relative w-24 sm:w-44 aspect-video shrink-0 overflow-hidden rounded bg-base-300"
-                  >
-                    <img
-                      [cachedSrc]="(entry.group.media.fanartUrl ?? entry.group.media.posterUrl) | resolveUrl: 'thumb'"
-                      alt=""
-                      class="h-full w-full object-cover"
-                      loading="lazy"
-                    />
-                  </div>
-                  <div class="min-w-0 flex-1">
-                    <p class="font-medium line-clamp-2">{{ entry.group.media.title }}</p>
-                    <p class="text-sm text-base-content/60">
-                      {{ 'playlists.episodes_count' | translate: { count: entry.group.episodes.length } }}
-                    </p>
-                  </div>
-                  @if (canEditItems()) {
-                    <button
-                      type="button"
-                      class="btn btn-ghost btn-sm btn-square text-error shrink-0"
-                      (click)="$event.stopPropagation(); removeSeries(entry.group)"
-                      [attr.aria-label]="'playlists.remove_series_title' | translate"
-                    >
-                      <svg lucideTrash2 class="h-4 w-4"></svg>
-                    </button>
-                  }
+                  <img
+                    [cachedSrc]="
+                      entry.group.media.fanartUrl ?? entry.group.media.posterUrl
+                        | resolveUrl: 'thumb'
+                    "
+                    alt=""
+                    class="h-full w-full object-cover"
+                    loading="lazy"
+                  />
                 </div>
-                <div class="collapse-content !px-0 !pb-0">
-                  <div class="flex flex-col gap-1 mt-1">
-                    @for (item of entry.group.episodes; track item.itemId) {
-                      <div
-                        class="flex items-center gap-2 rounded-lg p-1.5 hover:bg-base-200"
-                        [class.pl-4]="!canEditItems()"
-                        [class.sm:pl-10]="!canEditItems()"
-                      >
-                        <ng-container
-                          [ngTemplateOutlet]="itemRow"
-                          [ngTemplateOutletContext]="{ $implicit: item }"
-                        ></ng-container>
-                      </div>
-                    }
-                  </div>
+                <div class="min-w-0 flex-1">
+                  <p class="font-medium line-clamp-2">{{ entry.group.media.title }}</p>
+                  <p class="text-sm text-base-content/60">
+                    {{
+                      'playlists.episodes_count' | translate: { count: entry.group.episodes.length }
+                    }}
+                  </p>
+                </div>
+                @if (canEditItems()) {
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-sm btn-square text-error shrink-0"
+                    (click)="$event.stopPropagation(); removeSeries(entry.group)"
+                    [attr.aria-label]="'playlists.remove_series_title' | translate"
+                  >
+                    <svg lucideTrash2 class="h-4 w-4"></svg>
+                  </button>
+                }
+              </div>
+              <div class="collapse-content !px-0 !pb-0">
+                <div class="flex flex-col gap-1 mt-1">
+                  @for (item of entry.group.episodes; track item.itemId) {
+                    <div
+                      class="flex items-center gap-2 rounded-lg p-1.5 hover:bg-base-200"
+                      [class.pl-4]="!canEditItems()"
+                      [class.sm:pl-10]="!canEditItems()"
+                    >
+                      <ng-container
+                        [ngTemplateOutlet]="itemRow"
+                        [ngTemplateOutletContext]="{ $implicit: item }"
+                      ></ng-container>
+                    </div>
+                  }
                 </div>
               </div>
-            }
-          </div>
-        }
-      </div>
+            </div>
+          }
+        </div>
+      }
+    </div>
   }
 }
 
@@ -258,9 +287,7 @@
     (click)="playFrom(item)"
     class="flex items-center gap-3 flex-1 min-w-0 text-left cursor-pointer"
   >
-    <div
-      class="relative w-24 sm:w-44 aspect-video shrink-0 overflow-hidden rounded bg-base-300"
-    >
+    <div class="relative w-24 sm:w-44 aspect-video shrink-0 overflow-hidden rounded bg-base-300">
       @if (itemThumb(item); as thumb) {
         <img
           [cachedSrc]="thumb | resolveUrl: 'thumb'"
@@ -284,12 +311,16 @@
       @if (item.episode; as ep) {
         <p class="font-medium line-clamp-2">{{ episodeLabel(ep) }}</p>
         @if (ep.runtime) {
-          <p class="text-sm text-base-content/60 truncate">{{ ep.runtime }} {{ 'common.min' | translate }}</p>
+          <p class="text-sm text-base-content/60 truncate">
+            {{ ep.runtime }} {{ 'common.min' | translate }}
+          </p>
         }
       } @else {
         <p class="font-medium line-clamp-2">{{ item.media.title }}</p>
         @if (item.media.runtime) {
-          <p class="text-sm text-base-content/60 truncate">{{ item.media.runtime }} {{ 'common.min' | translate }}</p>
+          <p class="text-sm text-base-content/60 truncate">
+            {{ item.media.runtime }} {{ 'common.min' | translate }}
+          </p>
         }
       }
     </div>
@@ -297,7 +328,13 @@
   <!-- Secondary actions: view details + watched + remove, in one dropdown. -->
   <div class="shrink-0 self-center">
     <app-dropdown-menu placement="bottom-end">
-      <div trigger tabindex="0" role="button" class="btn btn-ghost btn-sm btn-circle" [attr.aria-label]="'common.more' | translate">
+      <div
+        trigger
+        tabindex="0"
+        role="button"
+        class="btn btn-ghost btn-sm btn-circle"
+        [attr.aria-label]="'common.more' | translate"
+      >
         <svg lucideEllipsisVertical class="h-5 w-5"></svg>
       </div>
       <a class="dropdown-item text-white" [routerLink]="itemLink(item)">
@@ -330,7 +367,7 @@
         (ngModelChange)="renameValue.set($event)"
         autofocus
       />
-      <div class="modal-action mt-0">
+      <app-modal-footer>
         <button type="button" class="btn" (click)="closeRename()">
           {{ 'common.cancel' | translate }}
         </button>
@@ -344,7 +381,7 @@
           }
           {{ 'common.save' | translate }}
         </button>
-      </div>
+      </app-modal-footer>
     </form>
   </div>
   <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
@@ -389,7 +426,7 @@
         />
       }
     </div>
-    <div class="modal-action">
+    <app-modal-footer>
       <button type="button" class="btn" (click)="closeSettings()">
         {{ 'common.cancel' | translate }}
       </button>
@@ -404,7 +441,7 @@
         }
         {{ 'common.save' | translate }}
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>
@@ -424,7 +461,9 @@
         <li class="flex items-center gap-3 p-1.5 rounded-lg">
           <span class="flex-1 min-w-0 truncate font-medium">{{ m.username }}</span>
           @if (m.role === 'owner' || m.userId === myUserId()) {
-            <span class="badge badge-sm badge-ghost">{{ ('playlists.role_' + m.role) | translate }}</span>
+            <span class="badge badge-sm badge-ghost">{{
+              'playlists.role_' + m.role | translate
+            }}</span>
           } @else {
             <select
               class="select select-bordered select-xs w-36 shrink-0"
@@ -434,9 +473,17 @@
             >
               <option value="viewer">{{ 'playlists.role_viewer' | translate }}</option>
               <option value="editor">{{ 'playlists.role_editor' | translate }}</option>
-              <option value="administrator">{{ 'playlists.role_administrator' | translate }}</option>
+              <option value="administrator">
+                {{ 'playlists.role_administrator' | translate }}
+              </option>
             </select>
-            <button type="button" class="btn btn-ghost btn-xs btn-square text-error" [disabled]="memberBusy()" (click)="removeMember(m.userId)" [attr.aria-label]="'playlists.remove_item_action' | translate">
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs btn-square text-error"
+              [disabled]="memberBusy()"
+              (click)="removeMember(m.userId)"
+              [attr.aria-label]="'playlists.remove_item_action' | translate"
+            >
               <svg lucideTrash2 class="h-4 w-4"></svg>
             </button>
           }
@@ -459,7 +506,12 @@
       <ul class="flex flex-col gap-1 mt-2 max-h-52 overflow-y-auto scroll-ring-safe">
         @for (u of memberResults(); track u.id) {
           <li>
-            <button type="button" class="w-full flex items-center gap-3 p-2 rounded-lg hover:bg-base-200 text-left" [disabled]="memberBusy()" (click)="addMember(u)">
+            <button
+              type="button"
+              class="w-full flex items-center gap-3 p-2 rounded-lg hover:bg-base-200 text-left"
+              [disabled]="memberBusy()"
+              (click)="addMember(u)"
+            >
               <span class="flex-1 min-w-0 truncate">{{ u.username }}</span>
               <svg lucideUserPlus class="h-4 w-4 text-base-content/60"></svg>
             </button>

--- a/client/src/app/features/playlists/playlist-detail/playlist-detail.ts
+++ b/client/src/app/features/playlists/playlist-detail/playlist-detail.ts
@@ -56,15 +56,13 @@ import {
   PlaylistShareRole,
   PlaylistVisibility,
 } from '../../../core/services/api/playlists-api.service';
-import {
-  SocialApiService,
-  SocialUser,
-} from '../../../core/services/api/social-api.service';
+import { SocialApiService, SocialUser } from '../../../core/services/api/social-api.service';
 import { AuthService } from '../../../core/services/auth.service';
 import { ToastService } from '../../../core/services/toast.service';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { TvService } from '../../../core/services/tv.service';
 import { CachedSrcDirective } from '../../../shared/directives/cached-src.directive';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 interface PlaylistSeriesGroup {
   seriesId: number;
@@ -80,6 +78,7 @@ type PlaylistGroupedEntry =
 @Component({
   selector: 'app-playlist-detail',
   imports: [
+    ModalFooterComponent,
     CachedSrcDirective,
     TranslateModule,
     FormsModule,
@@ -136,12 +135,9 @@ export class PlaylistDetailComponent {
   private readonly routeParams = toSignal(this.route.paramMap);
   readonly playlistId = computed(() => Number(this.routeParams()?.get('id')));
 
-  private readonly renameDialog =
-    viewChild<ElementRef<HTMLDialogElement>>('renameDialog');
-  private readonly settingsDialog =
-    viewChild<ElementRef<HTMLDialogElement>>('settingsDialog');
-  private readonly membersDialog =
-    viewChild<ElementRef<HTMLDialogElement>>('membersDialog');
+  private readonly renameDialog = viewChild<ElementRef<HTMLDialogElement>>('renameDialog');
+  private readonly settingsDialog = viewChild<ElementRef<HTMLDialogElement>>('settingsDialog');
+  private readonly membersDialog = viewChild<ElementRef<HTMLDialogElement>>('membersDialog');
 
   readonly loading = signal(true);
   readonly playlist = signal<Playlist | null>(null);
@@ -202,8 +198,7 @@ export class PlaylistDetailComponent {
     for (const g of groups.values()) {
       g.episodes.sort(
         (a, b) =>
-          (a.episode?.season?.seasonNumber ?? 0) -
-            (b.episode?.season?.seasonNumber ?? 0) ||
+          (a.episode?.season?.seasonNumber ?? 0) - (b.episode?.season?.seasonNumber ?? 0) ||
           (a.episode?.episodeNumber ?? 0) - (b.episode?.episodeNumber ?? 0),
       );
     }
@@ -236,10 +231,7 @@ export class PlaylistDetailComponent {
       ep.endEpisodeNumber && ep.endEpisodeNumber !== ep.episodeNumber
         ? `-${ep.endEpisodeNumber}`
         : '';
-    const code =
-      s != null
-        ? `S${s}E${ep.episodeNumber}${end}`
-        : `E${ep.episodeNumber}${end}`;
+    const code = s != null ? `S${s}E${ep.episodeNumber}${end}` : `E${ep.episodeNumber}${end}`;
     return ep.title ? `${code} · ${ep.title}` : code;
   }
 
@@ -258,9 +250,7 @@ export class PlaylistDetailComponent {
   itemThumb(it: PlaylistItem): string | null {
     // Prefer a landscape image (episode still, else the movie/series fanart),
     // like the history list; fall back to the poster.
-    return (
-      it.episode?.stillUrl ?? it.media.fanartUrl ?? it.media.posterUrl ?? null
-    );
+    return it.episode?.stillUrl ?? it.media.fanartUrl ?? it.media.posterUrl ?? null;
   }
 
   // ── Playback ──
@@ -309,21 +299,14 @@ export class PlaylistDetailComponent {
     const p = this.playlist();
     if (!p) return;
     const queue = this.orderedItems().map((i) => this.toQueueItem(i));
-    const launched = await this.playable.playFromPlaylist(
-      p.id,
-      queue,
-      startIndex,
-      p.autoPlay,
-    );
+    const launched = await this.playable.playFromPlaylist(p.id, queue, startIndex, p.autoPlay);
     if (!launched) {
       this.toast.error(this.translate.instant('playlists.item_unavailable'));
     }
   }
 
   private patchItem(itemId: number, patch: Partial<PlaylistItem>): void {
-    this.items.update((list) =>
-      list.map((i) => (i.itemId === itemId ? { ...i, ...patch } : i)),
-    );
+    this.items.update((list) => list.map((i) => (i.itemId === itemId ? { ...i, ...patch } : i)));
   }
 
   /** Toggle the viewer's watched state for a movie or episode item. */
@@ -343,9 +326,7 @@ export class PlaylistDetailComponent {
       // (owner-scoped), so mirror that by removing it from the list instead of
       // just flagging it.
       if (state.completed && this.playlist()?.autoRemoveWatched && this.isOwner()) {
-        this.items.update((list) =>
-          list.filter((i) => i.itemId !== item.itemId),
-        );
+        this.items.update((list) => list.filter((i) => i.itemId !== item.itemId));
       } else {
         this.patchItem(item.itemId, {
           watched: state.completed,
@@ -392,10 +373,7 @@ export class PlaylistDetailComponent {
   private async load(id: number): Promise<void> {
     this.loading.set(true);
     try {
-      const [playlist, items] = await Promise.all([
-        this.api.get(id),
-        this.api.items(id),
-      ]);
+      const [playlist, items] = await Promise.all([this.api.get(id), this.api.items(id)]);
       this.playlist.set(playlist);
       this.items.set(items);
     } catch {
@@ -610,9 +588,7 @@ export class PlaylistDetailComponent {
       else for (const ep of e.group.episodes) ids.push(ep.itemId);
     }
     const byId = new Map(this.items().map((i) => [i.itemId, i]));
-    this.items.set(
-      ids.map((id) => byId.get(id)).filter((x): x is PlaylistItem => !!x),
-    );
+    this.items.set(ids.map((id) => byId.get(id)).filter((x): x is PlaylistItem => !!x));
     this.persistOrder();
   }
 
@@ -634,9 +610,7 @@ export class PlaylistDetailComponent {
   async removeItem(item: PlaylistItem): Promise<void> {
     const id = this.playlist()?.id;
     if (id == null) return;
-    const title = item.episode
-      ? this.episodeLabel(item.episode)
-      : item.media.title;
+    const title = item.episode ? this.episodeLabel(item.episode) : item.media.title;
     const confirmed = await this.confirmation.confirm({
       title: this.translate.instant('playlists.remove_item_title'),
       message: this.translate.instant('playlists.remove_item_confirm', {

--- a/client/src/app/features/playlists/playlists.html
+++ b/client/src/app/features/playlists/playlists.html
@@ -47,12 +47,12 @@
         autofocus
       />
       <div class="modal-action mt-0">
-        <button type="button" class="btn btn-sm" (click)="closeCreate()">
+        <button type="button" class="btn" (click)="closeCreate()">
           {{ 'common.cancel' | translate }}
         </button>
         <button
           type="submit"
-          class="btn btn-primary btn-sm"
+          class="btn btn-primary"
           [disabled]="creating() || !newName().trim()"
         >
           @if (creating()) {

--- a/client/src/app/features/playlists/playlists.html
+++ b/client/src/app/features/playlists/playlists.html
@@ -25,7 +25,10 @@
         <app-mosaic-card
           [posters]="p.posters"
           [label]="p.name"
-          [subtitle]="(p.itemCount <= 1 ? 'common.item_count_one' : 'common.item_count_other') | translate: { count: p.itemCount }"
+          [subtitle]="
+            (p.itemCount <= 1 ? 'common.item_count_one' : 'common.item_count_other')
+              | translate: { count: p.itemCount }
+          "
           (clicked)="openPlaylist(p.id)"
         />
       }
@@ -46,21 +49,17 @@
         (ngModelChange)="newName.set($event)"
         autofocus
       />
-      <div class="modal-action mt-0">
+      <app-modal-footer>
         <button type="button" class="btn" (click)="closeCreate()">
           {{ 'common.cancel' | translate }}
         </button>
-        <button
-          type="submit"
-          class="btn btn-primary"
-          [disabled]="creating() || !newName().trim()"
-        >
+        <button type="submit" class="btn btn-primary" [disabled]="creating() || !newName().trim()">
           @if (creating()) {
             <span class="loading loading-spinner loading-xs"></span>
           }
           {{ 'playlists.create' | translate }}
         </button>
-      </div>
+      </app-modal-footer>
     </form>
   </div>
   <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>

--- a/client/src/app/features/playlists/playlists.ts
+++ b/client/src/app/features/playlists/playlists.ts
@@ -15,16 +15,15 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { LucidePlus } from '@lucide/angular';
 import { MosaicCardComponent } from '../../shared/components/mosaic-card/mosaic-card';
 import { ModalHeaderComponent } from '../../shared/components/modal-header';
-import {
-  Playlist,
-  PlaylistsApiService,
-} from '../../core/services/api/playlists-api.service';
+import { Playlist, PlaylistsApiService } from '../../core/services/api/playlists-api.service';
 import { ToastService } from '../../core/services/toast.service';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
+import { ModalFooterComponent } from '../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-playlists',
   imports: [
+    ModalFooterComponent,
     MosaicCardComponent,
     TranslateModule,
     FormsModule,
@@ -43,8 +42,7 @@ export class PlaylistsComponent implements OnInit {
   private readonly reuseStrategy = inject(CachingReuseStrategy);
   private readonly destroyRef = inject(DestroyRef);
 
-  private readonly createDialog =
-    viewChild<ElementRef<HTMLDialogElement>>('createDialog');
+  private readonly createDialog = viewChild<ElementRef<HTMLDialogElement>>('createDialog');
 
   readonly playlists = signal<Playlist[]>([]);
   readonly loading = signal(false);
@@ -57,11 +55,9 @@ export class PlaylistsComponent implements OnInit {
     // navigates back to a cached instance — refresh on reattach so a playlist
     // created/deleted elsewhere shows up (mirrors home/search/history).
     const ownKey = this.reuseStrategy.keyFor(this.route.snapshot);
-    this.reuseStrategy.attached$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((key) => {
-        if (key === ownKey) void this.load(true);
-      });
+    this.reuseStrategy.attached$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((key) => {
+      if (key === ownKey) void this.load(true);
+    });
   }
 
   private async load(force = false): Promise<void> {

--- a/client/src/app/features/profile/avatar-editor/avatar-editor.html
+++ b/client/src/app/features/profile/avatar-editor/avatar-editor.html
@@ -1,6 +1,6 @@
 <dialog #dialog class="modal">
   <div class="modal-box max-w-sm">
-    <h3 class="text-lg font-bold mb-4">{{ 'social.avatar_edit_title' | translate }}</h3>
+    <app-modal-header [title]="'social.avatar_edit_title' | translate" />
     <div class="flex flex-col items-center gap-4">
       <div
         class="relative overflow-hidden rounded-full bg-base-300 touch-none select-none cursor-move"

--- a/client/src/app/features/profile/avatar-editor/avatar-editor.html
+++ b/client/src/app/features/profile/avatar-editor/avatar-editor.html
@@ -34,14 +34,14 @@
         [attr.aria-label]="'social.avatar_zoom' | translate"
       />
     </div>
-    <div class="modal-action">
+    <app-modal-footer>
       <button type="button" class="btn btn-ghost" (click)="close()">
         {{ 'common.cancel' | translate }}
       </button>
       <button type="button" class="btn btn-primary" [disabled]="busy()" (click)="confirm()">
         {{ 'common.save' | translate }}
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
     <button (click)="close()">{{ 'common.close' | translate }}</button>

--- a/client/src/app/features/profile/avatar-editor/avatar-editor.ts
+++ b/client/src/app/features/profile/avatar-editor/avatar-editor.ts
@@ -8,6 +8,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 
 /** On-screen size of the circular crop viewport. */
 const VIEWPORT = 256;
@@ -24,7 +25,8 @@ const OUTPUT = 512;
  */
 @Component({
   selector: 'app-avatar-editor',
-  imports: [TranslateModule],
+  imports: [
+    ModalHeaderComponent,TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './avatar-editor.html',
 })

--- a/client/src/app/features/profile/avatar-editor/avatar-editor.ts
+++ b/client/src/app/features/profile/avatar-editor/avatar-editor.ts
@@ -9,6 +9,7 @@ import {
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { ModalHeaderComponent } from '../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 /** On-screen size of the circular crop viewport. */
 const VIEWPORT = 256;
@@ -25,14 +26,12 @@ const OUTPUT = 512;
  */
 @Component({
   selector: 'app-avatar-editor',
-  imports: [
-    ModalHeaderComponent,TranslateModule],
+  imports: [ModalFooterComponent, ModalHeaderComponent, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './avatar-editor.html',
 })
 export class AvatarEditorComponent {
-  private readonly dialogEl =
-    viewChild<ElementRef<HTMLDialogElement>>('dialog');
+  private readonly dialogEl = viewChild<ElementRef<HTMLDialogElement>>('dialog');
 
   readonly cropped = output<Blob>();
 

--- a/client/src/app/features/requests/request-decline-modal/request-decline-modal.component.html
+++ b/client/src/app/features/requests/request-decline-modal/request-decline-modal.component.html
@@ -1,8 +1,10 @@
 <dialog #dialog class="modal" aria-labelledby="request-decline-title">
   <div class="modal-box max-w-md">
-    <h2 id="request-decline-title" class="text-lg font-semibold">
-      {{ 'requests.decline_title' | translate }}
-    </h2>
+    <app-modal-header>
+      <h3 id="request-decline-title" class="text-lg font-bold">
+        {{ 'requests.decline_title' | translate }}
+      </h3>
+    </app-modal-header>
     <textarea
       class="textarea textarea-bordered w-full mt-3"
       rows="3"
@@ -11,12 +13,12 @@
       (ngModelChange)="reasonTextChange.emit($event)"
     ></textarea>
     <div class="modal-action mt-2">
-      <button type="button" class="btn btn-ghost btn-sm" (click)="close(); dismissed.emit()">
+      <button type="button" class="btn btn-ghost" (click)="close(); dismissed.emit()">
         {{ 'common.cancel' | translate }}
       </button>
       <button
         type="button"
-        class="btn btn-warning btn-sm"
+        class="btn btn-warning"
         [disabled]="submitBusy()"
         (click)="submitted.emit()"
       >

--- a/client/src/app/features/requests/request-decline-modal/request-decline-modal.component.html
+++ b/client/src/app/features/requests/request-decline-modal/request-decline-modal.component.html
@@ -12,7 +12,7 @@
       [ngModel]="reasonText()"
       (ngModelChange)="reasonTextChange.emit($event)"
     ></textarea>
-    <div class="modal-action mt-2">
+    <app-modal-footer>
       <button type="button" class="btn btn-ghost" (click)="close(); dismissed.emit()">
         {{ 'common.cancel' | translate }}
       </button>
@@ -24,10 +24,14 @@
       >
         {{ 'requests.decline_submit' | translate }}
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
-    <button type="button" (click)="close(); dismissed.emit()" [attr.aria-label]="'common.close' | translate">
+    <button
+      type="button"
+      (click)="close(); dismissed.emit()"
+      [attr.aria-label]="'common.close' | translate"
+    >
       {{ 'common.close' | translate }}
     </button>
   </form>

--- a/client/src/app/features/requests/request-decline-modal/request-decline-modal.component.ts
+++ b/client/src/app/features/requests/request-decline-modal/request-decline-modal.component.ts
@@ -1,10 +1,12 @@
 import { ChangeDetectionStrategy, Component, ElementRef, input, output, viewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 
 @Component({
   selector: 'app-request-decline-modal',
-  imports: [FormsModule, TranslateModule],
+  imports: [
+    ModalHeaderComponent,FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './request-decline-modal.component.html',
 })

--- a/client/src/app/features/requests/request-decline-modal/request-decline-modal.component.ts
+++ b/client/src/app/features/requests/request-decline-modal/request-decline-modal.component.ts
@@ -1,12 +1,19 @@
-import { ChangeDetectionStrategy, Component, ElementRef, input, output, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  input,
+  output,
+  viewChild,
+} from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { ModalHeaderComponent } from '../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-request-decline-modal',
-  imports: [
-    ModalHeaderComponent,FormsModule, TranslateModule],
+  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './request-decline-modal.component.html',
 })

--- a/client/src/app/features/requests/request-edit-modal/request-edit-modal.component.html
+++ b/client/src/app/features/requests/request-edit-modal/request-edit-modal.component.html
@@ -58,26 +58,25 @@
         }
       </div>
 
-      <div class="modal-action mt-2">
+      <app-modal-footer>
         <button type="button" class="btn btn-ghost" (click)="close(); dismissed.emit()">
           {{ 'common.cancel' | translate }}
         </button>
-        <button
-          type="button"
-          class="btn btn-primary"
-          [disabled]="saving()"
-          (click)="save.emit()"
-        >
+        <button type="button" class="btn btn-primary" [disabled]="saving()" (click)="save.emit()">
           @if (saving()) {
             <span class="loading loading-spinner loading-xs"></span>
           }
           {{ 'common.save' | translate }}
         </button>
-      </div>
+      </app-modal-footer>
     </div>
   }
   <form method="dialog" class="modal-backdrop">
-    <button type="button" (click)="close(); dismissed.emit()" [attr.aria-label]="'common.close' | translate">
+    <button
+      type="button"
+      (click)="close(); dismissed.emit()"
+      [attr.aria-label]="'common.close' | translate"
+    >
       {{ 'common.close' | translate }}
     </button>
   </form>

--- a/client/src/app/features/requests/request-edit-modal/request-edit-modal.component.html
+++ b/client/src/app/features/requests/request-edit-modal/request-edit-modal.component.html
@@ -1,10 +1,14 @@
 <dialog #dialog class="modal" aria-labelledby="request-edit-title">
   @if (row(); as editRow) {
     <div class="modal-box max-w-md">
-      <h2 id="request-edit-title" class="text-lg font-semibold">
-        {{ 'requests.edit_title' | translate }}
-      </h2>
-      <p class="text-sm text-base-content/60 mt-1">{{ editRow.title }}</p>
+      <app-modal-header>
+        <div>
+          <h3 id="request-edit-title" class="text-lg font-bold">
+            {{ 'requests.edit_title' | translate }}
+          </h3>
+          <p class="text-sm text-base-content/60 mt-1">{{ editRow.title }}</p>
+        </div>
+      </app-modal-header>
 
       <div class="flex flex-col gap-4 mt-4">
         @if (libraries().length > 1) {
@@ -55,12 +59,12 @@
       </div>
 
       <div class="modal-action mt-2">
-        <button type="button" class="btn btn-ghost btn-sm" (click)="close(); dismissed.emit()">
+        <button type="button" class="btn btn-ghost" (click)="close(); dismissed.emit()">
           {{ 'common.cancel' | translate }}
         </button>
         <button
           type="button"
-          class="btn btn-primary btn-sm"
+          class="btn btn-primary"
           [disabled]="saving()"
           (click)="save.emit()"
         >

--- a/client/src/app/features/requests/request-edit-modal/request-edit-modal.component.ts
+++ b/client/src/app/features/requests/request-edit-modal/request-edit-modal.component.ts
@@ -3,10 +3,12 @@ import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { FliksRequestRow } from '../../../core/services/api/requests.service';
 import { LibrarySummary } from '../../../core/services/api/libraries-api.service';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 
 @Component({
   selector: 'app-request-edit-modal',
-  imports: [FormsModule, TranslateModule],
+  imports: [
+    ModalHeaderComponent,FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './request-edit-modal.component.html',
 })

--- a/client/src/app/features/requests/request-edit-modal/request-edit-modal.component.ts
+++ b/client/src/app/features/requests/request-edit-modal/request-edit-modal.component.ts
@@ -1,14 +1,21 @@
-import { ChangeDetectionStrategy, Component, ElementRef, input, output, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  input,
+  output,
+  viewChild,
+} from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { FliksRequestRow } from '../../../core/services/api/requests.service';
 import { LibrarySummary } from '../../../core/services/api/libraries-api.service';
 import { ModalHeaderComponent } from '../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-request-edit-modal',
-  imports: [
-    ModalHeaderComponent,FormsModule, TranslateModule],
+  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './request-edit-modal.component.html',
 })

--- a/client/src/app/features/requests/request-view-decline-modal/request-view-decline-modal.component.html
+++ b/client/src/app/features/requests/request-view-decline-modal/request-view-decline-modal.component.html
@@ -1,15 +1,19 @@
 <dialog #dialog class="modal" aria-labelledby="request-view-decline-title">
   @if (payload(); as declineView) {
     <div class="modal-box max-w-md">
-      <h2 id="request-view-decline-title" class="text-lg font-semibold">
-        {{ 'requests.view_decline_title' | translate }}
-      </h2>
-      <p class="text-sm text-base-content/60 mt-1 line-clamp-2">{{ declineView.mediaTitle }}</p>
+      <app-modal-header>
+        <div class="min-w-0">
+          <h3 id="request-view-decline-title" class="text-lg font-bold">
+            {{ 'requests.view_decline_title' | translate }}
+          </h3>
+          <p class="text-sm text-base-content/60 mt-1 line-clamp-2">{{ declineView.mediaTitle }}</p>
+        </div>
+      </app-modal-header>
       <p class="mt-4 text-sm text-base-content whitespace-pre-wrap wrap-break-word">
         {{ declineView.reason }}
       </p>
       <div class="modal-action mt-2">
-        <button type="button" class="btn btn-primary btn-sm" (click)="close(); dismissed.emit()">
+        <button type="button" class="btn btn-primary" (click)="close(); dismissed.emit()">
           {{ 'common.close' | translate }}
         </button>
       </div>

--- a/client/src/app/features/requests/request-view-decline-modal/request-view-decline-modal.component.html
+++ b/client/src/app/features/requests/request-view-decline-modal/request-view-decline-modal.component.html
@@ -12,15 +12,19 @@
       <p class="mt-4 text-sm text-base-content whitespace-pre-wrap wrap-break-word">
         {{ declineView.reason }}
       </p>
-      <div class="modal-action mt-2">
+      <app-modal-footer>
         <button type="button" class="btn btn-primary" (click)="close(); dismissed.emit()">
           {{ 'common.close' | translate }}
         </button>
-      </div>
+      </app-modal-footer>
     </div>
   }
   <form method="dialog" class="modal-backdrop">
-    <button type="button" (click)="close(); dismissed.emit()" [attr.aria-label]="'common.close' | translate">
+    <button
+      type="button"
+      (click)="close(); dismissed.emit()"
+      [attr.aria-label]="'common.close' | translate"
+    >
       {{ 'common.close' | translate }}
     </button>
   </form>

--- a/client/src/app/features/requests/request-view-decline-modal/request-view-decline-modal.component.ts
+++ b/client/src/app/features/requests/request-view-decline-modal/request-view-decline-modal.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, ElementRef, input, output, viewChild } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 
 export interface RequestViewDeclinePayload {
   mediaTitle: string;
@@ -8,7 +9,8 @@ export interface RequestViewDeclinePayload {
 
 @Component({
   selector: 'app-request-view-decline-modal',
-  imports: [TranslateModule],
+  imports: [
+    ModalHeaderComponent,TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './request-view-decline-modal.component.html',
 })

--- a/client/src/app/features/requests/request-view-decline-modal/request-view-decline-modal.component.ts
+++ b/client/src/app/features/requests/request-view-decline-modal/request-view-decline-modal.component.ts
@@ -1,6 +1,14 @@
-import { ChangeDetectionStrategy, Component, ElementRef, input, output, viewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  input,
+  output,
+  viewChild,
+} from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { ModalHeaderComponent } from '../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 export interface RequestViewDeclinePayload {
   mediaTitle: string;
@@ -9,8 +17,7 @@ export interface RequestViewDeclinePayload {
 
 @Component({
   selector: 'app-request-view-decline-modal',
-  imports: [
-    ModalHeaderComponent,TranslateModule],
+  imports: [ModalFooterComponent, ModalHeaderComponent, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './request-view-decline-modal.component.html',
 })

--- a/client/src/app/features/settings/auto-approval/auto-approval.html
+++ b/client/src/app/features/settings/auto-approval/auto-approval.html
@@ -2,7 +2,9 @@
   <div class="flex items-center justify-between gap-3">
     <div>
       <h2 class="text-xl font-semibold">{{ 'settings.auto_approval.title' | translate }}</h2>
-      <p class="text-sm text-base-content/60 mt-1">{{ 'settings.auto_approval.subtitle' | translate }}</p>
+      <p class="text-sm text-base-content/60 mt-1">
+        {{ 'settings.auto_approval.subtitle' | translate }}
+      </p>
     </div>
     <button type="button" class="btn btn-primary btn-sm" (click)="openCreate()">
       + {{ 'settings.auto_approval.new' | translate }}
@@ -14,9 +16,13 @@
   }
 
   @if (loading()) {
-    <div class="flex justify-center py-8"><span class="loading loading-spinner loading-md"></span></div>
+    <div class="flex justify-center py-8">
+      <span class="loading loading-spinner loading-md"></span>
+    </div>
   } @else if (rules().length === 0) {
-    <p class="text-base-content/50 text-center py-8">{{ 'settings.auto_approval.empty' | translate }}</p>
+    <p class="text-base-content/50 text-center py-8">
+      {{ 'settings.auto_approval.empty' | translate }}
+    </p>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
       <table class="table">
@@ -33,18 +39,27 @@
           @for (rule of rules(); track rule.id) {
             <tr [class.opacity-50]="!rule.enabled">
               <td>
-                <button type="button" class="link link-hover font-medium" (click)="openEdit(rule)">{{ rule.name }}</button>
+                <button type="button" class="link link-hover font-medium" (click)="openEdit(rule)">
+                  {{ rule.name }}
+                </button>
               </td>
               <td>{{ rule.priority }}</td>
               <td class="text-sm text-base-content/70">{{ rule.conditions.length }}</td>
               <td>
-                <span class="badge badge-sm" [class]="rule.enabled ? 'badge-success' : 'badge-ghost'">
+                <span
+                  class="badge badge-sm"
+                  [class]="rule.enabled ? 'badge-success' : 'badge-ghost'"
+                >
                   {{ (rule.enabled ? 'common.yes' : 'common.no') | translate }}
                 </span>
               </td>
               <td class="text-end">
                 <div class="flex justify-end gap-1">
-                  <button type="button" class="btn btn-ghost btn-xs text-error" (click)="remove(rule)">
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-xs text-error"
+                    (click)="remove(rule)"
+                  >
                     {{ 'settings.auto_approval.delete' | translate }}
                   </button>
                 </div>
@@ -59,96 +74,110 @@
 
 <dialog #editorDialog class="modal">
   <div class="modal-box max-w-lg">
-      <app-modal-header
-        [title]="(editingId() != null ? 'settings.auto_approval.editor_edit' : 'settings.auto_approval.editor_create') | translate"
-      />
-      <div class="flex flex-col gap-4">
-        <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.auto_approval.field_name' | translate }}</span>
+    <app-modal-header
+      [title]="
+        (editingId() != null
+          ? 'settings.auto_approval.editor_edit'
+          : 'settings.auto_approval.editor_create'
+        ) | translate
+      "
+    />
+    <div class="flex flex-col gap-4">
+      <label class="form-control w-full">
+        <span class="label-text">{{ 'settings.auto_approval.field_name' | translate }}</span>
+        <input
+          type="text"
+          class="input input-bordered input-sm w-full"
+          [ngModel]="formName()"
+          (ngModelChange)="formName.set($event)"
+        />
+      </label>
+      <div class="flex gap-4">
+        <label class="form-control flex-1">
+          <span class="label-text">{{ 'settings.auto_approval.field_priority' | translate }}</span>
           <input
-            type="text"
+            type="number"
             class="input input-bordered input-sm w-full"
-            [ngModel]="formName()"
-            (ngModelChange)="formName.set($event)"
+            [ngModel]="formPriority()"
+            (ngModelChange)="formPriority.set(+$event)"
           />
         </label>
-        <div class="flex gap-4">
-          <label class="form-control flex-1">
-            <span class="label-text">{{ 'settings.auto_approval.field_priority' | translate }}</span>
-            <input
-              type="number"
-              class="input input-bordered input-sm w-full"
-              [ngModel]="formPriority()"
-              (ngModelChange)="formPriority.set(+$event)"
-            />
-          </label>
-          <label class="form-control flex-none flex-row items-center gap-2 mt-6">
-            <input
-              type="checkbox"
-              class="checkbox checkbox-sm"
-              [ngModel]="formEnabled()"
-              (ngModelChange)="formEnabled.set($event)"
-            />
-            <span class="label-text">{{ 'settings.auto_approval.field_enabled' | translate }}</span>
-          </label>
-        </div>
+        <label class="form-control flex-none flex-row items-center gap-2 mt-6">
+          <input
+            type="checkbox"
+            class="checkbox checkbox-sm"
+            [ngModel]="formEnabled()"
+            (ngModelChange)="formEnabled.set($event)"
+          />
+          <span class="label-text">{{ 'settings.auto_approval.field_enabled' | translate }}</span>
+        </label>
+      </div>
 
-        <div>
-          <div class="flex items-center justify-between mb-2">
-            <span class="label-text font-medium">{{ 'settings.auto_approval.conditions' | translate }}</span>
-            <button type="button" class="btn btn-ghost btn-xs" (click)="addCondition()">
-              + {{ 'settings.auto_approval.add_condition' | translate }}
+      <div>
+        <div class="flex items-center justify-between mb-2">
+          <span class="label-text font-medium">{{
+            'settings.auto_approval.conditions' | translate
+          }}</span>
+          <button type="button" class="btn btn-ghost btn-xs" (click)="addCondition()">
+            + {{ 'settings.auto_approval.add_condition' | translate }}
+          </button>
+        </div>
+        @if (formConditions().length === 0) {
+          <p class="text-sm text-base-content/50">
+            {{ 'settings.auto_approval.no_conditions' | translate }}
+          </p>
+        }
+        @for (cond of formConditions(); track $index; let i = $index) {
+          <div class="flex items-center gap-2 mb-2 p-2 border border-base-200 rounded">
+            <select
+              class="select select-bordered select-xs flex-1"
+              [ngModel]="cond.field"
+              (ngModelChange)="updateCondition(i, { field: $event })"
+            >
+              @for (f of fields; track f) {
+                <option [value]="f">{{ 'settings.auto_approval.field_' + f | translate }}</option>
+              }
+            </select>
+            <select
+              class="select select-bordered select-xs flex-1"
+              [ngModel]="cond.operator"
+              (ngModelChange)="updateCondition(i, { operator: $event })"
+            >
+              @for (op of operators; track op) {
+                <option [value]="op">{{ 'settings.auto_approval.op_' + op | translate }}</option>
+              }
+            </select>
+            <input
+              type="text"
+              class="input input-bordered input-xs flex-1"
+              [ngModel]="cond.value"
+              (ngModelChange)="updateCondition(i, { value: $event })"
+              [placeholder]="'settings.auto_approval.value_placeholder' | translate"
+            />
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs text-error"
+              (click)="removeCondition(i)"
+            >
+              ✕
             </button>
           </div>
-          @if (formConditions().length === 0) {
-            <p class="text-sm text-base-content/50">{{ 'settings.auto_approval.no_conditions' | translate }}</p>
-          }
-          @for (cond of formConditions(); track $index; let i = $index) {
-            <div class="flex items-center gap-2 mb-2 p-2 border border-base-200 rounded">
-              <select
-                class="select select-bordered select-xs flex-1"
-                [ngModel]="cond.field"
-                (ngModelChange)="updateCondition(i, { field: $event })"
-              >
-                @for (f of fields; track f) {
-                  <option [value]="f">{{ ('settings.auto_approval.field_' + f) | translate }}</option>
-                }
-              </select>
-              <select
-                class="select select-bordered select-xs flex-1"
-                [ngModel]="cond.operator"
-                (ngModelChange)="updateCondition(i, { operator: $event })"
-              >
-                @for (op of operators; track op) {
-                  <option [value]="op">{{ ('settings.auto_approval.op_' + op) | translate }}</option>
-                }
-              </select>
-              <input
-                type="text"
-                class="input input-bordered input-xs flex-1"
-                [ngModel]="cond.value"
-                (ngModelChange)="updateCondition(i, { value: $event })"
-                [placeholder]="'settings.auto_approval.value_placeholder' | translate"
-              />
-              <button type="button" class="btn btn-ghost btn-xs text-error" (click)="removeCondition(i)">✕</button>
-            </div>
-          }
-        </div>
-
-
-        <div class="modal-action">
-          <button type="button" class="btn btn-ghost" (click)="closeEditor()">
-            {{ 'common.cancel' | translate }}
-          </button>
-          <button type="button" class="btn btn-primary" [disabled]="saving()" (click)="save()">
-            @if (saving()) {
-              <span class="loading loading-spinner loading-xs"></span>
-            }
-            {{ 'common.save' | translate }}
-          </button>
-        </div>
+        }
       </div>
+
+      <app-modal-footer>
+        <button type="button" class="btn btn-ghost" (click)="closeEditor()">
+          {{ 'common.cancel' | translate }}
+        </button>
+        <button type="button" class="btn btn-primary" [disabled]="saving()" (click)="save()">
+          @if (saving()) {
+            <span class="loading loading-spinner loading-xs"></span>
+          }
+          {{ 'common.save' | translate }}
+        </button>
+      </app-modal-footer>
     </div>
+  </div>
   <form method="dialog" class="modal-backdrop">
     <button type="button" (click)="closeEditor()">close</button>
   </form>

--- a/client/src/app/features/settings/auto-approval/auto-approval.html
+++ b/client/src/app/features/settings/auto-approval/auto-approval.html
@@ -59,9 +59,9 @@
 
 <dialog #editorDialog class="modal">
   <div class="modal-box max-w-lg">
-      <h3 class="text-lg font-semibold mb-4">
-        {{ (editingId() != null ? 'settings.auto_approval.editor_edit' : 'settings.auto_approval.editor_create') | translate }}
-      </h3>
+      <app-modal-header
+        [title]="(editingId() != null ? 'settings.auto_approval.editor_edit' : 'settings.auto_approval.editor_create') | translate"
+      />
       <div class="flex flex-col gap-4">
         <label class="form-control w-full">
           <span class="label-text">{{ 'settings.auto_approval.field_name' | translate }}</span>
@@ -137,10 +137,10 @@
 
 
         <div class="modal-action">
-          <button type="button" class="btn btn-ghost btn-sm" (click)="closeEditor()">
+          <button type="button" class="btn btn-ghost" (click)="closeEditor()">
             {{ 'common.cancel' | translate }}
           </button>
-          <button type="button" class="btn btn-primary btn-sm" [disabled]="saving()" (click)="save()">
+          <button type="button" class="btn btn-primary" [disabled]="saving()" (click)="save()">
             @if (saving()) {
               <span class="loading loading-spinner loading-xs"></span>
             }

--- a/client/src/app/features/settings/auto-approval/auto-approval.ts
+++ b/client/src/app/features/settings/auto-approval/auto-approval.ts
@@ -16,6 +16,7 @@ import {
   RuleCondition,
 } from '../../../core/services/api/auto-approval-api.service';
 import { ModalHeaderComponent } from '../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 const EMPTY_CONDITION = (): RuleCondition => ({
   field: 'role',
@@ -25,8 +26,7 @@ const EMPTY_CONDITION = (): RuleCondition => ({
 
 @Component({
   selector: 'app-auto-approval',
-  imports: [
-    ModalHeaderComponent,FormsModule, TranslateModule],
+  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './auto-approval.html',
 })
@@ -129,12 +129,15 @@ export class AutoApprovalSettingsComponent implements OnInit {
 
   async remove(rule: AutoApprovalRule) {
     if (
-      !await this.confirmation.confirm({
+      !(await this.confirmation.confirm({
         title: this.translate.instant('common.confirm'),
-        message: this.translate.instant('settings.auto_approval.confirm_delete', { name: rule.name }),
+        message: this.translate.instant('settings.auto_approval.confirm_delete', {
+          name: rule.name,
+        }),
         variant: 'danger',
-      })
-    ) return;
+      }))
+    )
+      return;
     try {
       await this.api.remove(rule.id);
       this.rules.update((list) => list.filter((r) => r.id !== rule.id));

--- a/client/src/app/features/settings/auto-approval/auto-approval.ts
+++ b/client/src/app/features/settings/auto-approval/auto-approval.ts
@@ -15,6 +15,7 @@ import {
   AutoApprovalRule,
   RuleCondition,
 } from '../../../core/services/api/auto-approval-api.service';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 
 const EMPTY_CONDITION = (): RuleCondition => ({
   field: 'role',
@@ -24,7 +25,8 @@ const EMPTY_CONDITION = (): RuleCondition => ({
 
 @Component({
   selector: 'app-auto-approval',
-  imports: [FormsModule, TranslateModule],
+  imports: [
+    ModalHeaderComponent,FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './auto-approval.html',
 })

--- a/client/src/app/features/settings/custom-formats/custom-formats.html
+++ b/client/src/app/features/settings/custom-formats/custom-formats.html
@@ -2,7 +2,9 @@
   <div class="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
     <div>
       <h1 class="text-2xl font-bold">{{ 'settings.custom_formats.title' | translate }}</h1>
-      <p class="text-sm text-base-content/60 mt-1">{{ 'settings.custom_formats.subtitle' | translate }}</p>
+      <p class="text-sm text-base-content/60 mt-1">
+        {{ 'settings.custom_formats.subtitle' | translate }}
+      </p>
     </div>
     <button type="button" class="btn btn-primary self-start sm:self-auto" (click)="openCreate()">
       {{ 'settings.custom_formats.new' | translate }}
@@ -16,7 +18,9 @@
   } @else if (listError()) {
     <div role="alert" class="alert alert-error">{{ listError() }}</div>
   } @else if (rows().length === 0) {
-    <p class="text-center py-12 text-base-content/50">{{ 'settings.custom_formats.empty' | translate }}</p>
+    <p class="text-center py-12 text-base-content/50">
+      {{ 'settings.custom_formats.empty' | translate }}
+    </p>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
       <table class="table table-zebra">
@@ -32,7 +36,9 @@
           @for (cf of rows(); track cf.id) {
             <tr>
               <td>
-                <button type="button" class="link link-hover font-medium" (click)="openEdit(cf)">{{ cf.name }}</button>
+                <button type="button" class="link link-hover font-medium" (click)="openEdit(cf)">
+                  {{ cf.name }}
+                </button>
               </td>
               <td>
                 <span
@@ -46,7 +52,11 @@
               </td>
               <td class="text-sm text-base-content/60">{{ cf.specs.length }} spec(s)</td>
               <td class="text-end">
-                <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteRow(cf)">
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-xs text-error"
+                  (click)="deleteRow(cf)"
+                >
                   {{ 'settings.custom_formats.delete' | translate }}
                 </button>
               </td>
@@ -60,27 +70,51 @@
   <div class="divider"></div>
   <h2 class="text-lg font-semibold mb-2">{{ 'settings.custom_formats.test_title' | translate }}</h2>
   <div class="flex gap-2 items-end">
-    <input type="text" class="input input-bordered input-sm flex-1"
+    <input
+      type="text"
+      class="input input-bordered input-sm flex-1"
       [placeholder]="'settings.custom_formats.test_placeholder' | translate"
-      [ngModel]="testTitle()" (ngModelChange)="testTitle.set($event)" />
-    <button type="button" class="btn btn-sm btn-outline" (click)="runTest()" [disabled]="testLoading() || !testTitle().trim()">
-      @if (testLoading()) { <span class="loading loading-spinner loading-xs"></span> }
+      [ngModel]="testTitle()"
+      (ngModelChange)="testTitle.set($event)"
+    />
+    <button
+      type="button"
+      class="btn btn-sm btn-outline"
+      (click)="runTest()"
+      [disabled]="testLoading() || !testTitle().trim()"
+    >
+      @if (testLoading()) {
+        <span class="loading loading-spinner loading-xs"></span>
+      }
       {{ 'settings.custom_formats.test_btn' | translate }}
     </button>
   </div>
   @if (testResults().length) {
     <div class="overflow-x-auto mt-3 rounded-lg border border-base-200">
       <table class="table">
-        <thead><tr><th>Format</th><th>Match</th><th class="text-right">Score</th></tr></thead>
+        <thead>
+          <tr>
+            <th>Format</th>
+            <th>Match</th>
+            <th class="text-right">Score</th>
+          </tr>
+        </thead>
         <tbody>
           @for (r of testResults(); track r.formatId) {
             <tr [class.opacity-40]="!r.matched">
               <td>{{ r.formatName }}</td>
               <td>
-                @if (r.matched) { <span class="badge badge-success badge-sm">Oui</span> }
-                @else { <span class="badge badge-ghost badge-sm">Non</span> }
+                @if (r.matched) {
+                  <span class="badge badge-success badge-sm">Oui</span>
+                } @else {
+                  <span class="badge badge-ghost badge-sm">Non</span>
+                }
               </td>
-              <td class="text-right tabular-nums" [class.text-success]="r.score > 0" [class.text-error]="r.score < 0">
+              <td
+                class="text-right tabular-nums"
+                [class.text-success]="r.score > 0"
+                [class.text-error]="r.score < 0"
+              >
                 {{ r.score > 0 ? '+' : '' }}{{ r.score }}
               </td>
             </tr>
@@ -91,135 +125,133 @@
   }
 </div>
 
-  <dialog #editorDialog class="modal">
-    <div class="modal-box max-w-xl max-h-[92vh] flex flex-col p-0 gap-0 overflow-hidden">
-      <div class="px-5 sm:px-6 pt-4 pb-3 border-b border-base-200 flex justify-between items-center shrink-0 bg-base-100">
-        <h2 class="text-lg font-bold">
-          @if (editingId() === null) {
-            {{ 'settings.custom_formats.editor_create' | translate }}
-          } @else {
-            {{ 'settings.custom_formats.editor_edit' | translate }}
-          }
-        </h2>
-        <button
-          type="button"
-          class="btn btn-sm btn-ghost btn-circle"
-          (click)="closeEditor()"
-          [attr.aria-label]="'common.close' | translate"
-        >
-          <svg lucideX class="h-5 w-5"></svg>
-        </button>
+<dialog #editorDialog class="modal">
+  <div class="modal-box max-w-xl max-h-[92vh] flex flex-col p-0 gap-0 overflow-hidden">
+    <app-modal-header
+      flush
+      [title]="
+        (editingId() === null
+          ? 'settings.custom_formats.editor_create'
+          : 'settings.custom_formats.editor_edit'
+        ) | translate
+      "
+    />
+
+    <div class="px-5 sm:px-6 py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 bg-base-100">
+      <div class="grid grid-cols-3 gap-3">
+        <label class="form-control col-span-2">
+          <span class="label-text">{{ 'settings.custom_formats.field_name' | translate }}</span>
+          <input
+            type="text"
+            class="input input-bordered input-sm w-full"
+            [ngModel]="formName()"
+            (ngModelChange)="formName.set($event)"
+          />
+        </label>
+        <label class="form-control">
+          <span class="label-text">{{ 'settings.custom_formats.field_score' | translate }}</span>
+          <input
+            type="number"
+            class="input input-bordered input-sm w-full"
+            [ngModel]="formScore()"
+            (ngModelChange)="formScore.set(+$event)"
+          />
+        </label>
       </div>
 
-      <div class="px-5 sm:px-6 py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 bg-base-100">
-        <div class="grid grid-cols-3 gap-3">
-          <label class="form-control col-span-2">
-            <span class="label-text">{{ 'settings.custom_formats.field_name' | translate }}</span>
-            <input
-              type="text"
-              class="input input-bordered input-sm w-full"
-              [ngModel]="formName()"
-              (ngModelChange)="formName.set($event)"
-            />
-          </label>
-          <label class="form-control">
-            <span class="label-text">{{ 'settings.custom_formats.field_score' | translate }}</span>
-            <input
-              type="number"
-              class="input input-bordered input-sm w-full"
-              [ngModel]="formScore()"
-              (ngModelChange)="formScore.set(+$event)"
-            />
-          </label>
+      <div class="flex flex-col gap-2">
+        <div class="flex items-center justify-between">
+          <span class="text-sm font-medium">{{ 'settings.custom_formats.specs' | translate }}</span>
+          <button type="button" class="btn btn-ghost btn-xs" (click)="addSpec()">
+            + {{ 'settings.custom_formats.add_spec' | translate }}
+          </button>
         </div>
 
-        <div class="flex flex-col gap-2">
-          <div class="flex items-center justify-between">
-            <span class="text-sm font-medium">{{ 'settings.custom_formats.specs' | translate }}</span>
-            <button type="button" class="btn btn-ghost btn-xs" (click)="addSpec()">
-              + {{ 'settings.custom_formats.add_spec' | translate }}
-            </button>
-          </div>
-
-          @for (spec of formSpecs(); track $index) {
-            <div class="flex flex-wrap gap-2 p-3 rounded-lg bg-base-200/40 border border-base-300">
+        @for (spec of formSpecs(); track $index) {
+          <div class="flex flex-wrap gap-2 p-3 rounded-lg bg-base-200/40 border border-base-300">
+            <select
+              class="select select-bordered select-xs"
+              [ngModel]="spec.type"
+              (ngModelChange)="updateSpec($index, { type: $event })"
+            >
+              @for (t of specTypes; track t) {
+                <option [value]="t">{{ t }}</option>
+              }
+            </select>
+            @if (spec.type === 'release_flag') {
               <select
-                class="select select-bordered select-xs"
-                [ngModel]="spec.type"
-                (ngModelChange)="updateSpec($index, { type: $event })"
+                class="select select-bordered select-xs flex-1 min-w-32"
+                [ngModel]="spec.value"
+                (ngModelChange)="updateSpec($index, { value: $event })"
               >
-                @for (t of specTypes; track t) {
-                  <option [value]="t">{{ t }}</option>
+                @for (v of releaseFlagValues; track v) {
+                  <option [value]="v">{{ v }}</option>
                 }
               </select>
-              @if (spec.type === 'release_flag') {
-                <select
-                  class="select select-bordered select-xs flex-1 min-w-32"
-                  [ngModel]="spec.value"
-                  (ngModelChange)="updateSpec($index, { value: $event })"
-                >
-                  @for (v of releaseFlagValues; track v) {
-                    <option [value]="v">{{ v }}</option>
-                  }
-                </select>
-              } @else {
-                <input
-                  type="text"
-                  class="input input-bordered input-xs flex-1 min-w-32"
-                  [ngModel]="spec.value"
-                  (ngModelChange)="updateSpec($index, { value: $event })"
-                  placeholder="{{ spec.type === 'title_regex' ? '/regex/' : 'value' }}"
-                />
-              }
-              <label class="label cursor-pointer gap-1.5 px-1">
-                <input
-                  type="checkbox"
-                  class="checkbox checkbox-xs"
-                  [ngModel]="spec.negate"
-                  (ngModelChange)="updateSpec($index, { negate: $event })"
-                />
-                <span class="label-text text-sm">{{ 'settings.custom_formats.negate' | translate }}</span>
-              </label>
-              <label class="label cursor-pointer gap-1.5 px-1">
-                <input
-                  type="checkbox"
-                  class="checkbox checkbox-xs"
-                  [ngModel]="spec.required"
-                  (ngModelChange)="updateSpec($index, { required: $event })"
-                />
-                <span class="label-text text-sm">{{ 'settings.custom_formats.required' | translate }}</span>
-              </label>
-              <button
-                type="button"
-                class="btn btn-ghost btn-xs text-error"
-                (click)="removeSpec($index)"
-              >✕</button>
-            </div>
-          }
+            } @else {
+              <input
+                type="text"
+                class="input input-bordered input-xs flex-1 min-w-32"
+                [ngModel]="spec.value"
+                (ngModelChange)="updateSpec($index, { value: $event })"
+                placeholder="{{ spec.type === 'title_regex' ? '/regex/' : 'value' }}"
+              />
+            }
+            <label class="label cursor-pointer gap-1.5 px-1">
+              <input
+                type="checkbox"
+                class="checkbox checkbox-xs"
+                [ngModel]="spec.negate"
+                (ngModelChange)="updateSpec($index, { negate: $event })"
+              />
+              <span class="label-text text-sm">{{
+                'settings.custom_formats.negate' | translate
+              }}</span>
+            </label>
+            <label class="label cursor-pointer gap-1.5 px-1">
+              <input
+                type="checkbox"
+                class="checkbox checkbox-xs"
+                [ngModel]="spec.required"
+                (ngModelChange)="updateSpec($index, { required: $event })"
+              />
+              <span class="label-text text-sm">{{
+                'settings.custom_formats.required' | translate
+              }}</span>
+            </label>
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs text-error"
+              (click)="removeSpec($index)"
+            >
+              ✕
+            </button>
+          </div>
+        }
 
-          @if (formSpecs().length === 0) {
-            <p class="text-sm text-base-content/50 text-center py-4">
-              {{ 'settings.custom_formats.no_specs' | translate }}
-            </p>
-          }
-        </div>
-
-
-      </div>
-
-      <div class="modal-action modal-action-sticky">
-        <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
-          {{ 'settings.custom_formats.cancel' | translate }}
-        </button>
-        <button type="button" class="btn btn-primary" (click)="save()" [disabled]="saving()">
-          @if (saving()) {
-            <span class="loading loading-spinner loading-sm"></span>
-          }
-          {{ 'settings.custom_formats.save' | translate }}
-        </button>
+        @if (formSpecs().length === 0) {
+          <p class="text-sm text-base-content/50 text-center py-4">
+            {{ 'settings.custom_formats.no_specs' | translate }}
+          </p>
+        }
       </div>
     </div>
-    <form method="dialog" class="modal-backdrop">
-      <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">close</button>
-    </form>
-  </dialog>
+
+    <app-modal-footer flush>
+      <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
+        {{ 'settings.custom_formats.cancel' | translate }}
+      </button>
+      <button type="button" class="btn btn-primary" (click)="save()" [disabled]="saving()">
+        @if (saving()) {
+          <span class="loading loading-spinner loading-sm"></span>
+        }
+        {{ 'settings.custom_formats.save' | translate }}
+      </button>
+    </app-modal-footer>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">
+      close
+    </button>
+  </form>
+</dialog>

--- a/client/src/app/features/settings/custom-formats/custom-formats.html
+++ b/client/src/app/features/settings/custom-formats/custom-formats.html
@@ -207,7 +207,7 @@
 
       </div>
 
-      <div class="modal-action shrink-0 px-5 sm:px-6 pb-4 pt-2 border-t border-base-200 bg-base-100">
+      <div class="modal-action modal-action-sticky">
         <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
           {{ 'settings.custom_formats.cancel' | translate }}
         </button>

--- a/client/src/app/features/settings/custom-formats/custom-formats.ts
+++ b/client/src/app/features/settings/custom-formats/custom-formats.ts
@@ -16,10 +16,12 @@ import {
   CustomFormatSpec,
 } from '../../../core/services/api/custom-formats-api.service';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-custom-formats-settings',
-  imports: [FormsModule, LucideX, TranslateModule],
+  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './custom-formats.html',
 })
@@ -41,7 +43,9 @@ export class CustomFormatsSettingsComponent implements OnInit {
   readonly formSpecs = signal<CustomFormatSpec[]>([]);
 
   readonly testTitle = signal('');
-  readonly testResults = signal<{ formatId: number; formatName: string; matched: boolean; score: number }[]>([]);
+  readonly testResults = signal<
+    { formatId: number; formatName: string; matched: boolean; score: number }[]
+  >([]);
   readonly testLoading = signal(false);
 
   readonly specTypes = ['title_regex', 'source', 'resolution', 'language', 'release_flag'] as const;
@@ -95,9 +99,7 @@ export class CustomFormatsSettingsComponent implements OnInit {
   }
 
   updateSpec(index: number, patch: Partial<CustomFormatSpec>) {
-    this.formSpecs.update((specs) =>
-      specs.map((s, i) => (i === index ? { ...s, ...patch } : s)),
-    );
+    this.formSpecs.update((specs) => specs.map((s, i) => (i === index ? { ...s, ...patch } : s)));
   }
 
   async save() {
@@ -134,13 +136,26 @@ export class CustomFormatsSettingsComponent implements OnInit {
   }
 
   async deleteRow(cf: CustomFormat) {
-    if (!await this.confirmation.confirm({ title: this.translate.instant('common.confirm'), message: this.translate.instant('settings.custom_formats.confirm_delete', { name: cf.name }), variant: 'danger' })) return;
+    if (
+      !(await this.confirmation.confirm({
+        title: this.translate.instant('common.confirm'),
+        message: this.translate.instant('settings.custom_formats.confirm_delete', {
+          name: cf.name,
+        }),
+        variant: 'danger',
+      }))
+    )
+      return;
     try {
       await this.api.remove(cf.id);
       await this.reloadAll();
     } catch (err: unknown) {
       const httpErr = err as { error?: { message?: string } };
-      void this.confirmation.alert({ title: this.translate.instant('common.error'), message: httpErr.error?.message ?? 'Error', variant: 'danger' });
+      void this.confirmation.alert({
+        title: this.translate.instant('common.error'),
+        message: httpErr.error?.message ?? 'Error',
+        variant: 'danger',
+      });
     }
   }
 }

--- a/client/src/app/features/settings/data-imports/data-imports.html
+++ b/client/src/app/features/settings/data-imports/data-imports.html
@@ -1,7 +1,9 @@
 <div class="flex flex-col gap-6">
   <div>
     <h1 class="text-2xl font-bold">{{ 'settings.data_imports.title' | translate }}</h1>
-    <p class="text-sm text-base-content/60 mt-1">{{ 'settings.data_imports.subtitle' | translate }}</p>
+    <p class="text-sm text-base-content/60 mt-1">
+      {{ 'settings.data_imports.subtitle' | translate }}
+    </p>
   </div>
 
   @if (loading()) {
@@ -25,7 +27,9 @@
       <div class="card-body gap-4">
         <div>
           <h2 class="card-title text-lg">{{ 'settings.data_imports.emby.section' | translate }}</h2>
-          <p class="text-sm text-base-content/60 mt-1">{{ 'settings.data_imports.emby.description' | translate }}</p>
+          <p class="text-sm text-base-content/60 mt-1">
+            {{ 'settings.data_imports.emby.description' | translate }}
+          </p>
         </div>
 
         @if (embyServers().length === 0) {
@@ -39,7 +43,9 @@
                 <tr>
                   <th>{{ 'settings.media_servers.col_name' | translate }}</th>
                   <th>{{ 'settings.media_servers.col_url' | translate }}</th>
-                  <th class="text-center">{{ 'settings.media_servers.col_enabled' | translate }}</th>
+                  <th class="text-center">
+                    {{ 'settings.media_servers.col_enabled' | translate }}
+                  </th>
                   <th class="text-end w-48"></th>
                 </tr>
               </thead>
@@ -47,12 +53,18 @@
                 @for (server of embyServers(); track server.id) {
                   <tr>
                     <td class="font-medium">{{ server.name }}</td>
-                    <td class="text-sm text-base-content/60 truncate max-w-[16rem]">{{ server.url }}</td>
+                    <td class="text-sm text-base-content/60 truncate max-w-[16rem]">
+                      {{ server.url }}
+                    </td>
                     <td class="text-center">
                       @if (server.enabled) {
-                        <span class="badge badge-success badge-sm">{{ 'common.yes' | translate }}</span>
+                        <span class="badge badge-success badge-sm">{{
+                          'common.yes' | translate
+                        }}</span>
                       } @else {
-                        <span class="badge badge-ghost badge-sm">{{ 'common.no' | translate }}</span>
+                        <span class="badge badge-ghost badge-sm">{{
+                          'common.no' | translate
+                        }}</span>
                       }
                     </td>
                     <td class="text-end">
@@ -83,8 +95,12 @@
     <section class="card bg-base-200/60 border border-base-200">
       <div class="card-body gap-4">
         <div>
-          <h2 class="card-title text-lg">{{ 'settings.data_imports.seerr.section' | translate }}</h2>
-          <p class="text-sm text-base-content/60 mt-1">{{ 'settings.data_imports.seerr.description' | translate }}</p>
+          <h2 class="card-title text-lg">
+            {{ 'settings.data_imports.seerr.section' | translate }}
+          </h2>
+          <p class="text-sm text-base-content/60 mt-1">
+            {{ 'settings.data_imports.seerr.description' | translate }}
+          </p>
         </div>
 
         <label class="form-control w-full max-w-xl">
@@ -228,7 +244,9 @@
               (ngModelChange)="radarrLibrary.set($event)"
               required
             >
-              <option [ngValue]="null" disabled>{{ 'settings.libraries.import_target_placeholder' | translate }}</option>
+              <option [ngValue]="null" disabled>
+                {{ 'settings.libraries.import_target_placeholder' | translate }}
+              </option>
               @for (l of movieLibraries(); track l.id) {
                 <option [ngValue]="l.id">{{ l.name }}</option>
               }
@@ -300,16 +318,31 @@
               <div>
                 <p>{{ 'import.result_imported' | translate: { count: r.imported } }}</p>
                 @if (r.subtitlesImported) {
-                  <p class="mt-1">{{ 'import.result_subtitles' | translate: { count: r.subtitlesImported } }}</p>
+                  <p class="mt-1">
+                    {{ 'import.result_subtitles' | translate: { count: r.subtitlesImported } }}
+                  </p>
                 }
                 @if (r.qualityProfilesCreated.length) {
-                  <p class="mt-1">{{ 'import.quality_profiles_created' | translate: { count: r.qualityProfilesCreated.length } }}: {{ r.qualityProfilesCreated.join(', ') }}</p>
+                  <p class="mt-1">
+                    {{
+                      'import.quality_profiles_created'
+                        | translate: { count: r.qualityProfilesCreated.length }
+                    }}: {{ r.qualityProfilesCreated.join(', ') }}
+                  </p>
                 }
                 @if (r.rootFoldersCreated.length) {
-                  <p class="mt-1">{{ 'import.root_folders_created' | translate: { count: r.rootFoldersCreated.length } }}: {{ r.rootFoldersCreated.join(', ') }}</p>
+                  <p class="mt-1">
+                    {{
+                      'import.root_folders_created'
+                        | translate: { count: r.rootFoldersCreated.length }
+                    }}: {{ r.rootFoldersCreated.join(', ') }}
+                  </p>
                 }
                 @if (r.errors.length) {
-                  <p class="mt-1">{{ r.errors.length }} {{ 'import.result_errors' | translate }}: {{ r.errors.slice(0, 5).join(', ') }}</p>
+                  <p class="mt-1">
+                    {{ r.errors.length }} {{ 'import.result_errors' | translate }}:
+                    {{ r.errors.slice(0, 5).join(', ') }}
+                  </p>
                 }
               </div>
             </div>
@@ -377,7 +410,9 @@
               (ngModelChange)="sonarrLibrary.set($event)"
               required
             >
-              <option [ngValue]="null" disabled>{{ 'settings.libraries.import_target_placeholder' | translate }}</option>
+              <option [ngValue]="null" disabled>
+                {{ 'settings.libraries.import_target_placeholder' | translate }}
+              </option>
               @for (l of seriesLibraries(); track l.id) {
                 <option [ngValue]="l.id">{{ l.name }}</option>
               }
@@ -449,16 +484,31 @@
               <div>
                 <p>{{ 'import.result_imported' | translate: { count: r.imported } }}</p>
                 @if (r.subtitlesImported) {
-                  <p class="mt-1">{{ 'import.result_subtitles' | translate: { count: r.subtitlesImported } }}</p>
+                  <p class="mt-1">
+                    {{ 'import.result_subtitles' | translate: { count: r.subtitlesImported } }}
+                  </p>
                 }
                 @if (r.qualityProfilesCreated.length) {
-                  <p class="mt-1">{{ 'import.quality_profiles_created' | translate: { count: r.qualityProfilesCreated.length } }}: {{ r.qualityProfilesCreated.join(', ') }}</p>
+                  <p class="mt-1">
+                    {{
+                      'import.quality_profiles_created'
+                        | translate: { count: r.qualityProfilesCreated.length }
+                    }}: {{ r.qualityProfilesCreated.join(', ') }}
+                  </p>
                 }
                 @if (r.rootFoldersCreated.length) {
-                  <p class="mt-1">{{ 'import.root_folders_created' | translate: { count: r.rootFoldersCreated.length } }}: {{ r.rootFoldersCreated.join(', ') }}</p>
+                  <p class="mt-1">
+                    {{
+                      'import.root_folders_created'
+                        | translate: { count: r.rootFoldersCreated.length }
+                    }}: {{ r.rootFoldersCreated.join(', ') }}
+                  </p>
                 }
                 @if (r.errors.length) {
-                  <p class="mt-1">{{ r.errors.length }} {{ 'import.result_errors' | translate }}: {{ r.errors.slice(0, 5).join(', ') }}</p>
+                  <p class="mt-1">
+                    {{ r.errors.length }} {{ 'import.result_errors' | translate }}:
+                    {{ r.errors.slice(0, 5).join(', ') }}
+                  </p>
                 }
               </div>
             </div>
@@ -473,15 +523,25 @@
   @if (radarrShowWizard()) {
     <div class="modal modal-open">
       <div class="modal-box max-w-2xl">
-        <h3 class="font-bold text-lg">{{ 'import.path_wizard.title' | translate }}</h3>
-        <p class="text-sm text-base-content/60 mt-1">{{ 'import.path_wizard.description' | translate }}</p>
+        <app-modal-header (closed)="cancelWizard('radarr')">
+          <div>
+            <h3 class="text-lg font-bold">{{ 'import.path_wizard.title' | translate }}</h3>
+            <p class="text-sm text-base-content/60 mt-1">
+              {{ 'import.path_wizard.description' | translate }}
+            </p>
+          </div>
+        </app-modal-header>
 
         @if (radarrPreview(); as preview) {
           @if (eligibleLocalLibraries('radarr').length === 0) {
             <div role="alert" class="alert alert-warning mt-4 text-sm">
               <div>
                 <p>{{ 'import.path_wizard.no_root_folders' | translate }}</p>
-                <button type="button" class="btn btn-sm btn-primary mt-3" (click)="goToLibraries('radarr')">
+                <button
+                  type="button"
+                  class="btn btn-sm btn-primary mt-3"
+                  (click)="goToLibraries('radarr')"
+                >
                   {{ 'import.path_wizard.go_to_root_folders' | translate }}
                 </button>
               </div>
@@ -490,7 +550,9 @@
             <div class="flex flex-col gap-3 mt-4">
               @for (m of radarrMappings(); track m.remotePath) {
                 <div class="flex flex-col sm:flex-row sm:items-center gap-2">
-                  <code class="text-sm bg-base-300 px-2 py-1 rounded sm:flex-1 truncate">{{ m.remotePath }}</code>
+                  <code class="text-sm bg-base-300 px-2 py-1 rounded sm:flex-1 truncate">{{
+                    m.remotePath
+                  }}</code>
                   <span class="text-base-content/40 hidden sm:inline">→</span>
                   <select
                     class="select select-bordered select-sm sm:flex-1"
@@ -501,7 +563,9 @@
                     @for (lib of eligibleLocalLibraries('radarr'); track lib.id) {
                       <option [ngValue]="lib.id">{{ lib.name }} ({{ lib.path }})</option>
                     }
-                    <option [ngValue]="IGNORE_VALUE">{{ 'import.path_wizard.option_ignore' | translate }}</option>
+                    <option [ngValue]="IGNORE_VALUE">
+                      {{ 'import.path_wizard.option_ignore' | translate }}
+                    </option>
                   </select>
                 </div>
               }
@@ -509,7 +573,7 @@
           }
         }
 
-        <div class="modal-action">
+        <app-modal-footer>
           <button type="button" class="btn btn-ghost" (click)="cancelWizard('radarr')">
             {{ 'import.path_wizard.cancel' | translate }}
           </button>
@@ -526,7 +590,7 @@
               {{ 'import.path_wizard.confirm' | translate }}
             </button>
           }
-        </div>
+        </app-modal-footer>
       </div>
     </div>
   }
@@ -534,15 +598,25 @@
   @if (sonarrShowWizard()) {
     <div class="modal modal-open">
       <div class="modal-box max-w-2xl">
-        <h3 class="font-bold text-lg">{{ 'import.path_wizard.title' | translate }}</h3>
-        <p class="text-sm text-base-content/60 mt-1">{{ 'import.path_wizard.description' | translate }}</p>
+        <app-modal-header (closed)="cancelWizard('sonarr')">
+          <div>
+            <h3 class="text-lg font-bold">{{ 'import.path_wizard.title' | translate }}</h3>
+            <p class="text-sm text-base-content/60 mt-1">
+              {{ 'import.path_wizard.description' | translate }}
+            </p>
+          </div>
+        </app-modal-header>
 
         @if (sonarrPreview(); as preview) {
           @if (eligibleLocalLibraries('sonarr').length === 0) {
             <div role="alert" class="alert alert-warning mt-4 text-sm">
               <div>
                 <p>{{ 'import.path_wizard.no_root_folders' | translate }}</p>
-                <button type="button" class="btn btn-sm btn-primary mt-3" (click)="goToLibraries('sonarr')">
+                <button
+                  type="button"
+                  class="btn btn-sm btn-primary mt-3"
+                  (click)="goToLibraries('sonarr')"
+                >
                   {{ 'import.path_wizard.go_to_root_folders' | translate }}
                 </button>
               </div>
@@ -551,7 +625,9 @@
             <div class="flex flex-col gap-3 mt-4">
               @for (m of sonarrMappings(); track m.remotePath) {
                 <div class="flex flex-col sm:flex-row sm:items-center gap-2">
-                  <code class="text-sm bg-base-300 px-2 py-1 rounded sm:flex-1 truncate">{{ m.remotePath }}</code>
+                  <code class="text-sm bg-base-300 px-2 py-1 rounded sm:flex-1 truncate">{{
+                    m.remotePath
+                  }}</code>
                   <span class="text-base-content/40 hidden sm:inline">→</span>
                   <select
                     class="select select-bordered select-sm sm:flex-1"
@@ -562,7 +638,9 @@
                     @for (lib of eligibleLocalLibraries('sonarr'); track lib.id) {
                       <option [ngValue]="lib.id">{{ lib.name }} ({{ lib.path }})</option>
                     }
-                    <option [ngValue]="IGNORE_VALUE">{{ 'import.path_wizard.option_ignore' | translate }}</option>
+                    <option [ngValue]="IGNORE_VALUE">
+                      {{ 'import.path_wizard.option_ignore' | translate }}
+                    </option>
                   </select>
                 </div>
               }
@@ -570,7 +648,7 @@
           }
         }
 
-        <div class="modal-action">
+        <app-modal-footer>
           <button type="button" class="btn btn-ghost" (click)="cancelWizard('sonarr')">
             {{ 'import.path_wizard.cancel' | translate }}
           </button>
@@ -587,7 +665,7 @@
               {{ 'import.path_wizard.confirm' | translate }}
             </button>
           }
-        </div>
+        </app-modal-footer>
       </div>
     </div>
   }

--- a/client/src/app/features/settings/data-imports/data-imports.html
+++ b/client/src/app/features/settings/data-imports/data-imports.html
@@ -510,13 +510,13 @@
         }
 
         <div class="modal-action">
-          <button type="button" class="btn btn-ghost btn-sm" (click)="cancelWizard('radarr')">
+          <button type="button" class="btn btn-ghost" (click)="cancelWizard('radarr')">
             {{ 'import.path_wizard.cancel' | translate }}
           </button>
           @if (eligibleLocalLibraries('radarr').length > 0) {
             <button
               type="button"
-              class="btn btn-primary btn-sm"
+              class="btn btn-primary"
               [disabled]="!radarrCanConfirm() || radarrLoading()"
               (click)="confirmRadarrImport()"
             >
@@ -571,13 +571,13 @@
         }
 
         <div class="modal-action">
-          <button type="button" class="btn btn-ghost btn-sm" (click)="cancelWizard('sonarr')">
+          <button type="button" class="btn btn-ghost" (click)="cancelWizard('sonarr')">
             {{ 'import.path_wizard.cancel' | translate }}
           </button>
           @if (eligibleLocalLibraries('sonarr').length > 0) {
             <button
               type="button"
-              class="btn btn-primary btn-sm"
+              class="btn btn-primary"
               [disabled]="!sonarrCanConfirm() || sonarrLoading()"
               (click)="confirmSonarrImport()"
             >

--- a/client/src/app/features/settings/data-imports/data-imports.ts
+++ b/client/src/app/features/settings/data-imports/data-imports.ts
@@ -16,16 +16,15 @@ import { firstValueFrom } from 'rxjs';
 import { ImportDiskComponent } from '../../import-disk/import-disk';
 import { SeerrApiService } from '../../../core/services/api/seerr-api.service';
 import { SettingsApiService } from '../../../core/services/api/settings-api.service';
-import {
-  LibrariesApiService,
-  Library,
-} from '../../../core/services/api/libraries-api.service';
+import { LibrariesApiService, Library } from '../../../core/services/api/libraries-api.service';
 import {
   MediaServersApiService,
   MediaServerRow,
 } from '../../../core/services/api/media-servers-api.service';
 import { SseService } from '../../../core/services/sse.service';
 import { ToastService } from '../../../core/services/toast.service';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 
 const SETTING_SEERR_URL = 'seerr_url';
 const SETTING_SEERR_API_KEY = 'seerr_api_key';
@@ -77,7 +76,14 @@ type LibrarySelection = number | null;
 
 @Component({
   selector: 'app-data-imports-settings',
-  imports: [FormsModule, TranslateModule, LucideDownload, ImportDiskComponent],
+  imports: [
+    ModalHeaderComponent,
+    ModalFooterComponent,
+    FormsModule,
+    TranslateModule,
+    LucideDownload,
+    ImportDiskComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './data-imports.html',
 })
@@ -156,9 +162,7 @@ export class DataImportsSettingsComponent implements OnInit {
   readonly radarrPreviewing = signal(false);
   readonly radarrShowWizard = signal(false);
   readonly radarrCanConfirm = computed(() =>
-    this.radarrMappings().every(
-      (m) => m.ignore || m.localLibraryId != null,
-    ),
+    this.radarrMappings().every((m) => m.ignore || m.localLibraryId != null),
   );
 
   readonly sonarrPreview = signal<PreviewImportResult | null>(null);
@@ -166,9 +170,7 @@ export class DataImportsSettingsComponent implements OnInit {
   readonly sonarrPreviewing = signal(false);
   readonly sonarrShowWizard = signal(false);
   readonly sonarrCanConfirm = computed(() =>
-    this.sonarrMappings().every(
-      (m) => m.ignore || m.localLibraryId != null,
-    ),
+    this.sonarrMappings().every((m) => m.ignore || m.localLibraryId != null),
   );
 
   readonly IGNORE_VALUE = IGNORE_VALUE;
@@ -184,28 +186,20 @@ export class DataImportsSettingsComponent implements OnInit {
     if (event.type === 'watch-history.import.completed') {
       this.setEmbyImporting(Number(event['serverId']), false);
       this.toast.success(
-        this.translate.instant(
-          'settings.data_imports.emby.import_completed',
-          {
-            users: Number(event['users'] ?? 0),
-            usersCreated: Number(event['usersCreated'] ?? 0),
-            imported: Number(event['imported'] ?? 0),
-            skipped: Number(event['skipped'] ?? 0),
-          },
-        ),
+        this.translate.instant('settings.data_imports.emby.import_completed', {
+          users: Number(event['users'] ?? 0),
+          usersCreated: Number(event['usersCreated'] ?? 0),
+          imported: Number(event['imported'] ?? 0),
+          skipped: Number(event['skipped'] ?? 0),
+        }),
       );
       return;
     }
     if (event.type === 'watch-history.import.failed') {
       this.setEmbyImporting(Number(event['serverId']), false);
-      const err =
-        (event['error'] as string | undefined) ??
-        this.translate.instant('common.error');
+      const err = (event['error'] as string | undefined) ?? this.translate.instant('common.error');
       this.toast.error(
-        this.translate.instant(
-          'settings.data_imports.emby.import_failed',
-          { error: err },
-        ),
+        this.translate.instant('settings.data_imports.emby.import_failed', { error: err }),
       );
       return;
     }
@@ -220,21 +214,13 @@ export class DataImportsSettingsComponent implements OnInit {
       };
       this.seerrLastSummary.set(summary);
       this.toast.success(
-        this.translate.instant(
-          'settings.data_imports.seerr.import_completed',
-          summary,
-        ),
+        this.translate.instant('settings.data_imports.seerr.import_completed', summary),
       );
     } else if (event.type === 'seerr.import.failed') {
       this.seerrImporting.set(false);
-      const err =
-        (event['error'] as string | undefined) ??
-        this.translate.instant('common.error');
+      const err = (event['error'] as string | undefined) ?? this.translate.instant('common.error');
       this.toast.error(
-        this.translate.instant(
-          'settings.data_imports.seerr.import_failed',
-          { error: err },
-        ),
+        this.translate.instant('settings.data_imports.seerr.import_failed', { error: err }),
       );
     }
   });
@@ -279,20 +265,14 @@ export class DataImportsSettingsComponent implements OnInit {
     try {
       await this.mediaServersApi.importWatchHistory(server.id);
       this.toast.success(
-        this.translate.instant(
-          'settings.data_imports.emby.import_started',
-          { name: server.name },
-        ),
+        this.translate.instant('settings.data_imports.emby.import_started', { name: server.name }),
       );
     } catch (err: unknown) {
       this.setEmbyImporting(server.id, false);
       const httpErr = err as { error?: { message?: string } };
       this.toast.error(
         httpErr.error?.message ??
-          this.translate.instant(
-            'settings.data_imports.emby.import_failed',
-            { error: '' },
-          ),
+          this.translate.instant('settings.data_imports.emby.import_failed', { error: '' }),
       );
     }
   }
@@ -302,10 +282,7 @@ export class DataImportsSettingsComponent implements OnInit {
   // ---------------------------------------------------------------------------
 
   get canSubmitSeerr(): boolean {
-    return (
-      this.seerrUrl().trim().length > 0 &&
-      this.seerrApiKey().trim().length > 0
-    );
+    return this.seerrUrl().trim().length > 0 && this.seerrApiKey().trim().length > 0;
   }
 
   async saveSeerrCredentials() {
@@ -313,9 +290,7 @@ export class DataImportsSettingsComponent implements OnInit {
     this.seerrSaving.set(true);
     try {
       await this.settingsApi.setBulk({
-        [SETTING_SEERR_URL]: this.seerrUrl()
-          .trim()
-          .replace(/\/$/, ''),
+        [SETTING_SEERR_URL]: this.seerrUrl().trim().replace(/\/$/, ''),
         [SETTING_SEERR_API_KEY]: this.seerrApiKey().trim(),
       });
       this.toast.success(this.translate.instant('common.saved'));
@@ -338,8 +313,7 @@ export class DataImportsSettingsComponent implements OnInit {
       const httpErr = err as { error?: { message?: string } };
       this.seerrTestResult.set({
         ok: false,
-        message:
-          httpErr.error?.message ?? this.translate.instant('common.error'),
+        message: httpErr.error?.message ?? this.translate.instant('common.error'),
       });
     } finally {
       this.seerrTesting.set(false);
@@ -354,20 +328,13 @@ export class DataImportsSettingsComponent implements OnInit {
     this.seerrLastSummary.set(null);
     try {
       await this.seerrApi.importRequests();
-      this.toast.success(
-        this.translate.instant(
-          'settings.data_imports.seerr.import_started',
-        ),
-      );
+      this.toast.success(this.translate.instant('settings.data_imports.seerr.import_started'));
     } catch (err: unknown) {
       this.seerrImporting.set(false);
       const httpErr = err as { error?: { message?: string } };
       this.toast.error(
         httpErr.error?.message ??
-          this.translate.instant(
-            'settings.data_imports.seerr.import_failed',
-            { error: '' },
-          ),
+          this.translate.instant('settings.data_imports.seerr.import_failed', { error: '' }),
       );
     }
   }
@@ -377,10 +344,7 @@ export class DataImportsSettingsComponent implements OnInit {
   // ---------------------------------------------------------------------------
 
   get canSubmitRadarr(): boolean {
-    return (
-      this.radarrUrl().trim().length > 0 &&
-      this.radarrApiKey().trim().length > 0
-    );
+    return this.radarrUrl().trim().length > 0 && this.radarrApiKey().trim().length > 0;
   }
 
   /** Import-specific gate: credentials AND a picked target library. */
@@ -389,10 +353,7 @@ export class DataImportsSettingsComponent implements OnInit {
   }
 
   get canSubmitSonarr(): boolean {
-    return (
-      this.sonarrUrl().trim().length > 0 &&
-      this.sonarrApiKey().trim().length > 0
-    );
+    return this.sonarrUrl().trim().length > 0 && this.sonarrApiKey().trim().length > 0;
   }
 
   get canImportSonarr(): boolean {
@@ -419,21 +380,17 @@ export class DataImportsSettingsComponent implements OnInit {
     this.radarrTestResult.set(null);
     try {
       const r = await firstValueFrom(
-        this.http.post<{ ok: boolean; message: string }>(
-          '/api/imports/radarr/test',
-          {
-            url: this.radarrUrl().trim().replace(/\/$/, ''),
-            apiKey: this.radarrApiKey().trim(),
-          },
-        ),
+        this.http.post<{ ok: boolean; message: string }>('/api/imports/radarr/test', {
+          url: this.radarrUrl().trim().replace(/\/$/, ''),
+          apiKey: this.radarrApiKey().trim(),
+        }),
       );
       this.radarrTestResult.set(r);
     } catch (err: unknown) {
       const httpErr = err as { error?: { message?: string } };
       this.radarrTestResult.set({
         ok: false,
-        message:
-          httpErr.error?.message ?? this.translate.instant('common.error'),
+        message: httpErr.error?.message ?? this.translate.instant('common.error'),
       });
     } finally {
       this.radarrTesting.set(false);
@@ -460,21 +417,17 @@ export class DataImportsSettingsComponent implements OnInit {
     this.sonarrTestResult.set(null);
     try {
       const r = await firstValueFrom(
-        this.http.post<{ ok: boolean; message: string }>(
-          '/api/imports/sonarr/test',
-          {
-            url: this.sonarrUrl().trim().replace(/\/$/, ''),
-            apiKey: this.sonarrApiKey().trim(),
-          },
-        ),
+        this.http.post<{ ok: boolean; message: string }>('/api/imports/sonarr/test', {
+          url: this.sonarrUrl().trim().replace(/\/$/, ''),
+          apiKey: this.sonarrApiKey().trim(),
+        }),
       );
       this.sonarrTestResult.set(r);
     } catch (err: unknown) {
       const httpErr = err as { error?: { message?: string } };
       this.sonarrTestResult.set({
         ok: false,
-        message:
-          httpErr.error?.message ?? this.translate.instant('common.error'),
+        message: httpErr.error?.message ?? this.translate.instant('common.error'),
       });
     } finally {
       this.sonarrTesting.set(false);
@@ -513,10 +466,7 @@ export class DataImportsSettingsComponent implements OnInit {
     this.resultSig(provider).set(null);
     try {
       const preview = await firstValueFrom(
-        this.http.post<PreviewImportResult>(
-          `/api/imports/${provider}/preview`,
-          { url, apiKey },
-        ),
+        this.http.post<PreviewImportResult>(`/api/imports/${provider}/preview`, { url, apiKey }),
       );
       this.previewSig(provider).set(preview);
       if (preview.remoteRootFolders.length === 0) {
@@ -533,8 +483,7 @@ export class DataImportsSettingsComponent implements OnInit {
     } catch (err: unknown) {
       const httpErr = err as { error?: { message?: string } };
       this.errorSig(provider).set(
-        httpErr.error?.message ??
-          this.translate.instant('import.path_wizard.preview_error'),
+        httpErr.error?.message ?? this.translate.instant('import.path_wizard.preview_error'),
       );
     } finally {
       this.previewingSig(provider).set(false);
@@ -577,8 +526,7 @@ export class DataImportsSettingsComponent implements OnInit {
   eligibleLocalLibraries(provider: Provider) {
     const preview = this.previewSig(provider)();
     if (!preview) return [];
-    const target =
-      provider === 'radarr' ? this.radarrLibrary() : this.sonarrLibrary();
+    const target = provider === 'radarr' ? this.radarrLibrary() : this.sonarrLibrary();
     if (typeof target !== 'number') return [];
     return preview.localLibraries.filter((lib) => lib.id === target);
   }
@@ -601,13 +549,9 @@ export class DataImportsSettingsComponent implements OnInit {
     this.resultSig(provider).set(null);
     this.errorSig(provider).set('');
 
-    const lib =
-      provider === 'radarr' ? this.radarrLibrary() : this.sonarrLibrary();
+    const lib = provider === 'radarr' ? this.radarrLibrary() : this.sonarrLibrary();
     const mode = provider === 'radarr' ? this.radarrMode() : this.sonarrMode();
-    const importSubs =
-      provider === 'radarr'
-        ? this.radarrImportSubs()
-        : this.sonarrImportSubs();
+    const importSubs = provider === 'radarr' ? this.radarrImportSubs() : this.sonarrImportSubs();
 
     try {
       const result = await firstValueFrom(
@@ -623,9 +567,7 @@ export class DataImportsSettingsComponent implements OnInit {
       this.resultSig(provider).set(result);
     } catch (err: unknown) {
       const httpErr = err as { error?: { message?: string } };
-      this.errorSig(provider).set(
-        httpErr.error?.message ?? this.translate.instant('import.error'),
-      );
+      this.errorSig(provider).set(httpErr.error?.message ?? this.translate.instant('import.error'));
     } finally {
       this.loadingSig(provider).set(false);
     }

--- a/client/src/app/features/settings/language-profiles/language-profiles.html
+++ b/client/src/app/features/settings/language-profiles/language-profiles.html
@@ -2,7 +2,9 @@
   <div class="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
     <div>
       <h1 class="text-2xl font-bold">{{ 'settings.language_profiles.title' | translate }}</h1>
-      <p class="text-sm text-base-content/60 mt-1">{{ 'settings.language_profiles.subtitle' | translate }}</p>
+      <p class="text-sm text-base-content/60 mt-1">
+        {{ 'settings.language_profiles.subtitle' | translate }}
+      </p>
     </div>
     <button type="button" class="btn btn-primary" (click)="openCreate()">
       {{ 'settings.language_profiles.new' | translate }}
@@ -16,7 +18,9 @@
   } @else if (listError()) {
     <div role="alert" class="alert alert-error">{{ listError() }}</div>
   } @else if (profiles().length === 0) {
-    <p class="text-center py-12 text-base-content/50">{{ 'settings.language_profiles.empty' | translate }}</p>
+    <p class="text-center py-12 text-base-content/50">
+      {{ 'settings.language_profiles.empty' | translate }}
+    </p>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
       <table class="table table-zebra">
@@ -24,7 +28,9 @@
           <tr>
             <th>{{ 'settings.language_profiles.col_name' | translate }}</th>
             <th class="text-end">{{ 'settings.language_profiles.col_audio_count' | translate }}</th>
-            <th class="text-end">{{ 'settings.language_profiles.col_subtitle_count' | translate }}</th>
+            <th class="text-end">
+              {{ 'settings.language_profiles.col_subtitle_count' | translate }}
+            </th>
             <th class="text-end w-40">{{ 'settings.language_profiles.actions' | translate }}</th>
           </tr>
         </thead>
@@ -32,12 +38,18 @@
           @for (p of profiles(); track p.id) {
             <tr>
               <td>
-                <button type="button" class="link link-hover font-medium" (click)="openEdit(p)">{{ p.name }}</button>
+                <button type="button" class="link link-hover font-medium" (click)="openEdit(p)">
+                  {{ p.name }}
+                </button>
               </td>
               <td class="text-end">{{ audioCount(p) }}</td>
               <td class="text-end">{{ subtitleCount(p) }}</td>
               <td class="text-end">
-                <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteProfile(p)">
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-xs text-error"
+                  (click)="deleteProfile(p)"
+                >
                   {{ 'settings.language_profiles.delete' | translate }}
                 </button>
               </td>
@@ -49,112 +61,124 @@
   }
 </div>
 
-  <dialog #editorDialog class="modal">
-    <div class="modal-box max-w-2xl max-h-[90vh] flex flex-col">
-      <app-modal-header class="shrink-0">
-        <h3 class="text-lg font-bold">
-          @if (editingId() === null) {
-            {{ 'settings.language_profiles.editor_create_title' | translate }}
-          } @else {
-            {{ 'settings.language_profiles.editor_edit_title' | translate }}
+<dialog #editorDialog class="modal">
+  <div class="modal-box max-w-2xl max-h-[90vh] flex flex-col">
+    <app-modal-header class="shrink-0">
+      <h3 class="text-lg font-bold">
+        @if (editingId() === null) {
+          {{ 'settings.language_profiles.editor_create_title' | translate }}
+        } @else {
+          {{ 'settings.language_profiles.editor_edit_title' | translate }}
+        }
+      </h3>
+    </app-modal-header>
+    <div class="py-4 flex flex-col gap-6 overflow-y-auto flex-1 min-h-0 scroll-ring-safe">
+      <label class="form-control w-full">
+        <span class="label-text">{{ 'settings.language_profiles.field_name' | translate }}</span>
+        <input
+          type="text"
+          class="input input-bordered input-sm w-full"
+          [ngModel]="formName()"
+          (ngModelChange)="formName.set($event)"
+        />
+      </label>
+
+      <!-- Audio Languages -->
+      <div>
+        <p class="text-sm font-medium mb-2">
+          {{ 'settings.language_profiles.audio_languages' | translate }}
+        </p>
+        <p class="text-xs text-base-content/50 mb-2">
+          {{ 'settings.language_profiles.audio_languages_hint' | translate }}
+        </p>
+        <div
+          class="rounded-lg border border-base-200 divide-y divide-base-200 max-h-[14rem] overflow-y-auto"
+        >
+          @for (l of definitions(); track l.id) {
+            <div class="px-3 py-2 hover:bg-base-200/50">
+              <div class="flex items-center gap-3">
+                <input
+                  type="checkbox"
+                  class="checkbox checkbox-sm"
+                  [checked]="isAudioSelected(l.isoCode)"
+                  (change)="toggleAudio(l.isoCode, $event)"
+                />
+                <span class="text-sm flex-1">{{ l.name }}</span>
+                <span class="text-sm text-base-content/50 font-mono">{{ l.isoCode }}</span>
+              </div>
+            </div>
           }
-        </h3>
-      </app-modal-header>
-      <div class="py-4 flex flex-col gap-6 overflow-y-auto flex-1 min-h-0 scroll-ring-safe">
-        <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.language_profiles.field_name' | translate }}</span>
-          <input
-            type="text"
-            class="input input-bordered input-sm w-full"
-            [ngModel]="formName()"
-            (ngModelChange)="formName.set($event)"
-          />
-        </label>
-
-        <!-- Audio Languages -->
-        <div>
-          <p class="text-sm font-medium mb-2">{{ 'settings.language_profiles.audio_languages' | translate }}</p>
-          <p class="text-xs text-base-content/50 mb-2">{{ 'settings.language_profiles.audio_languages_hint' | translate }}</p>
-          <div class="rounded-lg border border-base-200 divide-y divide-base-200 max-h-[14rem] overflow-y-auto">
-            @for (l of definitions(); track l.id) {
-              <div class="px-3 py-2 hover:bg-base-200/50">
-                <div class="flex items-center gap-3">
-                  <input
-                    type="checkbox"
-                    class="checkbox checkbox-sm"
-                    [checked]="isAudioSelected(l.isoCode)"
-                    (change)="toggleAudio(l.isoCode, $event)"
-                  />
-                  <span class="text-sm flex-1">{{ l.name }}</span>
-                  <span class="text-sm text-base-content/50 font-mono">{{ l.isoCode }}</span>
-                </div>
-              </div>
-            }
-          </div>
         </div>
-
-        <!-- Subtitle Languages -->
-        <div>
-          <p class="text-sm font-medium mb-2">{{ 'settings.language_profiles.subtitle_languages' | translate }}</p>
-          <p class="text-xs text-base-content/50 mb-2">{{ 'settings.language_profiles.subtitle_languages_hint' | translate }}</p>
-          <div class="rounded-lg border border-base-200 divide-y divide-base-200 max-h-[14rem] overflow-y-auto">
-            @for (l of definitions(); track l.id) {
-              <div class="px-3 py-2 hover:bg-base-200/50">
-                <div class="flex items-center gap-3">
-                  <input
-                    type="checkbox"
-                    class="checkbox checkbox-sm"
-                    [checked]="isSubtitleSelected(l.isoCode)"
-                    (change)="toggleSubtitle(l.isoCode, $event)"
-                  />
-                  <span class="text-sm flex-1">{{ l.name }}</span>
-                  <span class="text-sm text-base-content/50 font-mono mr-2">{{ l.isoCode }}</span>
-                  @if (isSubtitleSelected(l.isoCode)) {
-                    <label class="flex items-center gap-1 text-xs">
-                      <input
-                        type="checkbox"
-                        class="checkbox checkbox-xs"
-                        [checked]="isSubForced(l.isoCode)"
-                        (change)="toggleSubForced(l.isoCode, $event)"
-                      />
-                      Forced
-                    </label>
-                    <label class="flex items-center gap-1 text-xs">
-                      <span>{{ 'settings.language_profiles.hi_label' | translate }}</span>
-                      <select
-                        class="select select-bordered select-xs"
-                        [ngModel]="subHiMode(l.isoCode)"
-                        (ngModelChange)="setSubHiMode(l.isoCode, $event)"
-                      >
-                        @for (m of hiModes; track m) {
-                          <option [value]="m">{{ 'settings.language_profiles.hi_mode.' + m | translate }}</option>
-                        }
-                      </select>
-                    </label>
-                  }
-                </div>
-              </div>
-            }
-          </div>
-        </div>
-
-
       </div>
-      <div class="modal-action shrink-0">
-        <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
-          {{ 'settings.language_profiles.cancel' | translate }}
-        </button>
-        <button type="button" class="btn btn-primary" (click)="save()" [disabled]="saving()">
-          @if (saving()) {
-            <span class="loading loading-spinner loading-sm"></span>
+
+      <!-- Subtitle Languages -->
+      <div>
+        <p class="text-sm font-medium mb-2">
+          {{ 'settings.language_profiles.subtitle_languages' | translate }}
+        </p>
+        <p class="text-xs text-base-content/50 mb-2">
+          {{ 'settings.language_profiles.subtitle_languages_hint' | translate }}
+        </p>
+        <div
+          class="rounded-lg border border-base-200 divide-y divide-base-200 max-h-[14rem] overflow-y-auto"
+        >
+          @for (l of definitions(); track l.id) {
+            <div class="px-3 py-2 hover:bg-base-200/50">
+              <div class="flex items-center gap-3">
+                <input
+                  type="checkbox"
+                  class="checkbox checkbox-sm"
+                  [checked]="isSubtitleSelected(l.isoCode)"
+                  (change)="toggleSubtitle(l.isoCode, $event)"
+                />
+                <span class="text-sm flex-1">{{ l.name }}</span>
+                <span class="text-sm text-base-content/50 font-mono mr-2">{{ l.isoCode }}</span>
+                @if (isSubtitleSelected(l.isoCode)) {
+                  <label class="flex items-center gap-1 text-xs">
+                    <input
+                      type="checkbox"
+                      class="checkbox checkbox-xs"
+                      [checked]="isSubForced(l.isoCode)"
+                      (change)="toggleSubForced(l.isoCode, $event)"
+                    />
+                    Forced
+                  </label>
+                  <label class="flex items-center gap-1 text-xs">
+                    <span>{{ 'settings.language_profiles.hi_label' | translate }}</span>
+                    <select
+                      class="select select-bordered select-xs"
+                      [ngModel]="subHiMode(l.isoCode)"
+                      (ngModelChange)="setSubHiMode(l.isoCode, $event)"
+                    >
+                      @for (m of hiModes; track m) {
+                        <option [value]="m">
+                          {{ 'settings.language_profiles.hi_mode.' + m | translate }}
+                        </option>
+                      }
+                    </select>
+                  </label>
+                }
+              </div>
+            </div>
           }
-          {{ 'settings.language_profiles.save' | translate }}
-        </button>
+        </div>
       </div>
     </div>
-    <form method="dialog" class="modal-backdrop">
-      <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">
-        {{ 'common.close' | translate }}
+    <app-modal-footer>
+      <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
+        {{ 'settings.language_profiles.cancel' | translate }}
       </button>
-    </form>
-  </dialog>
+      <button type="button" class="btn btn-primary" (click)="save()" [disabled]="saving()">
+        @if (saving()) {
+          <span class="loading loading-spinner loading-sm"></span>
+        }
+        {{ 'settings.language_profiles.save' | translate }}
+      </button>
+    </app-modal-footer>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">
+      {{ 'common.close' | translate }}
+    </button>
+  </form>
+</dialog>

--- a/client/src/app/features/settings/language-profiles/language-profiles.html
+++ b/client/src/app/features/settings/language-profiles/language-profiles.html
@@ -51,13 +51,15 @@
 
   <dialog #editorDialog class="modal">
     <div class="modal-box max-w-2xl max-h-[90vh] flex flex-col">
-      <h2 class="text-lg font-bold shrink-0">
-        @if (editingId() === null) {
-          {{ 'settings.language_profiles.editor_create_title' | translate }}
-        } @else {
-          {{ 'settings.language_profiles.editor_edit_title' | translate }}
-        }
-      </h2>
+      <app-modal-header class="shrink-0">
+        <h3 class="text-lg font-bold">
+          @if (editingId() === null) {
+            {{ 'settings.language_profiles.editor_create_title' | translate }}
+          } @else {
+            {{ 'settings.language_profiles.editor_edit_title' | translate }}
+          }
+        </h3>
+      </app-modal-header>
       <div class="py-4 flex flex-col gap-6 overflow-y-auto flex-1 min-h-0 scroll-ring-safe">
         <label class="form-control w-full">
           <span class="label-text">{{ 'settings.language_profiles.field_name' | translate }}</span>

--- a/client/src/app/features/settings/language-profiles/language-profiles.ts
+++ b/client/src/app/features/settings/language-profiles/language-profiles.ts
@@ -18,6 +18,7 @@ import {
   SubtitleLanguageItem,
   HearingImpairedMode,
 } from '../../../core/services/api/profiles.service';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 
 interface LangDef {
   id: number;
@@ -35,7 +36,8 @@ const HI_MODES: HearingImpairedMode[] = ['prefer', 'avoid', 'require', 'forbid']
 
 @Component({
   selector: 'app-language-profiles',
-  imports: [FormsModule, TranslateModule],
+  imports: [
+    ModalHeaderComponent,FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './language-profiles.html',
 })

--- a/client/src/app/features/settings/language-profiles/language-profiles.ts
+++ b/client/src/app/features/settings/language-profiles/language-profiles.ts
@@ -19,6 +19,7 @@ import {
   HearingImpairedMode,
 } from '../../../core/services/api/profiles.service';
 import { ModalHeaderComponent } from '../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 interface LangDef {
   id: number;
@@ -36,8 +37,7 @@ const HI_MODES: HearingImpairedMode[] = ['prefer', 'avoid', 'require', 'forbid']
 
 @Component({
   selector: 'app-language-profiles',
-  imports: [
-    ModalHeaderComponent,FormsModule, TranslateModule],
+  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './language-profiles.html',
 })
@@ -222,14 +222,29 @@ export class LanguageProfilesComponent implements OnInit {
   }
 
   async deleteProfile(p: LanguageProfile) {
-    const msg = this.translate.instant('settings.language_profiles.confirm_delete', { name: p.name });
-    if (!await this.confirmation.confirm({ title: this.translate.instant('common.confirm'), message: msg, variant: 'danger' })) return;
+    const msg = this.translate.instant('settings.language_profiles.confirm_delete', {
+      name: p.name,
+    });
+    if (
+      !(await this.confirmation.confirm({
+        title: this.translate.instant('common.confirm'),
+        message: msg,
+        variant: 'danger',
+      }))
+    )
+      return;
     try {
       await this.api.deleteLanguageProfile(p.id);
       await this.reloadAll();
     } catch (err: unknown) {
       const httpErr = err as { error?: { message?: string } };
-      void this.confirmation.alert({ title: this.translate.instant('common.error'), message: httpErr.error?.message ?? this.translate.instant('settings.language_profiles.delete_error'), variant: 'danger' });
+      void this.confirmation.alert({
+        title: this.translate.instant('common.error'),
+        message:
+          httpErr.error?.message ??
+          this.translate.instant('settings.language_profiles.delete_error'),
+        variant: 'danger',
+      });
     }
   }
 }

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-modal/orphan-scan-modal.html
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-modal/orphan-scan-modal.html
@@ -9,7 +9,7 @@
     <app-orphan-scan-panel #panel />
 
     <div class="modal-action mt-4 shrink-0">
-      <button type="button" class="btn btn-sm" (click)="close()">{{ 'common.close' | translate }}</button>
+      <button type="button" class="btn" (click)="close()">{{ 'common.close' | translate }}</button>
     </div>
   </div>
   <form method="dialog" class="modal-backdrop">

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-modal/orphan-scan-modal.html
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-modal/orphan-scan-modal.html
@@ -8,11 +8,13 @@
 
     <app-orphan-scan-panel #panel />
 
-    <div class="modal-action mt-4 shrink-0">
+    <app-modal-footer>
       <button type="button" class="btn" (click)="close()">{{ 'common.close' | translate }}</button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
-    <button type="button" (click)="close()" [attr.aria-label]="'common.close' | translate">close</button>
+    <button type="button" (click)="close()" [attr.aria-label]="'common.close' | translate">
+      close
+    </button>
   </form>
 </dialog>

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-modal/orphan-scan-modal.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-modal/orphan-scan-modal.ts
@@ -1,17 +1,12 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  output,
-  viewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, output, viewChild } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { ModalHeaderComponent } from '../../../../../shared/components/modal-header';
 import { OrphanScanPanelComponent } from '../orphan-scan-panel/orphan-scan-panel';
+import { ModalFooterComponent } from '../../../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-orphan-scan-modal',
-  imports: [TranslateModule, ModalHeaderComponent, OrphanScanPanelComponent],
+  imports: [ModalFooterComponent, TranslateModule, ModalHeaderComponent, OrphanScanPanelComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './orphan-scan-modal.html',
 })

--- a/client/src/app/features/settings/media-servers/media-servers.html
+++ b/client/src/app/features/settings/media-servers/media-servers.html
@@ -180,7 +180,7 @@
 
       </div>
 
-      <div class="modal-action shrink-0 px-5 sm:px-6 pb-4 pt-2 border-t border-base-200 bg-base-100">
+      <div class="modal-action modal-action-sticky">
         <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
           {{ 'settings.media_servers.cancel' | translate }}
         </button>

--- a/client/src/app/features/settings/media-servers/media-servers.html
+++ b/client/src/app/features/settings/media-servers/media-servers.html
@@ -2,7 +2,9 @@
   <div class="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
     <div>
       <h1 class="text-2xl font-bold">{{ 'settings.media_servers.title' | translate }}</h1>
-      <p class="text-sm text-base-content/60 mt-1">{{ 'settings.media_servers.subtitle' | translate }}</p>
+      <p class="text-sm text-base-content/60 mt-1">
+        {{ 'settings.media_servers.subtitle' | translate }}
+      </p>
     </div>
     <button type="button" class="btn btn-primary self-start sm:self-auto" (click)="openCreate()">
       {{ 'settings.media_servers.new' | translate }}
@@ -16,7 +18,9 @@
   } @else if (listError()) {
     <div role="alert" class="alert alert-error">{{ listError() }}</div>
   } @else if (rows().length === 0) {
-    <p class="text-center py-12 text-base-content/50">{{ 'settings.media_servers.empty' | translate }}</p>
+    <p class="text-center py-12 text-base-content/50">
+      {{ 'settings.media_servers.empty' | translate }}
+    </p>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
       <table class="table table-zebra">
@@ -34,9 +38,13 @@
           @for (row of rows(); track row.id) {
             <tr>
               <td>
-                <button type="button" class="link link-hover font-medium" (click)="openEdit(row)">{{ row.name }}</button>
+                <button type="button" class="link link-hover font-medium" (click)="openEdit(row)">
+                  {{ row.name }}
+                </button>
               </td>
-              <td><span class="badge badge-ghost badge-sm">{{ typeLabel(row.type) }}</span></td>
+              <td>
+                <span class="badge badge-ghost badge-sm">{{ typeLabel(row.type) }}</span>
+              </td>
               <td class="text-sm text-base-content/60 truncate max-w-[12rem]">{{ row.url }}</td>
               <td class="text-sm text-base-content/60">{{ row.events.length }} event(s)</td>
               <td class="text-center">
@@ -47,7 +55,11 @@
                 }
               </td>
               <td class="text-end">
-                <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteRow(row)">
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-xs text-error"
+                  (click)="deleteRow(row)"
+                >
                   {{ 'settings.media_servers.delete' | translate }}
                 </button>
               </td>
@@ -60,141 +72,131 @@
 </div>
 
 <dialog #editorDialog class="modal">
-    <div class="modal-box max-w-lg max-h-[92vh] flex flex-col p-0 gap-0 overflow-hidden">
-      <div class="px-5 sm:px-6 pt-4 pb-3 border-b border-base-200 flex justify-between items-center shrink-0 bg-base-100">
-        <h2 class="text-lg font-bold">
-          @if (editingId() === null) {
-            {{ 'settings.media_servers.editor_create' | translate }}
-          } @else {
-            {{ 'settings.media_servers.editor_edit' | translate }}
-          }
-        </h2>
-        <button
-          type="button"
-          class="btn btn-sm btn-ghost btn-circle"
-          (click)="closeEditor()"
-          [attr.aria-label]="'common.close' | translate"
+  <div class="modal-box max-w-lg max-h-[92vh] flex flex-col p-0 gap-0 overflow-hidden">
+    <app-modal-header
+      flush
+      [title]="
+        (editingId() === null
+          ? 'settings.media_servers.editor_create'
+          : 'settings.media_servers.editor_edit'
+        ) | translate
+      "
+    />
+
+    <div class="px-5 sm:px-6 py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 bg-base-100">
+      <label class="form-control w-full">
+        <span class="label-text">{{ 'settings.media_servers.field_name' | translate }}</span>
+        <input
+          type="text"
+          class="input input-bordered input-sm w-full"
+          [ngModel]="formName()"
+          (ngModelChange)="formName.set($event)"
+        />
+      </label>
+
+      <label class="form-control w-full">
+        <span class="label-text">{{ 'settings.media_servers.field_type' | translate }}</span>
+        <select
+          class="select select-bordered select-sm w-full"
+          [ngModel]="formType()"
+          (ngModelChange)="onTypeChange($event)"
         >
-          <svg lucideX class="h-5 w-5"></svg>
-        </button>
-      </div>
-
-      <div class="px-5 sm:px-6 py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 bg-base-100">
-        <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.media_servers.field_name' | translate }}</span>
-          <input
-            type="text"
-            class="input input-bordered input-sm w-full"
-            [ngModel]="formName()"
-            (ngModelChange)="formName.set($event)"
-          />
-        </label>
-
-        <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.media_servers.field_type' | translate }}</span>
-          <select
-            class="select select-bordered select-sm w-full"
-            [ngModel]="formType()"
-            (ngModelChange)="onTypeChange($event)"
-          >
-            @for (t of serverTypes(); track t.type) {
-              <option [value]="t.type">{{ t.label }}</option>
-            }
-          </select>
-        </label>
-
-        <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.media_servers.field_url' | translate }}</span>
-          <input
-            type="url"
-            class="input input-bordered input-sm w-full"
-            [ngModel]="formUrl()"
-            (ngModelChange)="formUrl.set($event)"
-            placeholder="http://emby:8096"
-          />
-        </label>
-
-        <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.media_servers.field_api_key' | translate }}</span>
-          <input
-            type="password"
-            class="input input-bordered input-sm w-full"
-            [ngModel]="formApiKey()"
-            (ngModelChange)="formApiKey.set($event)"
-          />
-        </label>
-
-        <div>
-          <p class="label-text mb-2">{{ 'settings.media_servers.field_events' | translate }}</p>
-          <div class="flex flex-wrap gap-2">
-            @for (event of currentSupportedEvents(); track event) {
-              <label class="label cursor-pointer gap-2 justify-start">
-                <input
-                  type="checkbox"
-                  class="checkbox checkbox-xs"
-                  [ngModel]="formEvents().includes(event)"
-                  (ngModelChange)="toggleEvent(event)"
-                />
-                <span class="label-text text-sm font-mono">{{ event }}</span>
-              </label>
-            }
-          </div>
-        </div>
-
-        <label class="label cursor-pointer justify-start gap-3">
-          <input
-            type="checkbox"
-            class="toggle toggle-sm"
-            [ngModel]="formEnabled()"
-            (ngModelChange)="formEnabled.set($event)"
-          />
-          <span class="label-text">{{ 'settings.media_servers.field_enabled' | translate }}</span>
-        </label>
-
-        @if (editingId() !== null) {
-          <div class="flex flex-col gap-2 pt-2 border-t border-base-200">
-            <button
-              type="button"
-              class="btn btn-outline btn-sm w-fit"
-              (click)="testConnection()"
-              [disabled]="testLoading()"
-            >
-              @if (testLoading()) {
-                <span class="loading loading-spinner loading-xs"></span>
-              }
-              {{ 'settings.media_servers.test_connection' | translate }}
-            </button>
-            @if (testResult(); as tr) {
-              <div
-                role="alert"
-                class="alert text-sm py-2"
-                [class.alert-success]="tr.ok"
-                [class.alert-error]="!tr.ok"
-              >
-                {{ tr.message }}
-              </div>
-            }
-          </div>
-        }
-
-
-      </div>
-
-      <div class="modal-action modal-action-sticky">
-        <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
-          {{ 'settings.media_servers.cancel' | translate }}
-        </button>
-        <button type="button" class="btn btn-primary" (click)="save()" [disabled]="saving()">
-          @if (saving()) {
-            <span class="loading loading-spinner loading-sm"></span>
+          @for (t of serverTypes(); track t.type) {
+            <option [value]="t.type">{{ t.label }}</option>
           }
-          {{ 'settings.media_servers.save' | translate }}
-        </button>
+        </select>
+      </label>
+
+      <label class="form-control w-full">
+        <span class="label-text">{{ 'settings.media_servers.field_url' | translate }}</span>
+        <input
+          type="url"
+          class="input input-bordered input-sm w-full"
+          [ngModel]="formUrl()"
+          (ngModelChange)="formUrl.set($event)"
+          placeholder="http://emby:8096"
+        />
+      </label>
+
+      <label class="form-control w-full">
+        <span class="label-text">{{ 'settings.media_servers.field_api_key' | translate }}</span>
+        <input
+          type="password"
+          class="input input-bordered input-sm w-full"
+          [ngModel]="formApiKey()"
+          (ngModelChange)="formApiKey.set($event)"
+        />
+      </label>
+
+      <div>
+        <p class="label-text mb-2">{{ 'settings.media_servers.field_events' | translate }}</p>
+        <div class="flex flex-wrap gap-2">
+          @for (event of currentSupportedEvents(); track event) {
+            <label class="label cursor-pointer gap-2 justify-start">
+              <input
+                type="checkbox"
+                class="checkbox checkbox-xs"
+                [ngModel]="formEvents().includes(event)"
+                (ngModelChange)="toggleEvent(event)"
+              />
+              <span class="label-text text-sm font-mono">{{ event }}</span>
+            </label>
+          }
+        </div>
       </div>
+
+      <label class="label cursor-pointer justify-start gap-3">
+        <input
+          type="checkbox"
+          class="toggle toggle-sm"
+          [ngModel]="formEnabled()"
+          (ngModelChange)="formEnabled.set($event)"
+        />
+        <span class="label-text">{{ 'settings.media_servers.field_enabled' | translate }}</span>
+      </label>
+
+      @if (editingId() !== null) {
+        <div class="flex flex-col gap-2 pt-2 border-t border-base-200">
+          <button
+            type="button"
+            class="btn btn-outline btn-sm w-fit"
+            (click)="testConnection()"
+            [disabled]="testLoading()"
+          >
+            @if (testLoading()) {
+              <span class="loading loading-spinner loading-xs"></span>
+            }
+            {{ 'settings.media_servers.test_connection' | translate }}
+          </button>
+          @if (testResult(); as tr) {
+            <div
+              role="alert"
+              class="alert text-sm py-2"
+              [class.alert-success]="tr.ok"
+              [class.alert-error]="!tr.ok"
+            >
+              {{ tr.message }}
+            </div>
+          }
+        </div>
+      }
     </div>
-    <form method="dialog" class="modal-backdrop">
-      <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">
-        {{ 'common.close' | translate }}
+
+    <app-modal-footer flush>
+      <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
+        {{ 'settings.media_servers.cancel' | translate }}
       </button>
-    </form>
-  </dialog>
+      <button type="button" class="btn btn-primary" (click)="save()" [disabled]="saving()">
+        @if (saving()) {
+          <span class="loading loading-spinner loading-sm"></span>
+        }
+        {{ 'settings.media_servers.save' | translate }}
+      </button>
+    </app-modal-footer>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">
+      {{ 'common.close' | translate }}
+    </button>
+  </form>
+</dialog>

--- a/client/src/app/features/settings/media-servers/media-servers.ts
+++ b/client/src/app/features/settings/media-servers/media-servers.ts
@@ -17,10 +17,12 @@ import {
   MediaServerRow,
   MediaServerTypeInfo,
 } from '../../../core/services/api/media-servers-api.service';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-media-servers-settings',
-  imports: [FormsModule, LucideX, TranslateModule],
+  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-servers.html',
 })
@@ -130,7 +132,10 @@ export class MediaServersSettingsComponent implements OnInit {
       const r = await this.api.testConnection(id);
       this.testResult.set(r);
     } catch {
-      this.testResult.set({ ok: false, message: this.translate.instant('settings.media_servers.test_error') });
+      this.testResult.set({
+        ok: false,
+        message: this.translate.instant('settings.media_servers.test_error'),
+      });
     } finally {
       this.testLoading.set(false);
     }
@@ -165,11 +170,16 @@ export class MediaServersSettingsComponent implements OnInit {
   }
 
   async deleteRow(row: MediaServerRow) {
-    if (!await this.confirmation.confirm({
-      title: this.translate.instant('common.confirm'),
-      message: this.translate.instant('settings.media_servers.confirm_delete', { name: row.name }),
-      variant: 'danger',
-    })) return;
+    if (
+      !(await this.confirmation.confirm({
+        title: this.translate.instant('common.confirm'),
+        message: this.translate.instant('settings.media_servers.confirm_delete', {
+          name: row.name,
+        }),
+        variant: 'danger',
+      }))
+    )
+      return;
     try {
       await this.api.remove(row.id);
       await this.reloadAll();

--- a/client/src/app/features/settings/notifications/notifications.html
+++ b/client/src/app/features/settings/notifications/notifications.html
@@ -233,7 +233,7 @@
 
       </div>
 
-      <div class="modal-action shrink-0 px-5 sm:px-6 pb-4 pt-2 border-t border-base-200 bg-base-100">
+      <div class="modal-action modal-action-sticky">
         <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
           {{ 'settings.notifications.cancel' | translate }}
         </button>

--- a/client/src/app/features/settings/notifications/notifications.html
+++ b/client/src/app/features/settings/notifications/notifications.html
@@ -2,7 +2,9 @@
   <div class="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
     <div>
       <h1 class="text-2xl font-bold">{{ 'settings.notifications.title' | translate }}</h1>
-      <p class="text-sm text-base-content/60 mt-1">{{ 'settings.notifications.subtitle' | translate }}</p>
+      <p class="text-sm text-base-content/60 mt-1">
+        {{ 'settings.notifications.subtitle' | translate }}
+      </p>
     </div>
     <button type="button" class="btn btn-primary self-start sm:self-auto" (click)="openCreate()">
       {{ 'settings.notifications.new' | translate }}
@@ -16,7 +18,9 @@
   } @else if (listError()) {
     <div role="alert" class="alert alert-error">{{ listError() }}</div>
   } @else if (rows().length === 0) {
-    <p class="text-center py-12 text-base-content/50">{{ 'settings.notifications.empty' | translate }}</p>
+    <p class="text-center py-12 text-base-content/50">
+      {{ 'settings.notifications.empty' | translate }}
+    </p>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
       <table class="table table-zebra">
@@ -33,9 +37,13 @@
           @for (nc of rows(); track nc.id) {
             <tr>
               <td>
-                <button type="button" class="link link-hover font-medium" (click)="openEdit(nc)">{{ nc.name }}</button>
+                <button type="button" class="link link-hover font-medium" (click)="openEdit(nc)">
+                  {{ nc.name }}
+                </button>
               </td>
-              <td><span class="badge badge-ghost badge-sm">{{ nc.type }}</span></td>
+              <td>
+                <span class="badge badge-ghost badge-sm">{{ nc.type }}</span>
+              </td>
               <td class="text-sm text-base-content/60">{{ nc.events.length }} event(s)</td>
               <td>
                 @if (nc.enabled) {
@@ -45,7 +53,11 @@
                 }
               </td>
               <td class="text-end">
-                <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteRow(nc)">
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-xs text-error"
+                  (click)="deleteRow(nc)"
+                >
                   {{ 'settings.notifications.delete' | translate }}
                 </button>
               </td>
@@ -57,195 +69,187 @@
   }
 </div>
 
-  <dialog #editorDialog class="modal">
-    <div class="modal-box max-w-lg max-h-[92vh] flex flex-col p-0 gap-0 overflow-hidden">
-      <div class="px-5 sm:px-6 pt-4 pb-3 border-b border-base-200 flex justify-between items-center shrink-0 bg-base-100">
-        <h2 class="text-lg font-bold">
-          @if (editingId() === null) {
-            {{ 'settings.notifications.editor_create' | translate }}
-          } @else {
-            {{ 'settings.notifications.editor_edit' | translate }}
-          }
-        </h2>
-        <button
-          type="button"
-          class="btn btn-sm btn-ghost btn-circle"
-          (click)="closeEditor()"
-          [attr.aria-label]="'common.close' | translate"
+<dialog #editorDialog class="modal">
+  <div class="modal-box max-w-lg max-h-[92vh] flex flex-col p-0 gap-0 overflow-hidden">
+    <app-modal-header
+      flush
+      [title]="
+        (editingId() === null
+          ? 'settings.notifications.editor_create'
+          : 'settings.notifications.editor_edit'
+        ) | translate
+      "
+    />
+
+    <div class="px-5 sm:px-6 py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 bg-base-100">
+      <label class="form-control w-full">
+        <span class="label-text">{{ 'settings.notifications.field_name' | translate }}</span>
+        <input
+          type="text"
+          class="input input-bordered input-sm w-full"
+          [ngModel]="formName()"
+          (ngModelChange)="formName.set($event)"
+        />
+      </label>
+
+      <label class="form-control w-full">
+        <span class="label-text">{{ 'settings.notifications.field_type' | translate }}</span>
+        <select
+          class="select select-bordered select-sm w-full"
+          [ngModel]="formType()"
+          (ngModelChange)="formType.set($event)"
         >
-          <svg lucideX class="h-5 w-5"></svg>
-        </button>
-      </div>
+          @for (t of connectionTypes; track t) {
+            <option [value]="t">{{ t }}</option>
+          }
+        </select>
+      </label>
 
-      <div class="px-5 sm:px-6 py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 bg-base-100">
-        <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.notifications.field_name' | translate }}</span>
-          <input
-            type="text"
-            class="input input-bordered input-sm w-full"
-            [ngModel]="formName()"
-            (ngModelChange)="formName.set($event)"
-          />
-        </label>
+      <label class="form-control w-full">
+        <span class="label-text">
+          @if (formType() === 'ntfy') {
+            {{ 'settings.notifications.field_server_url' | translate }}
+          } @else {
+            {{ 'settings.notifications.field_webhook_url' | translate }}
+          }
+        </span>
+        <input
+          type="url"
+          class="input input-bordered input-sm w-full"
+          [ngModel]="formWebhookUrl()"
+          (ngModelChange)="formWebhookUrl.set($event)"
+          placeholder="https://..."
+        />
+      </label>
 
-        <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.notifications.field_type' | translate }}</span>
-          <select
-            class="select select-bordered select-sm w-full"
-            [ngModel]="formType()"
-            (ngModelChange)="formType.set($event)"
-          >
-            @for (t of connectionTypes; track t) {
-              <option [value]="t">{{ t }}</option>
-            }
-          </select>
-        </label>
-
+      @if (supportsToken()) {
         <label class="form-control w-full">
           <span class="label-text">
-            @if (formType() === 'ntfy') {
-              {{ 'settings.notifications.field_server_url' | translate }}
-            } @else {
-              {{ 'settings.notifications.field_webhook_url' | translate }}
+            {{ 'settings.notifications.field_token' | translate }}
+            @if (formType() !== 'gotify') {
+              <span class="opacity-60">
+                {{ 'settings.notifications.field_token_optional' | translate }}
+              </span>
             }
           </span>
           <input
-            type="url"
+            type="password"
             class="input input-bordered input-sm w-full"
-            [ngModel]="formWebhookUrl()"
-            (ngModelChange)="formWebhookUrl.set($event)"
-            placeholder="https://..."
+            [placeholder]="tokenStored() && !formTokenCleared() ? secretMask : ''"
+            [ngModel]="formToken()"
+            (ngModelChange)="onTokenInput($event)"
           />
-        </label>
-
-        @if (supportsToken()) {
-          <label class="form-control w-full">
-            <span class="label-text">
-              {{ 'settings.notifications.field_token' | translate }}
-              @if (formType() !== 'gotify') {
-                <span class="opacity-60">
-                  {{ 'settings.notifications.field_token_optional' | translate }}
-                </span>
-              }
-            </span>
-            <input
-              type="password"
-              class="input input-bordered input-sm w-full"
-              [placeholder]="tokenStored() && !formTokenCleared() ? secretMask : ''"
-              [ngModel]="formToken()"
-              (ngModelChange)="onTokenInput($event)"
-            />
-            @if (canClearToken()) {
-              @if (formTokenCleared()) {
-                <span class="label-text-alt text-warning">
-                  {{ 'common.secret_will_clear' | translate }}
-                  <button
-                    type="button"
-                    class="link link-hover font-medium"
-                    (click)="formTokenCleared.set(false)"
-                  >
-                    {{ 'common.secret_keep' | translate }}
-                  </button>
-                </span>
-              } @else {
+          @if (canClearToken()) {
+            @if (formTokenCleared()) {
+              <span class="label-text-alt text-warning">
+                {{ 'common.secret_will_clear' | translate }}
                 <button
                   type="button"
-                  class="link link-hover label-text-alt self-start text-base-content/60"
-                  (click)="formTokenCleared.set(true)"
+                  class="link link-hover font-medium"
+                  (click)="formTokenCleared.set(false)"
                 >
-                  {{ 'common.secret_clear' | translate }}
+                  {{ 'common.secret_keep' | translate }}
                 </button>
-              }
-            } @else if (editingId() !== null) {
-              <span class="label-text-alt text-base-content/50">
-                {{ 'settings.notifications.token_hint' | translate }}
               </span>
-            }
-          </label>
-        }
-
-        @if (formType() === 'ntfy') {
-          <label class="form-control w-full">
-            <span class="label-text">{{ 'settings.notifications.field_topic' | translate }}</span>
-            <input
-              type="text"
-              class="input input-bordered input-sm w-full"
-              [ngModel]="formTopic()"
-              (ngModelChange)="formTopic.set($event)"
-              placeholder="fliks"
-            />
-          </label>
-        }
-
-        <div>
-          <p class="label-text mb-2">{{ 'settings.notifications.field_events' | translate }}</p>
-          <div class="flex flex-wrap gap-2">
-            @for (event of allEvents(); track event) {
-              <label class="label cursor-pointer gap-2 justify-start">
-                <input
-                  type="checkbox"
-                  class="checkbox checkbox-xs"
-                  [ngModel]="formEvents().includes(event)"
-                  (ngModelChange)="toggleEvent(event)"
-                />
-                <span class="label-text text-sm font-mono">{{ event }}</span>
-              </label>
-            }
-          </div>
-        </div>
-
-        <label class="label cursor-pointer justify-start gap-3">
-          <input
-            type="checkbox"
-            class="toggle toggle-sm"
-            [ngModel]="formEnabled()"
-            (ngModelChange)="formEnabled.set($event)"
-          />
-          <span class="label-text">{{ 'settings.notifications.field_enabled' | translate }}</span>
-        </label>
-
-        @if (editingId() !== null) {
-          <div class="flex flex-col gap-2 pt-2 border-t border-base-200">
-            <button
-              type="button"
-              class="btn btn-outline btn-sm w-fit"
-              (click)="testConnection()"
-              [disabled]="testLoading()"
-            >
-              @if (testLoading()) {
-                <span class="loading loading-spinner loading-xs"></span>
-              }
-              {{ 'settings.notifications.test_connection' | translate }}
-            </button>
-            @if (testResult(); as tr) {
-              <div
-                role="alert"
-                class="alert text-sm py-2"
-                [class.alert-success]="tr.ok"
-                [class.alert-error]="!tr.ok"
+            } @else {
+              <button
+                type="button"
+                class="link link-hover label-text-alt self-start text-base-content/60"
+                (click)="formTokenCleared.set(true)"
               >
-                {{ tr.message }}
-              </div>
+                {{ 'common.secret_clear' | translate }}
+              </button>
             }
-          </div>
-        }
-
-
-      </div>
-
-      <div class="modal-action modal-action-sticky">
-        <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
-          {{ 'settings.notifications.cancel' | translate }}
-        </button>
-        <button type="button" class="btn btn-primary" (click)="save()" [disabled]="saving()">
-          @if (saving()) {
-            <span class="loading loading-spinner loading-sm"></span>
+          } @else if (editingId() !== null) {
+            <span class="label-text-alt text-base-content/50">
+              {{ 'settings.notifications.token_hint' | translate }}
+            </span>
           }
-          {{ 'settings.notifications.save' | translate }}
-        </button>
+        </label>
+      }
+
+      @if (formType() === 'ntfy') {
+        <label class="form-control w-full">
+          <span class="label-text">{{ 'settings.notifications.field_topic' | translate }}</span>
+          <input
+            type="text"
+            class="input input-bordered input-sm w-full"
+            [ngModel]="formTopic()"
+            (ngModelChange)="formTopic.set($event)"
+            placeholder="fliks"
+          />
+        </label>
+      }
+
+      <div>
+        <p class="label-text mb-2">{{ 'settings.notifications.field_events' | translate }}</p>
+        <div class="flex flex-wrap gap-2">
+          @for (event of allEvents(); track event) {
+            <label class="label cursor-pointer gap-2 justify-start">
+              <input
+                type="checkbox"
+                class="checkbox checkbox-xs"
+                [ngModel]="formEvents().includes(event)"
+                (ngModelChange)="toggleEvent(event)"
+              />
+              <span class="label-text text-sm font-mono">{{ event }}</span>
+            </label>
+          }
+        </div>
       </div>
+
+      <label class="label cursor-pointer justify-start gap-3">
+        <input
+          type="checkbox"
+          class="toggle toggle-sm"
+          [ngModel]="formEnabled()"
+          (ngModelChange)="formEnabled.set($event)"
+        />
+        <span class="label-text">{{ 'settings.notifications.field_enabled' | translate }}</span>
+      </label>
+
+      @if (editingId() !== null) {
+        <div class="flex flex-col gap-2 pt-2 border-t border-base-200">
+          <button
+            type="button"
+            class="btn btn-outline btn-sm w-fit"
+            (click)="testConnection()"
+            [disabled]="testLoading()"
+          >
+            @if (testLoading()) {
+              <span class="loading loading-spinner loading-xs"></span>
+            }
+            {{ 'settings.notifications.test_connection' | translate }}
+          </button>
+          @if (testResult(); as tr) {
+            <div
+              role="alert"
+              class="alert text-sm py-2"
+              [class.alert-success]="tr.ok"
+              [class.alert-error]="!tr.ok"
+            >
+              {{ tr.message }}
+            </div>
+          }
+        </div>
+      }
     </div>
-    <form method="dialog" class="modal-backdrop">
-      <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">close</button>
-    </form>
-  </dialog>
+
+    <app-modal-footer flush>
+      <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
+        {{ 'settings.notifications.cancel' | translate }}
+      </button>
+      <button type="button" class="btn btn-primary" (click)="save()" [disabled]="saving()">
+        @if (saving()) {
+          <span class="loading loading-spinner loading-sm"></span>
+        }
+        {{ 'settings.notifications.save' | translate }}
+      </button>
+    </app-modal-footer>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">
+      close
+    </button>
+  </form>
+</dialog>

--- a/client/src/app/features/settings/notifications/notifications.ts
+++ b/client/src/app/features/settings/notifications/notifications.ts
@@ -16,6 +16,8 @@ import { firstValueFrom } from 'rxjs';
 import { SECRETS_SET_KEY } from '@fliks/plugin-contract/ui';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { SECRET_MASK } from '../../../shared/components/schema-form/schema-form';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 /** The types this editor knows how to render fields for — adding one server-side is not enough,
  *  each needs its own field set below. */
@@ -42,7 +44,7 @@ interface CreateNotificationBody {
 
 @Component({
   selector: 'app-notifications-settings',
-  imports: [FormsModule, LucideX, TranslateModule],
+  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './notifications.html',
 })
@@ -93,7 +95,9 @@ export class NotificationsSettingsComponent implements OnInit {
 
   private async loadEvents() {
     try {
-      this.allEvents.set(await firstValueFrom(this.http.get<string[]>('/api/notifications/events')));
+      this.allEvents.set(
+        await firstValueFrom(this.http.get<string[]>('/api/notifications/events')),
+      );
     } catch {
       this.listError.set(this.translate.instant('settings.notifications.load_error'));
     }
@@ -192,10 +196,7 @@ export class NotificationsSettingsComponent implements OnInit {
     this.testResult.set(null);
     try {
       const r = await firstValueFrom(
-        this.http.post<{ ok: boolean; message: string }>(
-          `/api/notifications/${id}/test`,
-          {},
-        ),
+        this.http.post<{ ok: boolean; message: string }>(`/api/notifications/${id}/test`, {}),
       );
       this.testResult.set(r);
     } catch {
@@ -231,13 +232,24 @@ export class NotificationsSettingsComponent implements OnInit {
   }
 
   async deleteRow(nc: NotificationConnection) {
-    if (!await this.confirmation.confirm({ title: this.translate.instant('common.confirm'), message: this.translate.instant('settings.notifications.confirm_delete', { name: nc.name }), variant: 'danger' })) return;
+    if (
+      !(await this.confirmation.confirm({
+        title: this.translate.instant('common.confirm'),
+        message: this.translate.instant('settings.notifications.confirm_delete', { name: nc.name }),
+        variant: 'danger',
+      }))
+    )
+      return;
     try {
       await firstValueFrom(this.http.delete(`/api/notifications/${nc.id}`));
       await this.reloadAll();
     } catch (err: unknown) {
       const httpErr = err as { error?: { message?: string } };
-      void this.confirmation.alert({ title: this.translate.instant('common.error'), message: httpErr.error?.message ?? 'Error', variant: 'danger' });
+      void this.confirmation.alert({
+        title: this.translate.instant('common.error'),
+        message: httpErr.error?.message ?? 'Error',
+        variant: 'danger',
+      });
     }
   }
 }

--- a/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.html
+++ b/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.html
@@ -2,14 +2,18 @@
   <div class="modal-box max-w-lg">
     @if (report(); as r) {
       @if (!r.installable) {
-        <h3 class="text-lg font-bold mb-2">{{ 'settings.plugins.consent.refused_title' | translate }}</h3>
+        <app-modal-header [title]="'settings.plugins.consent.refused_title' | translate" />
         <p class="text-sm text-base-content/70">{{ refusalMessage() }}</p>
         <div class="modal-action">
           <button type="button" class="btn" (click)="close()">{{ 'common.close' | translate }}</button>
         </div>
       } @else {
-        <h3 class="text-lg font-bold">{{ 'settings.plugins.consent.title' | translate: { name: r.name } }}</h3>
-        <p class="text-xs text-base-content/50 mb-3">{{ 'settings.plugins.consent.identity' | translate: { id: r.id, version: r.version } }}</p>
+        <app-modal-header>
+          <div>
+            <h3 class="text-lg font-bold">{{ 'settings.plugins.consent.title' | translate: { name: r.name } }}</h3>
+            <p class="text-xs text-base-content/50 mt-1">{{ 'settings.plugins.consent.identity' | translate: { id: r.id, version: r.version } }}</p>
+          </div>
+        </app-modal-header>
 
         <span class="badge badge-sm mb-3" [class]="trust().cssClass">
           {{ trust().labelKey | translate: trust().params }}

--- a/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.html
+++ b/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.html
@@ -4,14 +4,22 @@
       @if (!r.installable) {
         <app-modal-header [title]="'settings.plugins.consent.refused_title' | translate" />
         <p class="text-sm text-base-content/70">{{ refusalMessage() }}</p>
-        <div class="modal-action">
-          <button type="button" class="btn" (click)="close()">{{ 'common.close' | translate }}</button>
-        </div>
+        <app-modal-footer>
+          <button type="button" class="btn" (click)="close()">
+            {{ 'common.close' | translate }}
+          </button>
+        </app-modal-footer>
       } @else {
         <app-modal-header>
           <div>
-            <h3 class="text-lg font-bold">{{ 'settings.plugins.consent.title' | translate: { name: r.name } }}</h3>
-            <p class="text-xs text-base-content/50 mt-1">{{ 'settings.plugins.consent.identity' | translate: { id: r.id, version: r.version } }}</p>
+            <h3 class="text-lg font-bold">
+              {{ 'settings.plugins.consent.title' | translate: { name: r.name } }}
+            </h3>
+            <p class="text-xs text-base-content/50 mt-1">
+              {{
+                'settings.plugins.consent.identity' | translate: { id: r.id, version: r.version }
+              }}
+            </p>
           </div>
         </app-modal-header>
 
@@ -22,8 +30,12 @@
         @if (r.kind === 'data') {
           <p class="text-sm mb-4">{{ 'settings.plugins.consent.data_tier' | translate }}</p>
         } @else {
-          <p class="text-sm font-semibold mb-1">{{ 'settings.plugins.consent.process_tier_title' | translate: { name: r.name } }}</p>
-          <p class="text-sm text-base-content/70 mb-4">{{ 'settings.plugins.consent.process_tier_body' | translate }}</p>
+          <p class="text-sm font-semibold mb-1">
+            {{ 'settings.plugins.consent.process_tier_title' | translate: { name: r.name } }}
+          </p>
+          <p class="text-sm text-base-content/70 mb-4">
+            {{ 'settings.plugins.consent.process_tier_body' | translate }}
+          </p>
         }
 
         @if (r.capabilities?.length) {
@@ -45,7 +57,9 @@
               [ngModel]="acknowledged()"
               (ngModelChange)="acknowledged.set($event)"
             />
-            <span class="label-text text-sm">{{ 'settings.plugins.consent.unverified_ack' | translate }}</span>
+            <span class="label-text text-sm">{{
+              'settings.plugins.consent.unverified_ack' | translate
+            }}</span>
           </label>
         }
 
@@ -53,17 +67,22 @@
           <div role="alert" class="alert alert-error text-sm py-2 mb-2">{{ error() }}</div>
         }
 
-        <div class="modal-action">
+        <app-modal-footer>
           <button type="button" class="btn btn-ghost" (click)="close()" [disabled]="confirming()">
             {{ 'common.cancel' | translate }}
           </button>
-          <button type="button" class="btn btn-primary" (click)="confirm()" [disabled]="!canConfirm()">
+          <button
+            type="button"
+            class="btn btn-primary"
+            (click)="confirm()"
+            [disabled]="!canConfirm()"
+          >
             @if (confirming()) {
               <span class="loading loading-spinner loading-sm"></span>
             }
             {{ 'settings.plugins.consent.confirm' | translate }}
           </button>
-        </div>
+        </app-modal-footer>
       }
     }
   </div>

--- a/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.ts
+++ b/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.ts
@@ -18,6 +18,7 @@ import {
 import { trustBadgeFor, requiresAcknowledgement } from '../plugin-trust';
 import { refusalMessageKey } from '../plugin-refusal';
 import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../../shared/components/modal-footer';
 
 /**
  * The install consent sheet. Owns the confirm call itself — the caller only
@@ -25,8 +26,7 @@ import { ModalHeaderComponent } from '../../../../shared/components/modal-header
  */
 @Component({
   selector: 'app-plugin-install-consent',
-  imports: [
-    ModalHeaderComponent,FormsModule, TranslateModule],
+  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugin-install-consent.html',
 })

--- a/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.ts
+++ b/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../../core/services/api/plugins-api.service';
 import { trustBadgeFor, requiresAcknowledgement } from '../plugin-trust';
 import { refusalMessageKey } from '../plugin-refusal';
+import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
 
 /**
  * The install consent sheet. Owns the confirm call itself — the caller only
@@ -24,7 +25,8 @@ import { refusalMessageKey } from '../plugin-refusal';
  */
 @Component({
   selector: 'app-plugin-install-consent',
-  imports: [FormsModule, TranslateModule],
+  imports: [
+    ModalHeaderComponent,FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugin-install-consent.html',
 })

--- a/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.html
+++ b/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.html
@@ -1,15 +1,13 @@
 <dialog #dialog class="modal">
   <div class="modal-box max-w-xl">
-    <div class="flex justify-between items-start gap-4">
+    <app-modal-header>
       <div>
-        <h2 class="text-lg font-bold">{{ 'settings.plugins.settings.title' | translate }}</h2>
-        <p class="text-sm text-base-content/60 mt-1">{{ 'settings.plugins.settings.subtitle' | translate }}</p>
+        <h3 class="text-lg font-bold">{{ 'settings.plugins.settings.title' | translate }}</h3>
+        <p class="text-sm text-base-content/60 mt-1">
+          {{ 'settings.plugins.settings.subtitle' | translate }}
+        </p>
       </div>
-      <button type="button" class="btn btn-sm btn-ghost btn-circle" (click)="close()"
-        [attr.aria-label]="'common.close' | translate">
-        <svg lucideX class="h-4 w-4"></svg>
-      </button>
-    </div>
+    </app-modal-header>
 
     @if (loading()) {
       <div class="flex justify-center py-10">
@@ -27,11 +25,15 @@
       </div>
     }
 
-    <div class="modal-action">
-      <button type="button" class="btn btn-ghost" (click)="close()">{{ 'common.close' | translate }}</button>
-    </div>
+    <app-modal-footer>
+      <button type="button" class="btn btn-ghost" (click)="close()">
+        {{ 'common.close' | translate }}
+      </button>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
-    <button type="button" (click)="close()" [attr.aria-label]="'common.close' | translate">close</button>
+    <button type="button" (click)="close()" [attr.aria-label]="'common.close' | translate">
+      close
+    </button>
   </form>
 </dialog>

--- a/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.ts
+++ b/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.ts
@@ -11,13 +11,15 @@ import { LucideX } from '@lucide/angular';
 import { ToggleFieldComponent } from '../../../../shared/components/forms/toggle-field/toggle-field';
 import { SettingsApiService } from '../../../../core/services/api/settings-api.service';
 import { ToastService } from '../../../../core/services/toast.service';
+import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../../shared/components/modal-footer';
 
 /** Mirrors the backend's `PLUGIN_AUTO_UPDATE_SETTING`. */
 const AUTO_UPDATE_KEY = 'plugins.auto_update';
 
 @Component({
   selector: 'app-plugin-settings',
-  imports: [TranslateModule, LucideX, ToggleFieldComponent],
+  imports: [ModalFooterComponent, ModalHeaderComponent, TranslateModule, ToggleFieldComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugin-settings.html',
 })

--- a/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.html
+++ b/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.html
@@ -1,136 +1,152 @@
 <dialog #dialog class="modal">
   <div class="modal-box max-w-5xl max-h-[92vh] flex flex-col p-0 gap-0 overflow-hidden">
-    <div class="px-5 sm:px-6 pt-4 pb-3 border-b border-base-200 flex justify-between items-center shrink-0 bg-base-100">
+    <app-modal-header flush>
       <div>
-        <h2 class="text-lg font-bold">{{ 'settings.plugins.sources.title' | translate }}</h2>
-        <p class="text-sm text-base-content/60 mt-1">{{ 'settings.plugins.sources.subtitle' | translate }}</p>
+        <h3 class="text-lg font-bold">{{ 'settings.plugins.sources.title' | translate }}</h3>
+        <p class="text-sm text-base-content/60 mt-1">
+          {{ 'settings.plugins.sources.subtitle' | translate }}
+        </p>
       </div>
-      <button
-        type="button"
-        class="btn btn-sm btn-ghost btn-circle"
-        (click)="close()"
-        [attr.aria-label]="'common.close' | translate"
-      >
-        <svg lucideX class="h-5 w-5"></svg>
-      </button>
-    </div>
+    </app-modal-header>
 
     <div class="px-5 sm:px-6 py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 bg-base-100">
-  @if (loading()) {
-    <div class="flex justify-center py-10">
-      <span class="loading loading-spinner loading-lg"></span>
-    </div>
-  } @else if (listError()) {
-    <div role="alert" class="alert alert-error">{{ listError() }}</div>
-  } @else {
-    @if (sources().length === 0) {
-      <p class="text-center py-8 text-base-content/50">{{ 'settings.plugins.sources.empty' | translate }}</p>
-    } @else {
-      <div class="overflow-x-auto rounded-lg border border-base-200">
-        <table class="table table-zebra">
-          <thead>
-            <tr>
-              <th>{{ 'settings.plugins.sources.col_url' | translate }}</th>
-              <th>{{ 'settings.plugins.sources.col_key' | translate }}</th>
-              <th>{{ 'settings.plugins.sources.col_plugins' | translate }}</th>
-              <th>{{ 'settings.plugins.sources.col_last_refresh' | translate }}</th>
-              <th>{{ 'settings.plugins.sources.col_enabled' | translate }}</th>
-              <th class="text-end w-40"></th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (source of sources(); track source.id) {
-              <tr>
-                <td class="max-w-[20rem] truncate text-sm" [title]="source.url">{{ source.url }}</td>
-                <td>
-                  @if (source.hasPinnedKey) {
-                    <span class="badge badge-ghost badge-sm whitespace-nowrap">{{ 'settings.plugins.sources.pinned_key' | translate }}</span>
-                  } @else {
-                    <span class="badge badge-ghost badge-sm whitespace-nowrap">{{ 'settings.plugins.sources.official_key' | translate }}</span>
-                  }
-                </td>
-                <td class="text-sm">{{ source.pluginCount }}</td>
-                <td class="text-sm">
-                  @if (source.lastRefreshedAt) {
-                    {{ source.lastRefreshedAt | date: 'short' }}
-                  } @else {
-                    <span class="text-base-content/50">{{ 'settings.plugins.sources.never_refreshed' | translate }}</span>
-                  }
-                  @if (source.lastRefreshError) {
-                    <p class="text-sm text-error/80 mt-1 max-w-[14rem]">{{ source.lastRefreshError }}</p>
-                  }
-                </td>
-                <td>
-                  <input
-                    type="checkbox"
-                    class="toggle toggle-sm"
-                    [ngModel]="source.enabled"
-                    [disabled]="savingId() === source.id"
-                    (ngModelChange)="toggleEnabled(source)"
-                  />
-                </td>
-                <td class="text-end whitespace-nowrap">
-                  <button
-                    type="button"
-                    class="btn btn-ghost btn-xs"
-                    [disabled]="refreshingId() === source.id"
-                    (click)="refresh(source)"
-                  >
-                    @if (refreshingId() === source.id) {
-                      <span class="loading loading-spinner loading-xs"></span>
-                    }
-                    {{ 'settings.plugins.sources.refresh' | translate }}
-                  </button>
-                  <button type="button" class="btn btn-ghost btn-xs text-error" (click)="remove(source)">
-                    {{ 'settings.plugins.sources.delete' | translate }}
-                  </button>
-                </td>
-              </tr>
-            }
-          </tbody>
-        </table>
-      </div>
-    }
-  }
-
-  <form class="flex flex-col sm:flex-row gap-2 sm:items-start pt-2" (ngSubmit)="submitCreate()">
-    <input
-      type="url"
-      required
-      class="input input-sm input-bordered flex-1"
-      [placeholder]="'settings.plugins.sources.form.url_placeholder' | translate"
-      [ngModel]="formUrl()"
-      (ngModelChange)="formUrl.set($event)"
-      name="sourceUrl"
-    />
-    <input
-      type="text"
-      class="input input-sm input-bordered flex-1"
-      [placeholder]="'settings.plugins.sources.form.key_placeholder' | translate"
-      [ngModel]="formPublicKey()"
-      (ngModelChange)="formPublicKey.set($event)"
-      name="sourceKey"
-    />
-    <label class="label cursor-pointer gap-2 shrink-0">
-      <input
-        type="checkbox"
-        class="toggle toggle-sm"
-        [ngModel]="formEnabled()"
-        (ngModelChange)="formEnabled.set($event)"
-        name="sourceEnabled"
-      />
-      <span class="label-text text-sm">{{ 'settings.plugins.sources.form.enabled_label' | translate }}</span>
-    </label>
-    <button type="submit" class="btn btn-sm btn-primary shrink-0" [disabled]="creating() || !formUrl().trim()">
-      @if (creating()) {
-        <span class="loading loading-spinner loading-xs"></span>
+      @if (loading()) {
+        <div class="flex justify-center py-10">
+          <span class="loading loading-spinner loading-lg"></span>
+        </div>
+      } @else if (listError()) {
+        <div role="alert" class="alert alert-error">{{ listError() }}</div>
+      } @else {
+        @if (sources().length === 0) {
+          <p class="text-center py-8 text-base-content/50">
+            {{ 'settings.plugins.sources.empty' | translate }}
+          </p>
+        } @else {
+          <div class="overflow-x-auto rounded-lg border border-base-200">
+            <table class="table table-zebra">
+              <thead>
+                <tr>
+                  <th>{{ 'settings.plugins.sources.col_url' | translate }}</th>
+                  <th>{{ 'settings.plugins.sources.col_key' | translate }}</th>
+                  <th>{{ 'settings.plugins.sources.col_plugins' | translate }}</th>
+                  <th>{{ 'settings.plugins.sources.col_last_refresh' | translate }}</th>
+                  <th>{{ 'settings.plugins.sources.col_enabled' | translate }}</th>
+                  <th class="text-end w-40"></th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (source of sources(); track source.id) {
+                  <tr>
+                    <td class="max-w-[20rem] truncate text-sm" [title]="source.url">
+                      {{ source.url }}
+                    </td>
+                    <td>
+                      @if (source.hasPinnedKey) {
+                        <span class="badge badge-ghost badge-sm whitespace-nowrap">{{
+                          'settings.plugins.sources.pinned_key' | translate
+                        }}</span>
+                      } @else {
+                        <span class="badge badge-ghost badge-sm whitespace-nowrap">{{
+                          'settings.plugins.sources.official_key' | translate
+                        }}</span>
+                      }
+                    </td>
+                    <td class="text-sm">{{ source.pluginCount }}</td>
+                    <td class="text-sm">
+                      @if (source.lastRefreshedAt) {
+                        {{ source.lastRefreshedAt | date: 'short' }}
+                      } @else {
+                        <span class="text-base-content/50">{{
+                          'settings.plugins.sources.never_refreshed' | translate
+                        }}</span>
+                      }
+                      @if (source.lastRefreshError) {
+                        <p class="text-sm text-error/80 mt-1 max-w-[14rem]">
+                          {{ source.lastRefreshError }}
+                        </p>
+                      }
+                    </td>
+                    <td>
+                      <input
+                        type="checkbox"
+                        class="toggle toggle-sm"
+                        [ngModel]="source.enabled"
+                        [disabled]="savingId() === source.id"
+                        (ngModelChange)="toggleEnabled(source)"
+                      />
+                    </td>
+                    <td class="text-end whitespace-nowrap">
+                      <button
+                        type="button"
+                        class="btn btn-ghost btn-xs"
+                        [disabled]="refreshingId() === source.id"
+                        (click)="refresh(source)"
+                      >
+                        @if (refreshingId() === source.id) {
+                          <span class="loading loading-spinner loading-xs"></span>
+                        }
+                        {{ 'settings.plugins.sources.refresh' | translate }}
+                      </button>
+                      <button
+                        type="button"
+                        class="btn btn-ghost btn-xs text-error"
+                        (click)="remove(source)"
+                      >
+                        {{ 'settings.plugins.sources.delete' | translate }}
+                      </button>
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        }
       }
-      {{ 'settings.plugins.sources.form.add' | translate }}
-    </button>
-  </form>
-  @if (createError()) {
-    <div role="alert" class="alert alert-error text-sm py-2">{{ createError() }}</div>
-  }
+
+      <form class="flex flex-col sm:flex-row gap-2 sm:items-start pt-2" (ngSubmit)="submitCreate()">
+        <input
+          type="url"
+          required
+          class="input input-sm input-bordered flex-1"
+          [placeholder]="'settings.plugins.sources.form.url_placeholder' | translate"
+          [ngModel]="formUrl()"
+          (ngModelChange)="formUrl.set($event)"
+          name="sourceUrl"
+        />
+        <input
+          type="text"
+          class="input input-sm input-bordered flex-1"
+          [placeholder]="'settings.plugins.sources.form.key_placeholder' | translate"
+          [ngModel]="formPublicKey()"
+          (ngModelChange)="formPublicKey.set($event)"
+          name="sourceKey"
+        />
+        <label class="label cursor-pointer gap-2 shrink-0">
+          <input
+            type="checkbox"
+            class="toggle toggle-sm"
+            [ngModel]="formEnabled()"
+            (ngModelChange)="formEnabled.set($event)"
+            name="sourceEnabled"
+          />
+          <span class="label-text text-sm">{{
+            'settings.plugins.sources.form.enabled_label' | translate
+          }}</span>
+        </label>
+        <button
+          type="submit"
+          class="btn btn-sm btn-primary shrink-0"
+          [disabled]="creating() || !formUrl().trim()"
+        >
+          @if (creating()) {
+            <span class="loading loading-spinner loading-xs"></span>
+          }
+          {{ 'settings.plugins.sources.form.add' | translate }}
+        </button>
+      </form>
+      @if (createError()) {
+        <div role="alert" class="alert alert-error text-sm py-2">{{ createError() }}</div>
+      }
     </div>
   </div>
   <form method="dialog" class="modal-backdrop">

--- a/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.ts
+++ b/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.ts
@@ -14,7 +14,11 @@ import { LucideX } from '@lucide/angular';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ConfirmationService } from '../../../../core/services/confirmation.service';
 import { ToastService } from '../../../../core/services/toast.service';
-import { PluginsApiService, PluginSourceRow } from '../../../../core/services/api/plugins-api.service';
+import {
+  PluginsApiService,
+  PluginSourceRow,
+} from '../../../../core/services/api/plugins-api.service';
+import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
 
 /** One `code` per backend refusal (`plugin-sources.controller.ts`) — never the raw `detail`, which is not translated. */
 function createErrorKey(code: string | undefined): string {
@@ -33,7 +37,7 @@ function createErrorKey(code: string | undefined): string {
 /** Sources list + add form — any number of sources, the official catalog is just the seeded first row. */
 @Component({
   selector: 'app-plugin-sources',
-  imports: [FormsModule, DatePipe, LucideX, TranslateModule],
+  imports: [ModalHeaderComponent, FormsModule, DatePipe, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugin-sources.html',
 })
@@ -126,12 +130,18 @@ export class PluginSourcesComponent implements OnInit {
       if (result.ok) {
         this.toast.success(this.translate.instant('settings.plugins.sources.refresh_ok'));
       } else {
-        this.toast.error(this.translate.instant('settings.plugins.sources.refresh_error', { detail: result.detail }));
+        this.toast.error(
+          this.translate.instant('settings.plugins.sources.refresh_error', {
+            detail: result.detail,
+          }),
+        );
       }
       await this.reload();
       this.changed.emit();
     } catch {
-      this.toast.error(this.translate.instant('settings.plugins.sources.refresh_error', { detail: '' }));
+      this.toast.error(
+        this.translate.instant('settings.plugins.sources.refresh_error', { detail: '' }),
+      );
     } finally {
       this.refreshingId.set(null);
     }

--- a/client/src/app/features/settings/quality-profiles/quality-profiles.html
+++ b/client/src/app/features/settings/quality-profiles/quality-profiles.html
@@ -67,13 +67,15 @@
 
   <dialog #editorDialog class="modal">
     <div class="modal-box max-w-2xl max-h-[90vh] flex flex-col">
-      <h2 class="text-lg font-bold shrink-0">
-        @if (editingId() === null) {
-          {{ 'settings.quality_profiles.editor_create_title' | translate }}
-        } @else {
-          {{ 'settings.quality_profiles.editor_edit_title' | translate }}
-        }
-      </h2>
+      <app-modal-header class="shrink-0">
+        <h3 class="text-lg font-bold">
+          @if (editingId() === null) {
+            {{ 'settings.quality_profiles.editor_create_title' | translate }}
+          } @else {
+            {{ 'settings.quality_profiles.editor_edit_title' | translate }}
+          }
+        </h3>
+      </app-modal-header>
       <div class="py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 scroll-ring-safe">
         <label class="form-control w-full">
           <span class="label-text">{{ 'settings.quality_profiles.field_name' | translate }}</span>

--- a/client/src/app/features/settings/quality-profiles/quality-profiles.html
+++ b/client/src/app/features/settings/quality-profiles/quality-profiles.html
@@ -33,7 +33,9 @@
             <th>{{ 'settings.quality_profiles.col_name' | translate }}</th>
             <th>{{ 'settings.quality_profiles.col_cutoff' | translate }}</th>
             <th>{{ 'settings.quality_profiles.col_upgrade' | translate }}</th>
-            <th class="text-end">{{ 'settings.quality_profiles.col_allowed_count' | translate }}</th>
+            <th class="text-end">
+              {{ 'settings.quality_profiles.col_allowed_count' | translate }}
+            </th>
             <th class="text-end w-40">{{ 'settings.quality_profiles.actions' | translate }}</th>
           </tr>
         </thead>
@@ -41,7 +43,9 @@
           @for (p of profiles(); track p.id) {
             <tr>
               <td>
-                <button type="button" class="link link-hover font-medium" (click)="openEdit(p)">{{ p.name }}</button>
+                <button type="button" class="link link-hover font-medium" (click)="openEdit(p)">
+                  {{ p.name }}
+                </button>
               </td>
               <td class="text-sm">{{ cutoffLabel(p.cutoff) }}</td>
               <td>
@@ -53,7 +57,11 @@
               </td>
               <td class="text-end">{{ allowedCount(p) }}</td>
               <td class="text-end">
-                <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteProfile(p)">
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-xs text-error"
+                  (click)="deleteProfile(p)"
+                >
                   {{ 'settings.quality_profiles.delete' | translate }}
                 </button>
               </td>
@@ -65,93 +73,102 @@
   }
 </div>
 
-  <dialog #editorDialog class="modal">
-    <div class="modal-box max-w-2xl max-h-[90vh] flex flex-col">
-      <app-modal-header class="shrink-0">
-        <h3 class="text-lg font-bold">
-          @if (editingId() === null) {
-            {{ 'settings.quality_profiles.editor_create_title' | translate }}
-          } @else {
-            {{ 'settings.quality_profiles.editor_edit_title' | translate }}
+<dialog #editorDialog class="modal">
+  <div class="modal-box max-w-2xl max-h-[90vh] flex flex-col">
+    <app-modal-header class="shrink-0">
+      <h3 class="text-lg font-bold">
+        @if (editingId() === null) {
+          {{ 'settings.quality_profiles.editor_create_title' | translate }}
+        } @else {
+          {{ 'settings.quality_profiles.editor_edit_title' | translate }}
+        }
+      </h3>
+    </app-modal-header>
+    <div class="py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 scroll-ring-safe">
+      <label class="form-control w-full">
+        <span class="label-text">{{ 'settings.quality_profiles.field_name' | translate }}</span>
+        <input
+          type="text"
+          class="input input-bordered input-sm w-full"
+          [ngModel]="formName()"
+          (ngModelChange)="formName.set($event)"
+        />
+      </label>
+      <label class="form-control w-full">
+        <span class="label-text">{{ 'settings.quality_profiles.field_cutoff' | translate }}</span>
+        <select
+          class="select select-bordered select-sm w-full"
+          [ngModel]="formCutoff()"
+          (ngModelChange)="formCutoff.set(+$event)"
+        >
+          @for (q of definitions(); track q.id) {
+            <option [ngValue]="q.id">{{ q.name }} ({{ q.resolution }}p · {{ q.source }})</option>
           }
-        </h3>
-      </app-modal-header>
-      <div class="py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 scroll-ring-safe">
-        <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.quality_profiles.field_name' | translate }}</span>
-          <input
-            type="text"
-            class="input input-bordered input-sm w-full"
-            [ngModel]="formName()"
-            (ngModelChange)="formName.set($event)"
-          />
-        </label>
-        <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.quality_profiles.field_cutoff' | translate }}</span>
-          <select
-            class="select select-bordered select-sm w-full"
-            [ngModel]="formCutoff()"
-            (ngModelChange)="formCutoff.set(+$event)"
-          >
-            @for (q of definitions(); track q.id) {
-              <option [ngValue]="q.id">{{ q.name }} ({{ q.resolution }}p · {{ q.source }})</option>
-            }
-          </select>
-        </label>
+        </select>
+      </label>
+      <label class="label cursor-pointer justify-start items-center gap-3">
+        <input
+          type="checkbox"
+          class="toggle toggle-sm toggle-primary"
+          [ngModel]="formUpgrade()"
+          (ngModelChange)="formUpgrade.set($event)"
+        />
+        <span class="label-text">{{ 'settings.quality_profiles.field_upgrade' | translate }}</span>
+      </label>
+      @if (formUpgrade()) {
         <label class="label cursor-pointer justify-start items-center gap-3">
           <input
             type="checkbox"
             class="toggle toggle-sm toggle-primary"
-            [ngModel]="formUpgrade()"
-            (ngModelChange)="formUpgrade.set($event)"
+            [ngModel]="formResolutionUpgradeOnly()"
+            (ngModelChange)="formResolutionUpgradeOnly.set($event)"
           />
-          <span class="label-text">{{ 'settings.quality_profiles.field_upgrade' | translate }}</span>
+          <span class="label-text">{{
+            'settings.quality_profiles.field_resolution_upgrade_only' | translate
+          }}</span>
         </label>
-        @if (formUpgrade()) {
-          <label class="label cursor-pointer justify-start items-center gap-3">
-            <input
-              type="checkbox"
-              class="toggle toggle-sm toggle-primary"
-              [ngModel]="formResolutionUpgradeOnly()"
-              (ngModelChange)="formResolutionUpgradeOnly.set($event)"
-            />
-            <span class="label-text">{{ 'settings.quality_profiles.field_resolution_upgrade_only' | translate }}</span>
-          </label>
-        }
-        <div>
-          <p class="text-sm font-medium mb-2">{{ 'settings.quality_profiles.qualities_group' | translate }}</p>
-          <div class="rounded-lg border border-base-200 divide-y divide-base-200 max-h-[28rem] overflow-y-auto">
-            @for (q of definitions(); track q.id) {
-              <div class="px-3 py-2 hover:bg-base-200/50">
-                <div class="flex items-center gap-3">
-                  <input
-                    type="checkbox"
-                    class="checkbox checkbox-sm"
-                    [checked]="isAllowed(q.id)"
-                    (change)="toggleQuality(q.id, $event)"
-                  />
-                  <span class="text-sm flex-1">{{ q.name }}</span>
-                  <span class="text-sm text-base-content/50 tabular-nums">{{ q.resolution }}p · {{ q.source }}</span>
-                </div>
+      }
+      <div>
+        <p class="text-sm font-medium mb-2">
+          {{ 'settings.quality_profiles.qualities_group' | translate }}
+        </p>
+        <div
+          class="rounded-lg border border-base-200 divide-y divide-base-200 max-h-[28rem] overflow-y-auto"
+        >
+          @for (q of definitions(); track q.id) {
+            <div class="px-3 py-2 hover:bg-base-200/50">
+              <div class="flex items-center gap-3">
+                <input
+                  type="checkbox"
+                  class="checkbox checkbox-sm"
+                  [checked]="isAllowed(q.id)"
+                  (change)="toggleQuality(q.id, $event)"
+                />
+                <span class="text-sm flex-1">{{ q.name }}</span>
+                <span class="text-sm text-base-content/50 tabular-nums"
+                  >{{ q.resolution }}p · {{ q.source }}</span
+                >
               </div>
-            }
-          </div>
-        </div>
-
-      </div>
-      <div class="modal-action shrink-0">
-        <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
-          {{ 'settings.quality_profiles.cancel' | translate }}
-        </button>
-        <button type="button" class="btn btn-primary" (click)="save()" [disabled]="saving()">
-          @if (saving()) {
-            <span class="loading loading-spinner loading-sm"></span>
+            </div>
           }
-          {{ 'settings.quality_profiles.save' | translate }}
-        </button>
+        </div>
       </div>
     </div>
-    <form method="dialog" class="modal-backdrop">
-      <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">close</button>
-    </form>
-  </dialog>
+    <app-modal-footer>
+      <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
+        {{ 'settings.quality_profiles.cancel' | translate }}
+      </button>
+      <button type="button" class="btn btn-primary" (click)="save()" [disabled]="saving()">
+        @if (saving()) {
+          <span class="loading loading-spinner loading-sm"></span>
+        }
+        {{ 'settings.quality_profiles.save' | translate }}
+      </button>
+    </app-modal-footer>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">
+      close
+    </button>
+  </form>
+</dialog>

--- a/client/src/app/features/settings/quality-profiles/quality-profiles.ts
+++ b/client/src/app/features/settings/quality-profiles/quality-profiles.ts
@@ -20,10 +20,12 @@ import {
   MediaService,
   AppQualityDef,
 } from '../../../core/services/api/media.service';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 
 @Component({
   selector: 'app-quality-profiles',
-  imports: [FormsModule, LucideChevronLeft, RouterLink, TranslateModule],
+  imports: [
+    ModalHeaderComponent,FormsModule, LucideChevronLeft, RouterLink, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './quality-profiles.html',
 })

--- a/client/src/app/features/settings/quality-profiles/quality-profiles.ts
+++ b/client/src/app/features/settings/quality-profiles/quality-profiles.ts
@@ -12,20 +12,21 @@ import { RouterLink } from '@angular/router';
 import { LucideChevronLeft } from '@lucide/angular';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
-import {
-  ProfilesService,
-  QualityProfile,
-} from '../../../core/services/api/profiles.service';
-import {
-  MediaService,
-  AppQualityDef,
-} from '../../../core/services/api/media.service';
+import { ProfilesService, QualityProfile } from '../../../core/services/api/profiles.service';
+import { MediaService, AppQualityDef } from '../../../core/services/api/media.service';
 import { ModalHeaderComponent } from '../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-quality-profiles',
   imports: [
-    ModalHeaderComponent,FormsModule, LucideChevronLeft, RouterLink, TranslateModule],
+    ModalFooterComponent,
+    ModalHeaderComponent,
+    FormsModule,
+    LucideChevronLeft,
+    RouterLink,
+    TranslateModule,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './quality-profiles.html',
 })
@@ -65,9 +66,7 @@ export class QualityProfilesComponent implements OnInit {
       this.profiles.set(profiles);
       this.definitions.set(defs);
     } catch {
-      this.listError.set(
-        this.translate.instant('settings.quality_profiles.load_error'),
-      );
+      this.listError.set(this.translate.instant('settings.quality_profiles.load_error'));
     } finally {
       this.loading.set(false);
     }
@@ -98,9 +97,7 @@ export class QualityProfilesComponent implements OnInit {
     this.formCutoff.set(p.cutoff);
     this.formUpgrade.set(p.upgradeAllowed);
     this.formResolutionUpgradeOnly.set(p.resolutionUpgradeOnly ?? false);
-    const allowed = new Set(
-      p.items.filter((i) => i.allowed).map((i) => i.quality.id),
-    );
+    const allowed = new Set(p.items.filter((i) => i.allowed).map((i) => i.quality.id));
     this.allowedIds.set(allowed);
     this.editorDialog()?.nativeElement.showModal();
   }
@@ -159,11 +156,17 @@ export class QualityProfilesComponent implements OnInit {
   }
 
   async deleteProfile(p: QualityProfile) {
-    const msg = this.translate.instant(
-      'settings.quality_profiles.confirm_delete',
-      { name: p.name },
-    );
-    if (!await this.confirmation.confirm({ title: this.translate.instant('common.confirm'), message: msg, variant: 'danger' })) return;
+    const msg = this.translate.instant('settings.quality_profiles.confirm_delete', {
+      name: p.name,
+    });
+    if (
+      !(await this.confirmation.confirm({
+        title: this.translate.instant('common.confirm'),
+        message: msg,
+        variant: 'danger',
+      }))
+    )
+      return;
     try {
       await this.profilesApi.deleteQualityProfile(p.id);
       await this.reloadAll();
@@ -171,7 +174,8 @@ export class QualityProfilesComponent implements OnInit {
       const httpErr = err as { error?: { message?: string } };
       void this.confirmation.alert({
         title: this.translate.instant('common.error'),
-        message: httpErr.error?.message ??
+        message:
+          httpErr.error?.message ??
           this.translate.instant('settings.quality_profiles.delete_error'),
         variant: 'danger',
       });

--- a/client/src/app/features/settings/roles/roles.html
+++ b/client/src/app/features/settings/roles/roles.html
@@ -30,7 +30,9 @@
           @for (role of rows(); track role.id) {
             <tr>
               <td>
-                <button type="button" class="link link-hover font-medium" (click)="openEdit(role)">{{ role.name }}</button>
+                <button type="button" class="link link-hover font-medium" (click)="openEdit(role)">
+                  {{ role.name }}
+                </button>
               </td>
               <td>
                 <div class="flex flex-wrap gap-1">
@@ -41,11 +43,17 @@
               </td>
               <td>
                 @if (role.isDefault) {
-                  <span class="badge badge-success badge-sm">{{ 'settings.roles.default_badge' | translate }}</span>
+                  <span class="badge badge-success badge-sm">{{
+                    'settings.roles.default_badge' | translate
+                  }}</span>
                 }
               </td>
               <td class="text-end">
-                <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteRole(role)">
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-xs text-error"
+                  (click)="deleteRole(role)"
+                >
                   {{ 'settings.users.delete' | translate }}
                 </button>
               </td>
@@ -58,95 +66,93 @@
 </div>
 
 <dialog #editorDialog class="modal">
-    <div class="modal-box max-w-lg max-h-[92vh] flex flex-col p-0 gap-0 overflow-hidden">
-      <div class="px-5 sm:px-6 pt-4 pb-3 border-b border-base-200 flex justify-between items-center shrink-0 bg-base-100">
-        <h2 class="text-lg font-bold">{{ (isCreating() ? 'settings.roles.editor_create' : 'settings.roles.editor_edit') | translate }}</h2>
-        <button
-          type="button"
-          class="btn btn-sm btn-ghost btn-circle"
-          (click)="closeEditor()"
-          [attr.aria-label]="'common.close' | translate"
-        >
-          <svg lucideX class="h-5 w-5"></svg>
-        </button>
-      </div>
+  <div class="modal-box max-w-lg max-h-[92vh] flex flex-col p-0 gap-0 overflow-hidden">
+    <app-modal-header
+      flush
+      [title]="
+        (isCreating() ? 'settings.roles.editor_create' : 'settings.roles.editor_edit') | translate
+      "
+    />
 
-      <div class="px-5 sm:px-6 py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 bg-base-100">
-        <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.roles.field_name' | translate }}</span>
-          <input
-            type="text"
-            class="input input-bordered input-sm w-full"
-            [ngModel]="formName()"
-            (ngModelChange)="formName.set($event)"
-          />
-        </label>
+    <div class="px-5 sm:px-6 py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 bg-base-100">
+      <label class="form-control w-full">
+        <span class="label-text">{{ 'settings.roles.field_name' | translate }}</span>
+        <input
+          type="text"
+          class="input input-bordered input-sm w-full"
+          [ngModel]="formName()"
+          (ngModelChange)="formName.set($event)"
+        />
+      </label>
 
-        <div>
-          <span class="label-text">{{ 'settings.roles.field_permissions' | translate }}</span>
-          <div class="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
-            @for (perm of availablePermissions(); track perm) {
-              <label class="label cursor-pointer justify-start gap-2 p-2 rounded hover:bg-base-200">
-                <input
-                  type="checkbox"
-                  class="checkbox checkbox-sm"
-                  [checked]="formPermissions().has(perm)"
-                  (change)="togglePermission(perm)"
-                />
-                <span class="label-text text-sm">{{ permLabel(perm) }}</span>
-              </label>
-            }
-          </div>
-        </div>
-
-        <label class="label cursor-pointer justify-start gap-3">
-          <input
-            type="checkbox"
-            class="toggle toggle-sm"
-            [ngModel]="formIsDefault()"
-            (ngModelChange)="formIsDefault.set($event)"
-          />
-          <span class="label-text">{{ 'settings.roles.field_is_default' | translate }}</span>
-        </label>
-
-        <div>
-          <span class="label-text">{{ 'settings.roles.default_libraries' | translate }}</span>
-          <p class="text-xs text-base-content/50 mt-1">{{ 'settings.roles.default_libraries_hint' | translate }}</p>
-          <div class="flex flex-col gap-1 mt-2 max-h-40 overflow-auto border border-base-200 rounded p-2">
-            @for (l of libraries(); track l.id) {
-              <label class="label cursor-pointer gap-2 justify-start py-1">
-                <input
-                  type="checkbox"
-                  class="checkbox checkbox-sm"
-                  [checked]="formDefaultLibraryIds().has(l.id)"
-                  (change)="toggleDefaultLibrary(l.id)"
-                />
-                <span class="label-text text-sm">{{ l.name }}</span>
-              </label>
-            }
-            @if (libraries().length === 0) {
-              <p class="text-xs text-base-content/50 italic">—</p>
-            }
-          </div>
-        </div>
-
-      </div>
-
-      <div class="modal-action modal-action-sticky">
-        <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
-          {{ 'settings.users.cancel' | translate }}
-        </button>
-        <button type="button" class="btn btn-primary" (click)="save()" [disabled]="saving()">
-          @if (saving()) {
-            <span class="loading loading-spinner loading-sm"></span>
+      <div>
+        <span class="label-text">{{ 'settings.roles.field_permissions' | translate }}</span>
+        <div class="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
+          @for (perm of availablePermissions(); track perm) {
+            <label class="label cursor-pointer justify-start gap-2 p-2 rounded hover:bg-base-200">
+              <input
+                type="checkbox"
+                class="checkbox checkbox-sm"
+                [checked]="formPermissions().has(perm)"
+                (change)="togglePermission(perm)"
+              />
+              <span class="label-text text-sm">{{ permLabel(perm) }}</span>
+            </label>
           }
-          {{ 'settings.users.save' | translate }}
-        </button>
+        </div>
+      </div>
+
+      <label class="label cursor-pointer justify-start gap-3">
+        <input
+          type="checkbox"
+          class="toggle toggle-sm"
+          [ngModel]="formIsDefault()"
+          (ngModelChange)="formIsDefault.set($event)"
+        />
+        <span class="label-text">{{ 'settings.roles.field_is_default' | translate }}</span>
+      </label>
+
+      <div>
+        <span class="label-text">{{ 'settings.roles.default_libraries' | translate }}</span>
+        <p class="text-xs text-base-content/50 mt-1">
+          {{ 'settings.roles.default_libraries_hint' | translate }}
+        </p>
+        <div
+          class="flex flex-col gap-1 mt-2 max-h-40 overflow-auto border border-base-200 rounded p-2"
+        >
+          @for (l of libraries(); track l.id) {
+            <label class="label cursor-pointer gap-2 justify-start py-1">
+              <input
+                type="checkbox"
+                class="checkbox checkbox-sm"
+                [checked]="formDefaultLibraryIds().has(l.id)"
+                (change)="toggleDefaultLibrary(l.id)"
+              />
+              <span class="label-text text-sm">{{ l.name }}</span>
+            </label>
+          }
+          @if (libraries().length === 0) {
+            <p class="text-xs text-base-content/50 italic">—</p>
+          }
+        </div>
       </div>
     </div>
-    <form method="dialog" class="modal-backdrop">
-      <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">
-        {{ 'common.close' | translate }}
+
+    <app-modal-footer flush>
+      <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
+        {{ 'settings.users.cancel' | translate }}
       </button>
-    </form>
-  </dialog>
+      <button type="button" class="btn btn-primary" (click)="save()" [disabled]="saving()">
+        @if (saving()) {
+          <span class="loading loading-spinner loading-sm"></span>
+        }
+        {{ 'settings.users.save' | translate }}
+      </button>
+    </app-modal-footer>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">
+      {{ 'common.close' | translate }}
+    </button>
+  </form>
+</dialog>

--- a/client/src/app/features/settings/roles/roles.html
+++ b/client/src/app/features/settings/roles/roles.html
@@ -132,7 +132,7 @@
 
       </div>
 
-      <div class="modal-action shrink-0 px-5 sm:px-6 pb-4 pt-2 border-t border-base-200 bg-base-100">
+      <div class="modal-action modal-action-sticky">
         <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
           {{ 'settings.users.cancel' | translate }}
         </button>

--- a/client/src/app/features/settings/roles/roles.ts
+++ b/client/src/app/features/settings/roles/roles.ts
@@ -10,17 +10,16 @@ import {
 import { FormsModule } from '@angular/forms';
 import { LucideX } from '@lucide/angular';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import {
-  RolesApiService,
-  RoleRow,
-} from '../../../core/services/api/roles-api.service';
+import { RolesApiService, RoleRow } from '../../../core/services/api/roles-api.service';
 import { LibrariesApiService, Library } from '../../../core/services/api/libraries-api.service';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { ToastService } from '../../../core/services/toast.service';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-roles-settings',
-  imports: [FormsModule, LucideX, TranslateModule],
+  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './roles.html',
 })

--- a/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
+++ b/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
@@ -1,7 +1,9 @@
 <div class="flex flex-col gap-6">
   <div>
     <h1 class="text-2xl font-bold">{{ 'settings.subtitle_providers.title' | translate }}</h1>
-    <p class="text-sm text-base-content/60 mt-1">{{ 'settings.subtitle_providers.subtitle' | translate }}</p>
+    <p class="text-sm text-base-content/60 mt-1">
+      {{ 'settings.subtitle_providers.subtitle' | translate }}
+    </p>
   </div>
 
   <!-- AI subtitle translation -->
@@ -9,10 +11,18 @@
     <div class="card-body gap-4">
       <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
         <div>
-          <h2 class="card-title text-lg">{{ 'settings.subtitle_providers.translation_title' | translate }}</h2>
-          <p class="text-sm text-base-content/60">{{ 'settings.subtitle_providers.translation_hint' | translate }}</p>
+          <h2 class="card-title text-lg">
+            {{ 'settings.subtitle_providers.translation_title' | translate }}
+          </h2>
+          <p class="text-sm text-base-content/60">
+            {{ 'settings.subtitle_providers.translation_hint' | translate }}
+          </p>
         </div>
-        <button type="button" class="btn btn-primary btn-sm shrink-0 self-start" (click)="openCreateTranslation()">
+        <button
+          type="button"
+          class="btn btn-primary btn-sm shrink-0 self-start"
+          (click)="openCreateTranslation()"
+        >
           {{ 'settings.subtitle_providers.translation_new' | translate }}
         </button>
       </div>
@@ -26,11 +36,15 @@
             [ngModel]="translationEnabled()"
             (ngModelChange)="saveTranslationEnabled($event)"
           />
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_enabled' | translate }}</span>
+          <span class="label-text">{{
+            'settings.subtitle_providers.translation_enabled' | translate
+          }}</span>
         </label>
 
         <label class="form-control w-32">
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_concurrency' | translate }}</span>
+          <span class="label-text">{{
+            'settings.subtitle_providers.translation_concurrency' | translate
+          }}</span>
           <input
             type="number"
             min="1"
@@ -45,7 +59,9 @@
       @if (translationLoading()) {
         <div class="flex justify-center py-6"><span class="loading loading-spinner"></span></div>
       } @else if (translationRows().length === 0) {
-        <p class="text-sm text-base-content/50 py-4">{{ 'settings.subtitle_providers.translation_empty' | translate }}</p>
+        <p class="text-sm text-base-content/50 py-4">
+          {{ 'settings.subtitle_providers.translation_empty' | translate }}
+        </p>
       } @else {
         <div class="overflow-x-auto rounded-lg border border-base-200">
           <table class="table">
@@ -53,17 +69,31 @@
               <tr>
                 <th>{{ 'settings.subtitle_providers.col_name' | translate }}</th>
                 <th>{{ 'settings.subtitle_providers.translation_col_engine' | translate }}</th>
-                <th class="text-center">{{ 'settings.subtitle_providers.col_status' | translate }}</th>
-                <th class="text-end w-32">{{ 'settings.subtitle_providers.actions' | translate }}</th>
+                <th class="text-center">
+                  {{ 'settings.subtitle_providers.col_status' | translate }}
+                </th>
+                <th class="text-end w-32">
+                  {{ 'settings.subtitle_providers.actions' | translate }}
+                </th>
               </tr>
             </thead>
             <tbody>
               @for (row of translationRows(); track row.id) {
                 <tr>
                   <td class="font-medium">
-                    <div class="whitespace-nowrap"><button type="button" class="link link-hover" (click)="openEditTranslation(row)">{{ row.name }}</button></div>
+                    <div class="whitespace-nowrap">
+                      <button
+                        type="button"
+                        class="link link-hover"
+                        (click)="openEditTranslation(row)"
+                      >
+                        {{ row.name }}
+                      </button>
+                    </div>
                     @if (row.isDefault) {
-                      <span class="badge badge-primary badge-sm mt-1">{{ 'settings.subtitle_providers.translation_default' | translate }}</span>
+                      <span class="badge badge-primary badge-sm mt-1">{{
+                        'settings.subtitle_providers.translation_default' | translate
+                      }}</span>
                     }
                   </td>
                   <td class="text-sm">{{ translationEngineLabel(row.engine) }}</td>
@@ -76,7 +106,11 @@
                   </td>
                   <td class="text-end">
                     <div class="flex justify-end gap-1">
-                      <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteTranslationProvider(row)">
+                      <button
+                        type="button"
+                        class="btn btn-ghost btn-xs text-error"
+                        (click)="deleteTranslationProvider(row)"
+                      >
                         {{ 'common.delete' | translate }}
                       </button>
                     </div>
@@ -93,7 +127,9 @@
   <!-- Download providers -->
   <div class="card bg-base-100 border border-base-200">
     <div class="card-body gap-4">
-      <p class="text-sm text-base-content/60">{{ 'settings.subtitle_providers.download_hint' | translate }}</p>
+      <p class="text-sm text-base-content/60">
+        {{ 'settings.subtitle_providers.download_hint' | translate }}
+      </p>
 
       <app-provider-list
         titleKey="settings.subtitle_providers.download_title"
@@ -112,8 +148,12 @@
 
       <ng-template #rateLimitStatusTpl let-row>
         @if (row.enabled && getRateLimit(implementationOf(row)); as rl) {
-          <span class="badge badge-warning badge-sm gap-1" [title]="'settings.subtitle_providers.rate_limited_hint' | translate">
-            {{ 'settings.subtitle_providers.rate_limited' | translate }} — {{ formatDelay(rl.delaySec) }}
+          <span
+            class="badge badge-warning badge-sm gap-1"
+            [title]="'settings.subtitle_providers.rate_limited_hint' | translate"
+          >
+            {{ 'settings.subtitle_providers.rate_limited' | translate }} —
+            {{ formatDelay(rl.delaySec) }}
           </span>
         }
       </ng-template>
@@ -130,22 +170,36 @@
 <dialog #statsDialog class="modal">
   <div class="modal-box max-w-2xl">
     <app-modal-header>
-      <h3 class="text-lg font-bold">{{ statsProviderName() }} — {{ 'settings.subtitle_providers.stats_title' | translate }}</h3>
+      <h3 class="text-lg font-bold">
+        {{ statsProviderName() }} — {{ 'settings.subtitle_providers.stats_title' | translate }}
+      </h3>
     </app-modal-header>
     @if (statsLoading()) {
-      <div class="flex justify-center py-8"><span class="loading loading-spinner loading-lg"></span></div>
+      <div class="flex justify-center py-8">
+        <span class="loading loading-spinner loading-lg"></span>
+      </div>
     } @else if (statsData().length === 0) {
-      <p class="text-center py-8 text-base-content/50">{{ 'settings.subtitle_providers.stats_empty' | translate }}</p>
+      <p class="text-center py-8 text-base-content/50">
+        {{ 'settings.subtitle_providers.stats_empty' | translate }}
+      </p>
     } @else {
       <div class="overflow-x-auto mt-4 rounded-lg border border-base-200">
         <table class="table">
           <thead>
             <tr>
               <th>{{ 'settings.subtitle_providers.stats_date' | translate }}</th>
-              <th class="text-right">{{ 'settings.subtitle_providers.stats_queries' | translate }}</th>
-              <th class="text-right">{{ 'settings.subtitle_providers.stats_avg_time' | translate }}</th>
-              <th class="text-right">{{ 'settings.subtitle_providers.stats_results' | translate }}</th>
-              <th class="text-right">{{ 'settings.subtitle_providers.stats_errors' | translate }}</th>
+              <th class="text-right">
+                {{ 'settings.subtitle_providers.stats_queries' | translate }}
+              </th>
+              <th class="text-right">
+                {{ 'settings.subtitle_providers.stats_avg_time' | translate }}
+              </th>
+              <th class="text-right">
+                {{ 'settings.subtitle_providers.stats_results' | translate }}
+              </th>
+              <th class="text-right">
+                {{ 'settings.subtitle_providers.stats_errors' | translate }}
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -155,16 +209,20 @@
                 <td class="text-right tabular-nums">{{ row.queries }}</td>
                 <td class="text-right tabular-nums">{{ row.avgResponseMs }}ms</td>
                 <td class="text-right tabular-nums">{{ row.totalResults }}</td>
-                <td class="text-right tabular-nums" [class.text-error]="row.errors > 0">{{ row.errors }}</td>
+                <td class="text-right tabular-nums" [class.text-error]="row.errors > 0">
+                  {{ row.errors }}
+                </td>
               </tr>
             }
           </tbody>
         </table>
       </div>
     }
-    <div class="modal-action">
-      <button type="button" class="btn btn-ghost" (click)="closeStats()">{{ 'common.close' | translate }}</button>
-    </div>
+    <app-modal-footer>
+      <button type="button" class="btn btn-ghost" (click)="closeStats()">
+        {{ 'common.close' | translate }}
+      </button>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
     <button type="button" (click)="closeStats()">close</button>
@@ -186,14 +244,23 @@
     <div class="flex flex-col gap-3 p-2 -m-2 mt-1 overflow-y-auto">
       <label class="form-control w-full">
         <span class="label-text">{{ 'settings.subtitle_providers.col_name' | translate }}</span>
-        <input type="text" class="input input-bordered input-sm w-full"
-          [ngModel]="trFormName()" (ngModelChange)="trFormName.set($event)" />
+        <input
+          type="text"
+          class="input input-bordered input-sm w-full"
+          [ngModel]="trFormName()"
+          (ngModelChange)="trFormName.set($event)"
+        />
       </label>
 
       <label class="form-control w-full">
-        <span class="label-text">{{ 'settings.subtitle_providers.translation_engine' | translate }}</span>
-        <select class="select select-bordered select-sm w-full"
-          [ngModel]="trFormEngine()" (ngModelChange)="onTranslationEngineChange($event)">
+        <span class="label-text">{{
+          'settings.subtitle_providers.translation_engine' | translate
+        }}</span>
+        <select
+          class="select select-bordered select-sm w-full"
+          [ngModel]="trFormEngine()"
+          (ngModelChange)="onTranslationEngineChange($event)"
+        >
           @for (e of translationEngines; track e.value) {
             <option [value]="e.value">{{ e.label }}</option>
           }
@@ -202,14 +269,25 @@
 
       @if (trFormEngine() === 'gemini') {
         <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_api_key' | translate }}</span>
-          <input type="text" class="input input-bordered input-sm w-full font-mono"
-            [ngModel]="trFormApiKey()" (ngModelChange)="trFormApiKey.set($event)" />
+          <span class="label-text">{{
+            'settings.subtitle_providers.translation_api_key' | translate
+          }}</span>
+          <input
+            type="text"
+            class="input input-bordered input-sm w-full font-mono"
+            [ngModel]="trFormApiKey()"
+            (ngModelChange)="trFormApiKey.set($event)"
+          />
         </label>
         <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_model' | translate }}</span>
-          <select class="select select-bordered select-sm w-full font-mono"
-            [ngModel]="trFormModel()" (ngModelChange)="trFormModel.set($event)">
+          <span class="label-text">{{
+            'settings.subtitle_providers.translation_model' | translate
+          }}</span>
+          <select
+            class="select select-bordered select-sm w-full font-mono"
+            [ngModel]="trFormModel()"
+            (ngModelChange)="trFormModel.set($event)"
+          >
             @if (!geminiModels.includes(trFormModel())) {
               <option [value]="trFormModel()">{{ trFormModel() }}</option>
             }
@@ -220,74 +298,145 @@
         </label>
       } @else if (trFormEngine() === 'openai') {
         <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_openai_base_url' | translate }}</span>
-          <input type="text" class="input input-bordered input-sm w-full font-mono"
+          <span class="label-text">{{
+            'settings.subtitle_providers.translation_openai_base_url' | translate
+          }}</span>
+          <input
+            type="text"
+            class="input input-bordered input-sm w-full font-mono"
             placeholder="https://api.groq.com/openai/v1"
-            [ngModel]="trFormBaseUrl()" (ngModelChange)="trFormBaseUrl.set($event)" />
-          <span class="text-xs text-base-content/50 mt-1">{{ 'settings.subtitle_providers.translation_openai_base_url_hint' | translate }}</span>
+            [ngModel]="trFormBaseUrl()"
+            (ngModelChange)="trFormBaseUrl.set($event)"
+          />
+          <span class="text-xs text-base-content/50 mt-1">{{
+            'settings.subtitle_providers.translation_openai_base_url_hint' | translate
+          }}</span>
         </label>
         <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_api_key_optional' | translate }}</span>
-          <input type="text" class="input input-bordered input-sm w-full font-mono"
-            [ngModel]="trFormApiKey()" (ngModelChange)="trFormApiKey.set($event)" />
+          <span class="label-text">{{
+            'settings.subtitle_providers.translation_api_key_optional' | translate
+          }}</span>
+          <input
+            type="text"
+            class="input input-bordered input-sm w-full font-mono"
+            [ngModel]="trFormApiKey()"
+            (ngModelChange)="trFormApiKey.set($event)"
+          />
         </label>
         <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_openai_model' | translate }}</span>
-          <input type="text" class="input input-bordered input-sm w-full font-mono"
+          <span class="label-text">{{
+            'settings.subtitle_providers.translation_openai_model' | translate
+          }}</span>
+          <input
+            type="text"
+            class="input input-bordered input-sm w-full font-mono"
             placeholder="llama-3.3-70b-versatile"
-            [ngModel]="trFormModel()" (ngModelChange)="trFormModel.set($event)" />
+            [ngModel]="trFormModel()"
+            (ngModelChange)="trFormModel.set($event)"
+          />
         </label>
       } @else {
         <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_libretranslate_url' | translate }}</span>
-          <input type="text" class="input input-bordered input-sm w-full font-mono"
+          <span class="label-text">{{
+            'settings.subtitle_providers.translation_libretranslate_url' | translate
+          }}</span>
+          <input
+            type="text"
+            class="input input-bordered input-sm w-full font-mono"
             placeholder="http://libretranslate:5000"
-            [ngModel]="trFormUrl()" (ngModelChange)="trFormUrl.set($event)" />
-          <span class="text-xs text-base-content/50 mt-1">{{ 'settings.subtitle_providers.translation_libretranslate_url_hint' | translate }}</span>
+            [ngModel]="trFormUrl()"
+            (ngModelChange)="trFormUrl.set($event)"
+          />
+          <span class="text-xs text-base-content/50 mt-1">{{
+            'settings.subtitle_providers.translation_libretranslate_url_hint' | translate
+          }}</span>
         </label>
         <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_api_key_optional' | translate }}</span>
-          <input type="text" class="input input-bordered input-sm w-full font-mono"
-            [ngModel]="trFormApiKey()" (ngModelChange)="trFormApiKey.set($event)" />
+          <span class="label-text">{{
+            'settings.subtitle_providers.translation_api_key_optional' | translate
+          }}</span>
+          <input
+            type="text"
+            class="input input-bordered input-sm w-full font-mono"
+            [ngModel]="trFormApiKey()"
+            (ngModelChange)="trFormApiKey.set($event)"
+          />
         </label>
       }
 
       <div class="flex gap-6">
         <label class="flex items-center gap-2">
-          <input type="checkbox" class="checkbox checkbox-sm"
-            [ngModel]="trFormEnabled()" (ngModelChange)="trFormEnabled.set($event)" />
-          <span class="label-text">{{ 'settings.subtitle_providers.field_enabled' | translate }}</span>
+          <input
+            type="checkbox"
+            class="checkbox checkbox-sm"
+            [ngModel]="trFormEnabled()"
+            (ngModelChange)="trFormEnabled.set($event)"
+          />
+          <span class="label-text">{{
+            'settings.subtitle_providers.field_enabled' | translate
+          }}</span>
         </label>
         <label class="flex items-center gap-2">
-          <input type="checkbox" class="checkbox checkbox-sm"
-            [ngModel]="trFormDefault()" (ngModelChange)="trFormDefault.set($event)" />
-          <span class="label-text">{{ 'settings.subtitle_providers.translation_set_default' | translate }}</span>
+          <input
+            type="checkbox"
+            class="checkbox checkbox-sm"
+            [ngModel]="trFormDefault()"
+            (ngModelChange)="trFormDefault.set($event)"
+          />
+          <span class="label-text">{{
+            'settings.subtitle_providers.translation_set_default' | translate
+          }}</span>
         </label>
       </div>
 
       <div class="flex items-center gap-2">
-        <button type="button" class="btn btn-outline btn-sm" (click)="testTranslation()" [disabled]="trTestLoading()">
-          @if (trTestLoading()) { <span class="loading loading-spinner loading-xs"></span> }
+        <button
+          type="button"
+          class="btn btn-outline btn-sm"
+          (click)="testTranslation()"
+          [disabled]="trTestLoading()"
+        >
+          @if (trTestLoading()) {
+            <span class="loading loading-spinner loading-xs"></span>
+          }
           {{ 'settings.subtitle_providers.test' | translate }}
         </button>
         @if (trTestResult(); as r) {
-          <span class="text-sm" [class.text-success]="r.ok" [class.text-error]="!r.ok">{{ r.message }}</span>
+          <span class="text-sm" [class.text-success]="r.ok" [class.text-error]="!r.ok">{{
+            r.message
+          }}</span>
         }
       </div>
     </div>
 
-    <div class="modal-action shrink-0">
-      <button type="button" class="btn btn-ghost" (click)="closeTranslationEditor()" [disabled]="trSaving()">
+    <app-modal-footer>
+      <button
+        type="button"
+        class="btn btn-ghost"
+        (click)="closeTranslationEditor()"
+        [disabled]="trSaving()"
+      >
         {{ 'settings.subtitle_providers.cancel' | translate }}
       </button>
-      <button type="button" class="btn btn-primary" (click)="saveTranslationProvider()" [disabled]="trSaving()">
-        @if (trSaving()) { <span class="loading loading-spinner loading-sm"></span> }
+      <button
+        type="button"
+        class="btn btn-primary"
+        (click)="saveTranslationProvider()"
+        [disabled]="trSaving()"
+      >
+        @if (trSaving()) {
+          <span class="loading loading-spinner loading-sm"></span>
+        }
         {{ 'settings.subtitle_providers.save' | translate }}
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
-    <button type="button" (click)="closeTranslationEditor()" [attr.aria-label]="'common.close' | translate">
+    <button
+      type="button"
+      (click)="closeTranslationEditor()"
+      [attr.aria-label]="'common.close' | translate"
+    >
       {{ 'common.close' | translate }}
     </button>
   </form>

--- a/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
+++ b/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
@@ -129,7 +129,9 @@
 
 <dialog #statsDialog class="modal">
   <div class="modal-box max-w-2xl">
-    <h2 class="text-lg font-bold">{{ statsProviderName() }} — {{ 'settings.subtitle_providers.stats_title' | translate }}</h2>
+    <app-modal-header>
+      <h3 class="text-lg font-bold">{{ statsProviderName() }} — {{ 'settings.subtitle_providers.stats_title' | translate }}</h3>
+    </app-modal-header>
     @if (statsLoading()) {
       <div class="flex justify-center py-8"><span class="loading loading-spinner loading-lg"></span></div>
     } @else if (statsData().length === 0) {
@@ -171,13 +173,15 @@
 
 <dialog #translationEditorDialog class="modal">
   <div class="modal-box max-w-xl max-h-[90vh] flex flex-col">
-    <h2 class="text-lg font-bold shrink-0">
-      @if (trEditingId() === null) {
-        {{ 'settings.subtitle_providers.translation_editor_create' | translate }}
-      } @else {
-        {{ 'settings.subtitle_providers.translation_editor_edit' | translate }}
-      }
-    </h2>
+    <app-modal-header class="shrink-0">
+      <h3 class="text-lg font-bold">
+        @if (trEditingId() === null) {
+          {{ 'settings.subtitle_providers.translation_editor_create' | translate }}
+        } @else {
+          {{ 'settings.subtitle_providers.translation_editor_edit' | translate }}
+        }
+      </h3>
+    </app-modal-header>
 
     <div class="flex flex-col gap-3 p-2 -m-2 mt-1 overflow-y-auto">
       <label class="form-control w-full">

--- a/client/src/app/features/settings/subtitle-providers/subtitle-providers.ts
+++ b/client/src/app/features/settings/subtitle-providers/subtitle-providers.ts
@@ -27,6 +27,7 @@ import {
   ProviderListLabels,
   ProviderTestResult,
 } from '../../../shared/components/provider-list/provider-list.types';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 
 const DEFAULT_TRANSLATION_MODEL = 'gemini-2.0-flash';
 
@@ -91,7 +92,8 @@ const LABELS: ProviderListLabels = {
 
 @Component({
   selector: 'app-subtitle-providers-settings',
-  imports: [FormsModule, TranslateModule, ProviderListComponent],
+  imports: [
+    ModalHeaderComponent,FormsModule, TranslateModule, ProviderListComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './subtitle-providers.html',
 })

--- a/client/src/app/features/settings/subtitle-providers/subtitle-providers.ts
+++ b/client/src/app/features/settings/subtitle-providers/subtitle-providers.ts
@@ -13,7 +13,10 @@ import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { SettingsApiService } from '../../../core/services/api/settings-api.service';
-import { SubtitleProvidersApiService, ProviderRateLimit } from '../../../core/services/api/subtitle-providers-api.service';
+import {
+  SubtitleProvidersApiService,
+  ProviderRateLimit,
+} from '../../../core/services/api/subtitle-providers-api.service';
 import {
   TranslationProvidersApiService,
   TranslationProviderRow,
@@ -28,6 +31,7 @@ import {
   ProviderTestResult,
 } from '../../../shared/components/provider-list/provider-list.types';
 import { ModalHeaderComponent } from '../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 const DEFAULT_TRANSLATION_MODEL = 'gemini-2.0-flash';
 
@@ -58,10 +62,20 @@ const IMPLEMENTATIONS: ProviderImplementation[] = [
   {
     implementation: 'subdl',
     labelKey: 'settings.subtitle_providers.type_subdl',
-    fields: [{ key: 'apiKey', type: 'text', labelKey: 'settings.subtitle_providers.field_api_key' }],
+    fields: [
+      { key: 'apiKey', type: 'text', labelKey: 'settings.subtitle_providers.field_api_key' },
+    ],
   },
-  { implementation: 'subsynchro', labelKey: 'settings.subtitle_providers.type_subsynchro', fields: [] },
-  { implementation: 'supersubtitles', labelKey: 'settings.subtitle_providers.type_supersubtitles', fields: [] },
+  {
+    implementation: 'subsynchro',
+    labelKey: 'settings.subtitle_providers.type_subsynchro',
+    fields: [],
+  },
+  {
+    implementation: 'supersubtitles',
+    labelKey: 'settings.subtitle_providers.type_supersubtitles',
+    fields: [],
+  },
   { implementation: 'yify', labelKey: 'settings.subtitle_providers.type_yify', fields: [] },
   { implementation: 'gestdown', labelKey: 'settings.subtitle_providers.type_gestdown', fields: [] },
 ];
@@ -93,7 +107,12 @@ const LABELS: ProviderListLabels = {
 @Component({
   selector: 'app-subtitle-providers-settings',
   imports: [
-    ModalHeaderComponent,FormsModule, TranslateModule, ProviderListComponent],
+    ModalFooterComponent,
+    ModalHeaderComponent,
+    FormsModule,
+    TranslateModule,
+    ProviderListComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './subtitle-providers.html',
 })
@@ -105,7 +124,8 @@ export class SubtitleProvidersSettingsComponent implements OnInit {
   private readonly translate = inject(TranslateService);
   private readonly confirmation = inject(ConfirmationService);
 
-  private readonly translationEditorDialog = viewChild<ElementRef<HTMLDialogElement>>('translationEditorDialog');
+  private readonly translationEditorDialog =
+    viewChild<ElementRef<HTMLDialogElement>>('translationEditorDialog');
   private readonly statsDialog = viewChild<ElementRef<HTMLDialogElement>>('statsDialog');
 
   readonly listUrl = '/api/subtitles/providers';
@@ -115,7 +135,9 @@ export class SubtitleProvidersSettingsComponent implements OnInit {
   readonly rateLimits = signal<Map<string, ProviderRateLimit>>(new Map());
 
   readonly statsLoading = signal(false);
-  readonly statsData = signal<{ date: string; queries: number; avgResponseMs: number; totalResults: number; errors: number }[]>([]);
+  readonly statsData = signal<
+    { date: string; queries: number; avgResponseMs: number; totalResults: number; errors: number }[]
+  >([]);
   readonly statsProviderName = signal('');
 
   // Machine-translation — a list of admin-configured providers plus the global
@@ -280,8 +302,7 @@ export class SubtitleProvidersSettingsComponent implements OnInit {
         ok: res.ok,
         message: res.ok
           ? this.translate.instant('settings.subtitle_providers.test_success')
-          : res.error ||
-            this.translate.instant('settings.subtitle_providers.test_failed'),
+          : res.error || this.translate.instant('settings.subtitle_providers.test_failed'),
       });
     } catch {
       this.trTestResult.set({
@@ -306,9 +327,7 @@ export class SubtitleProvidersSettingsComponent implements OnInit {
     this.trSaving.set(true);
     const id = this.trEditingId();
     try {
-      await (id == null
-        ? this.translationApi.create(body)
-        : this.translationApi.update(id, body));
+      await (id == null ? this.translationApi.create(body) : this.translationApi.update(id, body));
       this.closeTranslationEditor();
       await this.reloadTranslationProviders();
     } catch {
@@ -319,10 +338,9 @@ export class SubtitleProvidersSettingsComponent implements OnInit {
   }
 
   async deleteTranslationProvider(row: TranslationProviderRow) {
-    const msg = this.translate.instant(
-      'settings.subtitle_providers.confirm_delete',
-      { name: row.name },
-    );
+    const msg = this.translate.instant('settings.subtitle_providers.confirm_delete', {
+      name: row.name,
+    });
     if (
       !(await this.confirmation.confirm({
         title: this.translate.instant('common.confirm'),
@@ -350,9 +368,15 @@ export class SubtitleProvidersSettingsComponent implements OnInit {
     try {
       this.statsData.set(
         await firstValueFrom(
-          this.http.get<{ date: string; queries: number; avgResponseMs: number; totalResults: number; errors: number }[]>(
-            `/api/subtitles/providers/${row.id}/stats`,
-          ),
+          this.http.get<
+            {
+              date: string;
+              queries: number;
+              avgResponseMs: number;
+              totalResults: number;
+              errors: number;
+            }[]
+          >(`/api/subtitles/providers/${row.id}/stats`),
         ),
       );
     } finally {
@@ -392,10 +416,13 @@ export class SubtitleProvidersSettingsComponent implements OnInit {
   readonly testConnection = async (draft: ProviderDraft): Promise<ProviderTestResult> => {
     try {
       const { ok, detail } = await firstValueFrom(
-        this.http.post<{ ok: boolean; detail?: string }>('/api/subtitles/providers/test-connection', {
-          type: draft.implementation,
-          settings: this.trimSettings(draft.settings),
-        }),
+        this.http.post<{ ok: boolean; detail?: string }>(
+          '/api/subtitles/providers/test-connection',
+          {
+            type: draft.implementation,
+            settings: this.trimSettings(draft.settings),
+          },
+        ),
       );
       const verdict = this.translate.instant(
         ok ? 'settings.subtitle_providers.test_success' : 'settings.subtitle_providers.test_failed',
@@ -403,7 +430,10 @@ export class SubtitleProvidersSettingsComponent implements OnInit {
       // `detail` is the provider's own reason (HTTP status, missing credential) — kept verbatim.
       return { ok, message: detail ? `${verdict} — ${detail}` : verdict };
     } catch {
-      return { ok: false, message: this.translate.instant('settings.subtitle_providers.test_network_error') };
+      return {
+        ok: false,
+        message: this.translate.instant('settings.subtitle_providers.test_network_error'),
+      };
     }
   };
 

--- a/client/src/app/features/settings/users/users.html
+++ b/client/src/app/features/settings/users/users.html
@@ -30,9 +30,13 @@
           @for (user of rows(); track user.id) {
             <tr>
               <td class="font-medium">
-                <a [routerLink]="['/admin/users', user.id]" class="link link-hover">{{ user.username }}</a>
+                <a [routerLink]="['/admin/users', user.id]" class="link link-hover">{{
+                  user.username
+                }}</a>
                 @if (auth.user()?.id === user.id) {
-                  <span class="badge badge-primary badge-sm ml-2">{{ 'settings.users.you' | translate }}</span>
+                  <span class="badge badge-primary badge-sm ml-2">{{
+                    'settings.users.you' | translate
+                  }}</span>
                 }
               </td>
               <td>
@@ -40,9 +44,13 @@
               </td>
               <td>
                 @if (user.enabled) {
-                  <span class="badge badge-success badge-sm">{{ 'common.active' | translate }}</span>
+                  <span class="badge badge-success badge-sm">{{
+                    'common.active' | translate
+                  }}</span>
                 } @else {
-                  <span class="badge badge-ghost badge-sm">{{ 'common.disabled' | translate }}</span>
+                  <span class="badge badge-ghost badge-sm">{{
+                    'common.disabled' | translate
+                  }}</span>
                 }
               </td>
               <td class="text-base-content/70 text-sm">
@@ -61,113 +69,104 @@
 </div>
 
 <dialog #editorDialog class="modal">
-    <div class="modal-box max-w-md max-h-[92vh] flex flex-col p-0 gap-0 overflow-hidden">
-      <div class="px-5 sm:px-6 pt-4 pb-3 border-b border-base-200 flex justify-between items-center shrink-0 bg-base-100">
-        <h2 class="text-lg font-bold">{{ 'settings.users.editor_create' | translate }}</h2>
-        <button
-          type="button"
-          class="btn btn-sm btn-ghost btn-circle"
-          (click)="closeEditor()"
-          [attr.aria-label]="'common.close' | translate"
+  <div class="modal-box max-w-md max-h-[92vh] flex flex-col p-0 gap-0 overflow-hidden">
+    <app-modal-header flush [title]="'settings.users.editor_create' | translate" />
+
+    <div class="px-5 sm:px-6 py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 bg-base-100">
+      <label class="form-control w-full">
+        <span class="label-text">{{ 'settings.users.field_username' | translate }}</span>
+        <input
+          type="text"
+          class="input input-bordered input-sm w-full"
+          [ngModel]="formUsername()"
+          (ngModelChange)="formUsername.set($event)"
+        />
+      </label>
+
+      <label class="form-control w-full">
+        <span class="label-text">{{ 'settings.users.field_email' | translate }}</span>
+        <input
+          type="email"
+          class="input input-bordered input-sm w-full"
+          [ngModel]="formEmail()"
+          (ngModelChange)="formEmail.set($event)"
+          placeholder="email@example.com"
+        />
+      </label>
+
+      <label class="form-control w-full">
+        <span class="label-text">{{ 'settings.users.field_password' | translate }}</span>
+        <input
+          type="password"
+          class="input input-bordered input-sm w-full"
+          [ngModel]="formPassword()"
+          (ngModelChange)="formPassword.set($event)"
+          placeholder="••••••••"
+        />
+      </label>
+
+      <label class="form-control w-full">
+        <span class="label-text">{{ 'settings.users.field_role' | translate }}</span>
+        <select
+          class="select select-bordered select-sm w-full"
+          [ngModel]="formRoleId()"
+          (ngModelChange)="formRoleId.set($event)"
         >
-          <svg lucideX class="h-5 w-5"></svg>
-        </button>
-      </div>
+          @for (role of roles(); track role.id) {
+            <option [ngValue]="role.id">{{ role.name }}</option>
+          }
+        </select>
+      </label>
 
-      <div class="px-5 sm:px-6 py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 bg-base-100">
-        <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.users.field_username' | translate }}</span>
-          <input
-            type="text"
-            class="input input-bordered input-sm w-full"
-            [ngModel]="formUsername()"
-            (ngModelChange)="formUsername.set($event)"
-          />
-        </label>
+      <label class="label cursor-pointer justify-start gap-3">
+        <input
+          type="checkbox"
+          class="toggle toggle-sm"
+          [ngModel]="formEnabled()"
+          (ngModelChange)="formEnabled.set($event)"
+        />
+        <span class="label-text">{{ 'settings.users.field_enabled' | translate }}</span>
+      </label>
 
-        <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.users.field_email' | translate }}</span>
-          <input
-            type="email"
-            class="input input-bordered input-sm w-full"
-            [ngModel]="formEmail()"
-            (ngModelChange)="formEmail.set($event)"
-            placeholder="email@example.com"
-          />
-        </label>
-
-        <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.users.field_password' | translate }}</span>
-          <input
-            type="password"
-            class="input input-bordered input-sm w-full"
-            [ngModel]="formPassword()"
-            (ngModelChange)="formPassword.set($event)"
-            placeholder="••••••••"
-          />
-        </label>
-
-        <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.users.field_role' | translate }}</span>
-          <select
-            class="select select-bordered select-sm w-full"
-            [ngModel]="formRoleId()"
-            (ngModelChange)="formRoleId.set($event)"
-          >
-            @for (role of roles(); track role.id) {
-              <option [ngValue]="role.id">{{ role.name }}</option>
+      <div>
+        <p class="label-text mb-2">{{ 'settings.users.field_libraries' | translate }}</p>
+        @if (libraries().length === 0) {
+          <p class="text-xs text-base-content/50">
+            {{ 'settings.users.no_libraries' | translate }}
+          </p>
+        } @else {
+          <div class="flex flex-col gap-1">
+            @for (lib of libraries(); track lib.id) {
+              <label class="label cursor-pointer justify-start gap-2 py-1">
+                <input
+                  type="checkbox"
+                  class="checkbox checkbox-xs"
+                  [ngModel]="formLibraryIds().has(lib.id)"
+                  (ngModelChange)="toggleLibrary(lib.id)"
+                />
+                <span class="label-text text-sm">{{ lib.name }}</span>
+              </label>
             }
-          </select>
-        </label>
-
-        <label class="label cursor-pointer justify-start gap-3">
-          <input
-            type="checkbox"
-            class="toggle toggle-sm"
-            [ngModel]="formEnabled()"
-            (ngModelChange)="formEnabled.set($event)"
-          />
-          <span class="label-text">{{ 'settings.users.field_enabled' | translate }}</span>
-        </label>
-
-        <div>
-          <p class="label-text mb-2">{{ 'settings.users.field_libraries' | translate }}</p>
-          @if (libraries().length === 0) {
-            <p class="text-xs text-base-content/50">{{ 'settings.users.no_libraries' | translate }}</p>
-          } @else {
-            <div class="flex flex-col gap-1">
-              @for (lib of libraries(); track lib.id) {
-                <label class="label cursor-pointer justify-start gap-2 py-1">
-                  <input
-                    type="checkbox"
-                    class="checkbox checkbox-xs"
-                    [ngModel]="formLibraryIds().has(lib.id)"
-                    (ngModelChange)="toggleLibrary(lib.id)"
-                  />
-                  <span class="label-text text-sm">{{ lib.name }}</span>
-                </label>
-              }
-            </div>
-          }
-        </div>
-
-      </div>
-
-      <div class="modal-action modal-action-sticky">
-        <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
-          {{ 'settings.users.cancel' | translate }}
-        </button>
-        <button type="button" class="btn btn-primary" (click)="save()" [disabled]="saving()">
-          @if (saving()) {
-            <span class="loading loading-spinner loading-sm"></span>
-          }
-          {{ 'settings.users.save' | translate }}
-        </button>
+          </div>
+        }
       </div>
     </div>
-    <form method="dialog" class="modal-backdrop">
-      <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">
-        {{ 'common.close' | translate }}
+
+    <app-modal-footer flush>
+      <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
+        {{ 'settings.users.cancel' | translate }}
       </button>
-    </form>
-  </dialog>
+      <button type="button" class="btn btn-primary" (click)="save()" [disabled]="saving()">
+        @if (saving()) {
+          <span class="loading loading-spinner loading-sm"></span>
+        }
+        {{ 'settings.users.save' | translate }}
+      </button>
+    </app-modal-footer>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">
+      {{ 'common.close' | translate }}
+    </button>
+  </form>
+</dialog>

--- a/client/src/app/features/settings/users/users.html
+++ b/client/src/app/features/settings/users/users.html
@@ -153,7 +153,7 @@
 
       </div>
 
-      <div class="modal-action shrink-0 px-5 sm:px-6 pb-4 pt-2 border-t border-base-200 bg-base-100">
+      <div class="modal-action modal-action-sticky">
         <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
           {{ 'settings.users.cancel' | translate }}
         </button>

--- a/client/src/app/features/settings/users/users.ts
+++ b/client/src/app/features/settings/users/users.ts
@@ -21,10 +21,12 @@ import { LibrariesApiService, Library } from '../../../core/services/api/librari
 import { AuthService } from '../../../core/services/auth.service';
 import { ToastService } from '../../../core/services/toast.service';
 import { formatRelativeTime } from '../../../core/utils/relative-time';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-users-settings',
-  imports: [FormsModule, LucideX, RouterLink, TranslateModule],
+  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, RouterLink, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './users.html',
 })
@@ -127,5 +129,4 @@ export class UsersSettingsComponent implements OnInit {
       this.saving.set(false);
     }
   }
-
 }

--- a/client/src/app/features/system/streams/streams.html
+++ b/client/src/app/features/system/streams/streams.html
@@ -169,12 +169,12 @@
         (ngModelChange)="messageText.set($event)"
       ></textarea>
       <div class="modal-action mt-2">
-        <button type="button" class="btn btn-ghost btn-sm" (click)="closeMessage()">
+        <button type="button" class="btn btn-ghost" (click)="closeMessage()">
           {{ 'common.cancel' | translate }}
         </button>
         <button
           type="button"
-          class="btn btn-primary btn-sm"
+          class="btn btn-primary"
           [disabled]="messageBusy() || !messageText().trim()"
           (click)="sendMessage()"
         >

--- a/client/src/app/features/system/streams/streams.html
+++ b/client/src/app/features/system/streams/streams.html
@@ -4,162 +4,244 @@
     <p class="text-sm text-base-content/60 mt-1">{{ 'system.streams_subtitle' | translate }}</p>
   </div>
 
-@if (loading()) {
-  <div class="flex justify-center py-12">
-    <span class="loading loading-spinner loading-lg"></span>
-  </div>
-} @else if (streams().length === 0) {
-  <div class="text-center text-base-content/50 py-12">
-    {{ 'system.streams_empty' | translate }}
-  </div>
-} @else {
-  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4">
-    @for (s of streams(); track s.sessionId) {
-      <div class="card bg-base-100 shadow-sm overflow-hidden">
-        <!-- Header: poster + title + time -->
-        <div class="flex gap-3 p-3 pb-0">
-          @if (s.posterUrl) {
-            <img [src]="s.posterUrl | resolveUrl:'thumb'" class="w-14 h-20 rounded object-cover shrink-0" alt="" />
-          } @else {
-            <div class="w-14 h-20 rounded bg-base-300 shrink-0"></div>
+  @if (loading()) {
+    <div class="flex justify-center py-12">
+      <span class="loading loading-spinner loading-lg"></span>
+    </div>
+  } @else if (streams().length === 0) {
+    <div class="text-center text-base-content/50 py-12">
+      {{ 'system.streams_empty' | translate }}
+    </div>
+  } @else {
+    <div
+      class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4"
+    >
+      @for (s of streams(); track s.sessionId) {
+        <div class="card bg-base-100 shadow-sm overflow-hidden">
+          <!-- Header: poster + title + time -->
+          <div class="flex gap-3 p-3 pb-0">
+            @if (s.posterUrl) {
+              <img
+                [src]="s.posterUrl | resolveUrl: 'thumb'"
+                class="w-14 h-20 rounded object-cover shrink-0"
+                alt=""
+              />
+            } @else {
+              <div class="w-14 h-20 rounded bg-base-300 shrink-0"></div>
+            }
+            <div class="flex-1 min-w-0 py-0.5">
+              <a
+                [routerLink]="mediaLink(s)"
+                class="font-bold text-sm leading-tight truncate block hover:underline"
+                >{{ s.mediaTitle }}</a
+              >
+              @if (s.episodeLabel) {
+                <a
+                  [routerLink]="s.episodeId ? episodeLink(s) : mediaLink(s)"
+                  class="text-xs text-base-content/60 truncate block mt-0.5 hover:underline"
+                  >{{ s.episodeLabel }}</a
+                >
+              }
+              <div class="text-xs text-base-content/50 tabular-nums mt-1">
+                {{ formatTime(s.positionSeconds) }} / {{ formatTime(s.durationSeconds) }}
+              </div>
+            </div>
+          </div>
+
+          <!-- Progress bar (Emby style: red progress + green transcode buffer) -->
+          @if (s.durationSeconds > 0) {
+            <div class="relative w-full h-1.5 bg-base-300 mt-2">
+              <!-- Transcode buffer (red, behind progress) -->
+              @if (s.transcodePercent != null) {
+                <div
+                  class="absolute inset-y-0 left-0 bg-error/60"
+                  [style.width.%]="s.transcodePercent"
+                ></div>
+              }
+              <!-- Playback progress (green) -->
+              <div
+                class="absolute inset-y-0 left-0 bg-success"
+                [style.width.%]="(s.positionSeconds / s.durationSeconds) * 100"
+              ></div>
+            </div>
           }
-          <div class="flex-1 min-w-0 py-0.5">
-            <a [routerLink]="mediaLink(s)" class="font-bold text-sm leading-tight truncate block hover:underline">{{ s.mediaTitle }}</a>
-            @if (s.episodeLabel) {
-              <a [routerLink]="s.episodeId ? episodeLink(s) : mediaLink(s)" class="text-xs text-base-content/60 truncate block mt-0.5 hover:underline">{{ s.episodeLabel }}</a>
-            }
-            <div class="text-xs text-base-content/50 tabular-nums mt-1">
-              {{ formatTime(s.positionSeconds) }} / {{ formatTime(s.durationSeconds) }}
-            </div>
-          </div>
-        </div>
 
-        <!-- Progress bar (Emby style: red progress + green transcode buffer) -->
-        @if (s.durationSeconds > 0) {
-          <div class="relative w-full h-1.5 bg-base-300 mt-2">
-            <!-- Transcode buffer (red, behind progress) -->
-            @if (s.transcodePercent != null) {
-              <div class="absolute inset-y-0 left-0 bg-error/60" [style.width.%]="s.transcodePercent"></div>
-            }
-            <!-- Playback progress (green) -->
-            <div class="absolute inset-y-0 left-0 bg-success" [style.width.%]="(s.positionSeconds / s.durationSeconds) * 100"></div>
-          </div>
-        }
+          <div class="divider my-0 mx-3"></div>
 
-        <div class="divider my-0 mx-3"></div>
-
-        <!-- Stream details -->
-        <div class="px-3 py-2 space-y-1.5 text-xs">
-          <div class="flex gap-2">
-            <span class="text-base-content/40 w-10 shrink-0">{{ 'system.streams_label_stream' | translate }}</span>
-            <div>
-              <span class="font-medium">{{ (s.container ?? '?') | uppercase }}</span>
-              @if (s.videoBitrate) { ({{ formatBitrate(s.videoBitrate) }}) }
-              @if (s.mode === 'directplay') {
-                <div class="text-base-content/50">&rarr; {{ 'system.streams_container_direct' | translate }}</div>
-              } @else if (s.outputContainer) {
-                <div class="text-base-content/50">&rarr; {{ s.outputContainer }}
-                  @if (s.outputBitrate) { ({{ formatBitrate(s.outputBitrate) }}) }
-                </div>
-              }
-              @for (r of s.containerReasons; track r) {
-                <div class="text-warning/80 italic">{{ r }}</div>
-              }
-            </div>
-          </div>
-          <div class="flex gap-2">
-            <span class="text-base-content/40 w-10 shrink-0">{{ 'system.streams_label_video' | translate }}</span>
-            <div>
-              <span class="font-medium">{{ s.videoResolution ?? '?' }} {{ s.videoCodec ?? '?' }}</span>
-              <div class="text-base-content/50">&rarr;
-                @switch (s.mode) {
-                  @case ('transcode') {
-                    {{ 'system.streams_video_transcode' | translate:{ hw: hwLabel(s.hwAccel) } }}
-                  }
-                  @default {
-                    {{ 'system.streams_video_direct' | translate }}
-                  }
+          <!-- Stream details -->
+          <div class="px-3 py-2 space-y-1.5 text-xs">
+            <div class="flex gap-2">
+              <span class="text-base-content/40 w-10 shrink-0">{{
+                'system.streams_label_stream' | translate
+              }}</span>
+              <div>
+                <span class="font-medium">{{ s.container ?? '?' | uppercase }}</span>
+                @if (s.videoBitrate) {
+                  ({{ formatBitrate(s.videoBitrate) }})
+                }
+                @if (s.mode === 'directplay') {
+                  <div class="text-base-content/50">
+                    &rarr; {{ 'system.streams_container_direct' | translate }}
+                  </div>
+                } @else if (s.outputContainer) {
+                  <div class="text-base-content/50">
+                    &rarr; {{ s.outputContainer }}
+                    @if (s.outputBitrate) {
+                      ({{ formatBitrate(s.outputBitrate) }})
+                    }
+                  </div>
+                }
+                @for (r of s.containerReasons; track r) {
+                  <div class="text-warning/80 italic">{{ r }}</div>
                 }
               </div>
-              @for (r of s.videoReasons; track r) {
-                <div class="text-warning/80 italic">{{ r }}</div>
-              }
             </div>
-          </div>
-          <div class="flex gap-2">
-            <span class="text-base-content/40 w-10 shrink-0">{{ 'system.streams_label_audio' | translate }}</span>
-            <div>
-              <span class="font-medium">
-                @if (s.audioLanguage) { {{ s.audioLanguage }} }
-                {{ s.audioCodec ?? '?' }}
-                @if (s.audioChannels) { {{ s.audioChannels }} }
-              </span>
-              <div class="text-base-content/50">
-                &rarr;
-                @switch (s.audioMode) {
-                  @case ('direct') {
-                    {{ 'system.streams_audio_direct' | translate }}
-                  }
-                  @case ('copy') {
-                    {{ 'system.streams_audio_copy' | translate:{ codec: (s.audioCodec ?? '?').toUpperCase() } }}
-                  }
-                  @case ('transcode') {
-                    @if (s.audioOutputBitrateBps) {
-                      {{ 'system.streams_audio_transcode_with_bitrate' | translate:{ codec: (s.audioOutputCodec ?? 'aac').toUpperCase(), kbps: (s.audioOutputBitrateBps / 1000) } }}
-                    } @else {
-                      {{ 'system.streams_audio_transcode' | translate:{ codec: (s.audioOutputCodec ?? 'aac').toUpperCase() } }}
+            <div class="flex gap-2">
+              <span class="text-base-content/40 w-10 shrink-0">{{
+                'system.streams_label_video' | translate
+              }}</span>
+              <div>
+                <span class="font-medium"
+                  >{{ s.videoResolution ?? '?' }} {{ s.videoCodec ?? '?' }}</span
+                >
+                <div class="text-base-content/50">
+                  &rarr;
+                  @switch (s.mode) {
+                    @case ('transcode') {
+                      {{ 'system.streams_video_transcode' | translate: { hw: hwLabel(s.hwAccel) } }}
+                    }
+                    @default {
+                      {{ 'system.streams_video_direct' | translate }}
                     }
                   }
+                </div>
+                @for (r of s.videoReasons; track r) {
+                  <div class="text-warning/80 italic">{{ r }}</div>
                 }
               </div>
-              @for (r of s.audioReasons; track r) {
-                <div class="text-warning/80 italic">{{ r }}</div>
-              }
+            </div>
+            <div class="flex gap-2">
+              <span class="text-base-content/40 w-10 shrink-0">{{
+                'system.streams_label_audio' | translate
+              }}</span>
+              <div>
+                <span class="font-medium">
+                  @if (s.audioLanguage) {
+                    {{ s.audioLanguage }}
+                  }
+                  {{ s.audioCodec ?? '?' }}
+                  @if (s.audioChannels) {
+                    {{ s.audioChannels }}
+                  }
+                </span>
+                <div class="text-base-content/50">
+                  &rarr;
+                  @switch (s.audioMode) {
+                    @case ('direct') {
+                      {{ 'system.streams_audio_direct' | translate }}
+                    }
+                    @case ('copy') {
+                      {{
+                        'system.streams_audio_copy'
+                          | translate: { codec: (s.audioCodec ?? '?').toUpperCase() }
+                      }}
+                    }
+                    @case ('transcode') {
+                      @if (s.audioOutputBitrateBps) {
+                        {{
+                          'system.streams_audio_transcode_with_bitrate'
+                            | translate
+                              : {
+                                  codec: (s.audioOutputCodec ?? 'aac').toUpperCase(),
+                                  kbps: s.audioOutputBitrateBps / 1000,
+                                }
+                        }}
+                      } @else {
+                        {{
+                          'system.streams_audio_transcode'
+                            | translate: { codec: (s.audioOutputCodec ?? 'aac').toUpperCase() }
+                        }}
+                      }
+                    }
+                  }
+                </div>
+                @for (r of s.audioReasons; track r) {
+                  <div class="text-warning/80 italic">{{ r }}</div>
+                }
+              </div>
             </div>
           </div>
-        </div>
 
-        <div class="divider my-0 mx-3"></div>
+          <div class="divider my-0 mx-3"></div>
 
-        <!-- User + device -->
-        <div class="text-center text-xs text-base-content/60 py-1.5">
-          {{ s.username ?? '—' }}
-          @if (formatDevice(s.device, s.systemName); as deviceLabel) {
-            <div class="text-base-content/40">
-              {{ deviceLabel }}@if (s.appVersion) {<span class="opacity-70"> · {{ 'system.device_client_version' | translate:{ version: s.appVersion } }}</span>}
-            </div>
-          }
-        </div>
-
-        <!-- Controls (centered, Emby style) -->
-        <div class="flex items-center justify-center gap-3 pb-3">
-          <button class="btn btn-ghost btn-sm btn-square" (click)="togglePause(s)" [title]="(isPaused(s.sessionId) ? 'system.stream_resume' : 'system.stream_pause') | translate">
-            @if (isPaused(s.sessionId)) {
-              <svg lucidePlay class="h-4 w-4"></svg>
-            } @else {
-              <svg lucidePause class="h-4 w-4"></svg>
+          <!-- User + device -->
+          <div class="text-center text-xs text-base-content/60 py-1.5">
+            {{ s.username ?? '—' }}
+            @if (formatDevice(s.device, s.systemName); as deviceLabel) {
+              <div class="text-base-content/40">
+                {{ deviceLabel }}
+                @if (s.appVersion) {
+                  <span class="opacity-70">
+                    ·
+                    {{
+                      'system.device_client_version' | translate: { version: s.appVersion }
+                    }}</span
+                  >
+                }
+              </div>
             }
-          </button>
-          <button class="btn btn-ghost btn-sm btn-square" (click)="openMessage(s)" [title]="'system.stream_message_btn' | translate">
-            <svg lucideMessageSquare class="h-4 w-4"></svg>
-          </button>
-          <button class="btn btn-ghost btn-sm btn-square" (click)="confirmStop(s)" [title]="'system.stream_stop' | translate">
-            <svg lucideSquare class="h-4 w-4"></svg>
-          </button>
+          </div>
+
+          <!-- Controls (centered, Emby style) -->
+          <div class="flex items-center justify-center gap-3 pb-3">
+            <button
+              class="btn btn-ghost btn-sm btn-square"
+              (click)="togglePause(s)"
+              [title]="
+                (isPaused(s.sessionId) ? 'system.stream_resume' : 'system.stream_pause') | translate
+              "
+            >
+              @if (isPaused(s.sessionId)) {
+                <svg lucidePlay class="h-4 w-4"></svg>
+              } @else {
+                <svg lucidePause class="h-4 w-4"></svg>
+              }
+            </button>
+            <button
+              class="btn btn-ghost btn-sm btn-square"
+              (click)="openMessage(s)"
+              [title]="'system.stream_message_btn' | translate"
+            >
+              <svg lucideMessageSquare class="h-4 w-4"></svg>
+            </button>
+            <button
+              class="btn btn-ghost btn-sm btn-square"
+              (click)="confirmStop(s)"
+              [title]="'system.stream_stop' | translate"
+            >
+              <svg lucideSquare class="h-4 w-4"></svg>
+            </button>
+          </div>
         </div>
-      </div>
-    }
-  </div>
-}
+      }
+    </div>
+  }
 </div>
 
 @if (messageTarget(); as target) {
   <div class="modal modal-open">
     <div class="modal-box max-w-md">
-      <h2 class="text-lg font-semibold">{{ 'system.stream_message_title' | translate }}</h2>
-      <p class="text-sm text-base-content/60 mt-1">
-        {{ 'system.stream_message_subtitle' | translate:{ user: target.username ?? '—', title: target.mediaTitle } }}
-      </p>
+      <app-modal-header (closed)="closeMessage()">
+        <div class="min-w-0">
+          <h3 class="text-lg font-bold">{{ 'system.stream_message_title' | translate }}</h3>
+          <p class="text-sm text-base-content/60 mt-1">
+            {{
+              'system.stream_message_subtitle'
+                | translate: { user: target.username ?? '—', title: target.mediaTitle }
+            }}
+          </p>
+        </div>
+      </app-modal-header>
       <textarea
         class="textarea textarea-bordered w-full mt-3"
         rows="3"
@@ -168,7 +250,7 @@
         [ngModel]="messageText()"
         (ngModelChange)="messageText.set($event)"
       ></textarea>
-      <div class="modal-action mt-2">
+      <app-modal-footer>
         <button type="button" class="btn btn-ghost" (click)="closeMessage()">
           {{ 'common.cancel' | translate }}
         </button>
@@ -180,9 +262,8 @@
         >
           {{ 'system.stream_message_send' | translate }}
         </button>
-      </div>
+      </app-modal-footer>
     </div>
     <div class="modal-backdrop" (click)="closeMessage()"></div>
   </div>
 }
-

--- a/client/src/app/features/system/streams/streams.ts
+++ b/client/src/app/features/system/streams/streams.ts
@@ -16,10 +16,24 @@ import { ToastService } from '../../../core/services/toast.service';
 import { LucideMessageSquare, LucidePause, LucidePlay, LucideSquare } from '@lucide/angular';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import { parseDeviceLabel } from '../../../core/utils/format-device-label';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 
 @Component({
   selector: 'app-system-streams',
-  imports: [UpperCasePipe, RouterLink, TranslateModule, FormsModule, ResolveUrlPipe, LucideMessageSquare, LucidePause, LucidePlay, LucideSquare],
+  imports: [
+    ModalHeaderComponent,
+    ModalFooterComponent,
+    UpperCasePipe,
+    RouterLink,
+    TranslateModule,
+    FormsModule,
+    ResolveUrlPipe,
+    LucideMessageSquare,
+    LucidePause,
+    LucidePlay,
+    LucideSquare,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './streams.html',
 })
@@ -63,9 +77,12 @@ export class SystemStreamsComponent implements OnInit, OnDestroy {
     try {
       await this.streamsApi.sendCommand(stream.sessionId, isPaused ? 'play' : 'pause');
       const next = new Set(paused);
-      if (isPaused) next.delete(stream.sessionId); else next.add(stream.sessionId);
+      if (isPaused) next.delete(stream.sessionId);
+      else next.add(stream.sessionId);
       this.pausedSessions.set(next);
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
   isPaused(sessionId: string): boolean {
@@ -103,9 +120,7 @@ export class SystemStreamsComponent implements OnInit, OnDestroy {
     const confirmed = await this.confirmation.confirm({
       title: this.translate.instant('system.stream_stop'),
       message: this.translate.instant(
-        stream.username
-          ? 'system.stream_stop_confirm_user'
-          : 'system.stream_stop_confirm',
+        stream.username ? 'system.stream_stop_confirm_user' : 'system.stream_stop_confirm',
         { title: stream.mediaTitle, user: stream.username },
       ),
       confirmLabel: this.translate.instant('system.stream_stop_action'),
@@ -115,7 +130,9 @@ export class SystemStreamsComponent implements OnInit, OnDestroy {
     try {
       await this.streamsApi.sendCommand(stream.sessionId, 'stop');
       this.streams.update((s) => s.filter((x) => x.sessionId !== stream.sessionId));
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
   formatTime(seconds: number): string {

--- a/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.html
+++ b/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.html
@@ -1,7 +1,11 @@
 <dialog #dialog class="modal">
   <div class="modal-box max-w-lg">
-    <h2 class="text-lg font-bold text-primary">{{ 'discover.add_to_library' | translate }}</h2>
-    <p class="text-base-content/80">{{ title() }}</p>
+    <app-modal-header>
+      <div>
+        <h3 class="text-lg font-bold text-primary">{{ 'discover.add_to_library' | translate }}</h3>
+        <p class="text-base-content/80">{{ title() }}</p>
+      </div>
+    </app-modal-header>
 
     @if (error()) {
       <div role="alert" class="alert alert-error text-sm mt-4 py-2">{{ error() }}</div>

--- a/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.html
+++ b/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.html
@@ -19,7 +19,9 @@
       <div class="mt-6 flex flex-col gap-3">
         @if (qualityProfiles().length) {
           <label class="form-control w-full">
-            <span class="label-text text-base-content/60">{{ 'discover.quality_profile' | translate }}</span>
+            <span class="label-text text-base-content/60">{{
+              'discover.quality_profile' | translate
+            }}</span>
             <select
               class="select select-bordered select-sm w-full"
               [ngModel]="selectedQualityProfileId()"
@@ -33,7 +35,9 @@
         }
         @if (languageProfiles().length) {
           <label class="form-control w-full">
-            <span class="label-text text-base-content/60">{{ 'discover.language_profile' | translate }}</span>
+            <span class="label-text text-base-content/60">{{
+              'discover.language_profile' | translate
+            }}</span>
             <select
               class="select select-bordered select-sm w-full"
               [ngModel]="selectedLanguageProfileId()"
@@ -47,7 +51,9 @@
         }
         @if (compatibleLibraries().length > 1) {
           <label class="form-control w-full">
-            <span class="label-text text-base-content/60">{{ 'settings.libraries.title' | translate }}</span>
+            <span class="label-text text-base-content/60">{{
+              'settings.libraries.title' | translate
+            }}</span>
             <select
               class="select select-bordered select-sm w-full"
               [ngModel]="selectedLibraryId()"
@@ -62,7 +68,7 @@
       </div>
     }
 
-    <div class="modal-action">
+    <app-modal-footer>
       <button type="button" class="btn btn-ghost" (click)="close()">
         {{ 'common.cancel' | translate }}
       </button>
@@ -77,7 +83,7 @@
         }
         {{ 'discover.add_to_library' | translate }}
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
     <button type="button" (click)="close()">close</button>

--- a/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.ts
+++ b/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.ts
@@ -18,10 +18,12 @@ import { LibrariesApiService, Library } from '../../../../core/services/api/libr
 import { SettingsApiService } from '../../../../core/services/api/settings-api.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { MediaType } from '../../../../core/enums/media-type.enum';
+import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
 
 @Component({
   selector: 'app-import-modal',
-  imports: [FormsModule, TranslateModule],
+  imports: [
+    ModalHeaderComponent,FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './import-modal.component.html',
 })

--- a/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.ts
+++ b/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.ts
@@ -19,11 +19,11 @@ import { SettingsApiService } from '../../../../core/services/api/settings-api.s
 import { ToastService } from '../../../../core/services/toast.service';
 import { MediaType } from '../../../../core/enums/media-type.enum';
 import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-import-modal',
-  imports: [
-    ModalHeaderComponent,FormsModule, TranslateModule],
+  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './import-modal.component.html',
 })
@@ -60,7 +60,13 @@ export class ImportModalComponent {
     this.libraries().filter((l) => l.mediaTypes.includes(this.mediaType())),
   );
 
-  async open(params: { title: string; mediaType: MediaType; tmdbId: number; provider?: string; externalId?: string }) {
+  async open(params: {
+    title: string;
+    mediaType: MediaType;
+    tmdbId: number;
+    provider?: string;
+    externalId?: string;
+  }) {
     this.title.set(params.title);
     this.mediaType.set(params.mediaType);
     this.tmdbId.set(params.tmdbId);
@@ -123,7 +129,9 @@ export class ImportModalComponent {
     } catch (err: unknown) {
       const httpErr = err as { status?: number; error?: { message?: string } };
       if (httpErr?.status === 400) {
-        this.error.set(httpErr.error?.message ?? this.translate.instant('discover.tmdb_not_configured'));
+        this.error.set(
+          httpErr.error?.message ?? this.translate.instant('discover.tmdb_not_configured'),
+        );
       } else if (httpErr?.status === 403) {
         this.error.set(this.translate.instant('discover.forbidden'));
       } else {

--- a/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.html
+++ b/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.html
@@ -40,9 +40,11 @@
             <tbody>
               @for (s of seasons(); track s.seasonNumber) {
                 @let alreadyRequested = alreadyRequestedSeasons().has(s.seasonNumber);
-                <tr class="hover"
-                    [class.opacity-50]="!selectedSeasons().has(s.seasonNumber) && !alreadyRequested"
-                    [class.opacity-60]="alreadyRequested">
+                <tr
+                  class="hover"
+                  [class.opacity-50]="!selectedSeasons().has(s.seasonNumber) && !alreadyRequested"
+                  [class.opacity-60]="alreadyRequested"
+                >
                   <td>
                     <input
                       type="checkbox"
@@ -52,15 +54,23 @@
                       (change)="toggleSeason(s.seasonNumber)"
                     />
                   </td>
-                  <td class="font-medium">{{ 'discover.season_label' | translate }} {{ s.seasonNumber }}</td>
+                  <td class="font-medium">
+                    {{ 'discover.season_label' | translate }} {{ s.seasonNumber }}
+                  </td>
                   <td>{{ s.episodeCount }}</td>
                   <td>
                     @if (alreadyRequested) {
-                      <span class="badge badge-warning badge-sm">{{ 'discover.already_requested' | translate }}</span>
+                      <span class="badge badge-warning badge-sm">{{
+                        'discover.already_requested' | translate
+                      }}</span>
                     } @else if (selectedSeasons().has(s.seasonNumber)) {
-                      <span class="badge badge-primary badge-sm">{{ 'discover.status_selected' | translate }}</span>
+                      <span class="badge badge-primary badge-sm">{{
+                        'discover.status_selected' | translate
+                      }}</span>
                     } @else {
-                      <span class="badge badge-ghost badge-sm">{{ 'discover.status_not_requested' | translate }}</span>
+                      <span class="badge badge-ghost badge-sm">{{
+                        'discover.status_not_requested' | translate
+                      }}</span>
                     }
                   </td>
                 </tr>
@@ -71,13 +81,17 @@
       }
     }
 
-    @if (qualityProfiles().length || languageProfiles().length || compatibleLibraries().length > 1) {
+    @if (
+      qualityProfiles().length || languageProfiles().length || compatibleLibraries().length > 1
+    ) {
       <div class="mt-6">
         <h3 class="text-base font-semibold mb-3">{{ 'discover.advanced_options' | translate }}</h3>
         <div class="flex flex-col gap-3">
           @if (compatibleLibraries().length > 1) {
             <label class="form-control w-full">
-              <span class="label-text text-base-content/60">{{ 'settings.libraries.title' | translate }}</span>
+              <span class="label-text text-base-content/60">{{
+                'settings.libraries.title' | translate
+              }}</span>
               <select
                 class="select select-bordered select-sm w-full"
                 [ngModel]="libraryId()"
@@ -92,7 +106,9 @@
           }
           @if (qualityProfiles().length && !profilesLocked()) {
             <label class="form-control w-full">
-              <span class="label-text text-base-content/60">{{ 'discover.quality_profile' | translate }}</span>
+              <span class="label-text text-base-content/60">{{
+                'discover.quality_profile' | translate
+              }}</span>
               <select
                 class="select select-bordered select-sm w-full"
                 [ngModel]="qualityProfileId()"
@@ -106,7 +122,9 @@
           }
           @if (languageProfiles().length && !profilesLocked()) {
             <label class="form-control w-full">
-              <span class="label-text text-base-content/60">{{ 'discover.language_profile' | translate }}</span>
+              <span class="label-text text-base-content/60">{{
+                'discover.language_profile' | translate
+              }}</span>
               <select
                 class="select select-bordered select-sm w-full"
                 [ngModel]="languageProfileId()"
@@ -122,7 +140,7 @@
       </div>
     }
 
-    <div class="modal-action">
+    <app-modal-footer>
       <button type="button" class="btn btn-ghost" (click)="close()">
         {{ 'common.cancel' | translate }}
       </button>
@@ -141,7 +159,7 @@
           {{ 'discover.request' | translate }}
         }
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
     <button type="button" (click)="close()">close</button>

--- a/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.html
+++ b/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.html
@@ -1,13 +1,17 @@
 <dialog #dialog class="modal">
   <div class="modal-box max-w-2xl">
-    <h2 class="text-lg font-bold text-primary">
-      @if (mediaType() === 'series') {
-        {{ 'discover.request_series_title' | translate }}
-      } @else {
-        {{ 'discover.request_movie_title' | translate }}
-      }
-    </h2>
-    <p class="text-base-content/80">{{ title() }}</p>
+    <app-modal-header>
+      <div>
+        <h3 class="text-lg font-bold text-primary">
+          @if (mediaType() === 'series') {
+            {{ 'discover.request_series_title' | translate }}
+          } @else {
+            {{ 'discover.request_movie_title' | translate }}
+          }
+        </h3>
+        <p class="text-base-content/80">{{ title() }}</p>
+      </div>
+    </app-modal-header>
 
     @if (mediaType() === 'series') {
       @if (seasonsLoading()) {

--- a/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.ts
+++ b/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.ts
@@ -16,10 +16,12 @@ import { RequestsService } from '../../../../core/services/api/requests.service'
 import { LibrarySummary } from '../../../../core/services/api/libraries-api.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { MediaType } from '../../../../core/enums/media-type.enum';
+import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
 
 @Component({
   selector: 'app-request-modal',
-  imports: [FormsModule, TranslateModule],
+  imports: [
+    ModalHeaderComponent,FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './request-modal.component.html',
 })

--- a/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.ts
+++ b/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.ts
@@ -17,11 +17,11 @@ import { LibrarySummary } from '../../../../core/services/api/libraries-api.serv
 import { ToastService } from '../../../../core/services/toast.service';
 import { MediaType } from '../../../../core/enums/media-type.enum';
 import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-request-modal',
-  imports: [
-    ModalHeaderComponent,FormsModule, TranslateModule],
+  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './request-modal.component.html',
 })
@@ -82,14 +82,10 @@ export class RequestModalComponent {
     const locked = !!params.profilesLocked;
     this.profilesLocked.set(locked);
     this.qualityProfileId.set(
-      locked
-        ? (params.lockedQualityProfileId ?? null)
-        : (this.qualityProfiles()[0]?.id ?? null),
+      locked ? (params.lockedQualityProfileId ?? null) : (this.qualityProfiles()[0]?.id ?? null),
     );
     this.languageProfileId.set(
-      locked
-        ? (params.lockedLanguageProfileId ?? null)
-        : (this.languageProfiles()[0]?.id ?? null),
+      locked ? (params.lockedLanguageProfileId ?? null) : (this.languageProfiles()[0]?.id ?? null),
     );
     const compatible = this.libraries().filter((l) => l.mediaTypes.includes(params.mediaType));
     const defaultLib =
@@ -105,25 +101,27 @@ export class RequestModalComponent {
     if (params.mediaType === 'series') {
       this.seasonsLoading.set(true);
       const preselected = new Set(params.preselectedSeasons ?? []);
-      this.metadata.getTvSeasons(params.tmdbId).then((s) => {
-        this.seasons.set(s);
-        // Default empty unless the caller passed `preselectedSeasons`
-        // (e.g. the season-level Demander entry pre-fills the season
-        // it was clicked on). Already-requested rows are filtered out
-        // — they're disabled and can't be re-picked anyway.
-        const taken = this.alreadyRequestedSeasons();
-        this.selectedSeasons.set(
-          new Set(
-            s
-              .map((x) => x.seasonNumber)
-              .filter((n) => preselected.has(n) && !taken.has(n)),
-          ),
-        );
-      }).catch(() => {
-        this.seasons.set([]);
-      }).finally(() => {
-        this.seasonsLoading.set(false);
-      });
+      this.metadata
+        .getTvSeasons(params.tmdbId)
+        .then((s) => {
+          this.seasons.set(s);
+          // Default empty unless the caller passed `preselectedSeasons`
+          // (e.g. the season-level Demander entry pre-fills the season
+          // it was clicked on). Already-requested rows are filtered out
+          // — they're disabled and can't be re-picked anyway.
+          const taken = this.alreadyRequestedSeasons();
+          this.selectedSeasons.set(
+            new Set(
+              s.map((x) => x.seasonNumber).filter((n) => preselected.has(n) && !taken.has(n)),
+            ),
+          );
+        })
+        .catch(() => {
+          this.seasons.set([]);
+        })
+        .finally(() => {
+          this.seasonsLoading.set(false);
+        });
     }
   }
 

--- a/client/src/app/shared/components/add-to-playlist-modal/add-to-playlist-modal.component.html
+++ b/client/src/app/shared/components/add-to-playlist-modal/add-to-playlist-modal.component.html
@@ -11,11 +11,7 @@
         <ul class="menu bg-base-200 rounded-box w-full mb-4">
           @for (p of playlists(); track p.id) {
             <li>
-              <button
-                type="button"
-                [disabled]="busyId() !== null"
-                (click)="addTo(p)"
-              >
+              <button type="button" [disabled]="busyId() !== null" (click)="addTo(p)">
                 @if (busyId() === p.id) {
                   <span class="loading loading-spinner loading-xs"></span>
                 } @else {
@@ -56,11 +52,11 @@
         </button>
       </form>
 
-      <div class="modal-action">
+      <app-modal-footer>
         <button type="button" class="btn" (click)="close()">
           {{ 'common.close' | translate }}
         </button>
-      </div>
+      </app-modal-footer>
     }
   </div>
   <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>

--- a/client/src/app/shared/components/add-to-playlist-modal/add-to-playlist-modal.component.html
+++ b/client/src/app/shared/components/add-to-playlist-modal/add-to-playlist-modal.component.html
@@ -57,7 +57,7 @@
       </form>
 
       <div class="modal-action">
-        <button type="button" class="btn btn-sm" (click)="close()">
+        <button type="button" class="btn" (click)="close()">
           {{ 'common.close' | translate }}
         </button>
       </div>

--- a/client/src/app/shared/components/add-to-playlist-modal/add-to-playlist-modal.component.ts
+++ b/client/src/app/shared/components/add-to-playlist-modal/add-to-playlist-modal.component.ts
@@ -18,6 +18,7 @@ import {
 import { ToastService } from '../../../core/services/toast.service';
 import { AutoDownloadService } from '../../../core/services/auto-download.service';
 import { ModalHeaderComponent } from '../modal-header';
+import { ModalFooterComponent } from '../modal-footer';
 
 /**
  * Small dialog to add a media to an existing playlist or create a new one on
@@ -28,6 +29,7 @@ import { ModalHeaderComponent } from '../modal-header';
 @Component({
   selector: 'app-add-to-playlist-modal',
   imports: [
+    ModalFooterComponent,
     FormsModule,
     TranslateModule,
     LucideListPlus,
@@ -43,8 +45,7 @@ export class AddToPlaylistModalComponent {
   private readonly translate = inject(TranslateService);
   private readonly autoDownload = inject(AutoDownloadService);
 
-  private readonly dialogEl =
-    viewChild<ElementRef<HTMLDialogElement>>('dialog');
+  private readonly dialogEl = viewChild<ElementRef<HTMLDialogElement>>('dialog');
 
   readonly added = output<void>();
 
@@ -104,9 +105,7 @@ export class AddToPlaylistModalComponent {
     try {
       const created = await this.api.create({ name });
       await this.api.addItem(created.id, target);
-      this.toast.success(
-        this.translate.instant('playlists.created_and_added_toast'),
-      );
+      this.toast.success(this.translate.instant('playlists.created_and_added_toast'));
       this.added.emit();
       this.close();
     } catch {

--- a/client/src/app/shared/components/app-update-modal/app-update-modal.html
+++ b/client/src/app/shared/components/app-update-modal/app-update-modal.html
@@ -15,13 +15,16 @@
           {{ 'update.version_available' | translate: { version: info.version } }}
         }
         @if (info.releaseDate) {
-          · {{ info.releaseDate | localeDate:{ dateStyle: 'medium' } }}
+          · {{ info.releaseDate | localeDate: { dateStyle: 'medium' } }}
         }
       </p>
 
       <div class="rounded-box bg-base-200 p-3 max-h-72 overflow-y-auto mb-4">
         @if (info.releaseNotes) {
-          <div class="changelog-md text-sm break-words" [innerHTML]="info.releaseNotes | markdown"></div>
+          <div
+            class="changelog-md text-sm break-words"
+            [innerHTML]="info.releaseNotes | markdown"
+          ></div>
         } @else {
           <p class="text-sm opacity-60">{{ 'update.no_notes' | translate }}</p>
         }
@@ -29,7 +32,11 @@
 
       @if (downloading()) {
         <div class="mb-4">
-          <progress class="progress progress-primary w-full" [value]="update.progress()" max="100"></progress>
+          <progress
+            class="progress progress-primary w-full"
+            [value]="update.progress()"
+            max="100"
+          ></progress>
           <p class="text-xs opacity-70 mt-1 text-center">
             {{ 'update.downloading' | translate: { percent: update.progress() } }}
           </p>
@@ -38,7 +45,7 @@
         <p class="text-sm text-error mb-3">{{ 'update.error' | translate }}: {{ err }}</p>
       }
 
-      <div class="modal-action">
+      <app-modal-footer>
         <form method="dialog">
           <button class="btn btn-ghost">{{ 'common.close' | translate }}</button>
         </form>
@@ -59,7 +66,7 @@
             {{ 'update.open_release' | translate }}
           </button>
         }
-      </div>
+      </app-modal-footer>
     }
   </div>
   <form method="dialog" class="modal-backdrop">

--- a/client/src/app/shared/components/app-update-modal/app-update-modal.ts
+++ b/client/src/app/shared/components/app-update-modal/app-update-modal.ts
@@ -12,33 +12,84 @@ import { AppUpdateService } from '../../../core/services/app-update.service';
 import { MarkdownPipe } from '../../pipes/markdown.pipe';
 import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
 import { ModalHeaderComponent } from '../modal-header';
+import { ModalFooterComponent } from '../modal-footer';
 
 /** Changelog + install dialog for the topbar update button. Reads everything
  *  from AppUpdateService; the action adapts to the platform (in-app install on
  *  desktop, external release link on web/.deb). */
 @Component({
   selector: 'app-update-modal',
-  imports: [LocaleDatePipe, TranslateModule, MarkdownPipe, LucideDownload, LucideExternalLink, LucideRocket, ModalHeaderComponent],
+  imports: [
+    ModalFooterComponent,
+    LocaleDatePipe,
+    TranslateModule,
+    MarkdownPipe,
+    LucideDownload,
+    LucideExternalLink,
+    LucideRocket,
+    ModalHeaderComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './app-update-modal.html',
   styles: [
     `
       /* ::ng-deep — the changelog HTML is injected via [innerHTML], so it
          carries no encapsulation attribute and plain component styles miss it. */
-      :host ::ng-deep .changelog-md { line-height: 1.55; }
-      :host ::ng-deep .changelog-md > :first-child { margin-top: 0; }
+      :host ::ng-deep .changelog-md {
+        line-height: 1.55;
+      }
+      :host ::ng-deep .changelog-md > :first-child {
+        margin-top: 0;
+      }
       :host ::ng-deep .changelog-md h1,
-      :host ::ng-deep .changelog-md h2 { font-size: 1.1rem; font-weight: 700; margin: 1rem 0 0.45rem; }
-      :host ::ng-deep .changelog-md h3 { font-size: 0.95rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; opacity: 0.75; margin: 0.9rem 0 0.35rem; }
+      :host ::ng-deep .changelog-md h2 {
+        font-size: 1.1rem;
+        font-weight: 700;
+        margin: 1rem 0 0.45rem;
+      }
+      :host ::ng-deep .changelog-md h3 {
+        font-size: 0.95rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        opacity: 0.75;
+        margin: 0.9rem 0 0.35rem;
+      }
       :host ::ng-deep .changelog-md ul,
-      :host ::ng-deep .changelog-md ol { list-style: disc; padding-left: 1.4rem; margin: 0.4rem 0; }
-      :host ::ng-deep .changelog-md ol { list-style: decimal; }
-      :host ::ng-deep .changelog-md li { margin: 0.3rem 0; padding-left: 0.15rem; }
-      :host ::ng-deep .changelog-md li::marker { color: var(--color-primary); }
-      :host ::ng-deep .changelog-md p { margin: 0.5rem 0; }
-      :host ::ng-deep .changelog-md a { color: var(--color-primary); text-decoration: underline; }
-      :host ::ng-deep .changelog-md code { font-family: monospace; font-size: 0.85em; background: rgba(127, 127, 127, 0.18); padding: 0.05rem 0.3rem; border-radius: 0.25rem; }
-      :host ::ng-deep .changelog-md hr { margin: 0.75rem 0; border: 0; border-top: 1px solid rgba(127, 127, 127, 0.3); }
+      :host ::ng-deep .changelog-md ol {
+        list-style: disc;
+        padding-left: 1.4rem;
+        margin: 0.4rem 0;
+      }
+      :host ::ng-deep .changelog-md ol {
+        list-style: decimal;
+      }
+      :host ::ng-deep .changelog-md li {
+        margin: 0.3rem 0;
+        padding-left: 0.15rem;
+      }
+      :host ::ng-deep .changelog-md li::marker {
+        color: var(--color-primary);
+      }
+      :host ::ng-deep .changelog-md p {
+        margin: 0.5rem 0;
+      }
+      :host ::ng-deep .changelog-md a {
+        color: var(--color-primary);
+        text-decoration: underline;
+      }
+      :host ::ng-deep .changelog-md code {
+        font-family: monospace;
+        font-size: 0.85em;
+        background: rgba(127, 127, 127, 0.18);
+        padding: 0.05rem 0.3rem;
+        border-radius: 0.25rem;
+      }
+      :host ::ng-deep .changelog-md hr {
+        margin: 0.75rem 0;
+        border: 0;
+        border-top: 1px solid rgba(127, 127, 127, 0.3);
+      }
     `,
   ],
 })

--- a/client/src/app/shared/components/confirmation-modal.html
+++ b/client/src/app/shared/components/confirmation-modal.html
@@ -2,7 +2,7 @@
   <div class="modal-box">
     <app-modal-header [title]="title()" />
     <p class="py-4 whitespace-pre-line">{{ message() }}</p>
-    <div class="modal-action">
+    <app-modal-footer>
       @if (dismissLabel(); as dl) {
         <button class="btn btn-ghost" (click)="confirmService.dismiss()">{{ dl }}</button>
       }
@@ -14,10 +14,14 @@
       <button class="btn" [class]="confirmBtnClass()" (click)="confirmService.accept()">
         {{ alertOnly() ? ('common.ok' | translate) : confirmLabel() }}
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
-    <button type="button" (click)="dismissLabel() ? confirmService.dismiss() : confirmService.cancel()" [attr.aria-label]="'common.close' | translate">
+    <button
+      type="button"
+      (click)="dismissLabel() ? confirmService.dismiss() : confirmService.cancel()"
+      [attr.aria-label]="'common.close' | translate"
+    >
       {{ 'common.close' | translate }}
     </button>
   </form>

--- a/client/src/app/shared/components/confirmation-modal.html
+++ b/client/src/app/shared/components/confirmation-modal.html
@@ -1,6 +1,6 @@
 <dialog #dialog class="modal" role="dialog" aria-modal="true" (close)="onDialogClose()">
   <div class="modal-box">
-    <h3 class="text-lg font-bold">{{ title() }}</h3>
+    <app-modal-header [title]="title()" />
     <p class="py-4 whitespace-pre-line">{{ message() }}</p>
     <div class="modal-action">
       @if (dismissLabel(); as dl) {

--- a/client/src/app/shared/components/confirmation-modal.ts
+++ b/client/src/app/shared/components/confirmation-modal.ts
@@ -10,11 +10,11 @@ import {
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ConfirmationService } from '../../core/services/confirmation.service';
 import { ModalHeaderComponent } from './modal-header';
+import { ModalFooterComponent } from './modal-footer';
 
 @Component({
   selector: 'app-confirmation-modal',
-  imports: [
-    ModalHeaderComponent,TranslateModule],
+  imports: [ModalFooterComponent, ModalHeaderComponent, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './confirmation-modal.html',
 })
@@ -22,25 +22,18 @@ export class ConfirmationModalComponent {
   readonly confirmService = inject(ConfirmationService);
   private readonly translate = inject(TranslateService);
 
-  private readonly dialog =
-    viewChild<ElementRef<HTMLDialogElement>>('dialog');
+  private readonly dialog = viewChild<ElementRef<HTMLDialogElement>>('dialog');
 
   readonly isOpen = computed(() => !!this.confirmService.state());
   readonly title = computed(() => this.confirmService.state()?.title ?? '');
   readonly message = computed(() => this.confirmService.state()?.message ?? '');
   readonly confirmLabel = computed(
-    () =>
-      this.confirmService.state()?.confirmLabel ??
-      this.translate.instant('common.confirm'),
+    () => this.confirmService.state()?.confirmLabel ?? this.translate.instant('common.confirm'),
   );
   readonly cancelLabel = computed(
-    () =>
-      this.confirmService.state()?.cancelLabel ??
-      this.translate.instant('common.cancel'),
+    () => this.confirmService.state()?.cancelLabel ?? this.translate.instant('common.cancel'),
   );
-  readonly variant = computed(
-    () => this.confirmService.state()?.variant ?? 'default',
-  );
+  readonly variant = computed(() => this.confirmService.state()?.variant ?? 'default');
 
   readonly alertOnly = computed(() => this.confirmService.state()?.alertOnly ?? false);
   readonly dismissLabel = computed(() => this.confirmService.state()?.dismissLabel ?? null);

--- a/client/src/app/shared/components/confirmation-modal.ts
+++ b/client/src/app/shared/components/confirmation-modal.ts
@@ -9,10 +9,12 @@ import {
 } from '@angular/core';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ConfirmationService } from '../../core/services/confirmation.service';
+import { ModalHeaderComponent } from './modal-header';
 
 @Component({
   selector: 'app-confirmation-modal',
-  imports: [TranslateModule],
+  imports: [
+    ModalHeaderComponent,TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './confirmation-modal.html',
 })

--- a/client/src/app/shared/components/data-table/data-table.html
+++ b/client/src/app/shared/components/data-table/data-table.html
@@ -160,7 +160,7 @@
 @if (detail(); as open) {
   <dialog class="modal modal-open">
     <div class="modal-box max-w-2xl">
-      <h3 class="font-bold text-lg mb-4">{{ open.titleKey | translate }}</h3>
+      <app-modal-header [title]="open.titleKey | translate" />
       <pre class="text-sm whitespace-pre-wrap break-words bg-base-200 rounded p-3 max-h-[60vh] overflow-auto">{{ open.text }}</pre>
       <div class="modal-action">
         <button type="button" class="btn btn-ghost" (click)="closeDetail()">{{ 'common.close' | translate }}</button>

--- a/client/src/app/shared/components/data-table/data-table.html
+++ b/client/src/app/shared/components/data-table/data-table.html
@@ -56,7 +56,10 @@
               (change)="onSelectChange(filter.key, $event)"
             >
               @for (option of filter.options; track option.value) {
-                <option [value]="option.value" [selected]="filterValue(filter.key) === option.value">
+                <option
+                  [value]="option.value"
+                  [selected]="filterValue(filter.key) === option.value"
+                >
                   {{ option.labelKey | translate }}
                 </option>
               }
@@ -94,10 +97,18 @@
               @for (col of columns(); track col.key) {
                 <td [class.whitespace-nowrap]="cellNowrap(col)">
                   @switch (col.format) {
-                    @case ('date') { {{ cellDate(row[col.key]) | localeDate }} }
-                    @case ('bytes') { {{ cellBytes(row[col.key]) }} }
-                    @case ('percent') { {{ cellPercent(row[col.key]) }} }
-                    @case ('speed') { {{ cellSpeed(row[col.key]) }} }
+                    @case ('date') {
+                      {{ cellDate(row[col.key]) | localeDate }}
+                    }
+                    @case ('bytes') {
+                      {{ cellBytes(row[col.key]) }}
+                    }
+                    @case ('percent') {
+                      {{ cellPercent(row[col.key]) }}
+                    }
+                    @case ('speed') {
+                      {{ cellSpeed(row[col.key]) }}
+                    }
                     @default {
                       @if (col.truncate) {
                         <!-- The width cap is what makes the ellipsis appear: a table cell sizes
@@ -105,18 +116,27 @@
                         <span
                           class="block truncate max-w-[12rem] sm:max-w-xs lg:max-w-md"
                           [title]="cellLabel(col, row[col.key])"
-                        >{{ cellLabel(col, row[col.key]) }}</span>
+                          >{{ cellLabel(col, row[col.key]) }}</span
+                        >
                       } @else if (detailText(col, row); as detail) {
-                        <button type="button" class="link link-hover" (click)="openDetail(col, row)"
-                          [attr.aria-label]="(col.detailTitleKey ?? col.labelKey) | translate">
+                        <button
+                          type="button"
+                          class="link link-hover"
+                          (click)="openDetail(col, row)"
+                          [attr.aria-label]="col.detailTitleKey ?? col.labelKey | translate"
+                        >
                           @if (badgeClass(col, row[col.key]); as badge) {
-                            <span class="badge badge-sm" [class]="badge">{{ cellLabel(col, row[col.key]) }}</span>
+                            <span class="badge badge-sm" [class]="badge">{{
+                              cellLabel(col, row[col.key])
+                            }}</span>
                           } @else {
                             {{ cellLabel(col, row[col.key]) }}
                           }
                         </button>
                       } @else if (badgeClass(col, row[col.key]); as badge) {
-                        <span class="badge badge-sm" [class]="badge">{{ cellLabel(col, row[col.key]) }}</span>
+                        <span class="badge badge-sm" [class]="badge">{{
+                          cellLabel(col, row[col.key])
+                        }}</span>
                       } @else {
                         {{ cellLabel(col, row[col.key]) }}
                       }
@@ -125,11 +145,17 @@
                   @if (col.subValues?.length) {
                     <div class="flex flex-wrap items-center gap-1 mt-1 whitespace-nowrap">
                       @for (sub of col.subValues; track sub.key) {
-                        @if (row[sub.key] !== null && row[sub.key] !== undefined && row[sub.key] !== '') {
+                        @if (
+                          row[sub.key] !== null && row[sub.key] !== undefined && row[sub.key] !== ''
+                        ) {
                           @if (badgeClass(sub, row[sub.key]); as badge) {
-                            <span class="badge badge-sm" [class]="badge">{{ subValueText(sub, row[sub.key]) }}</span>
+                            <span class="badge badge-sm" [class]="badge">{{
+                              subValueText(sub, row[sub.key])
+                            }}</span>
                           } @else {
-                            <span class="text-sm text-base-content/60">{{ subValueText(sub, row[sub.key]) }}</span>
+                            <span class="text-sm text-base-content/60">{{
+                              subValueText(sub, row[sub.key])
+                            }}</span>
                           }
                         }
                       }
@@ -140,7 +166,15 @@
               @if (rowActions().length) {
                 <td class="text-end">
                   @for (item of visibleActions(row); track item.action.labelKey) {
-                    <button type="button" class="btn btn-ghost btn-xs" (click)="item.run()" [disabled]="busy() === (row.id + ':' + (item.action.kind === 'proxy' ? item.action.path : ''))">
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs"
+                      (click)="item.run()"
+                      [disabled]="
+                        busy() ===
+                        row.id + ':' + (item.action.kind === 'proxy' ? item.action.path : '')
+                      "
+                    >
                       {{ item.action.labelKey | translate }}
                     </button>
                   }
@@ -152,7 +186,12 @@
       </table>
     </div>
     @if (paged() && totalPages() > 1) {
-      <app-pagination class="pt-2" [current]="page()" [total]="totalPages()" (pageChange)="goToPage($event)" />
+      <app-pagination
+        class="pt-2"
+        [current]="page()"
+        [total]="totalPages()"
+        (pageChange)="goToPage($event)"
+      />
     }
   }
 </div>
@@ -160,14 +199,21 @@
 @if (detail(); as open) {
   <dialog class="modal modal-open">
     <div class="modal-box max-w-2xl">
-      <app-modal-header [title]="open.titleKey | translate" />
-      <pre class="text-sm whitespace-pre-wrap break-words bg-base-200 rounded p-3 max-h-[60vh] overflow-auto">{{ open.text }}</pre>
-      <div class="modal-action">
-        <button type="button" class="btn btn-ghost" (click)="closeDetail()">{{ 'common.close' | translate }}</button>
-      </div>
+      <app-modal-header [title]="open.titleKey | translate" (closed)="closeDetail()" />
+      <pre
+        class="text-sm whitespace-pre-wrap break-words bg-base-200 rounded p-3 max-h-[60vh] overflow-auto"
+        >{{ open.text }}</pre
+      >
+      <app-modal-footer>
+        <button type="button" class="btn btn-ghost" (click)="closeDetail()">
+          {{ 'common.close' | translate }}
+        </button>
+      </app-modal-footer>
     </div>
     <form method="dialog" class="modal-backdrop">
-      <button type="button" (click)="closeDetail()" [attr.aria-label]="'common.close' | translate">close</button>
+      <button type="button" (click)="closeDetail()" [attr.aria-label]="'common.close' | translate">
+        close
+      </button>
     </form>
   </dialog>
 }

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -9,6 +9,7 @@ import { ConfirmationService } from '../../../core/services/confirmation.service
 import { SseService } from '../../../core/services/sse.service';
 import { PaginationComponent } from '../pagination/pagination';
 import { BadgeTone, CellValue, ListAction, PagedResult, RowAction, TableColumn, TableFilter, TableRow, TableSubValue } from './data-table.types';
+import { ModalHeaderComponent } from '../modal-header';
 
 /** Keystroke-to-request debounce for a `search` filter — see `onSearchInput`. */
 const SEARCH_DEBOUNCE_MS = 300;
@@ -38,7 +39,8 @@ const BADGE_CLASSES: Readonly<Record<BadgeTone, string>> = {
  */
 @Component({
   selector: 'app-data-table',
-  imports: [TranslateModule, LocaleDatePipe, PaginationComponent],
+  imports: [
+    ModalHeaderComponent,TranslateModule, LocaleDatePipe, PaginationComponent],
   providers: [LocaleDatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './data-table.html',

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -1,4 +1,15 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, computed, effect, inject, input, signal, untracked } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  OnInit,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+  untracked,
+} from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
@@ -8,8 +19,19 @@ import { formatBytes, formatSpeed } from '../../utils/download-format';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { SseService } from '../../../core/services/sse.service';
 import { PaginationComponent } from '../pagination/pagination';
-import { BadgeTone, CellValue, ListAction, PagedResult, RowAction, TableColumn, TableFilter, TableRow, TableSubValue } from './data-table.types';
+import {
+  BadgeTone,
+  CellValue,
+  ListAction,
+  PagedResult,
+  RowAction,
+  TableColumn,
+  TableFilter,
+  TableRow,
+  TableSubValue,
+} from './data-table.types';
 import { ModalHeaderComponent } from '../modal-header';
+import { ModalFooterComponent } from '../modal-footer';
 
 /** Keystroke-to-request debounce for a `search` filter — see `onSearchInput`. */
 const SEARCH_DEBOUNCE_MS = 300;
@@ -40,7 +62,12 @@ const BADGE_CLASSES: Readonly<Record<BadgeTone, string>> = {
 @Component({
   selector: 'app-data-table',
   imports: [
-    ModalHeaderComponent,TranslateModule, LocaleDatePipe, PaginationComponent],
+    ModalFooterComponent,
+    ModalHeaderComponent,
+    TranslateModule,
+    LocaleDatePipe,
+    PaginationComponent,
+  ],
   providers: [LocaleDatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './data-table.html',
@@ -64,7 +91,9 @@ export class DataTableComponent implements OnInit {
   readonly loadErrorKey = input('data_table.load_error');
   readonly emptyKey = input('data_table.empty');
   /** Resolves a core `actionId`; undefined = unknown = the button must not render (fail closed). */
-  readonly resolveAction = input<(actionId: string, row: TableRow) => (() => void) | undefined>(() => undefined);
+  readonly resolveAction = input<(actionId: string, row: TableRow) => (() => void) | undefined>(
+    () => undefined,
+  );
   /** `list` answers `{data,total,page,pageSize}` rather than a bare array. */
   readonly paged = input(false);
   readonly pageSize = input(20);
@@ -114,7 +143,10 @@ export class DataTableComponent implements OnInit {
     void this.loadRows();
     const declared = this.refreshMs();
     if (declared > 0) {
-      this.refreshTimer = setInterval(() => this.requestRefresh(), Math.max(declared, REFRESH_MIN_MS));
+      this.refreshTimer = setInterval(
+        () => this.requestRefresh(),
+        Math.max(declared, REFRESH_MIN_MS),
+      );
     }
   }
 
@@ -160,7 +192,9 @@ export class DataTableComponent implements OnInit {
       }
       if (this.paged()) {
         params = params.set('page', this.page()).set('pageSize', this.pageSize());
-        const res = await firstValueFrom(this.http.get<PagedResult<TableRow>>(this.listUrl(), { params }));
+        const res = await firstValueFrom(
+          this.http.get<PagedResult<TableRow>>(this.listUrl(), { params }),
+        );
         if (seq !== this.loadSeq) return;
         this.rows.set(this.applyDefaultSort(Array.isArray(res?.data) ? res.data : []));
         this.total.set(res?.total ?? 0);
@@ -211,7 +245,7 @@ export class DataTableComponent implements OnInit {
 
   /** `LocaleDatePipe` doesn't accept a boolean — no declared column is ever meant to be one. */
   cellDate(value: CellValue): string | number | null {
-    return typeof value === 'boolean' ? null : value ?? null;
+    return typeof value === 'boolean' ? null : (value ?? null);
   }
 
   cellBytes(value: CellValue): string {
@@ -306,7 +340,12 @@ export class DataTableComponent implements OnInit {
         const handler = this.resolveAction()(action.actionId, row);
         if (handler) result.push({ action, run: handler });
       } else if (action.kind === 'route') {
-        result.push({ action, run: () => { void this.router.navigateByUrl(action.path); } });
+        result.push({
+          action,
+          run: () => {
+            void this.router.navigateByUrl(action.path);
+          },
+        });
       } else {
         result.push({ action, run: () => this.runProxy(row, action) });
       }
@@ -320,7 +359,8 @@ export class DataTableComponent implements OnInit {
   ): Promise<void> {
     this.busy.set(`${row.id}:${action.path}`);
     try {
-      if (await this.runHttpAction(action.method, action.path, action.confirmKey)) await this.loadRows();
+      if (await this.runHttpAction(action.method, action.path, action.confirmKey))
+        await this.loadRows();
     } catch {
       // handled by the global error interceptor
     } finally {
@@ -332,7 +372,8 @@ export class DataTableComponent implements OnInit {
   async runListAction(action: ListAction): Promise<void> {
     this.listActionBusy.set(action.path);
     try {
-      if (await this.runHttpAction(action.method, action.path, action.confirmKey)) await this.loadRows();
+      if (await this.runHttpAction(action.method, action.path, action.confirmKey))
+        await this.loadRows();
     } catch {
       // handled by the global error interceptor
     } finally {
@@ -341,7 +382,11 @@ export class DataTableComponent implements OnInit {
   }
 
   /** Returns false without calling anything when the user declines the confirm — not an error. */
-  private async runHttpAction(method: 'POST' | 'DELETE', path: string, confirmKey?: string): Promise<boolean> {
+  private async runHttpAction(
+    method: 'POST' | 'DELETE',
+    path: string,
+    confirmKey?: string,
+  ): Promise<boolean> {
     if (confirmKey) {
       const ok = await this.confirmation.confirm({
         title: this.translate.instant('common.confirm'),

--- a/client/src/app/shared/components/download-detail-modal/download-detail-modal.html
+++ b/client/src/app/shared/components/download-detail-modal/download-detail-modal.html
@@ -9,9 +9,15 @@
         }
         <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-base-content/70">
           <span class="font-medium">{{ overallStateLabelKey() | translate }}</span>
-          @if (p.percent !== null) { <span class="tabular-nums">{{ p.percent }}%</span> }
-          @if (speedLabel(); as sp) { <span>↓ {{ sp }}</span> }
-          @if (etaLabel(); as e) { <span>{{ 'activity.eta' | translate }} {{ e }}</span> }
+          @if (p.percent !== null) {
+            <span class="tabular-nums">{{ p.percent }}%</span>
+          }
+          @if (speedLabel(); as sp) {
+            <span>↓ {{ sp }}</span>
+          }
+          @if (etaLabel(); as e) {
+            <span>{{ 'activity.eta' | translate }} {{ e }}</span>
+          }
         </div>
       </div>
 
@@ -21,9 +27,14 @@
           @for (s of seasonRows(); track s.seasonNumber) {
             <div class="flex flex-col gap-1">
               <div class="flex items-center justify-between gap-3">
-                <span class="text-sm font-medium">{{ 'tracking.season' | translate:{ number: s.seasonNumber } }}</span>
+                <span class="text-sm font-medium">{{
+                  'tracking.season' | translate: { number: s.seasonNumber }
+                }}</span>
                 <span class="text-sm text-base-content/60">
-                  {{ s.stateLabelKey | translate }}@if (s.percent !== null) { · {{ s.percent }}%}
+                  {{ s.stateLabelKey | translate }}
+                  @if (s.percent !== null) {
+                    · {{ s.percent }}%
+                  }
                 </span>
               </div>
               @if (s.percent !== null) {
@@ -32,8 +43,10 @@
               @if (s.leaves.length) {
                 <div class="flex flex-col gap-1 pl-3 mt-1">
                   @for (l of s.leaves; track l.key) {
-                    <div class="flex items-center justify-between gap-3 text-xs text-base-content/60">
-                      <span>{{ l.labelKey | translate:{ number: l.labelNumber } }}</span>
+                    <div
+                      class="flex items-center justify-between gap-3 text-xs text-base-content/60"
+                    >
+                      <span>{{ l.labelKey | translate: { number: l.labelNumber } }}</span>
                       <span>{{ l.stateLabelKey | translate }} · {{ l.percent }}%</span>
                     </div>
                   }
@@ -49,11 +62,11 @@
       </p>
     }
 
-    <div class="modal-action">
+    <app-modal-footer>
       <button type="button" class="btn" (click)="close()">
         {{ 'common.close' | translate }}
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/shared/components/download-detail-modal/download-detail-modal.html
+++ b/client/src/app/shared/components/download-detail-modal/download-detail-modal.html
@@ -50,7 +50,7 @@
     }
 
     <div class="modal-action">
-      <button type="button" class="btn btn-sm" (click)="close()">
+      <button type="button" class="btn" (click)="close()">
         {{ 'common.close' | translate }}
       </button>
     </div>

--- a/client/src/app/shared/components/download-detail-modal/download-detail-modal.ts
+++ b/client/src/app/shared/components/download-detail-modal/download-detail-modal.ts
@@ -7,10 +7,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
-import {
-  LeafKey,
-  MediaDownloadProgress,
-} from '../../../core/services/download-progress.service';
+import { LeafKey, MediaDownloadProgress } from '../../../core/services/download-progress.service';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
 import { ModalHeaderComponent } from '../modal-header';
 import {
@@ -21,6 +18,7 @@ import {
   formatEta,
   ProgressVariant,
 } from '../../utils/download-format';
+import { ModalFooterComponent } from '../modal-footer';
 
 interface LeafRow {
   key: string;
@@ -52,19 +50,16 @@ interface SeasonRow {
 @Component({
   selector: 'app-download-detail-modal',
   standalone: true,
-  imports: [TranslateModule, ProgressBarComponent, ModalHeaderComponent],
+  imports: [ModalFooterComponent, TranslateModule, ProgressBarComponent, ModalHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './download-detail-modal.html',
 })
 export class DownloadDetailModalComponent {
   readonly progress = input<MediaDownloadProgress | null>(null);
 
-  private readonly dialog =
-    viewChild<ElementRef<HTMLDialogElement>>('dialog');
+  private readonly dialog = viewChild<ElementRef<HTMLDialogElement>>('dialog');
 
-  readonly overallStateLabelKey = computed(() =>
-    qbStateLabelKey(this.progress()?.state ?? ''),
-  );
+  readonly overallStateLabelKey = computed(() => qbStateLabelKey(this.progress()?.state ?? ''));
   readonly overallVariant = computed<ProgressVariant>(() =>
     qbStateVariant(this.progress()?.state ?? ''),
   );

--- a/client/src/app/shared/components/folder-picker-modal/folder-picker-modal.html
+++ b/client/src/app/shared/components/folder-picker-modal/folder-picker-modal.html
@@ -40,7 +40,7 @@
       }
     </div>
 
-    <div class="modal-action">
+    <app-modal-footer>
       <button type="button" class="btn" (click)="cancel()">
         {{ 'common.cancel' | translate }}
       </button>
@@ -52,7 +52,7 @@
       >
         {{ 'folder_picker.select' | translate }}
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
     <button type="button" (click)="cancel()" [attr.aria-label]="'common.close' | translate">

--- a/client/src/app/shared/components/folder-picker-modal/folder-picker-modal.html
+++ b/client/src/app/shared/components/folder-picker-modal/folder-picker-modal.html
@@ -1,6 +1,6 @@
 <dialog #dialog class="modal" role="dialog" aria-modal="true" (close)="cancel()">
   <div class="modal-box max-w-2xl">
-    <h3 class="text-lg font-bold">{{ 'folder_picker.title' | translate }}</h3>
+    <app-modal-header [title]="'folder_picker.title' | translate" />
 
     <div class="mt-2 flex items-center gap-2">
       <button

--- a/client/src/app/shared/components/folder-picker-modal/folder-picker-modal.ts
+++ b/client/src/app/shared/components/folder-picker-modal/folder-picker-modal.ts
@@ -11,6 +11,7 @@ import { HttpClient } from '@angular/common/http';
 import { TranslateModule } from '@ngx-translate/core';
 import { firstValueFrom } from 'rxjs';
 import { FolderPickerService } from '../../../core/services/folder-picker.service';
+import { ModalHeaderComponent } from '../modal-header';
 
 interface FsEntry {
   name: string;
@@ -25,7 +26,8 @@ interface FsListing {
 
 @Component({
   selector: 'app-folder-picker-modal',
-  imports: [TranslateModule],
+  imports: [
+    ModalHeaderComponent,TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './folder-picker-modal.html',
 })

--- a/client/src/app/shared/components/folder-picker-modal/folder-picker-modal.ts
+++ b/client/src/app/shared/components/folder-picker-modal/folder-picker-modal.ts
@@ -12,6 +12,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { firstValueFrom } from 'rxjs';
 import { FolderPickerService } from '../../../core/services/folder-picker.service';
 import { ModalHeaderComponent } from '../modal-header';
+import { ModalFooterComponent } from '../modal-footer';
 
 interface FsEntry {
   name: string;
@@ -26,8 +27,7 @@ interface FsListing {
 
 @Component({
   selector: 'app-folder-picker-modal',
-  imports: [
-    ModalHeaderComponent,TranslateModule],
+  imports: [ModalFooterComponent, ModalHeaderComponent, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './folder-picker-modal.html',
 })
@@ -35,8 +35,7 @@ export class FolderPickerModalComponent {
   private readonly picker = inject(FolderPickerService);
   private readonly http = inject(HttpClient);
 
-  private readonly dialog =
-    viewChild<ElementRef<HTMLDialogElement>>('dialog');
+  private readonly dialog = viewChild<ElementRef<HTMLDialogElement>>('dialog');
 
   readonly listing = signal<FsListing | null>(null);
   readonly loading = signal(false);
@@ -61,9 +60,7 @@ export class FolderPickerModalComponent {
     this.error.set('');
     try {
       const params: Record<string, string> = path ? { path } : {};
-      const listing = await firstValueFrom(
-        this.http.get<FsListing>('/api/fs/browse', { params }),
-      );
+      const listing = await firstValueFrom(this.http.get<FsListing>('/api/fs/browse', { params }));
       this.listing.set(listing);
     } catch {
       // Directory unreadable — stay where we are, surface a message.

--- a/client/src/app/shared/components/modal-footer.ts
+++ b/client/src/app/shared/components/modal-footer.ts
@@ -16,9 +16,7 @@ import {
   template: '<ng-content />',
   host: {
     class: 'modal-action border-t border-base-200 bg-base-100',
-    '[class]': `flush()
-      ? 'shrink-0 mt-0 px-5 sm:px-6 pt-3 pb-4'
-      : '-mx-6 -mb-6 mt-6 px-6 py-4'`,
+    '[class]': `flush() ? 'shrink-0 mt-0 px-5 sm:px-6 pt-3 pb-4' : 'modal-footer-bar'`,
   },
 })
 export class ModalFooterComponent {

--- a/client/src/app/shared/components/modal-footer.ts
+++ b/client/src/app/shared/components/modal-footer.ts
@@ -1,0 +1,26 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  booleanAttribute,
+  input,
+} from '@angular/core';
+
+/**
+ * Standard dialog footer: actions right-aligned, ruled off from the body.
+ * Mirrors {@link ModalHeaderComponent}, `flush` included — in a `p-0` box the
+ * flex column pins it, in a padded one it sits at the end of the content.
+ */
+@Component({
+  selector: 'app-modal-footer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content />',
+  host: {
+    class: 'modal-action border-t border-base-200 bg-base-100',
+    '[class]': `flush()
+      ? 'shrink-0 mt-0 px-5 sm:px-6 pt-3 pb-4'
+      : '-mx-6 -mb-6 mt-6 px-6 py-4'`,
+  },
+})
+export class ModalFooterComponent {
+  readonly flush = input(false, { transform: booleanAttribute });
+}

--- a/client/src/app/shared/components/modal-header.html
+++ b/client/src/app/shared/components/modal-header.html
@@ -1,15 +1,14 @@
-<div class="flex items-start justify-between gap-4 mb-4">
-  @if (title()) {
-    <h3 class="text-lg font-bold">{{ title() }}</h3>
-  } @else {
-    <ng-content />
-  }
-  <form method="dialog">
-    <button
-      class="btn btn-sm btn-circle btn-ghost shrink-0"
-      [attr.aria-label]="'common.close' | translate"
-    >
-      ✕
-    </button>
-  </form>
-</div>
+@if (title()) {
+  <h3 class="text-lg font-bold">{{ title() }}</h3>
+} @else {
+  <ng-content />
+}
+<form method="dialog">
+  <button
+    class="btn btn-sm btn-circle btn-ghost shrink-0"
+    [attr.aria-label]="'common.close' | translate"
+    (click)="closed.emit()"
+  >
+    ✕
+  </button>
+</form>

--- a/client/src/app/shared/components/modal-header.ts
+++ b/client/src/app/shared/components/modal-header.ts
@@ -1,18 +1,32 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, booleanAttribute, input, output } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 
 /**
- * Standard dialog header: title on the left, close button on the right, laid
- * out in a flex row so the button's focus ring isn't clipped by the modal-box
- * corner. The button submits the enclosing native <dialog>, so no handler is
- * needed. Pass a plain `title`, or project a custom title area (icon, subtitle).
+ * Standard dialog header: title on the left, close button on the right, ruled
+ * off from the body. The button submits
+ * the enclosing native <dialog>, so no handler is needed. Pass a plain `title`,
+ * or project a custom title area (icon, subtitle). A modal shown by CSS rather
+ * than showModal() has no dialog to submit to and must close on `(closed)`.
+ *
+ * The default variant bleeds out of `.modal-box`'s 1.5rem padding so the rule
+ * spans the full width; `flush` is for a box that already sets `p-0` and lays
+ * its header, body and footer out as a flex column.
  */
 @Component({
   selector: 'app-modal-header',
   imports: [TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './modal-header.html',
+  host: {
+    class:
+      'flex items-start justify-between gap-4 border-b border-base-200 bg-base-100',
+    '[class]': `flush()
+      ? 'shrink-0 px-5 sm:px-6 pt-4 pb-3'
+      : '-mx-6 -mt-6 mb-4 px-6 pt-5 pb-3'`,
+  },
 })
 export class ModalHeaderComponent {
   readonly title = input('');
+  readonly flush = input(false, { transform: booleanAttribute });
+  readonly closed = output<void>();
 }

--- a/client/src/app/shared/components/modal-header.ts
+++ b/client/src/app/shared/components/modal-header.ts
@@ -20,9 +20,7 @@ import { TranslateModule } from '@ngx-translate/core';
   host: {
     class:
       'flex items-start justify-between gap-4 border-b border-base-200 bg-base-100',
-    '[class]': `flush()
-      ? 'shrink-0 px-5 sm:px-6 pt-4 pb-3'
-      : '-mx-6 -mt-6 mb-4 px-6 pt-5 pb-3'`,
+    '[class]': `flush() ? 'shrink-0 px-5 sm:px-6 pt-4 pb-3' : 'modal-header-bar'`,
   },
 })
 export class ModalHeaderComponent {

--- a/client/src/app/shared/components/provider-list/provider-list.html
+++ b/client/src/app/shared/components/provider-list/provider-list.html
@@ -37,11 +37,19 @@
         <thead>
           <tr>
             <th>{{ labels().colNameKey | translate }}</th>
-            @if (showImplementation()) { <th>{{ labels().colImplementationKey | translate }}</th> }
-            @if (showPriority()) { <th class="text-end">{{ labels().colPriorityKey | translate }}</th> }
+            @if (showImplementation()) {
+              <th>{{ labels().colImplementationKey | translate }}</th>
+            }
+            @if (showPriority()) {
+              <th class="text-end">{{ labels().colPriorityKey | translate }}</th>
+            }
             <th class="text-center">{{ labels().colEnabledKey | translate }}</th>
-            @if (showCooldown()) { <th>{{ 'provider_list.col_cooldown' | translate }}</th> }
-            @if (rowExtraStatus()) { <th></th> }
+            @if (showCooldown()) {
+              <th>{{ 'provider_list.col_cooldown' | translate }}</th>
+            }
+            @if (rowExtraStatus()) {
+              <th></th>
+            }
             <th class="text-end">{{ labels().actionsKey | translate }}</th>
           </tr>
         </thead>
@@ -49,12 +57,16 @@
           @for (row of orderedRows(); track row.id; let i = $index) {
             <tr>
               <td>
-                <button type="button" class="link link-hover font-medium" (click)="openEdit(row)">{{ row.name }}</button>
+                <button type="button" class="link link-hover font-medium" (click)="openEdit(row)">
+                  {{ row.name }}
+                </button>
               </td>
               @if (showImplementation()) {
                 <td class="text-sm">{{ implementationLabel(row[implementationKey()] + '') }}</td>
               }
-              @if (showPriority()) { <td class="text-end tabular-nums">{{ row.priority }}</td> }
+              @if (showPriority()) {
+                <td class="text-end tabular-nums">{{ row.priority }}</td>
+              }
               <td class="text-center">
                 <input
                   type="checkbox"
@@ -69,8 +81,12 @@
                 <td class="text-sm">
                   @if (cooldownOf(row); as cd) {
                     <span class="inline-flex flex-nowrap items-center gap-1.5">
-                      <span class="badge badge-sm badge-warning whitespace-nowrap">{{ cooldownRemaining(cd) }}</span>
-                      <span class="text-xs text-base-content/60">{{ cooldownReasonKey(cd) | translate }}</span>
+                      <span class="badge badge-sm badge-warning whitespace-nowrap">{{
+                        cooldownRemaining(cd)
+                      }}</span>
+                      <span class="text-xs text-base-content/60">{{
+                        cooldownReasonKey(cd) | translate
+                      }}</span>
                       @if (cooldownAction(); as action) {
                         <button
                           type="button"
@@ -98,35 +114,49 @@
               }
               <td class="text-end">
                 <span class="inline-flex flex-nowrap items-center justify-end gap-1">
-                @if (reorderable()) {
-                  <button type="button" class="btn btn-ghost btn-xs btn-square" [disabled]="i === 0"
-                          (click)="moveRow(row, -1)" [attr.aria-label]="'provider_list.move_up' | translate">
-                    <svg lucideArrowUp class="h-4 w-4"></svg>
-                  </button>
-                  <button type="button" class="btn btn-ghost btn-xs btn-square" [disabled]="i === orderedRows().length - 1"
-                          (click)="moveRow(row, 1)" [attr.aria-label]="'provider_list.move_down' | translate">
-                    <svg lucideArrowDown class="h-4 w-4"></svg>
-                  </button>
-                }
-                @if (rowExtraActions(); as tpl) {
-                  <ng-container *ngTemplateOutlet="tpl; context: { $implicit: row }" />
-                }
-                @for (action of visibleRowActions(); track action.labelKey) {
+                  @if (reorderable()) {
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs btn-square"
+                      [disabled]="i === 0"
+                      (click)="moveRow(row, -1)"
+                      [attr.aria-label]="'provider_list.move_up' | translate"
+                    >
+                      <svg lucideArrowUp class="h-4 w-4"></svg>
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs btn-square"
+                      [disabled]="i === orderedRows().length - 1"
+                      (click)="moveRow(row, 1)"
+                      [attr.aria-label]="'provider_list.move_down' | translate"
+                    >
+                      <svg lucideArrowDown class="h-4 w-4"></svg>
+                    </button>
+                  }
+                  @if (rowExtraActions(); as tpl) {
+                    <ng-container *ngTemplateOutlet="tpl; context: { $implicit: row }" />
+                  }
+                  @for (action of visibleRowActions(); track action.labelKey) {
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs"
+                      (click)="runRowAction(row, action)"
+                      [disabled]="rowActionBusy() === rowActionKey(row, action)"
+                    >
+                      @if (rowActionBusy() === rowActionKey(row, action)) {
+                        <span class="loading loading-spinner loading-xs"></span>
+                      }
+                      {{ action.labelKey | translate }}
+                    </button>
+                  }
                   <button
                     type="button"
-                    class="btn btn-ghost btn-xs"
-                    (click)="runRowAction(row, action)"
-                    [disabled]="rowActionBusy() === rowActionKey(row, action)"
+                    class="btn btn-ghost btn-xs text-error"
+                    (click)="deleteRow(row)"
                   >
-                    @if (rowActionBusy() === rowActionKey(row, action)) {
-                      <span class="loading loading-spinner loading-xs"></span>
-                    }
-                    {{ action.labelKey | translate }}
+                    {{ labels().deleteKey | translate }}
                   </button>
-                }
-                <button type="button" class="btn btn-ghost btn-xs text-error" (click)="deleteRow(row)">
-                  {{ labels().deleteKey | translate }}
-                </button>
                 </span>
               </td>
             </tr>
@@ -139,20 +169,10 @@
 
 <dialog #editorDialog class="modal">
   <div class="modal-box max-w-2xl max-h-[92vh] flex flex-col p-0 gap-0 overflow-hidden">
-    <div class="px-5 sm:px-6 pt-4 pb-3 border-b border-base-200 flex justify-between items-center gap-3 shrink-0 bg-base-100">
-      <h2 class="text-lg font-bold leading-tight">
-        {{ (editingId() === null ? labels().createTitleKey : labels().editTitleKey) | translate }}
-      </h2>
-      <button
-        type="button"
-        class="btn btn-sm btn-circle btn-ghost shrink-0"
-        (click)="closeEditor()"
-        [disabled]="saving()"
-        [attr.aria-label]="labels().cancelKey | translate"
-      >
-        ✕
-      </button>
-    </div>
+    <app-modal-header
+      flush
+      [title]="(editingId() === null ? labels().createTitleKey : labels().editTitleKey) | translate"
+    />
     <div class="px-5 sm:px-6 py-4 flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 bg-base-100">
       <app-input-field
         [label]="labels().fieldNameKey | translate"
@@ -161,7 +181,11 @@
       />
 
       @if (implementations().length > 1) {
-        <app-select-field [label]="labels().fieldImplementationKey | translate" [value]="draftImplementation()" (valueChange)="onImplementationChange($event)">
+        <app-select-field
+          [label]="labels().fieldImplementationKey | translate"
+          [value]="draftImplementation()"
+          (valueChange)="onImplementationChange($event)"
+        >
           @for (impl of implementations(); track impl.implementation) {
             <option [value]="impl.implementation">{{ impl.labelKey | translate }}</option>
           }
@@ -169,7 +193,11 @@
       }
 
       @if (currentImplementation(); as impl) {
-        <app-schema-form [fields]="impl.fields" [(value)]="draftValue" [secretsSet]="secretsSet()" />
+        <app-schema-form
+          [fields]="impl.fields"
+          [(value)]="draftValue"
+          [secretsSet]="secretsSet()"
+        />
       } @else if (draftImplementation()) {
         <p class="text-sm text-warning">{{ 'provider_list.unknown_implementation' | translate }}</p>
       }
@@ -185,10 +213,15 @@
             @if (testLoading()) {
               <span class="loading loading-spinner loading-xs"></span>
             }
-            {{ (labels().testConnectionKey ?? 'provider_list.test_connection') | translate }}
+            {{ labels().testConnectionKey ?? 'provider_list.test_connection' | translate }}
           </button>
           @if (testResult(); as tr) {
-            <div role="alert" class="alert text-sm py-2" [class.alert-success]="tr.ok" [class.alert-error]="!tr.ok">
+            <div
+              role="alert"
+              class="alert text-sm py-2"
+              [class.alert-success]="tr.ok"
+              [class.alert-error]="!tr.ok"
+            >
               {{ tr.message }}
             </div>
           }
@@ -205,9 +238,13 @@
           />
         }
       </div>
-      <app-toggle-field [label]="labels().fieldEnabledKey | translate" [value]="draftEnabled()" (valueChange)="draftEnabled.set($event)" />
+      <app-toggle-field
+        [label]="labels().fieldEnabledKey | translate"
+        [value]="draftEnabled()"
+        (valueChange)="draftEnabled.set($event)"
+      />
     </div>
-    <div class="modal-action modal-action-sticky">
+    <app-modal-footer flush>
       <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
         {{ labels().cancelKey | translate }}
       </button>
@@ -217,10 +254,12 @@
         }
         {{ labels().saveKey | translate }}
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
-    <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">close</button>
+    <button type="button" (click)="closeEditor()" [attr.aria-label]="'common.close' | translate">
+      close
+    </button>
   </form>
 </dialog>
 
@@ -234,11 +273,15 @@
         [emptyKey]="view.result.emptyKey"
       />
     }
-    <div class="modal-action">
-      <button type="button" class="btn btn-ghost" (click)="closeResult()">{{ 'common.close' | translate }}</button>
-    </div>
+    <app-modal-footer>
+      <button type="button" class="btn btn-ghost" (click)="closeResult()">
+        {{ 'common.close' | translate }}
+      </button>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
-    <button type="button" (click)="closeResult()" [attr.aria-label]="'common.close' | translate">close</button>
+    <button type="button" (click)="closeResult()" [attr.aria-label]="'common.close' | translate">
+      close
+    </button>
   </form>
 </dialog>

--- a/client/src/app/shared/components/provider-list/provider-list.html
+++ b/client/src/app/shared/components/provider-list/provider-list.html
@@ -207,7 +207,7 @@
       </div>
       <app-toggle-field [label]="labels().fieldEnabledKey | translate" [value]="draftEnabled()" (valueChange)="draftEnabled.set($event)" />
     </div>
-    <div class="modal-action shrink-0 px-5 sm:px-6 pb-4 pt-2 border-t border-base-200 bg-base-100">
+    <div class="modal-action modal-action-sticky">
       <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
         {{ labels().cancelKey | translate }}
       </button>
@@ -227,7 +227,7 @@
 <dialog #resultDialog class="modal">
   <div class="modal-box max-w-2xl">
     @if (resultView(); as view) {
-      <h3 class="font-bold text-lg mb-4">{{ view.title }}</h3>
+      <app-modal-header [title]="view.title" />
       <app-data-table
         [listUrl]="view.url"
         [columns]="view.result.columns"

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -33,6 +33,7 @@ import {
   ProviderTestResult,
 } from './provider-list.types';
 import { DataTableComponent } from '../data-table/data-table';
+import { ModalHeaderComponent } from '../modal-header';
 
 interface RowActionResultView {
   url: string;
@@ -59,6 +60,7 @@ export function resolveRowActionRoute(route: string, id: number | string): strin
 @Component({
   selector: 'app-provider-list',
   imports: [
+    ModalHeaderComponent,
     TranslateModule,
     NgTemplateOutlet,
     InputFieldComponent,

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -34,6 +34,7 @@ import {
 } from './provider-list.types';
 import { DataTableComponent } from '../data-table/data-table';
 import { ModalHeaderComponent } from '../modal-header';
+import { ModalFooterComponent } from '../modal-footer';
 
 interface RowActionResultView {
   url: string;
@@ -60,6 +61,7 @@ export function resolveRowActionRoute(route: string, id: number | string): strin
 @Component({
   selector: 'app-provider-list',
   imports: [
+    ModalFooterComponent,
     ModalHeaderComponent,
     TranslateModule,
     NgTemplateOutlet,
@@ -107,9 +109,13 @@ export class ProviderListComponent implements OnInit {
   /** Matches subtitle-providers' current UX: renaming the draft to the driver's label while creating. */
   readonly autoFillNameFromImplementation = input(false);
   /** Runs against the unsaved draft (before create/update), catching a bad connection before it's saved. */
-  readonly testConnection = input<((draft: ProviderDraft) => Promise<ProviderTestResult>) | null>(null);
+  readonly testConnection = input<((draft: ProviderDraft) => Promise<ProviderTestResult>) | null>(
+    null,
+  );
   /** Last chance to normalise the save body (e.g. trim a URL) without resurrecting a dropped secret. */
-  readonly beforeSave = input<((body: Record<string, unknown>) => Record<string, unknown>) | null>(null);
+  readonly beforeSave = input<((body: Record<string, unknown>) => Record<string, unknown>) | null>(
+    null,
+  );
   /** Extra per-row column/actions the generic shape can't express (e.g. subtitle providers' rate-limit badge). */
   readonly rowExtraStatus = input<TemplateRef<{ $implicit: ProviderInstance }> | null>(null);
   readonly rowExtraActions = input<TemplateRef<{ $implicit: ProviderInstance }> | null>(null);
@@ -142,7 +148,9 @@ export class ProviderListComponent implements OnInit {
 
   /** A `GET` with no declared `result` has nothing to show, so it gets no button — the same
    *  fail-closed rule the `table` kind applies to an unknown `actionId`. */
-  readonly visibleRowActions = computed(() => this.rowActions().filter((a) => a.method !== 'GET' || !!a.result));
+  readonly visibleRowActions = computed(() =>
+    this.rowActions().filter((a) => a.method !== 'GET' || !!a.result),
+  );
 
   /** Display order: priority ascending when `reorderable`, otherwise the server's own order. */
   readonly orderedRows = computed(() =>
@@ -150,7 +158,8 @@ export class ProviderListComponent implements OnInit {
   );
 
   readonly currentImplementation = computed(
-    () => this.implementations().find((i) => i.implementation === this.draftImplementation()) ?? null,
+    () =>
+      this.implementations().find((i) => i.implementation === this.draftImplementation()) ?? null,
   );
 
   readonly requiredFieldMissing = computed(() => {
@@ -179,7 +188,9 @@ export class ProviderListComponent implements OnInit {
 
   implementationLabel(value: string): string {
     const impl = this.implementations().find((i) => i.implementation === value);
-    return impl ? this.translate.instant(impl.labelKey) : this.translate.instant('provider_list.unknown_implementation');
+    return impl
+      ? this.translate.instant(impl.labelKey)
+      : this.translate.instant('provider_list.unknown_implementation');
   }
 
   private seedValue(row: ProviderInstance | null, impl: ProviderImplementation): SchemaFormValue {
@@ -200,7 +211,9 @@ export class ProviderListComponent implements OnInit {
     this.editingId.set(null);
     const impl = this.implementations()[0] ?? null;
     this.draftImplementation.set(impl?.implementation ?? '');
-    this.draftName.set(impl && this.autoFillNameFromImplementation() ? this.translate.instant(impl.labelKey) : '');
+    this.draftName.set(
+      impl && this.autoFillNameFromImplementation() ? this.translate.instant(impl.labelKey) : '',
+    );
     this.draftPriority.set(this.defaultPriority());
     this.draftEnabled.set(this.defaultEnabled());
     this.draftValue.set(impl ? this.seedValue(null, impl) : {});
@@ -279,7 +292,10 @@ export class ProviderListComponent implements OnInit {
         }),
       );
     } catch {
-      this.testResult.set({ ok: false, message: this.translate.instant('provider_list.test_network_error') });
+      this.testResult.set({
+        ok: false,
+        message: this.translate.instant('provider_list.test_network_error'),
+      });
     } finally {
       this.testLoading.set(false);
     }
@@ -318,7 +334,13 @@ export class ProviderListComponent implements OnInit {
   async deleteRow(row: ProviderInstance): Promise<void> {
     const l = this.labels();
     const msg = this.translate.instant(l.confirmDeleteKey, { name: row.name });
-    if (!(await this.confirmation.confirm({ title: this.translate.instant('common.confirm'), message: msg, variant: 'danger' })))
+    if (
+      !(await this.confirmation.confirm({
+        title: this.translate.instant('common.confirm'),
+        message: msg,
+        variant: 'danger',
+      }))
+    )
       return;
     try {
       await firstValueFrom(this.http.delete(`${this.listUrl()}/${row.id}`));
@@ -341,8 +363,12 @@ export class ProviderListComponent implements OnInit {
     if (idx < 0 || swapIdx < 0 || swapIdx >= ordered.length) return;
     const other = ordered[swapIdx];
     try {
-      await firstValueFrom(this.http.put(`${this.listUrl()}/${row.id}`, { ...row, priority: other.priority }));
-      await firstValueFrom(this.http.put(`${this.listUrl()}/${other.id}`, { ...other, priority: row.priority }));
+      await firstValueFrom(
+        this.http.put(`${this.listUrl()}/${row.id}`, { ...row, priority: other.priority }),
+      );
+      await firstValueFrom(
+        this.http.put(`${this.listUrl()}/${other.id}`, { ...other, priority: row.priority }),
+      );
       await this.reload();
     } catch {
       // handled by the global error interceptor
@@ -378,11 +404,15 @@ export class ProviderListComponent implements OnInit {
   cooldownRemaining(cd: ProviderCooldown): string {
     const minutes = Math.ceil(cd.remainingMs / 60_000);
     if (minutes < 60) return this.translate.instant('provider_list.cooldown_minutes', { minutes });
-    return this.translate.instant('provider_list.cooldown_hours', { hours: Math.ceil(minutes / 60) });
+    return this.translate.instant('provider_list.cooldown_hours', {
+      hours: Math.ceil(minutes / 60),
+    });
   }
 
   cooldownReasonKey(cd: ProviderCooldown): string {
-    return cd.reason === 'rate-limit' ? 'provider_list.cooldown_rate_limit' : 'provider_list.cooldown_failures';
+    return cd.reason === 'rate-limit'
+      ? 'provider_list.cooldown_rate_limit'
+      : 'provider_list.cooldown_failures';
   }
 
   /** Persists the whole row, as `moveRow` does: the resource merges secrets on update, so
@@ -390,7 +420,9 @@ export class ProviderListComponent implements OnInit {
   async toggleEnabled(row: ProviderInstance): Promise<void> {
     this.togglingId.set(row.id);
     try {
-      await firstValueFrom(this.http.put(`${this.listUrl()}/${row.id}`, { ...row, enabled: !row.enabled }));
+      await firstValueFrom(
+        this.http.put(`${this.listUrl()}/${row.id}`, { ...row, enabled: !row.enabled }),
+      );
       await this.reload();
     } catch {
       // handled by the global error interceptor
@@ -418,7 +450,11 @@ export class ProviderListComponent implements OnInit {
     }
     if (action.method === 'GET') {
       if (!action.result) return;
-      this.resultView.set({ url, title: `${row.name} — ${this.translate.instant(action.labelKey)}`, result: action.result });
+      this.resultView.set({
+        url,
+        title: `${row.name} — ${this.translate.instant(action.labelKey)}`,
+        result: action.result,
+      });
       this.resultDialog()?.nativeElement.showModal();
       return;
     }

--- a/client/src/app/shared/components/subtitle-viewer-modal/subtitle-viewer-modal.html
+++ b/client/src/app/shared/components/subtitle-viewer-modal/subtitle-viewer-modal.html
@@ -29,7 +29,7 @@
     }
 
     <div class="modal-action">
-      <button type="button" class="btn btn-sm" (click)="close()">
+      <button type="button" class="btn" (click)="close()">
         {{ 'common.close' | translate }}
       </button>
     </div>

--- a/client/src/app/shared/components/subtitle-viewer-modal/subtitle-viewer-modal.html
+++ b/client/src/app/shared/components/subtitle-viewer-modal/subtitle-viewer-modal.html
@@ -14,7 +14,7 @@
       </p>
     } @else {
       <p class="text-xs text-base-content/50 mb-2">
-        {{ 'media_detail.subtitle_view_count' | translate:{ count: cues().length } }}
+        {{ 'media_detail.subtitle_view_count' | translate: { count: cues().length } }}
       </p>
       <div class="max-h-[60vh] overflow-y-auto flex flex-col gap-2 pr-1">
         @for (cue of cues(); track $index) {
@@ -28,11 +28,11 @@
       </div>
     }
 
-    <div class="modal-action">
+    <app-modal-footer>
       <button type="button" class="btn" (click)="close()">
         {{ 'common.close' | translate }}
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/shared/components/subtitle-viewer-modal/subtitle-viewer-modal.ts
+++ b/client/src/app/shared/components/subtitle-viewer-modal/subtitle-viewer-modal.ts
@@ -12,12 +12,13 @@ import { TranslateModule } from '@ngx-translate/core';
 import { ModalHeaderComponent } from '../modal-header';
 import { VttCue, parseVtt } from '../../../core/services/playback-engine/subtitle-overlay.util';
 import { formatTime } from '../../../core/utils/player.utils';
+import { ModalFooterComponent } from '../modal-footer';
 
 /** Read-only cue list. Reads the player's own WebVTT through the engine's
  *  parser, so it shows what would be rendered, tag sanitisation included. */
 @Component({
   selector: 'app-subtitle-viewer-modal',
-  imports: [TranslateModule, ModalHeaderComponent],
+  imports: [ModalFooterComponent, TranslateModule, ModalHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './subtitle-viewer-modal.html',
 })

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -11,7 +11,9 @@
                 type="button"
                 class="btn btn-ghost btn-sm shrink-0"
                 [disabled]="searchDisabled() || subtitleActionBusy()"
-                [attr.title]="searchDisabled() ? ('media_detail.subtitles_need_episode_file' | translate) : null"
+                [attr.title]="
+                  searchDisabled() ? ('media_detail.subtitles_need_episode_file' | translate) : null
+                "
                 (click)="searchMissing()"
               >
                 @if (subtitleActionBusy()) {
@@ -32,21 +34,25 @@
                 type="button"
                 class="btn btn-ghost btn-sm shrink-0"
                 [disabled]="searchDisabled() || subtitleActionBusy()"
-                [attr.title]="searchDisabled() ? ('media_detail.subtitles_need_episode_file' | translate) : null"
+                [attr.title]="
+                  searchDisabled() ? ('media_detail.subtitles_need_episode_file' | translate) : null
+                "
                 (click)="pickSubtitleFile()"
               >
                 <svg lucideUpload class="h-4 w-4 shrink-0" aria-hidden="true"></svg>
-                {{ 'media_detail.upload_subtitle' | translate }}
+                {{ 'media_detail.subtitles_import' | translate }}
               </button>
             }
             <button
               type="button"
               class="btn btn-primary btn-sm shrink-0"
               [disabled]="searchDisabled() || subtitleActionBusy()"
-              [attr.title]="searchDisabled() ? ('media_detail.subtitles_need_episode_file' | translate) : null"
+              [attr.title]="
+                searchDisabled() ? ('media_detail.subtitles_need_episode_file' | translate) : null
+              "
               (click)="openSubtitleSearch()"
             >
-              {{ 'media_detail.search_subtitles' | translate }}
+              {{ 'media_detail.subtitles_search' | translate }}
             </button>
           </div>
         }
@@ -86,11 +92,16 @@
                   @let sub = row.sub!;
                   <tr>
                     <td class="font-medium">{{ sub.language | localizeLanguage }}</td>
-                    <td class="text-sm text-base-content/60 truncate max-w-48" [title]="sub.relativePath ?? ''">
+                    <td
+                      class="text-sm text-base-content/60 truncate max-w-48"
+                      [title]="sub.relativePath ?? ''"
+                    >
                       @if (sub.relativePath) {
                         {{ sub.relativePath | subtitleFilename }}
                       } @else if (sub.providerType === 'embedded') {
-                        <span class="text-base-content/30">{{ 'media_detail.embedded' | translate }}</span>
+                        <span class="text-base-content/30">{{
+                          'media_detail.embedded' | translate
+                        }}</span>
                       } @else {
                         —
                       }
@@ -99,7 +110,9 @@
                       @if (sub.providerType === 'embedded') {
                         <span class="badge badge-sm badge-neutral">embedded</span>
                       } @else if (sub.providerType === 'translated') {
-                        <span [title]="sub.translationModel ?? ''">{{ translationServiceLabel(sub) }}</span>
+                        <span [title]="sub.translationModel ?? ''">{{
+                          translationServiceLabel(sub)
+                        }}</span>
                       } @else {
                         {{ sub.providerType }}
                       }
@@ -113,22 +126,43 @@
                     </td>
                     <td class="text-center text-sm">
                       @if (sub.status === 'processing') {
-                        @if (sub.providerType === 'translated' && translationPercent(sub.id) !== null) {
+                        @if (
+                          sub.providerType === 'translated' && translationPercent(sub.id) !== null
+                        ) {
                           <span class="inline-flex items-center gap-1 align-middle">
-                            <progress class="progress progress-warning w-16 h-1.5 align-middle" [value]="translationPercent(sub.id)" max="100"></progress>
-                            <span class="tabular-nums text-[10px]">{{ translationPercent(sub.id) }}%</span>
+                            <progress
+                              class="progress progress-warning w-16 h-1.5 align-middle"
+                              [value]="translationPercent(sub.id)"
+                              max="100"
+                            ></progress>
+                            <span class="tabular-nums text-[10px]"
+                              >{{ translationPercent(sub.id) }}%</span
+                            >
                           </span>
                         } @else {
                           <span class="badge badge-sm badge-warning gap-1">
                             <span class="loading loading-spinner loading-xs"></span>
-                            {{ (sub.providerType === 'translated' ? 'media_detail.translate_processing' : 'media_detail.ocr_processing') | translate }}
+                            {{
+                              (sub.providerType === 'translated'
+                                ? 'media_detail.translate_processing'
+                                : 'media_detail.ocr_processing'
+                              ) | translate
+                            }}
                           </span>
                         }
                       }
-                      @if (sub.forced) { <span class="badge badge-sm badge-outline mr-1">F</span> }
-                      @if (sub.hearingImpaired) { <span class="badge badge-sm badge-outline">HI</span> }
-                      @if (sub.synced) { <span class="badge badge-sm badge-info ml-1">Synced</span> }
-                      @if (sub.codec) { <span class="badge badge-sm badge-ghost ml-1">{{ sub.codec }}</span> }
+                      @if (sub.forced) {
+                        <span class="badge badge-sm badge-outline mr-1">F</span>
+                      }
+                      @if (sub.hearingImpaired) {
+                        <span class="badge badge-sm badge-outline">HI</span>
+                      }
+                      @if (sub.synced) {
+                        <span class="badge badge-sm badge-info ml-1">Synced</span>
+                      }
+                      @if (sub.codec) {
+                        <span class="badge badge-sm badge-ghost ml-1">{{ sub.codec }}</span>
+                      }
                     </td>
                     <td class="text-end">
                       @if (canManage() && rowHasActions(sub) && sub.status !== 'processing') {
@@ -185,7 +219,9 @@
     <app-modal-header>
       <div>
         <h3 class="text-lg font-bold">{{ 'media_detail.sync_modal_title' | translate }}</h3>
-        <p class="text-sm text-base-content/60 mt-1">{{ 'media_detail.sync_modal_subtitle' | translate }}</p>
+        <p class="text-sm text-base-content/60 mt-1">
+          {{ 'media_detail.sync_modal_subtitle' | translate }}
+        </p>
       </div>
     </app-modal-header>
 
@@ -201,21 +237,33 @@
           @if (audioStreams().length) {
             <optgroup [label]="'media_detail.sync_audio_tracks' | translate">
               @for (s of audioStreams(); track s.streamIndex) {
-                <option [value]="'audio:' + s.streamIndex">{{ s.language | localizeLanguage }} — {{ s.codec }}@if (s.title) { ({{ s.title }}) }</option>
+                <option [value]="'audio:' + s.streamIndex">
+                  {{ s.language | localizeLanguage }} — {{ s.codec }}
+                  @if (s.title) {
+                    ({{ s.title }})
+                  }
+                </option>
               }
             </optgroup>
           }
           @if (subtitleStreams().length) {
             <optgroup [label]="'media_detail.sync_subtitle_tracks' | translate">
               @for (s of subtitleStreams(); track s.streamIndex) {
-                <option [value]="'subtitle:' + s.streamIndex">{{ s.language | localizeLanguage }} — {{ s.codec }}@if (s.title) { ({{ s.title }}) }</option>
+                <option [value]="'subtitle:' + s.streamIndex">
+                  {{ s.language | localizeLanguage }} — {{ s.codec }}
+                  @if (s.title) {
+                    ({{ s.title }})
+                  }
+                </option>
               }
             </optgroup>
           }
           @if (externalSubtitleRefs().length) {
             <optgroup [label]="'media_detail.sync_external_subtitles' | translate">
               @for (s of externalSubtitleRefs(); track s.id) {
-                <option [value]="'file:' + s.relativePath">{{ s.language | localizeLanguage }} — {{ s.providerType }} ({{ s.status }})</option>
+                <option [value]="'file:' + s.relativePath">
+                  {{ s.language | localizeLanguage }} — {{ s.providerType }} ({{ s.status }})
+                </option>
               }
             </optgroup>
           }
@@ -233,7 +281,9 @@
           (ngModelChange)="syncMaxOffset.set($event)"
         />
         <div class="label">
-          <span class="label-text-alt text-base-content/50">{{ 'media_detail.sync_max_offset_hint' | translate }}</span>
+          <span class="label-text-alt text-base-content/50">{{
+            'media_detail.sync_max_offset_hint' | translate
+          }}</span>
         </div>
       </label>
 
@@ -258,14 +308,14 @@
       </label>
     </div>
 
-    <div class="modal-action">
+    <app-modal-footer>
       <button type="button" class="btn btn-ghost" (click)="closeSyncModal()">
         {{ 'common.cancel' | translate }}
       </button>
       <button type="button" class="btn btn-primary" (click)="confirmSync()">
         {{ 'media_detail.action_sync' | translate }}
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
     <button type="button" tabindex="-1" (click)="closeSyncModal()">close</button>
@@ -278,7 +328,9 @@
     <app-modal-header>
       <div>
         <h3 class="text-lg font-bold">{{ 'media_detail.adjust_times_title' | translate }}</h3>
-        <p class="text-sm text-base-content/60 mt-1">{{ 'media_detail.adjust_times_subtitle' | translate }}</p>
+        <p class="text-sm text-base-content/60 mt-1">
+          {{ 'media_detail.adjust_times_subtitle' | translate }}
+        </p>
       </div>
     </app-modal-header>
 
@@ -312,17 +364,19 @@
       </label>
     </div>
     <div class="label">
-      <span class="label-text-alt text-base-content/50">{{ 'media_detail.adjust_offset_hint' | translate }}</span>
+      <span class="label-text-alt text-base-content/50">{{
+        'media_detail.adjust_offset_hint' | translate
+      }}</span>
     </div>
 
-    <div class="modal-action">
+    <app-modal-footer>
       <button type="button" class="btn btn-ghost" (click)="closeAdjustModal()">
         {{ 'common.cancel' | translate }}
       </button>
       <button type="button" class="btn btn-primary" (click)="confirmAdjust()">
         {{ 'media_detail.action_adjust_times' | translate }}
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
     <button type="button" tabindex="-1" (click)="closeAdjustModal()">close</button>
@@ -335,7 +389,9 @@
     <app-modal-header>
       <div>
         <h3 class="text-lg font-bold">{{ 'media_detail.change_fps_title' | translate }}</h3>
-        <p class="text-sm text-base-content/60 mt-1">{{ 'media_detail.change_fps_subtitle' | translate }}</p>
+        <p class="text-sm text-base-content/60 mt-1">
+          {{ 'media_detail.change_fps_subtitle' | translate }}
+        </p>
       </div>
     </app-modal-header>
 
@@ -370,14 +426,19 @@
       </label>
     </div>
 
-    <div class="modal-action">
+    <app-modal-footer>
       <button type="button" class="btn btn-ghost" (click)="closeFpsModal()">
         {{ 'common.cancel' | translate }}
       </button>
-      <button type="button" class="btn btn-primary" [disabled]="fpsFrom() === fpsTo()" (click)="confirmFps()">
+      <button
+        type="button"
+        class="btn btn-primary"
+        [disabled]="fpsFrom() === fpsTo()"
+        (click)="confirmFps()"
+      >
         {{ 'media_detail.action_change_fps' | translate }}
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
     <button type="button" tabindex="-1" (click)="closeFpsModal()">close</button>
@@ -390,22 +451,36 @@
       <div class="min-w-0">
         @if (langDialogMode() === 'relabel') {
           <h3 class="text-lg font-bold">{{ 'media_detail.change_language_title' | translate }}</h3>
-          <p class="py-2 text-sm text-base-content/70">{{ 'media_detail.change_language_hint' | translate }}</p>
+          <p class="py-2 text-sm text-base-content/70">
+            {{ 'media_detail.change_language_hint' | translate }}
+          </p>
         } @else if (langDialogMode() === 'translate') {
-          <h3 class="text-lg font-bold">{{ 'media_detail.translate_target_language' | translate }}</h3>
-          <p class="py-2 text-sm text-base-content/70">{{ 'media_detail.translate_hint' | translate }}</p>
+          <h3 class="text-lg font-bold">
+            {{ 'media_detail.translate_target_language' | translate }}
+          </h3>
+          <p class="py-2 text-sm text-base-content/70">
+            {{ 'media_detail.translate_hint' | translate }}
+          </p>
         } @else if (langDialogMode() === 'upload') {
           <h3 class="text-lg font-bold">{{ 'media_detail.upload_subtitle' | translate }}</h3>
           <p class="py-2 text-sm text-base-content/70 break-all">{{ pendingUploadName() }}</p>
-          <p class="text-sm text-base-content/70">{{ 'media_detail.upload_subtitle_hint' | translate }}</p>
+          <p class="text-sm text-base-content/70">
+            {{ 'media_detail.upload_subtitle_hint' | translate }}
+          </p>
         } @else {
           <h3 class="text-lg font-bold">{{ 'media_detail.ocr_language_title' | translate }}</h3>
-          <p class="py-2 text-sm text-base-content/70">{{ 'media_detail.ocr_language_hint' | translate }}</p>
+          <p class="py-2 text-sm text-base-content/70">
+            {{ 'media_detail.ocr_language_hint' | translate }}
+          </p>
         }
       </div>
     </app-modal-header>
     <div class="mt-2 space-y-4">
-      <select class="select select-bordered w-full" [ngModel]="ocrLang()" (ngModelChange)="ocrLang.set($event)">
+      <select
+        class="select select-bordered w-full"
+        [ngModel]="ocrLang()"
+        (ngModelChange)="ocrLang.set($event)"
+      >
         @for (code of langDialogCodes(); track code) {
           <option [value]="code">{{ code | localizeLanguage }}</option>
         }
@@ -425,12 +500,23 @@
         </label>
       }
     </div>
-    <div class="modal-action">
-      <button type="button" class="btn" (click)="closeOcrLangModal()">{{ 'common.cancel' | translate }}</button>
-      <button type="button" class="btn btn-primary" (click)="confirmLanguage()">
-        {{ (langDialogMode() === 'relabel' ? 'common.save' : langDialogMode() === 'translate' ? 'media_detail.translate' : langDialogMode() === 'upload' ? 'media_detail.upload_subtitle' : 'media_detail.action_ocr_extract') | translate }}
+    <app-modal-footer>
+      <button type="button" class="btn" (click)="closeOcrLangModal()">
+        {{ 'common.cancel' | translate }}
       </button>
-    </div>
+      <button type="button" class="btn btn-primary" (click)="confirmLanguage()">
+        {{
+          (langDialogMode() === 'relabel'
+            ? 'common.save'
+            : langDialogMode() === 'translate'
+              ? 'media_detail.translate'
+              : langDialogMode() === 'upload'
+                ? 'media_detail.upload_subtitle'
+                : 'media_detail.action_ocr_extract'
+          ) | translate
+        }}
+      </button>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop">
     <button type="button" tabindex="-1" (click)="closeOcrLangModal()">close</button>

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -1,11 +1,6 @@
 <dialog #modal class="modal">
   <div class="modal-box w-11/12 max-w-5xl">
-    <div class="flex items-start justify-between gap-4 mb-4">
-      <h3 class="text-lg font-bold">{{ 'media_detail.edit_subtitles' | translate }}</h3>
-      <form method="dialog">
-        <button class="btn btn-sm btn-circle btn-ghost" [attr.aria-label]="'common.close' | translate">✕</button>
-      </form>
-    </div>
+    <app-modal-header [title]="'media_detail.edit_subtitles' | translate" />
 
     <section class="space-y-3">
       <div class="flex flex-wrap items-center justify-between gap-2">
@@ -187,8 +182,12 @@
 <!-- Sync options modal -->
 <dialog #syncDialog class="modal">
   <div class="modal-box max-w-2xl w-11/12">
-    <h3 class="text-lg font-bold">{{ 'media_detail.sync_modal_title' | translate }}</h3>
-    <p class="text-sm text-base-content/60 mt-1">{{ 'media_detail.sync_modal_subtitle' | translate }}</p>
+    <app-modal-header>
+      <div>
+        <h3 class="text-lg font-bold">{{ 'media_detail.sync_modal_title' | translate }}</h3>
+        <p class="text-sm text-base-content/60 mt-1">{{ 'media_detail.sync_modal_subtitle' | translate }}</p>
+      </div>
+    </app-modal-header>
 
     <div class="flex flex-col gap-4 mt-4">
       <label class="form-control w-full">
@@ -276,8 +275,12 @@
 <!-- Adjust Times modal -->
 <dialog #adjustDialog class="modal">
   <div class="modal-box max-w-md">
-    <h3 class="text-lg font-bold">{{ 'media_detail.adjust_times_title' | translate }}</h3>
-    <p class="text-sm text-base-content/60 mt-1">{{ 'media_detail.adjust_times_subtitle' | translate }}</p>
+    <app-modal-header>
+      <div>
+        <h3 class="text-lg font-bold">{{ 'media_detail.adjust_times_title' | translate }}</h3>
+        <p class="text-sm text-base-content/60 mt-1">{{ 'media_detail.adjust_times_subtitle' | translate }}</p>
+      </div>
+    </app-modal-header>
 
     <div class="flex gap-3 mt-4">
       <label class="form-control flex-1">
@@ -329,8 +332,12 @@
 <!-- Change Frame Rate modal -->
 <dialog #fpsDialog class="modal">
   <div class="modal-box max-w-md">
-    <h3 class="text-lg font-bold">{{ 'media_detail.change_fps_title' | translate }}</h3>
-    <p class="text-sm text-base-content/60 mt-1">{{ 'media_detail.change_fps_subtitle' | translate }}</p>
+    <app-modal-header>
+      <div>
+        <h3 class="text-lg font-bold">{{ 'media_detail.change_fps_title' | translate }}</h3>
+        <p class="text-sm text-base-content/60 mt-1">{{ 'media_detail.change_fps_subtitle' | translate }}</p>
+      </div>
+    </app-modal-header>
 
     <div class="flex gap-4 mt-4">
       <label class="form-control flex-1">
@@ -379,20 +386,24 @@
 
 <dialog #ocrLangDialog class="modal">
   <div class="modal-box max-w-sm">
-    @if (langDialogMode() === 'relabel') {
-      <h3 class="text-lg font-bold">{{ 'media_detail.change_language_title' | translate }}</h3>
-      <p class="py-2 text-sm text-base-content/70">{{ 'media_detail.change_language_hint' | translate }}</p>
-    } @else if (langDialogMode() === 'translate') {
-      <h3 class="text-lg font-bold">{{ 'media_detail.translate_target_language' | translate }}</h3>
-      <p class="py-2 text-sm text-base-content/70">{{ 'media_detail.translate_hint' | translate }}</p>
-    } @else if (langDialogMode() === 'upload') {
-      <h3 class="text-lg font-bold">{{ 'media_detail.upload_subtitle' | translate }}</h3>
-      <p class="py-2 text-sm text-base-content/70 break-all">{{ pendingUploadName() }}</p>
-      <p class="text-sm text-base-content/70">{{ 'media_detail.upload_subtitle_hint' | translate }}</p>
-    } @else {
-      <h3 class="text-lg font-bold">{{ 'media_detail.ocr_language_title' | translate }}</h3>
-      <p class="py-2 text-sm text-base-content/70">{{ 'media_detail.ocr_language_hint' | translate }}</p>
-    }
+    <app-modal-header>
+      <div class="min-w-0">
+        @if (langDialogMode() === 'relabel') {
+          <h3 class="text-lg font-bold">{{ 'media_detail.change_language_title' | translate }}</h3>
+          <p class="py-2 text-sm text-base-content/70">{{ 'media_detail.change_language_hint' | translate }}</p>
+        } @else if (langDialogMode() === 'translate') {
+          <h3 class="text-lg font-bold">{{ 'media_detail.translate_target_language' | translate }}</h3>
+          <p class="py-2 text-sm text-base-content/70">{{ 'media_detail.translate_hint' | translate }}</p>
+        } @else if (langDialogMode() === 'upload') {
+          <h3 class="text-lg font-bold">{{ 'media_detail.upload_subtitle' | translate }}</h3>
+          <p class="py-2 text-sm text-base-content/70 break-all">{{ pendingUploadName() }}</p>
+          <p class="text-sm text-base-content/70">{{ 'media_detail.upload_subtitle_hint' | translate }}</p>
+        } @else {
+          <h3 class="text-lg font-bold">{{ 'media_detail.ocr_language_title' | translate }}</h3>
+          <p class="py-2 text-sm text-base-content/70">{{ 'media_detail.ocr_language_hint' | translate }}</p>
+        }
+      </div>
+    </app-modal-header>
     <div class="mt-2 space-y-4">
       <select class="select select-bordered w-full" [ngModel]="ocrLang()" (ngModelChange)="ocrLang.set($event)">
         @for (code of langDialogCodes(); track code) {

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -17,10 +17,7 @@ import {
 } from '@lucide/angular';
 import { LocalizeLanguagePipe } from '../../../core/pipes/localize-language.pipe';
 import { formatSubtitleLabel, formatSubtitleParts } from '../../../core/utils/player.utils';
-import {
-  guessLanguageFromFilename,
-  localizeLanguage,
-} from '../../../core/utils/language.utils';
+import { guessLanguageFromFilename, localizeLanguage } from '../../../core/utils/language.utils';
 import {
   isImageBasedSubtitleCodec,
   isOcrSupportedSubtitleCodec,
@@ -48,16 +45,14 @@ import {
   AvailableTranslationProvider,
 } from '../../../core/services/api/translation-providers-api.service';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
-import {
-  LanguageProfile,
-  ProfilesService,
-} from '../../../core/services/api/profiles.service';
+import { LanguageProfile, ProfilesService } from '../../../core/services/api/profiles.service';
 import { SseService } from '../../../core/services/sse.service';
 import { ToastService } from '../../../core/services/toast.service';
 import { PaginationComponent } from '../pagination/pagination';
 import { MediaDetailSubtitleSearchModalComponent } from '../../../features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component';
 import type { MediaInfoHeaderSubtitle } from '../media-info-header/media-info-header';
 import { ModalHeaderComponent } from '../modal-header';
+import { ModalFooterComponent } from '../modal-footer';
 
 interface SubtitleRow {
   sub?: SubtitleFileRow;
@@ -74,6 +69,7 @@ interface SubtitleRow {
 @Component({
   selector: 'app-subtitles-modal',
   imports: [
+    ModalFooterComponent,
     ModalHeaderComponent,
     FormsModule,
     TranslateModule,
@@ -120,8 +116,7 @@ export class SubtitlesModalComponent {
 
   private readonly cardActions = inject(CardActionsService);
 
-  private readonly viewer =
-    viewChild<SubtitleViewerModalComponent>('subtitleViewer');
+  private readonly viewer = viewChild<SubtitleViewerModalComponent>('subtitleViewer');
 
   protected readonly canDownload = this.device.canSaveFiles;
 
@@ -140,20 +135,14 @@ export class SubtitlesModalComponent {
     if (!sub) return '';
     return sub.relativePath
       ? this.streamingApi.getSubtitleDownloadUrl(sub.mediaFileId, sub.id)
-      : this.streamingApi.getEmbeddedSubtitleDownloadUrl(
-          sub.mediaFileId,
-          sub.streamIndex!,
-        );
+      : this.streamingApi.getEmbeddedSubtitleDownloadUrl(sub.mediaFileId, sub.streamIndex!);
   }
 
   /** Reads the playback WebVTT, so an embedded track is extracted on demand. */
   protected viewSubtitle(sub: SubtitleFileRow): void {
     const url = sub.relativePath
       ? this.streamingApi.getSubtitleUrl(sub.mediaFileId, sub.id)
-      : this.streamingApi.getEmbeddedSubtitleUrl(
-          sub.mediaFileId,
-          sub.streamIndex!,
-        );
+      : this.streamingApi.getEmbeddedSubtitleUrl(sub.mediaFileId, sub.streamIndex!);
     void this.viewer()?.open(formatSubtitleLabel(sub, this.translate), url);
   }
 
@@ -324,9 +313,39 @@ export class SubtitlesModalComponent {
 
   // OCR language picker (used when an image track is untagged — 'und').
   readonly ocrLangCodes: readonly string[] = [
-    'en', 'fr', 'de', 'es', 'it', 'pt', 'nl', 'sv', 'da', 'no', 'fi',
-    'pl', 'cs', 'sk', 'hu', 'ro', 'el', 'ru', 'uk', 'bg', 'sr', 'hr',
-    'tr', 'ar', 'he', 'fa', 'hi', 'th', 'vi', 'id', 'ja', 'ko', 'zh',
+    'en',
+    'fr',
+    'de',
+    'es',
+    'it',
+    'pt',
+    'nl',
+    'sv',
+    'da',
+    'no',
+    'fi',
+    'pl',
+    'cs',
+    'sk',
+    'hu',
+    'ro',
+    'el',
+    'ru',
+    'uk',
+    'bg',
+    'sr',
+    'hr',
+    'tr',
+    'ar',
+    'he',
+    'fa',
+    'hi',
+    'th',
+    'vi',
+    'id',
+    'ja',
+    'ko',
+    'zh',
   ];
   private readonly ocrTargetId = signal<number | null>(null);
   readonly ocrLang = signal('en');
@@ -355,8 +374,7 @@ export class SubtitlesModalComponent {
   readonly uploadAccept = computed(() =>
     this.device.isAndroidNative() ? '*/*' : '.srt,.ass,.ssa,.vtt,.sub,text/plain',
   );
-  private readonly uploadInput =
-    viewChild<ElementRef<HTMLInputElement>>('uploadInput');
+  private readonly uploadInput = viewChild<ElementRef<HTMLInputElement>>('uploadInput');
   /** File chosen in the picker, held until the language dialog is confirmed. */
   private readonly pendingUpload = signal<File | null>(null);
   readonly pendingUploadName = computed(() => this.pendingUpload()?.name ?? '');
@@ -595,7 +613,10 @@ export class SubtitlesModalComponent {
   private readonly loadProfilesEffect = effect(() => {
     const lpId = this.languageProfileId();
     if (lpId && !this.languageProfiles().length) {
-      this.profilesApi.getLanguageProfiles().then((lp) => this.languageProfiles.set(lp)).catch(() => {});
+      this.profilesApi
+        .getLanguageProfiles()
+        .then((lp) => this.languageProfiles.set(lp))
+        .catch(() => {});
     }
   });
 
@@ -734,12 +755,7 @@ export class SubtitlesModalComponent {
       }))
     )
       return;
-    await this.subActions.validate(
-      this.mediaId(),
-      sub.id,
-      this.subtitles,
-      this.subtitleActionBusy,
-    );
+    await this.subActions.validate(this.mediaId(), sub.id, this.subtitles, this.subtitleActionBusy);
     this.toast.success(this.translate.instant('media_detail.validate_success'));
   }
 
@@ -783,15 +799,11 @@ export class SubtitlesModalComponent {
       return; // global interceptor surfaced the error
     }
     if (providers.length === 0) {
-      this.toast.error(
-        this.translate.instant('media_detail.translate_no_providers'),
-      );
+      this.toast.error(this.translate.instant('media_detail.translate_no_providers'));
       return;
     }
     this.translationProviders.set(providers);
-    this.selectedTranslationProviderId.set(
-      (providers.find((p) => p.isDefault) ?? providers[0]).id,
-    );
+    this.selectedTranslationProviderId.set((providers.find((p) => p.isDefault) ?? providers[0]).id);
     const src = (sub.language ?? '').toLowerCase();
     this.langDialogMode.set('translate');
     this.ocrTargetId.set(sub.id);
@@ -823,9 +835,7 @@ export class SubtitlesModalComponent {
     if (!file) return;
     this.pendingUpload.set(file);
     this.langDialogMode.set('upload');
-    this.ocrLang.set(
-      guessLanguageFromFilename(file.name, SUBTITLE_LANGUAGE_CODES) ?? 'en',
-    );
+    this.ocrLang.set(guessLanguageFromFilename(file.name, SUBTITLE_LANGUAGE_CODES) ?? 'en');
     this.ocrLangDialog()?.nativeElement.showModal();
   }
 
@@ -864,8 +874,13 @@ export class SubtitlesModalComponent {
         this.selectedTranslationProviderId() ?? undefined,
       );
     } else {
-      void this.subActions
-        .setLanguage(this.mediaId(), id, this.subtitles, this.subtitleActionBusy, this.ocrLang());
+      void this.subActions.setLanguage(
+        this.mediaId(),
+        id,
+        this.subtitles,
+        this.subtitleActionBusy,
+        this.ocrLang(),
+      );
     }
   }
 
@@ -885,11 +900,7 @@ export class SubtitlesModalComponent {
     this.toast.info(this.translate.instant('media_detail.ocr_started'));
   }
 
-  private async triggerTranslate(
-    subtitleId: number,
-    targetLanguage: string,
-    providerId?: number,
-  ) {
+  private async triggerTranslate(subtitleId: number, targetLanguage: string, providerId?: number) {
     await this.subActions.translateSubtitle(
       this.mediaId(),
       subtitleId,
@@ -910,6 +921,11 @@ export class SubtitlesModalComponent {
       }))
     )
       return;
-    await this.subActions.remove(this.mediaId(), subtitleId, this.subtitles, this.subtitleActionBusy);
+    await this.subActions.remove(
+      this.mediaId(),
+      subtitleId,
+      this.subtitles,
+      this.subtitleActionBusy,
+    );
   }
 }

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -57,6 +57,7 @@ import { ToastService } from '../../../core/services/toast.service';
 import { PaginationComponent } from '../pagination/pagination';
 import { MediaDetailSubtitleSearchModalComponent } from '../../../features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component';
 import type { MediaInfoHeaderSubtitle } from '../media-info-header/media-info-header';
+import { ModalHeaderComponent } from '../modal-header';
 
 interface SubtitleRow {
   sub?: SubtitleFileRow;
@@ -73,6 +74,7 @@ interface SubtitleRow {
 @Component({
   selector: 'app-subtitles-modal',
   imports: [
+    ModalHeaderComponent,
     FormsModule,
     TranslateModule,
     LocalizeLanguagePipe,

--- a/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.html
+++ b/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.html
@@ -23,15 +23,21 @@
           @for (s of seasons(); track s.seasonNumber) {
             <div>
               @if (scope().kind === 'series') {
-                <div class="text-xs font-semibold uppercase tracking-wide text-base-content/50 mb-1">
-                  {{ 'tracking.season' | translate:{ number: s.seasonNumber } }}
+                <div
+                  class="text-xs font-semibold uppercase tracking-wide text-base-content/50 mb-1"
+                >
+                  {{ 'tracking.season' | translate: { number: s.seasonNumber } }}
                 </div>
               }
               <div class="flex flex-col">
                 @for (ep of s.episodes; track ep.episodeId) {
-                  <div class="flex items-center justify-between gap-3 py-1.5 border-b border-base-200 last:border-0">
+                  <div
+                    class="flex items-center justify-between gap-3 py-1.5 border-b border-base-200 last:border-0"
+                  >
                     <span class="text-sm truncate">{{ episodeLabel(ep) }}</span>
-                    <ng-container *ngTemplateOutlet="line; context: { $implicit: ep }"></ng-container>
+                    <ng-container
+                      *ngTemplateOutlet="line; context: { $implicit: ep }"
+                    ></ng-container>
                   </div>
                 }
               </div>
@@ -49,11 +55,11 @@
       </p>
     }
 
-    <div class="modal-action">
+    <app-modal-footer>
       <button type="button" class="btn" (click)="close()">
         {{ 'common.close' | translate }}
       </button>
-    </div>
+    </app-modal-footer>
   </div>
   <form method="dialog" class="modal-backdrop"><button tabindex="-1">close</button></form>
 </dialog>

--- a/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.html
+++ b/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.html
@@ -50,7 +50,7 @@
     }
 
     <div class="modal-action">
-      <button type="button" class="btn btn-sm" (click)="close()">
+      <button type="button" class="btn" (click)="close()">
         {{ 'common.close' | translate }}
       </button>
     </div>

--- a/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.ts
+++ b/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.ts
@@ -9,18 +9,14 @@ import {
 } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
-import {
-  LucideArrowRight,
-  LucideCheck,
-  LucideCircleAlert,
-  LucideEyeOff,
-} from '@lucide/angular';
+import { LucideArrowRight, LucideCheck, LucideCircleAlert, LucideEyeOff } from '@lucide/angular';
 import {
   MediaService,
   TrackingEpisode,
   TrackingStatus,
 } from '../../../core/services/api/media.service';
 import { ModalHeaderComponent } from '../modal-header';
+import { ModalFooterComponent } from '../modal-footer';
 
 export type TrackingScope =
   | { kind: 'movie' }
@@ -32,6 +28,7 @@ export type TrackingScope =
   selector: 'app-tracking-status-modal',
   standalone: true,
   imports: [
+    ModalFooterComponent,
     NgTemplateOutlet,
     TranslateModule,
     ModalHeaderComponent,
@@ -45,8 +42,7 @@ export type TrackingScope =
 })
 export class TrackingStatusModalComponent {
   private readonly media = inject(MediaService);
-  private readonly dialog =
-    viewChild<ElementRef<HTMLDialogElement>>('dialog');
+  private readonly dialog = viewChild<ElementRef<HTMLDialogElement>>('dialog');
 
   readonly loading = signal(false);
   readonly data = signal<TrackingStatus | null>(null);

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -682,6 +682,19 @@ body.tv .to-base-100\/50 {
   }
 }
 
+/* Modal chrome in a padded `.modal-box`: the header and footer bleed out of its
+   1.5rem padding so their rule reaches both edges, the way a `p-0` box's flex
+   column does it. Real CSS, not utilities — the negative margins live in a host
+   binding, which Tailwind's scanner does not pick up. */
+.modal-header-bar {
+  margin: -1.5rem -1.5rem 1rem;
+  padding: 1.25rem 1.5rem 0.75rem;
+}
+.modal-footer-bar {
+  margin: 1.5rem -1.5rem -1.5rem;
+  padding: 1rem 1.5rem;
+}
+
 /* Shared item style for app-dropdown-menu (desktop dropdown + mobile/TV
    bottom sheet). Caller adds a colour utility (`text-white`, `text-error`,
    …) and an icon — everything else (padding, hover, focus, layout) lives

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -682,12 +682,6 @@ body.tv .to-base-100\/50 {
   }
 }
 
-/* Footer of a scrollable modal: pinned under the scroll area and ruled off
-   from it, so the actions stay reachable while the body scrolls. */
-.modal-action-sticky {
-  @apply shrink-0 px-5 sm:px-6 pb-4 pt-2 border-t border-base-200 bg-base-100;
-}
-
 /* Shared item style for app-dropdown-menu (desktop dropdown + mobile/TV
    bottom sheet). Caller adds a colour utility (`text-white`, `text-error`,
    …) and an icon — everything else (padding, hover, focus, layout) lives

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -682,6 +682,12 @@ body.tv .to-base-100\/50 {
   }
 }
 
+/* Footer of a scrollable modal: pinned under the scroll area and ruled off
+   from it, so the actions stay reachable while the body scrolls. */
+.modal-action-sticky {
+  @apply shrink-0 px-5 sm:px-6 pb-4 pt-2 border-t border-base-200 bg-base-100;
+}
+
 /* Shared item style for app-dropdown-menu (desktop dropdown + mobile/TV
    bottom sheet). Caller adds a colour utility (`text-white`, `text-error`,
    …) and an icon — everything else (padding, hover, focus, layout) lives


### PR DESCRIPTION
Audit of the 52 `<dialog>` in the app, then the sweep. The identify modal was the only one framing its body with a ruled header and footer — that look is now the norm everywhere.

## Components

- `app-modal-header` carries the rule, the padding and the ✕. It bleeds out of `.modal-box`'s 1.5rem padding so the rule spans the full width; `flush` opts out for the 9 boxes that already set `p-0` and lay header/body/footer out as a flex column.
- `app-modal-footer` is the same idea for the actions row, replacing 47 hand-written `<div class="modal-action">`.
- Neither is sticky. A sticky box with a negative `margin-top` paints below its flow position and swallows the top of the body — that was a real regression during this work. The `p-0` boxes still pin their header and footer through the flex column, which is what they always did.
- A modal shown by CSS (`div.modal.modal-open`) has no dialog for the ✕ to submit to, so the header also emits `(closed)`.

## What changed per dialog

- 24 dialogs hand-wrote their title bar in eight spellings of the same `<h2>`/`<h3>`; 10 more had a bespoke bordered bar with their own ✕. All 34 now use the component.
- **~20 dialogs gain a ✕ they did not have.** Every dialog in the app has one now.
- Footer order: [media-detail-library-modal](client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.html) and [media-detail-profiles-modal](client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.html) put Save *before* Close, against every other dialog. Flipped, and their inline `onclick="this.closest('dialog').close()"` — the only two in the app — becomes a `close()` method. A `<form method="dialog">` was not an option: both sit inside an `ngSubmit` form.
- Footer size: 17 footers used `btn-sm`, 30 the full size. Normalised on the full size.
- The subtitle toolbar's two buttons drop the redundant noun: **Import** and **Search** (6 locales).

Left alone: the restart-in-progress modal in `system/status`, which is deliberately not closable.

## Verification

`ng build` clean, `tsc --noEmit` clean, 531 tests green. Structural checks: no `flush`/padding mismatch across the 81 header and footer usages, and every bleed utility is emitted in the built CSS.

Not verified visually — there is no headless browser in this checkout, so the ~40 migrated dialogs have not been rendered. Worth a click through a padded modal (Decline reason, Edit subtitles) and a `p-0` one (Identify, a settings editor) before merging.