### PR TITLE
fix(media-card): hide the metadata actions on a card with no library row

### DIFF
--- a/client/src/app/shared/components/media-card/media-card.spec.ts
+++ b/client/src/app/shared/components/media-card/media-card.spec.ts
@@ -31,10 +31,12 @@ import type { SlotId, UiContribution } from '@fliks/plugin-contract/ui';
 interface Role {
   isTv?: boolean;
   sharingDisabled?: boolean;
+  isAdmin?: boolean;
 }
 const FULL_MEMBER: Role = {};
 const TV_VIEWER: Role = { isTv: true };
 const SHARING_DISABLED: Role = { sharingDisabled: true };
+const ADMIN: Role = { isAdmin: true };
 
 interface Harness {
   fixture: ComponentFixture<MediaCardComponent>;
@@ -67,7 +69,7 @@ async function createFixture(
       {
         provide: AuthService,
         useValue: {
-          hasPermission: () => false,
+          hasPermission: () => !!role.isAdmin,
           sharingDisabled: () => !!role.sharingDisabled,
         },
       },
@@ -520,5 +522,22 @@ describe('MediaCardComponent — card.actions merges with plugin contributions',
     canDelete.fixture.componentInstance.dismissed.subscribe(() => (dismissed = true));
     findAction(canDelete, 'x.remove_wide').run();
     expect(dismissed).toBe(true);
+  });
+
+  it('the metadata group needs a library row: offered on a card bound to media, absent on a search-page card without one', async () => {
+    const inLibrary = await createFixture(ADMIN, { media: makeMedia(), link: ['/movies', '5'] });
+    expect(labels(inLibrary)).toContain('media_detail.metadata_group');
+    const group = findAction(inLibrary, 'media_detail.metadata_group');
+    expect(group.children.map((c: { labelKey: string }) => c.labelKey)).toEqual([
+      'media_detail.identify',
+      'media_detail.refresh_metadata',
+    ]);
+
+    // A discovery / external-search card carries no `media`, so Identify and
+    // Refresh would be no-ops — the group must not be offered at all.
+    const notInLibrary = await createFixture(ADMIN, { title: 'Not here', link: null });
+    expect(labels(notInLibrary)).not.toContain('media_detail.metadata_group');
+    expect(labels(notInLibrary)).not.toContain('media_detail.identify');
+    expect(labels(notInLibrary)).not.toContain('media_detail.refresh_metadata');
   });
 });

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -405,6 +405,11 @@ export class MediaCardComponent {
     },
     'core.toggle_watched': () => this.interactiveWatched(),
     'core.remove': () => this.dismissable(),
+    // Identity and a metadata re-read need a library row. A card for a title
+    // that isn't in the library (search, discovery) has none, and the enclosing
+    // group drops itself once both children are gone.
+    'core.identify': () => this.media()?.id != null,
+    'core.refresh_metadata': () => this.media()?.id != null,
   };
 
   /**


### PR DESCRIPTION
## Why

On the search page, the **Métadonnées** group appeared on cards for titles that are not in the
library — external search results and the discovery rows.

Those cards bind no `media`:

```html
<app-media-card [imageUrl]="row.posterUrl" [title]="row.title" … (clicked)="onExternalCardClick(row)" />
```

while library results do:

```html
<app-media-card [media]="media" … />
```

Both handlers bail on their own null check (`media.identify` → `if (!m) return`,
`media.refresh-metadata` → `if (mediaId == null) return`), so an admin was offered two rows that did
nothing when clicked. Identity and a metadata re-read are operations on a library row; there is
nothing to identify or refresh for a title the server has never imported.

`core.identify` and `core.refresh_metadata` were gated on `isAdmin` (plus `!isEpisode`) only, and
the `when` vocabulary has no "has a library row" predicate — which is exactly what `extraGuards` in
`media-card.ts` exists for, and where nearly every other core row is already gated.

## Fix

Two guards. The `core.metadata_group` submenu then drops itself through the resolver's existing
empty-submenu rule (`if (!children.length) continue`), so the group disappears rather than opening
onto nothing.

No other card row has the same defect: `core.tracking` and `core.mark_series_watched` read
`media()` through their `when` predicates (`isMonitored`, `mediaType:series`), which are already
false without a media row, and every remaining id that needs one is guarded.

## Why the spec missed it

`createFixture`'s auth stub answered `hasPermission: () => false` unconditionally, so `isAdmin` was
false in all 29 characterisation cases and the metadata group was never built. The stub now takes an
`isAdmin` role, and the new case asserts both directions — offered with a bound `media`, absent
without one.

Verified the new test fails against the unfixed code (`expected [ 'media_detail.metadata_group' ] to
not include 'media_detail.metadata_group'`) before restoring the guards. Full client suite green:
532 tests, 62 files.
