### PR TITLE
fix(releases): let the table reach the modal edges on a narrow screen

### DIFF
--- a/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.html
+++ b/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.html
@@ -53,7 +53,9 @@
       }
     </div>
 
-    <div class="flex-1 overflow-y-auto px-4 sm:px-6">
+    <!-- Edge to edge on a narrow screen: the table's own cell padding is the
+         only inset the rows need, and 16px on each side is width they lose. -->
+    <div class="flex-1 overflow-y-auto sm:px-6">
       @if (error()) {
         <div role="alert" class="alert alert-error text-sm">{{ error() }}</div>
       } @else if (showSpinnerPanel()) {


### PR DESCRIPTION
The releases list body had `px-4` on top of the table's own cell padding, so on a phone each row lost 32px of width and its separator stopped 16px short of both edges. The padding now starts at `sm`; below it the cell padding is the only inset.

Measured in a headless render at a 400px viewport, before → after:

| | before | after |
|---|---|---|
| row spans box (L/R) | 16 / 16 | 0 / 0 |
| body horizontal scroll | 0 | 0 |

Only the container's padding changes — the table, its cells and the row layout are untouched.