### PR TITLE
fix(migrations): drop the criteria column default that fails the drift check

### DIFF
--- a/backend/src/migrations/1784200000000-auto-approval-criteria.ts
+++ b/backend/src/migrations/1784200000000-auto-approval-criteria.ts
@@ -8,6 +8,9 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  *
  * `priority` goes with it. Rules are OR'd (one match approves), so the ordering it defined never
  * changed an outcome.
+ *
+ * Both `ADD COLUMN`s are `NOT NULL` without a default: the `DELETE` above leaves no row to
+ * backfill, and a default the entity does not declare fails the schema-drift check.
  */
 export class AutoApprovalCriteria1784200000000 implements MigrationInterface {
   name = 'AutoApprovalCriteria1784200000000';
@@ -21,7 +24,7 @@ export class AutoApprovalCriteria1784200000000 implements MigrationInterface {
       `ALTER TABLE "auto_approval_rules" DROP COLUMN "priority"`,
     );
     await queryRunner.query(
-      `ALTER TABLE "auto_approval_rules" ADD "criteria" jsonb NOT NULL DEFAULT '{}'`,
+      `ALTER TABLE "auto_approval_rules" ADD "criteria" jsonb NOT NULL`,
     );
   }
 


### PR DESCRIPTION
Fixes the red `DB migrations` job on `main` (introduced by #1092).

## What failed

The drift step generates a migration against the freshly migrated DB and fails if one is emitted. It
emitted this:

```sql
ALTER TABLE "auto_approval_rules" ALTER COLUMN "criteria" DROP DEFAULT
```

The migration added the column as `jsonb NOT NULL DEFAULT '{}'` while the entity declares
`@Column({ type: 'jsonb' })` with no default — so the migrated schema carried a default the entities
do not, which is exactly the dev/prod drift this job exists to catch.

## Fix

The default only existed to satisfy `NOT NULL` on an already-created table. The migration `DELETE`s
every row first — the write path had been broken since the file was introduced, so there is nothing
to preserve — which leaves no row to backfill, and Postgres accepts `ADD COLUMN ... NOT NULL` on an
empty table. Same reasoning for the `conditions` column that `down` recreates.

## Verification

Reproduced the CI job locally against a throwaway `postgres:17` — running the exact
`migration:generate` the workflow runs, which now reports `No changes in database schema were found`
(the workflow's own second condition, so the check is not vacuous). Chain re-run up / down / up, and
the column comes back with `is_nullable=NO` and an empty `column_default` both times.

This is the check I should have run before #1092: `migration:run` up/down/up passed there, but it
never compared entity metadata against the resulting schema.
