### PR TITLE
fix(release-search): stop an indexer tab spinning after the search answered

### DIFF
--- a/client/src/app/features/media-detail/release-search-stream.service.spec.ts
+++ b/client/src/app/features/media-detail/release-search-stream.service.spec.ts
@@ -129,6 +129,25 @@ describe('ReleaseSearchStreamService', () => {
     expect(releases()).toEqual([]);
   });
 
+  it('VERDICT: an indexer left pending when the answer lands stops spinning', async () => {
+    const { service, releases, indexers, deliver } = setup();
+    const f = deferredFetch();
+    const run = service.run(f.fetch, { releases, indexers });
+
+    await deliver(`plugin.${PLUGIN_ID}.search.state`, {
+      searchId: f.searchId(),
+      indexers: [
+        { id: 1, name: 'alpha', state: 'done' },
+        { id: 2, name: 'beta', state: 'pending' },
+        { id: 3, name: 'gamma', state: 'failed' },
+      ],
+    });
+    f.finish([]);
+    await run;
+
+    expect(indexers().map((i) => i.state)).toEqual(['done', 'done', 'failed']);
+  });
+
   it('ignores another plugin’s events entirely', async () => {
     const { service, releases, indexers, deliver } = setup();
     const f = deferredFetch();

--- a/client/src/app/features/media-detail/release-search-stream.service.ts
+++ b/client/src/app/features/media-detail/release-search-stream.service.ts
@@ -48,6 +48,11 @@ export class ReleaseSearchStreamService {
       return await fetch(searchId);
     } finally {
       stop();
+      // The answer ends the search: an indexer still pending never got its completion
+      // event, and its tab would spin forever.
+      sinks.indexers.update((roster) =>
+        roster.map((ix) => (ix.state === 'pending' ? { ...ix, state: 'done' } : ix)),
+      );
     }
   }
 


### PR DESCRIPTION
## Problem

In the release modal, one indexer's tab (TR4KER in the report) kept showing the loading spinner long after the search had finished — its panel already said "no result for this indexer", so nothing was pending except the badge.

The tab spinner is driven by `state === 'pending'` on the roster entry, and the roster's only source is the plugin's `search.partial` / `search.state` SSE events. `ReleaseSearchStreamService.run()` destroys that listener the moment the HTTP answer resolves, so a completion event that races the answer — or one lost to an SSE reconnect — never arrives, and the entry stays `pending` forever. `showSpinnerPanel` already defends against this stale state; the tab badge did not.

## Change

When the search answers, mark any still-`pending` roster entry `done` in the same shared `run()`, so the fix covers movie, episode, and season searches at once. `failed` / `skipped` entries are untouched — they got their event.

An indexer finalized this way shows its real count (usually 0, i.e. "no result for this indexer") instead of a spinner.

## Tests

New case in `release-search-stream.service.spec.ts`: a roster of done/pending/failed finalizes to done/done/failed once the answer lands. 8 + 17 tests pass in the stream and modal specs; `tsc --noEmit` clean.