### PR TITLE
fix(metadata-search): report why a provider search failed instead of a bare 500

### DIFF
--- a/backend/src/modules/metadata-providers/metadata-providers.controller.ts
+++ b/backend/src/modules/metadata-providers/metadata-providers.controller.ts
@@ -1,11 +1,14 @@
 import {
   Controller,
   Get,
+  Logger,
   Param,
   Query,
+  ServiceUnavailableException,
   UseGuards,
   BadRequestException,
 } from '@nestjs/common';
+import axios from 'axios';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { TmdbProvider, DiscoverOptions } from './providers/tmdb.provider';
@@ -14,9 +17,29 @@ import { MetadataSearchResult } from './interfaces/metadata-provider.interface';
 import { Media } from '../media/entities/media.entity';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
 
+/** What the upstream actually said: TMDB/TVDB answer a `status_message`, a dead socket
+ *  only carries a code, and the breaker carries just its own message. */
+function upstreamReason(err: unknown): string {
+  if (axios.isAxiosError(err)) {
+    const status = err.response?.status;
+    const upstream = err.response?.data as
+      | { status_message?: string; message?: string }
+      | undefined;
+    return [
+      status ? `HTTP ${status}` : (err.code ?? 'network error'),
+      upstream?.status_message ?? upstream?.message ?? err.message,
+    ]
+      .filter(Boolean)
+      .join(' — ');
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
 @Controller('metadata')
 @UseGuards(JwtOrApiKeyGuard)
 export class MetadataProvidersController {
+  private readonly logger = new Logger(MetadataProvidersController.name);
+
   constructor(
     private readonly tmdb: TmdbProvider,
     private readonly registry: MetadataProviderRegistry,
@@ -38,6 +61,7 @@ export class MetadataProvidersController {
     const results = await this.searchWithFallback(
       providerName ?? (await this.providerPreferredFor(mediaId)),
       (p) => p.searchMovie(query, year ? +year : undefined),
+      `movie q="${query}" year=${year ?? '-'}`,
     );
     return this.enrichWithExisting(results, 'movie');
   }
@@ -54,6 +78,7 @@ export class MetadataProvidersController {
     const results = await this.searchWithFallback(
       providerName ?? (await this.providerPreferredFor(mediaId)),
       (p) => p.searchTvShow(query, year ? +year : undefined),
+      `tv q="${query}" year=${year ?? '-'}`,
     );
     return this.enrichWithExisting(results, 'series');
   }
@@ -241,18 +266,35 @@ export class MetadataProvidersController {
       searchMovie: any;
       searchTvShow: any;
     }) => Promise<MetadataSearchResult[]>,
+    label: string,
   ): Promise<MetadataSearchResult[]> {
     const provider = this.registry.resolve(providerName ?? null);
-    let results = await searchFn(provider);
+    try {
+      let results = await searchFn(provider);
 
-    // Fallback if empty and another provider is available
-    if (!results.length) {
-      const fallback = this.registry.getFallback(provider.name);
-      if (fallback) {
-        results = await searchFn(fallback);
+      // Fallback if empty and another provider is available
+      if (!results.length) {
+        const fallback = this.registry.getFallback(provider.name);
+        if (fallback) {
+          this.logger.log(
+            `Search empty on ${provider.name}, retrying ${fallback.name} — ${label}`,
+          );
+          results = await searchFn(fallback);
+        }
       }
+      return results;
+    } catch (err) {
+      // A raw throw here reaches the client as a bare 500, which says nothing about
+      // the key, the quota or the outage that actually caused it.
+      const reason = upstreamReason(err);
+      this.logger.error(
+        `Search failed on ${provider.name} — ${label}: ${reason}`,
+        err instanceof Error ? err.stack : undefined,
+      );
+      throw new ServiceUnavailableException(
+        `Metadata search failed on ${provider.name}: ${reason}`,
+      );
     }
-    return results;
   }
 
   private async enrichWithExisting(

--- a/backend/src/modules/metadata-providers/metadata-providers.search-failure.spec.ts
+++ b/backend/src/modules/metadata-providers/metadata-providers.search-failure.spec.ts
@@ -1,0 +1,71 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import { MetadataProvidersController } from './metadata-providers.controller';
+
+/**
+ * A provider that throws used to reach the client as a bare 500 ("Scan failed." in the
+ * orphan-scan panel), hiding whether the key was rejected, the quota spent, or TMDB down.
+ */
+describe('MetadataProvidersController — a failed provider search', () => {
+  function harness(err: unknown) {
+    const logged: string[] = [];
+    const controller = Object.create(
+      MetadataProvidersController.prototype,
+    ) as MetadataProvidersController;
+    Object.assign(controller, {
+      logger: {
+        log: jest.fn(),
+        error: jest.fn((msg: string) => logged.push(msg)),
+      },
+      registry: {
+        resolve: () => ({
+          name: 'tmdb',
+          searchMovie: () => Promise.reject(err),
+          searchTvShow: () => Promise.reject(err),
+        }),
+        getFallback: () => null,
+      },
+      mediaRepo: { findOne: () => Promise.resolve(null) },
+      enrichWithExisting: (r: unknown[]) => Promise.resolve(r),
+    });
+    return { controller, logged };
+  }
+
+  it("VERDICT: answers 503 carrying the upstream's own message, and logs it", async () => {
+    const { controller, logged } = harness({
+      isAxiosError: true,
+      message: 'Request failed with status code 401',
+      response: { status: 401, data: { status_message: 'Invalid API key' } },
+    });
+
+    await expect(controller.searchMovie('a film', '2019')).rejects.toThrow(
+      ServiceUnavailableException,
+    );
+    await expect(controller.searchMovie('a film', '2019')).rejects.toThrow(
+      /tmdb: HTTP 401 — Invalid API key/,
+    );
+    expect(logged[0]).toContain('movie q="a film" year=2019');
+    expect(logged[0]).toContain('HTTP 401 — Invalid API key');
+  });
+
+  it('reports a dead socket as its axios code rather than a status', async () => {
+    const { controller } = harness({
+      isAxiosError: true,
+      code: 'ECONNREFUSED',
+      message: 'connect ECONNREFUSED',
+    });
+
+    await expect(controller.searchTv('a series')).rejects.toThrow(
+      /ECONNREFUSED/,
+    );
+  });
+
+  it('falls back to a plain error message (breaker open, for instance)', async () => {
+    const { controller } = harness(
+      new Error('tmdb circuit open — upstream temporarily unreachable'),
+    );
+
+    await expect(controller.searchMovie('a film')).rejects.toThrow(
+      /circuit open/,
+    );
+  });
+});

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.spec.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.spec.ts
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
@@ -62,7 +63,7 @@ const scanResult = (folders: string[]): OrphanScanResult => ({
   orphanCount: folders.length,
 });
 
-function setup(folders: string[]) {
+function setup(folders: string[], metadataOverrides: Record<string, unknown> = {}) {
   const relinked: RelinkOrphansBody[] = [];
   const importsApi = {
     previewOrphans: () => Promise.resolve(scanResult(folders)),
@@ -74,6 +75,7 @@ function setup(folders: string[]) {
   const metadata = {
     searchMovie: () => Promise.resolve([result(11, 'First'), result(22, 'Second')]),
     searchTv: () => Promise.resolve([]),
+    ...metadataOverrides,
   };
 
   TestBed.configureTestingModule({
@@ -134,8 +136,7 @@ describe('OrphanScanPanelComponent.importAll', () => {
 /** A TVDB work TheMovieDB does not know is reported with `tmdbId: 0`, so every
  *  such row would answer to the same identity. */
 describe('OrphanScanPanelComponent — picking among TVDB-only results', () => {
-  const tvdb = (tvdbId: number, title: string) =>
-    result(0, title, { provider: 'tvdb', tvdbId });
+  const tvdb = (tvdbId: number, title: string) => result(0, title, { provider: 'tvdb', tvdbId });
 
   it('VERDICT: switches the pick between two results that share tmdbId 0', async () => {
     const { panel } = setup(['Alpha']);
@@ -167,6 +168,24 @@ describe('OrphanScanPanelComponent — picking among TVDB-only results', () => {
 
     expect(panel.isPicked(first, first)).toBe(true);
     expect(panel.isPicked(first, second)).toBe(false);
+  });
+});
+
+describe('OrphanScanPanelComponent — a failing search', () => {
+  it('VERDICT: shows the server\'s own reason instead of a bare "scan failed"', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { panel } = setup(['Alpha'], {
+      searchMovie: () =>
+        Promise.reject({
+          status: 503,
+          error: { message: 'Metadata search failed on tmdb: HTTP 401 — Invalid API key' },
+        }),
+    });
+    await panel.scanPath('/medias', ['movie'], 'tmdb');
+
+    expect(panel.groups()[0].error).toBe(
+      'Metadata search failed on tmdb: HTTP 401 — Invalid API key (HTTP 503)',
+    );
   });
 });
 

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
@@ -14,6 +14,7 @@ import { MediaType } from '../../../../../core/enums/media-type.enum';
 import { PaginationComponent } from '../../../../../shared/components/pagination/pagination';
 import { ResolveUrlPipe } from '../../../../../core/pipes/resolve-url.pipe';
 import { ToastService } from '../../../../../core/services/toast.service';
+import { serverMessage } from '../../../../../core/utils/server-message';
 import {
   MetadataService,
   MetadataSearchResult,
@@ -172,8 +173,8 @@ export class OrphanScanPanelComponent {
         })),
       );
       await this.searchPage();
-    } catch {
-      this.scanError.set(this.translate.instant('settings.libraries.scan_error'));
+    } catch (err: unknown) {
+      this.scanError.set(this.failure('scan', err));
     } finally {
       this.scanning.set(false);
     }
@@ -244,6 +245,19 @@ export class OrphanScanPanelComponent {
     };
   }
 
+  /** The server's own reason plus the status, so a bare 500 or a dropped request is still
+   *  identifiable; the raw error stays in the console. */
+  private failure(context: string, err: unknown): string {
+    console.error(`[orphan-scan] ${context} failed:`, err);
+    const message = serverMessage(
+      err,
+      this.translate,
+      'settings.libraries.scan_error',
+    );
+    const status = (err as { status?: number })?.status;
+    return status ? `${message} (HTTP ${status})` : message;
+  }
+
   private patch(index: number, partial: Partial<GroupVM>) {
     this.groups.update((list) =>
       list.map((g, i) => (i === index ? { ...g, ...partial } : g)),
@@ -281,11 +295,11 @@ export class OrphanScanPanelComponent {
         pick: auto ?? results[0] ?? null,
         fromNfo: !!auto,
       });
-    } catch {
+    } catch (err: unknown) {
       this.patch(index, {
         searching: false,
         searched: true,
-        error: this.translate.instant('settings.libraries.scan_error'),
+        error: this.failure(`search "${query}"`, err),
       });
     }
   }
@@ -330,12 +344,9 @@ export class OrphanScanPanelComponent {
         });
       }
     } catch (err: unknown) {
-      const httpErr = err as { error?: { message?: string } };
       this.patch(index, {
         linking: false,
-        error:
-          httpErr.error?.message ??
-          this.translate.instant('settings.libraries.scan_error'),
+        error: this.failure(`link "${vm.group.folderName}"`, err),
       });
     }
   }


### PR DESCRIPTION
## Problem

In the orphan-scan panel, a failed title search showed only **"Scan failed."** — no cause in the UI, nothing in the browser console, nothing in the server log.

Two layers were swallowing the error:

- `MetadataProvidersController.searchWithFallback` had no `try`/`catch`: an axios rejection (401 on the API key, 429 quota, 5xx) or a `CircuitOpenError` propagated raw, so Nest answered a generic 500 `"Internal server error"`, and nothing was logged.
- `orphan-scan-panel` used three bare `catch {}` blocks that replaced whatever happened with the `scan_error` string, discarding the error object entirely.

## Change

**Backend** — `searchWithFallback` logs and re-throws with the upstream reason:

- `upstreamReason()` decodes what the provider actually said: TMDB/TVDB `status_message`, else the axios code for a dead socket, else the error message (breaker open).
- `logger.error` records provider + query + year + reason + stack; the empty-result retry on the fallback provider is logged too, so a search that silently switched provider is visible.
- The client gets a 503 whose message is e.g. `Metadata search failed on tmdb: HTTP 401 — Invalid API key`. The endpoint is behind `JwtOrApiKeyGuard`, and no credential appears in the relayed text.

**Frontend** — one `failure(context, err)` helper replaces the three catch blocks: `console.error` with the raw error, and `serverMessage()` for the displayed text (server's message when there is one, `scan_error` otherwise) plus `(HTTP <status>)`. This also gives the scan and link paths the detail only link had.

## Tests

- New `metadata-providers.search-failure.spec.ts`: 503 carrying the upstream message + the log line for an axios 401, an `ECONNREFUSED` with no response, and a plain `Error` (breaker).
- New case in `orphan-scan-panel.spec.ts`: a rejected search shows the server's reason with the status instead of the fallback string.
- 17 backend tests (`metadata-providers`, `imports`) and 9 panel tests pass; `tsc --noEmit` clean on both sides.