### PR TITLE
fix(series-refresh): converge a season on one provider instead of mixing two

### DIFF
--- a/backend/src/modules/media/media-service/media-metadata.refresh-prune.spec.ts
+++ b/backend/src/modules/media/media-service/media-metadata.refresh-prune.spec.ts
@@ -1,0 +1,106 @@
+import { MediaMetadataService } from './media-metadata.service';
+import { MediaType } from '../../../common/enums';
+
+type ProviderSeason = {
+  seasonNumber: number;
+  episodes: { episodeNumber: number }[];
+};
+
+/**
+ * A media that once read another provider keeps episodes the current one does not have, and
+ * the season becomes a mix of both — one provider's episode list with the other's titles.
+ * The refresh drops that surplus, but only for a season the provider actually answered for.
+ */
+describe('MediaMetadataService.refreshSeriesEpisodes — stale episodes', () => {
+  function harness(opts: {
+    providerSeasons: ProviderSeason[];
+    dbSeasons: {
+      id: number;
+      seasonNumber: number;
+      preferredProvider?: string | null;
+      episodes: { id: number; episodeNumber: number }[];
+    }[];
+  }) {
+    const removedEpisodes: number[] = [];
+    const seasonRepo = {
+      find: jest.fn(() => Promise.resolve(opts.dbSeasons)),
+      create: jest.fn((v: unknown) => v),
+      save: jest.fn((v: Record<string, unknown>) =>
+        Promise.resolve({ id: 900, ...v }),
+      ),
+    };
+    const episodeRepo = {
+      remove: jest.fn((eps: { id: number }[]) => {
+        eps.forEach((e) => removedEpisodes.push(e.id));
+        return Promise.resolve(eps);
+      }),
+    };
+
+    const service = Object.create(
+      MediaMetadataService.prototype,
+    ) as MediaMetadataService;
+    Object.assign(service, {
+      seasonRepo,
+      episodeRepo,
+      log: { log: jest.fn(), warn: jest.fn() },
+      loadLibraryOverride: jest.fn(() => Promise.resolve(undefined)),
+      resolveProviderForMedia: jest.fn(() =>
+        Promise.resolve({
+          provider: {
+            name: 'tvdb',
+            getTvShowSeasons: () => Promise.resolve(opts.providerSeasons),
+          },
+          externalId: '42',
+        }),
+      ),
+      // The upsert itself is covered by its own callers; only the prune is under test.
+      applySeasonDetails: jest.fn(() => Promise.resolve({ insertedCount: 0 })),
+    });
+    return { service, removedEpisodes };
+  }
+
+  const media = { id: 7, type: MediaType.SERIES, title: 'A series' } as never;
+  const eps = (...numbers: number[]) =>
+    numbers.map((n) => ({ id: 100 + n, episodeNumber: n }));
+
+  it('VERDICT: drops an episode the provider no longer lists', async () => {
+    const { service, removedEpisodes } = harness({
+      providerSeasons: [
+        {
+          seasonNumber: 1,
+          episodes: [{ episodeNumber: 1 }, { episodeNumber: 2 }],
+        },
+      ],
+      dbSeasons: [{ id: 1, seasonNumber: 1, episodes: eps(1, 2, 3) }],
+    });
+
+    await service.refreshSeriesEpisodes(media);
+
+    expect(removedEpisodes).toEqual([103]);
+  });
+
+  it('keeps everything when the provider lists no episode for the season', async () => {
+    const { service, removedEpisodes } = harness({
+      providerSeasons: [{ seasonNumber: 1, episodes: [] }],
+      dbSeasons: [{ id: 1, seasonNumber: 1, episodes: eps(1, 2) }],
+    });
+
+    await service.refreshSeriesEpisodes(media);
+
+    expect(removedEpisodes).toEqual([]);
+  });
+
+  it('VERDICT: leaves a season the provider never answered for untouched', async () => {
+    const { service, removedEpisodes } = harness({
+      providerSeasons: [{ seasonNumber: 1, episodes: [{ episodeNumber: 1 }] }],
+      dbSeasons: [
+        { id: 1, seasonNumber: 1, episodes: eps(1) },
+        { id: 2, seasonNumber: 2, episodes: eps(1, 2) },
+      ],
+    });
+
+    await service.refreshSeriesEpisodes(media);
+
+    expect(removedEpisodes).toEqual([]);
+  });
+});

