### PR TITLE
fix(release-sort): rank a season pack above loose episodes at equal resolution

### DIFF
--- a/backend/src/common/release-scoring/release-rejection.helper.spec.ts
+++ b/backend/src/common/release-scoring/release-rejection.helper.spec.ts
@@ -10,6 +10,7 @@ type Row = Parameters<typeof sortReleasesByRelevance>[0][number];
 
 function row(over: Partial<Row> & { id: string }): Row & { id: string } {
   return {
+    qualityId: 16, // WEBDL-1080p
     rank: 100,
     allowed: true,
     blocklisted: false,
@@ -327,14 +328,25 @@ describe('sortReleasesByRelevance — season-scoped pack preference', () => {
     ).toEqual(['pack', 'single']);
   });
 
-  it('keeps a better-quality single episode above a weaker pack', () => {
-    const single = row({ id: 'single-1080p', rank: 200 });
-    const seasonPack = pack({ id: 'pack-720p', rank: 100 });
+  it('keeps a higher-resolution single episode above a weaker pack', () => {
+    const single = row({ id: 'single-1080p', qualityId: 16, rank: 200 });
+    const seasonPack = pack({ id: 'pack-720p', qualityId: 12, rank: 100 });
     expect(
       sortReleasesByRelevance([seasonPack, single], {
         preferFullSeason: true,
       }).map((r) => r.id),
     ).toEqual(['single-1080p', 'pack-720p']);
+  });
+
+  it('prefers a weaker-source pack at the same resolution', () => {
+    // WEBRip-1080p ranks below WEBDL-1080p, same 1080p resolution.
+    const single = row({ id: 'single-webdl', qualityId: 16, rank: 62 });
+    const seasonPack = pack({ id: 'pack-webrip', qualityId: 17, rank: 60 });
+    expect(
+      sortReleasesByRelevance([single, seasonPack], {
+        preferFullSeason: true,
+      }).map((r) => r.id),
+    ).toEqual(['pack-webrip', 'single-webdl']);
   });
 
   it('ignores pack status when the search is not season-scoped', () => {

--- a/backend/src/common/release-scoring/release-rejection.helper.ts
+++ b/backend/src/common/release-scoring/release-rejection.helper.ts
@@ -1,6 +1,7 @@
 import { QualityProfileItem } from '../../modules/profiles/entities/quality-profile.entity';
 import { AudioLanguageItem } from '../../modules/profiles/entities/language-profile.entity';
 import { APP_LANGUAGES } from '../constants/app-languages';
+import { getAppQualityById } from '../constants/app-qualities';
 import {
   parseReleaseLanguage,
   parseReleaseQuality,
@@ -574,9 +575,10 @@ export function computeRejections(opts: {
  * 3. Language allowed > not allowed
  * 4. Alive (seeders > 0) > dead — a zero-seeder release can't be downloaded,
  *    so it sinks below every live release regardless of quality.
- * 5. Quality rank (higher = better)
- * 6. Full-season pack (`preferFullSeason` only) — one pack beats loose
- *    episodes of the same quality, but never outranks a better quality.
+ * 5. Full-season pack (`preferFullSeason` only) — one pack beats loose
+ *    episodes at the same resolution whatever the source, but never
+ *    outranks a higher resolution.
+ * 6. Quality rank (higher = better)
  * 7. Freeleech bonus
  * 8. Custom format score (higher = better)
  * 9. Seeders (more = better, log scale to avoid over-weighting)
@@ -590,6 +592,7 @@ export function computeRejections(opts: {
  */
 export function sortReleasesByRelevance<
   T extends {
+    qualityId: number;
     rank: number;
     allowed: boolean;
     blocklisted: boolean;
@@ -626,12 +629,16 @@ export function sortReleasesByRelevance<
     const bAlive = b.seeders > 0 ? 1 : 0;
     if (aAlive !== bAlive) return bAlive - aAlive;
 
-    // 5. Quality rank desc
-    if (a.rank !== b.rank) return b.rank - a.rank;
+    // 5. One pack over loose episodes at the same resolution — a weaker
+    //    source is worth less than eight files to stitch together.
+    if (opts?.preferFullSeason && !!a.isFullSeason !== !!b.isFullSeason) {
+      const aRes = getAppQualityById(a.qualityId)?.resolution ?? 0;
+      const bRes = getAppQualityById(b.qualityId)?.resolution ?? 0;
+      if (aRes === bRes) return a.isFullSeason ? -1 : 1;
+    }
 
-    // 6. One pack over loose episodes, but only at equal quality.
-    if (opts?.preferFullSeason && !!a.isFullSeason !== !!b.isFullSeason)
-      return a.isFullSeason ? -1 : 1;
+    // 6. Quality rank desc
+    if (a.rank !== b.rank) return b.rank - a.rank;
 
     // 7. Freeleech bonus
     if (a.freeleech !== b.freeleech) return a.freeleech ? -1 : 1;


### PR DESCRIPTION
## Problem

Opening **Season packs available** on a series listed the eight loose `S01Exx 1080p WEB-DL` files first and pushed the `S01 1080p WEBRip`/`HDTV` packs below them — the one thing the modal is for was at the bottom of the list.

The pack preference was tiebreak **6**, applied only when the quality *rank* was identical. WEBDL-1080p is rank 62, WEBRip-1080p 60, HDTV-1080p 55 — all 1080p, so rank alone put every single episode ahead of every pack.

## Change

Move the pack criterion above the rank comparison and gate it on equal **resolution** instead of equal rank: at 1080p a pack wins whatever its source, while a 720p pack still stays below a 1080p single episode.

Resolution comes from `getAppQualityById(qualityId)` rather than a new row field, so nothing in the API shape or the plugin contract changes.

Same comparator backs the season auto-grab, so that now prefers a same-resolution pack too — which is the intended behaviour.

## Tests

`release-rejection.helper.spec.ts`: the "better quality" case is now expressed in resolutions (1080p single vs 720p pack), plus a new case asserting a WEBRip-1080p pack outranks a WEBDL-1080p single. 139 tests pass across `release-scoring` and `plugins/host`; `tsc --noEmit` clean.