### PR TITLE
feat(series): keep the specials season instead of dropping it

### DIFF
--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -719,7 +719,7 @@ export class DiskImportService {
           this.seasonRepo.create({
             media: { id: matched.id } as Media,
             seasonNumber: epNums.season,
-            monitored: true,
+            monitored: epNums.season > 0,
           }),
         );
         dirtyMediaIds?.add(matched.id);

--- a/backend/src/modules/media/media-service/media-import.season-scope.spec.ts
+++ b/backend/src/modules/media/media-service/media-import.season-scope.spec.ts
@@ -85,15 +85,22 @@ describe('MediaImportService — season monitoring scope on import', () => {
     ).toEqual([0, 5, 6]);
   });
 
-  it('monitors every season when the scope is null (whole series / admin add)', async () => {
+  it('monitors every season but the specials when the scope is null (whole series / admin add)', async () => {
     const { svc, created } = makeService();
     await svc.importFromTmdb(dto, null, null);
-    expect(created.every((s) => s.monitored)).toBe(true);
+    expect(monitoredNumbers(created)).toEqual([1, 2, 3, 4, 5, 6]);
   });
 
-  it('monitors every season when the scope is an empty array', async () => {
+  it('monitors every season but the specials when the scope is an empty array', async () => {
     const { svc, created } = makeService();
     await svc.importFromTmdb(dto, null, []);
-    expect(created.every((s) => s.monitored)).toBe(true);
+    expect(monitoredNumbers(created)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  /** Season 0 is only ever monitored on purpose, by number. */
+  it('VERDICT: monitors the specials when the scope names season 0', async () => {
+    const { svc, created } = makeService();
+    await svc.importFromTmdb(dto, null, [0]);
+    expect(monitoredNumbers(created)).toEqual([0]);
   });
 });

--- a/backend/src/modules/media/media-service/media-import.service.ts
+++ b/backend/src/modules/media/media-service/media-import.service.ts
@@ -426,9 +426,10 @@ export class MediaImportService {
 
     // A season-scoped request only monitors the seasons it asked for; the rest
     // import unmonitored so the auto-grab leaves them alone. An empty/absent
-    // scope (whole-series request or admin add) monitors every season.
+    // scope (whole-series request or admin add) monitors every season but the
+    // specials, which are only monitored when asked for by number.
     const inScope = (n: number) =>
-      !monitoredSeasons?.length || monitoredSeasons.includes(n);
+      monitoredSeasons?.length ? monitoredSeasons.includes(n) : n > 0;
 
     for (const sd of seasons) {
       const sSaved = await this.seasonRepo.save(

--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -362,7 +362,8 @@ export class MediaMetadataService {
           this.seasonRepo.create({
             media,
             seasonNumber: sd.seasonNumber,
-            monitored: true,
+            // Specials arrive unmonitored: nobody wants a season 0 grabbed implicitly.
+            monitored: sd.seasonNumber > 0,
           }),
         );
         dbSeason.episodes = [];

--- a/backend/src/modules/media/media-service/media-query.service.ts
+++ b/backend/src/modules/media/media-service/media-query.service.ts
@@ -661,7 +661,9 @@ export class MediaQueryService {
       throw new NotFoundException(`Media #${id} not found`);
     }
     if (media.seasons?.length) {
-      media.seasons.sort((a, b) => a.seasonNumber - b.seasonNumber);
+      // Specials (season 0) sort last: an appendix, not the opening season.
+      const rank = (n: number) => (n === 0 ? Number.MAX_SAFE_INTEGER : n);
+      media.seasons.sort((a, b) => rank(a.seasonNumber) - rank(b.seasonNumber));
       for (const s of media.seasons) {
         s.episodes?.sort((a, b) => a.episodeNumber - b.episodeNumber);
       }

--- a/backend/src/modules/media/media-service/media-rescan.service.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.ts
@@ -847,7 +847,7 @@ export class MediaRescanService {
         this.seasonRepo.create({
           media,
           seasonNumber: epNums.season,
-          monitored: true,
+          monitored: epNums.season > 0,
         }),
       );
       created = true;

--- a/backend/src/modules/metadata-providers/providers/specials.spec.ts
+++ b/backend/src/modules/metadata-providers/providers/specials.spec.ts
@@ -1,0 +1,67 @@
+import { TmdbProvider } from './tmdb.provider';
+import { TvdbProvider } from './tvdb.provider';
+
+/** Both providers used to drop season 0, so a special could never be matched to a file. */
+describe('Season 0 reaches the caller', () => {
+  it('VERDICT: TVDB returns the specials season', async () => {
+    const provider = Object.create(TvdbProvider.prototype) as TvdbProvider;
+    const episode = (id: number, seasonNumber: number, number: number) => ({
+      id,
+      number,
+      seasonNumber,
+      name: `E${number}`,
+      overview: '',
+      aired: '2025-01-01',
+      runtime: 20,
+      image: null,
+      nameTranslations: [],
+      overviewTranslations: [],
+    });
+    Object.assign(provider, {
+      metaLang: { resolve: () => Promise.resolve({ tvdbCode: 'eng' }) },
+      ensureAuth: () => Promise.resolve(),
+      client: {
+        get: (url: string) =>
+          url.endsWith('/episodes/default')
+            ? Promise.resolve({
+                data: {
+                  data: { episodes: [episode(1, 0, 1), episode(2, 1, 1)] },
+                },
+              })
+            : Promise.resolve({ data: { data: { seasons: [] } } }),
+      },
+    });
+
+    const seasons = await provider.getTvShowSeasons('42');
+
+    expect(seasons.map((s) => s.seasonNumber)).toEqual([0, 1]);
+  });
+
+  it('VERDICT: TMDB returns the specials season', async () => {
+    const provider = Object.create(TmdbProvider.prototype) as TmdbProvider;
+    Object.assign(provider, {
+      metaLang: { resolve: () => Promise.resolve({ tmdbLocale: 'en-US' }) },
+      logger: { warn: jest.fn() },
+      client: {
+        get: (url: string) => {
+          const season = /\/season\/(\d+)$/.exec(url);
+          if (season) {
+            return Promise.resolve({
+              data: {
+                season_number: Number(season[1]),
+                episodes: [{ episode_number: 1, name: 'E1' }],
+              },
+            });
+          }
+          return Promise.resolve({
+            data: { seasons: [{ season_number: 0 }, { season_number: 1 }] },
+          });
+        },
+      },
+    });
+
+    const seasons = await provider.getTvShowSeasons('42');
+
+    expect(seasons.map((s) => s.seasonNumber)).toEqual([0, 1]);
+  });
+});

--- a/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
@@ -478,7 +478,6 @@ export class TmdbProvider implements IMetadataProvider {
 
     const seasons: SeasonDetails[] = [];
     for (const s of show.seasons ?? []) {
-      if (s.season_number === 0) continue;
       try {
         const { data: season } = await this.client.get<TmdbTvSeasonResponse>(
           `/tv/${tmdbId}/season/${s.season_number}`,
@@ -505,7 +504,9 @@ export class TmdbProvider implements IMetadataProvider {
         });
       } catch (err) {
         this.logger.warn(
-          `Failed to fetch season ${s.season_number} for TV ${tmdbId}`,
+          `Failed to fetch season ${s.season_number} for TV ${tmdbId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
         );
       }
     }

--- a/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
@@ -352,7 +352,6 @@ export class TvdbProvider implements IMetadataProvider {
     // Group episodes by season
     const seasonMap = new Map<number, TvdbEpisodeBase[]>();
     for (const ep of allEpisodes) {
-      if (ep.seasonNumber === 0) continue; // skip specials
       const list = seasonMap.get(ep.seasonNumber) ?? [];
       list.push(ep);
       seasonMap.set(ep.seasonNumber, list);

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -953,6 +953,7 @@
     "seasons_section": "Staffeln & Folgen",
     "season": "Staffel",
     "season_number": "Staffel {{number}}",
+    "specials": "Specials",
     "more_from_season": "Mehr aus Staffel {{season}}",
     "other_seasons_of": "Andere Staffeln von {{title}}",
     "col_ep": "F.",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -958,6 +958,7 @@
     "seasons_section": "Seasons & episodes",
     "season": "Season",
     "season_number": "Season {{number}}",
+    "specials": "Specials",
     "more_from_season": "More from season {{season}}",
     "other_seasons_of": "Other seasons of {{title}}",
     "col_ep": "Ep.",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -953,6 +953,7 @@
     "seasons_section": "Temporadas y episodios",
     "season": "Temporada",
     "season_number": "Temporada {{number}}",
+    "specials": "Especiales",
     "more_from_season": "Más de la temporada {{season}}",
     "other_seasons_of": "Otras temporadas de {{title}}",
     "col_ep": "Ep.",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -958,6 +958,7 @@
     "seasons_section": "Saisons & épisodes",
     "season": "Saison",
     "season_number": "Saison {{number}}",
+    "specials": "Spéciaux",
     "more_from_season": "Plus de saison {{season}}",
     "other_seasons_of": "Autres saisons de {{title}}",
     "col_ep": "Ep.",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -953,6 +953,7 @@
     "seasons_section": "Stagioni ed episodi",
     "season": "Stagione",
     "season_number": "Stagione {{number}}",
+    "specials": "Speciali",
     "more_from_season": "Altro dalla stagione {{season}}",
     "other_seasons_of": "Altre stagioni di {{title}}",
     "col_ep": "Ep.",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -953,6 +953,7 @@
     "seasons_section": "Temporadas e episódios",
     "season": "Temporada",
     "season_number": "Temporada {{number}}",
+    "specials": "Especiais",
     "more_from_season": "Mais da temporada {{season}}",
     "other_seasons_of": "Outras temporadas de {{title}}",
     "col_ep": "Ep.",

--- a/client/src/app/core/pipes/season-label.pipe.spec.ts
+++ b/client/src/app/core/pipes/season-label.pipe.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { SeasonLabelPipe } from './season-label.pipe';
+
+describe('SeasonLabelPipe', () => {
+  function pipe() {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideTranslateService({
+          lang: 'en',
+          loader: {
+            provide: TranslateLoader,
+            useValue: {
+              getTranslation: () =>
+                of({
+                  media_detail: {
+                    specials: 'Specials',
+                    season_number: 'Season {{number}}',
+                  },
+                }),
+            },
+          },
+        }),
+        SeasonLabelPipe,
+      ],
+    });
+    return TestBed.inject(SeasonLabelPipe);
+  }
+
+  it('VERDICT: names season 0 the specials instead of "Season 0"', () => {
+    expect(pipe().transform(0)).toBe('Specials');
+  });
+
+  it('numbers every other season', () => {
+    expect(pipe().transform(3)).toBe('Season 3');
+  });
+});

--- a/client/src/app/core/pipes/season-label.pipe.ts
+++ b/client/src/app/core/pipes/season-label.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform, inject } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+
+/**
+ * Season heading: "Specials" for season 0, "Season N" otherwise.
+ *
+ * Impure because the translation table loads asynchronously and changes when
+ * the user switches locale.
+ */
+@Pipe({ name: 'seasonLabel', pure: false })
+export class SeasonLabelPipe implements PipeTransform {
+  private readonly translate = inject(TranslateService);
+
+  transform(seasonNumber: number | null | undefined): string {
+    if (seasonNumber === 0) return this.translate.instant('media_detail.specials');
+    return this.translate.instant('media_detail.season_number', { number: seasonNumber });
+  }
+}

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -159,7 +159,7 @@
     <app-dropdown-menu placement="bottom-start">
       <button trigger type="button" class="select select-bordered w-fit shrink-0 text-left text-lg font-bold cursor-pointer transition-colors hover:bg-base-content/10">
         @if (selSeason) {
-          {{ 'media_detail.season_number' | translate:{ number: selSeason.seasonNumber } }}
+          {{ selSeason.seasonNumber | seasonLabel }}
         } @else {
           {{ 'media_detail.season' | translate }}
         }
@@ -167,7 +167,7 @@
       @for (season of displaySeasons(); track season.id) {
         <app-dropdown-option
           [imageUrl]="season.posterUrl ?? m.posterUrl"
-          [head]="'media_detail.season_number' | translate:{ number: season.seasonNumber }"
+          [head]="season.seasonNumber | seasonLabel"
           [sub]="(tabEpisodeCount(season) <= 1 ? 'media_detail.episode_count_one' : 'media_detail.episode_count_other') | translate:{ count: tabEpisodeCount(season) }"
           [selected]="season.id === activeSeasonId()"
           (click)="selectSeason.emit(season.id)"

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -52,6 +52,7 @@ import { TvService } from '../../../../core/services/tv.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { DeviceService } from '../../../../core/services/device.service';
 import { LocaleDatePipe } from '../../../../core/pipes/locale-date.pipe';
+import { SeasonLabelPipe } from '../../../../core/pipes/season-label.pipe';
 import { PluginUiRegistryService } from '../../../../core/plugin-ui/plugin-ui-registry.service';
 import { evaluateWhen, type WhenContext } from '../../../../core/plugin-ui/when-evaluator';
 import { resolveSeasonAction, type CoreSeasonActionId, type SeasonActionHandlers } from '../../../../core/plugin-ui/season-action-registry';
@@ -72,7 +73,7 @@ function readEpisodeViewFromStorage(): EpisodeView {
 
 @Component({
   selector: 'app-media-detail-seasons',
-  imports: [TranslateModule, UpperCasePipe, NgTemplateOutlet, RouterLink, LocaleDatePipe, HorizontalScrollerComponent, CollapsibleSectionComponent, MediaCardComponent, DropdownMenuComponent, DropdownOptionComponent, TvRowDirective, ClampToggleDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideHeart, LucideLayoutGrid, LucideList, LucideListChecks, LucideListPlus, LucidePackage, LucideUserPlus, LucideX],
+  imports: [TranslateModule, UpperCasePipe, SeasonLabelPipe, NgTemplateOutlet, RouterLink, LocaleDatePipe, HorizontalScrollerComponent, CollapsibleSectionComponent, MediaCardComponent, DropdownMenuComponent, DropdownOptionComponent, TvRowDirective, ClampToggleDirective, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideHeart, LucideLayoutGrid, LucideList, LucideListChecks, LucideListPlus, LucidePackage, LucideUserPlus, LucideX],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-seasons.component.html',
 })

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -104,7 +104,7 @@
                   class="shrink-0 w-28 sm:w-32 lg:w-40"
                   [aspect]="'portrait'"
                   [imageUrl]="other.posterUrl ?? m.posterUrl"
-                  [title]="('media_detail.season' | translate) + ' ' + other.seasonNumber"
+                  [title]="other.seasonNumber | seasonLabel"
                   [subtitle]="other.episodes.length + ' ' + ('media_detail.episodes' | translate)"
                   [link]="seasonLink(m, other)"
                   [replaceUrl]="true"

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -87,6 +87,7 @@ import { ToastService } from '../../core/services/toast.service';
 import { SseService, type SseEvent } from '../../core/services/sse.service';
 import { MediaType } from '../../core/enums/media-type.enum';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
+import { SeasonLabelPipe } from '../../core/pipes/season-label.pipe';
 import { TvSectionDirective } from '../../shared/directives/tv-section.directive';
 import { ImgFadeInDirective } from '../../shared/directives/img-fade-in.directive';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
@@ -130,6 +131,7 @@ function readEpisodesHasFileOnlyFromStorage(): boolean {
     RouterLink,
     NgTemplateOutlet,
     ResolveUrlPipe,
+    SeasonLabelPipe,
     ImgFadeInDirective,
     TvSectionDirective,
   ],

--- a/client/src/app/features/tmdb-preview/components/preview-seasons/preview-seasons.component.html
+++ b/client/src/app/features/tmdb-preview/components/preview-seasons/preview-seasons.component.html
@@ -14,7 +14,7 @@
         [class.btn-ghost]="s.seasonNumber !== activeSeasonNumber()"
         (click)="selectSeason(s.seasonNumber)"
       >
-        {{ 'media_detail.season' | translate }} {{ s.seasonNumber }}
+        {{ s.seasonNumber | seasonLabel }}
         <span class="opacity-60 tabular-nums">{{ s.episodeCount }}</span>
       </button>
     }

--- a/client/src/app/features/tmdb-preview/components/preview-seasons/preview-seasons.component.ts
+++ b/client/src/app/features/tmdb-preview/components/preview-seasons/preview-seasons.component.ts
@@ -13,6 +13,7 @@ import {
   MetadataService,
 } from '../../../../core/services/api/metadata.service';
 import { LocaleDatePipe } from '../../../../core/pipes/locale-date.pipe';
+import { SeasonLabelPipe } from '../../../../core/pipes/season-label.pipe';
 import { ImgFadeInDirective } from '../../../../shared/directives/img-fade-in.directive';
 import { ClampToggleDirective } from '../../../../shared/directives/clamp-toggle.directive';
 import { TvRowDirective } from '../../../../shared/directives/tv-row.directive';
@@ -22,6 +23,7 @@ import { TvRowDirective } from '../../../../shared/directives/tv-row.directive';
   imports: [
     TranslateModule,
     LocaleDatePipe,
+    SeasonLabelPipe,
     ImgFadeInDirective,
     ClampToggleDirective,
     TvRowDirective,


### PR DESCRIPTION
## Problem

Neither provider ever returned season 0:

- `tvdb.provider`: `if (ep.seasonNumber === 0) continue; // skip specials`
- `tmdb.provider`: `if (s.season_number === 0) continue;`

So a special had no episode row, and a `S00Exx` file on disk could never be matched to one. The disk scan *could* create a season 0 by itself (`parseEpisodeNumbers` reads `S00E01`), which is why every progress/next-up/marker query already carries a `seasonNumber > 0` guard — the schema was ready, the metadata side was not.

## Change

**Backend**

- Both providers now include season 0 in `getTvShowSeasons`.
- Specials are created **unmonitored** — on refresh (`monitored: sd.seasonNumber > 0`), on disk-created seasons (rescan + orphan import), and on import, where an absent/empty season scope now means "every season but the specials". A request that names season 0 still monitors it. The auto-grab gates on `season.monitored = true`, so nothing gets grabbed implicitly.
- Seasons sort with the specials last in the media detail payload: an appendix, not the opening season, and every client reads that order.
- The TMDB per-season fetch warning now carries the error reason instead of just the season number.

**Frontend**

- New `seasonLabel` pipe: "Specials" for season 0, "Season N" otherwise. Replaces the four hand-built season headings (season selector, dropdown, other-seasons tiles, pre-add preview).
- `media_detail.specials` added to the six locales.

## Not in this PR

The naming/organize templates still render a special as `Season 00`; renaming them to a `Specials` folder is a separate decision.

## Tests

- `providers/specials.spec.ts`: both providers return season 0.
- `media-import.season-scope.spec.ts`: a null/empty scope monitors 1..6 and leaves 0 alone; a scope of `[0]` monitors the specials.
- `season-label.pipe.spec.ts`: season 0 reads "Specials", others are numbered.
- 72 backend tests (`media`, `metadata-providers`, `imports`) and 26 client tests pass; `tsc --noEmit` clean both sides; `ng build` clean.