### PR TITLE
ci(native): stop installing the Android emulator on the build runner

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -51,7 +51,12 @@ jobs:
           java-version: 21
           cache: gradle
 
+      # Only what `assembleDebug` compiles against. The default package set
+      # pulls the emulator, whose archive has arrived corrupt on the runner and
+      # failed the job before a line of our code was built.
       - uses: android-actions/setup-android@v4
+        with:
+          packages: 'tools platform-tools platforms;android-36'
 
       - name: Install client dependencies
         run: npm ci


### PR DESCRIPTION
## The failure

The `android` job has been failing intermittently at step 5, `android-actions/setup-android@v4`, before any of our code is touched:

```
21% Unzipping...
Warning: An error occurred while preparing SDK package Android Emulator:
         Error reading Zip content from a SeekableByteChannel.
Error: The process '.../sdkmanager' failed with exit code 1
```

`Install client dependencies`, `Build Angular client`, `cap sync` and `gradlew assembleDebug` were all `skipped` — nothing of ours ran. The Angular production build passes locally with the exact command CI uses.

## The fix

The job compiles `assembleDebug` headlessly and never launches an emulator, but the action's default package set downloads one anyway. Naming the packages drops it, so a corrupt archive for an artefact we never use can't block a PR. It also shortens the job.

`build-tools` is deliberately not listed: AGP resolves and downloads the version it wants, so pinning one here would just be a version to keep in sync.

## Test

This PR touches `.github/workflows/native-build.yml`, which is one of the workflow's own path filters — the run on this PR exercises the change.