--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -30,6 +30,9 @@ import { mapWithConcurrency } from '../../../common/utils/concurrency';
 import { buildMediaFieldsFromTmdb } from './tmdb-mapping.util';
 import type { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 
+const episodeNumbersOf = (sd: SeasonDetails): Set<number> =>
+  new Set((sd.episodes ?? []).map((e) => e.episodeNumber));
+
 @Injectable()
 export class MediaMetadataService {
   private readonly log = new Logger(MediaMetadataService.name);
@@ -352,6 +355,9 @@ export class MediaMetadataService {
     const dbSeasonMap = new Map(dbSeasons.map((s) => [s.seasonNumber, s]));
 
     let insertedCount = 0;
+    // What the provider listed, per DB season, so the prune below only touches a season
+    // this run actually applied — a season it never answered for keeps its rows.
+    const applied = new Map<number, Set<number>>();
 
     // 2. Upsert seasons + apply media-level episode data, skipping seasons
     //    whose override points elsewhere (handled in the second pass).
@@ -375,6 +381,7 @@ export class MediaMetadataService {
         continue;
       }
       insertedCount += (await this.applySeasonDetails(dbSeason, sd)).insertedCount;
+      applied.set(dbSeason.id, episodeNumbersOf(sd));
     }
 
     // 3. Second pass: re-fetch overridden seasons from their own provider.
@@ -385,7 +392,6 @@ export class MediaMetadataService {
         s.preferredProvider &&
         s.preferredProvider !== mediaResolve.provider.name,
     );
-    if (!overridden.length) return { insertedCount };
     const cache = new Map<string, SeasonDetails[]>();
     for (const dbSeason of overridden) {
       let overrideResolve: {
@@ -407,6 +413,7 @@ export class MediaMetadataService {
         );
         if (fallback) {
           insertedCount += (await this.applySeasonDetails(dbSeason, fallback)).insertedCount;
+          applied.set(dbSeason.id, episodeNumbersOf(fallback));
         }
         continue;
       }
@@ -428,12 +435,49 @@ export class MediaMetadataService {
         );
         if (fallback) {
           insertedCount += (await this.applySeasonDetails(dbSeason, fallback)).insertedCount;
+          applied.set(dbSeason.id, episodeNumbersOf(fallback));
         }
         continue;
       }
       insertedCount += (await this.applySeasonDetails(dbSeason, seasonData)).insertedCount;
+      applied.set(dbSeason.id, episodeNumbersOf(seasonData));
     }
+    await this.dropEpisodesAbsentFromProvider(media, applied);
     return { insertedCount };
+  }
+
+  /**
+   * Delete the episodes of an applied season that the provider no longer lists. Without it a
+   * media that once read another provider keeps its surplus rows forever, and the season ends
+   * up a mix of both — one provider's episode list with the other's titles.
+   *
+   * Only seasons this run applied are touched, and only when the provider listed at least one
+   * episode for them: a failed or truncated fetch must never look like an empty season. Files
+   * survive as unmatched (`media_files.episodeId` is ON DELETE SET NULL); playback states and
+   * markers on those episodes go, as they described content the work does not have.
+   */
+  private async dropEpisodesAbsentFromProvider(
+    media: Media,
+    applied: Map<number, Set<number>>,
+  ): Promise<void> {
+    if (!applied.size) return;
+    const seasons = await this.seasonRepo.find({
+      where: { media: { id: media.id } },
+      relations: ['episodes'],
+    });
+    for (const season of seasons) {
+      const live = applied.get(season.id);
+      if (!live?.size) continue;
+      const surplus = (season.episodes ?? []).filter(
+        (ep) => !live.has(ep.episodeNumber),
+      );
+      if (!surplus.length) continue;
+      await this.episodeRepo.remove(surplus);
+      this.log.log(
+        `refresh: dropped ${surplus.length} episode(s) of S${season.seasonNumber} on media#${media.id} ` +
+          `(${surplus.map((e) => e.episodeNumber).join(', ')}) — absent from the provider`,
+      );
+    }
   }
 
   /** Upsert episodes of one DB season from provider season details, download

--- a/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
@@ -164,7 +164,7 @@ export class TvdbProvider implements IMetadataProvider {
       tvdbId: m.id,
       imdbId,
       provider: 'tvdb',
-      title: localized?.name ?? m.name,
+      title: localized?.name || m.name,
       originalTitle: m.name,
       overview: localized?.overview ?? '',
       year: m.year ? parseInt(m.year) : null,
@@ -243,7 +243,7 @@ export class TvdbProvider implements IMetadataProvider {
       tvdbId: s.id,
       imdbId,
       provider: 'tvdb',
-      title: localized?.name ?? s.name,
+      title: localized?.name || s.name,
       originalTitle: s.name,
       overview: localized?.overview ?? '',
       year: s.year ? parseInt(s.year) : null,
@@ -373,8 +373,10 @@ export class TvdbProvider implements IMetadataProvider {
           const tr = epTranslations.get(ep.id);
           return {
             episodeNumber: ep.number,
-            title: tr?.name ?? ep.name,
-            overview: tr?.overview ?? ep.overview ?? null,
+            // An advertised translation can come back with an empty name (overview-only
+            // translations do), and an empty title would leave the previous provider's in place.
+            title: tr?.name || ep.name,
+            overview: tr?.overview || ep.overview || null,
             airDate: ep.aired ?? null,
             runtime: ep.runtime ?? null,
             stillUrl: ep.image ?? null,

--- a/backend/src/modules/metadata-providers/providers/tvdb.season-translations.spec.ts
+++ b/backend/src/modules/metadata-providers/providers/tvdb.season-translations.spec.ts
@@ -1,0 +1,67 @@
+import { TvdbProvider } from './tvdb.provider';
+
+/**
+ * TVDB advertises a translation per field: an episode with a translated overview but no
+ * translated name answers `{ name: '' }`. Passing that empty name on left the previous
+ * provider's title in place (the metadata refresh only overwrites a non-empty value), so a
+ * season ended up with one provider's episodes and another's titles.
+ */
+describe('TvdbProvider.getTvShowSeasons — an empty translated name', () => {
+  function harness(translation: { name: string; overview: string }) {
+    const provider = Object.create(TvdbProvider.prototype) as TvdbProvider;
+    Object.assign(provider, {
+      metaLang: { resolve: () => Promise.resolve({ tvdbCode: 'fra' }) },
+      ensureAuth: () => Promise.resolve(),
+      client: {
+        get: (url: string) => {
+          if (url.endsWith('/episodes/default')) {
+            return Promise.resolve({
+              data: {
+                data: {
+                  episodes: [
+                    {
+                      id: 55,
+                      number: 1,
+                      seasonNumber: 1,
+                      name: 'Origin Title',
+                      overview: 'Origin overview.',
+                      aired: '2025-06-11',
+                      runtime: 23,
+                      image: null,
+                      nameTranslations: [],
+                      overviewTranslations: ['fra'],
+                    },
+                  ],
+                },
+              },
+            });
+          }
+          if (url.endsWith('/extended')) {
+            return Promise.resolve({ data: { data: { seasons: [] } } });
+          }
+          return Promise.resolve({ data: { data: translation } });
+        },
+      },
+    });
+    return provider;
+  }
+
+  it('VERDICT: keeps the origin-language name when the translation carries none', async () => {
+    const seasons = await harness({
+      name: '',
+      overview: 'Résumé traduit.',
+    }).getTvShowSeasons('42');
+
+    expect(seasons[0].episodes[0].title).toBe('Origin Title');
+    expect(seasons[0].episodes[0].overview).toBe('Résumé traduit.');
+  });
+
+  it('still prefers a real translated name', async () => {
+    const seasons = await harness({
+      name: 'Titre traduit',
+      overview: 'Résumé traduit.',
+    }).getTvShowSeasons('42');
+
+    expect(seasons[0].episodes[0].title).toBe('Titre traduit');
+  });
+});


### PR DESCRIPTION
## Problem

A series in a TVDB library showed 9 episodes for a season TVDB lists 8 of, and the extra row rendered as "Episode 9" with no title. The rest of the season was a mix: episode **titles** from TMDB (in French), episode **runtimes** from TVDB.

Two independent leaks:

1. **TVDB returns an empty translated name.** TVDB advertises translations per field, so an episode with a translated overview but no translated name answers `{ name: '', overview: '…' }`. `getTvShowSeasons` used `tr?.name ?? ep.name`, which keeps `''`. The refresh only overwrites a non-empty value (`if (ep.title && …)`), so the title written by whichever provider ran before survived every subsequent refresh. Same `??` shape on the movie/series detail titles.
2. **Nothing prunes outside re-identification.** `applySeasonDetails` only inserts and updates; `dropSeasonsAbsentFromProvider` is called from `completeIdentify` alone. A season read once from a provider that lists 9 episodes keeps the 9th row forever, whatever the current provider says.

## Change

- `tvdb.provider`: `||` instead of `??` for the translated episode name/overview and the movie/series title, so an empty translation falls back to the origin-language value instead of blanking the field.
- `refreshSeriesEpisodes` records the episode numbers the provider listed per DB season, then `dropEpisodesAbsentFromProvider` deletes the surplus. Guards: only a season this run applied, and only when the provider listed at least one episode for it — a failed or truncated fetch must never look like an emptied season. Files survive as unmatched (`media_files.episodeId` is `ON DELETE SET NULL`), which is what re-identification already does.
- Dropped the `if (!overridden.length) return` shortcut so the second pass falls through to the prune; the loop over an empty list is already a no-op.

Re-identifying the media fixes an already-mixed season today; after this, a plain refresh converges on its own.

## Tests

- `media-metadata.refresh-prune.spec.ts`: drops the episode the provider no longer lists, keeps everything when the provider listed none, leaves a season it never answered for untouched.
- `tvdb.season-translations.spec.ts`: an empty translated name keeps the origin-language title, a real translation still wins.
- 69 tests pass across `modules/media` and `modules/metadata-providers`; `tsc --noEmit` clean.

## Not in this PR

Specials (season 0) are still skipped by both providers — tracked separately.