### PR TITLE
fix(import): read a new title through the provider its library prefers

### DIFF
--- a/backend/src/modules/media/media-service/media-import.library-provider.spec.ts
+++ b/backend/src/modules/media/media-service/media-import.library-provider.spec.ts
@@ -1,0 +1,161 @@
+import { MediaImportService } from './media-import.service';
+import { MediaType } from '../../../common/enums';
+
+/**
+ * The search answers from whichever provider is configured globally and the library is picked
+ * afterwards, so importing what the search returned wrote TMDB rows into a TVDB library: one
+ * provider's episode list with the other's titles.
+ */
+describe('MediaImportService — the destination library owns the provider', () => {
+  function makeService(opts: {
+    preferredProvider: string | null;
+    tvdbAvailable?: boolean;
+    tmdbDetails?: Record<string, unknown>;
+  }) {
+    const seasonsFrom: string[] = [];
+    const warnings: string[] = [];
+    const seasonRepo = {
+      create: jest.fn((s: unknown) => s),
+      save: jest.fn(async (s: { seasonNumber: number }) => ({
+        id: s.seasonNumber + 100,
+        ...s,
+      })),
+    };
+    const saved: Record<string, unknown>[] = [];
+    const mediaRepo = {
+      findOne: jest
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue({ id: 1 }),
+      create: jest.fn((m: Record<string, unknown>) => m),
+      save: jest.fn(async (m: Record<string, unknown>) => {
+        saved.push(m);
+        return { id: 1, ...m };
+      }),
+    };
+    const tmdb = {
+      getTvShowDetails: jest.fn().mockResolvedValue(
+        opts.tmdbDetails ?? {
+          title: 'A series',
+          tmdbId: 42,
+          tvdbId: 777,
+          imdbId: 'tt1',
+        },
+      ),
+      getTvShowSeasons: jest.fn(async () => {
+        seasonsFrom.push('tmdb');
+        return [{ seasonNumber: 1 }, { seasonNumber: 2 }];
+      }),
+    };
+    const tvdb = {
+      name: 'tvdb',
+      getTvShowDetails: jest
+        .fn()
+        .mockResolvedValue({ title: 'A series', tmdbId: 0, tvdbId: 777 }),
+      getTvShowSeasons: jest.fn(async () => {
+        seasonsFrom.push('tvdb');
+        return [{ seasonNumber: 1 }];
+      }),
+    };
+    const registry = {
+      isAvailable: jest.fn(() => opts.tvdbAvailable ?? true),
+      get: jest.fn(() => tvdb),
+    };
+
+    const svc = new MediaImportService(
+      mediaRepo as never,
+      seasonRepo as never,
+      {} as never,
+      {} as never,
+      { query: jest.fn().mockResolvedValue([]) } as never,
+      { name: 'tmdb', ...tmdb } as never,
+      registry as never,
+      { get: jest.fn().mockReturnValue('tmdb-key') } as never,
+      {
+        resolveQualityProfileIdForImport: jest.fn().mockResolvedValue(null),
+        resolveLanguageProfileIdForImport: jest.fn().mockResolvedValue(null),
+      } as never,
+      {} as never,
+      { applySeriesFolderFormat: jest.fn().mockReturnValue('folder') } as never,
+      {
+        downloadMediaImagesInBackground: jest.fn(),
+        applySeasonDetails: jest.fn().mockResolvedValue(undefined),
+        updateSearchVector: jest.fn().mockResolvedValue(undefined),
+        persistMediaMetadataInBackground: jest.fn(),
+      } as never,
+      { onMediaImported: jest.fn().mockResolvedValue(undefined) } as never,
+      { emitDomain: jest.fn() } as never,
+    );
+    Object.assign(svc, {
+      log: { log: jest.fn(), warn: jest.fn((m: string) => warnings.push(m)) },
+    });
+    jest
+      .spyOn(
+        svc as never as { resolveImportTarget: unknown },
+        'resolveImportTarget' as never,
+      )
+      .mockResolvedValue({
+        libraryId: 7,
+        library: {
+          metadataLanguage: null,
+          metadataRegion: null,
+          preferredProvider: opts.preferredProvider,
+        },
+      } as never);
+    return { svc, seasonsFrom, saved, warnings, tvdb };
+  }
+
+  const dto = { type: MediaType.SERIES, tmdbId: 42 } as never;
+
+  it('VERDICT: reads a TMDB hit from TVDB when the library prefers it, keeping both ids', async () => {
+    const { svc, seasonsFrom, saved, tvdb } = makeService({
+      preferredProvider: 'tvdb',
+    });
+
+    await svc.importFromTmdb(dto);
+
+    expect(tvdb.getTvShowDetails).toHaveBeenCalledWith(
+      '777',
+      expect.anything(),
+    );
+    expect(seasonsFrom).toEqual(['tvdb']);
+    expect(saved[0]).toMatchObject({ tmdbId: 42, tvdbId: 777 });
+  });
+
+  it('stays on the provider that found the title when the library has no preference', async () => {
+    const { svc, seasonsFrom } = makeService({ preferredProvider: null });
+
+    await svc.importFromTmdb(dto);
+
+    expect(seasonsFrom).toEqual(['tmdb']);
+  });
+
+  it('falls back with a warning when the preferred provider is not configured', async () => {
+    const { svc, seasonsFrom, warnings } = makeService({
+      preferredProvider: 'tvdb',
+      tvdbAvailable: false,
+    });
+
+    await svc.importFromTmdb(dto);
+
+    expect(seasonsFrom).toEqual(['tmdb']);
+    expect(warnings[0]).toContain('not available');
+  });
+
+  it('VERDICT: falls back when the work has no id on the preferred provider', async () => {
+    const { svc, seasonsFrom, warnings } = makeService({
+      preferredProvider: 'tvdb',
+      tmdbDetails: {
+        title: 'A series',
+        tmdbId: 42,
+        tvdbId: null,
+        imdbId: null,
+      },
+    });
+
+    await svc.importFromTmdb(dto);
+
+    expect(seasonsFrom).toEqual(['tmdb']);
+    expect(warnings[0]).toContain('cross-reference failed');
+  });
+});

--- a/backend/src/modules/media/media-service/media-import.service.ts
+++ b/backend/src/modules/media/media-service/media-import.service.ts
@@ -18,6 +18,7 @@ import { ImportMediaDto } from '../dto/import-media.dto';
 import { TmdbProvider } from '../../metadata-providers/providers/tmdb.provider';
 import { MetadataProviderRegistry } from '../../metadata-providers/metadata-provider.registry';
 import {
+  IMetadataProvider,
   MetadataDetails,
   SeasonDetails,
 } from '../../metadata-providers/interfaces/metadata-provider.interface';
@@ -105,8 +106,11 @@ export class MediaImportService {
     const fmtMap = Object.fromEntries(fmtRows.map((r) => [r.key, r.value]));
 
     if (dto.type === MediaType.MOVIE) {
-      const details = await this.tmdb.getMovieDetails(
+      const { details } = await this.readForLibrary(
+        dto.type,
+        this.tmdb,
         String(dto.tmdbId),
+        library,
         override,
       );
       const movieFolderFormat =
@@ -128,12 +132,16 @@ export class MediaImportService {
       );
     }
 
-    const details = await this.tmdb.getTvShowDetails(
+    const read = await this.readForLibrary(
+      dto.type,
+      this.tmdb,
       String(dto.tmdbId),
+      library,
       override,
     );
-    const seasons = await this.tmdb.getTvShowSeasons(
-      String(dto.tmdbId),
+    const details = read.details;
+    const seasons = await read.provider.getTvShowSeasons(
+      read.externalId,
       override,
     );
     const seriesFolderFormat =
@@ -212,7 +220,13 @@ export class MediaImportService {
     const fmtMap = Object.fromEntries(fmtRows.map((r) => [r.key, r.value]));
 
     if (dto.type === MediaType.MOVIE) {
-      const details = await provider.getMovieDetails(dto.externalId, override);
+      const { details } = await this.readForLibrary(
+        dto.type,
+        provider,
+        dto.externalId,
+        library,
+        override,
+      );
       if (!details.tmdbId && details.tvdbId && this.tmdb.findByExternalId) {
         const cross = await this.tmdb.findByExternalId(
           'tvdb',
@@ -239,8 +253,18 @@ export class MediaImportService {
       );
     }
 
-    const details = await provider.getTvShowDetails(dto.externalId, override);
-    const seasons = await provider.getTvShowSeasons(dto.externalId, override);
+    const read = await this.readForLibrary(
+      dto.type,
+      provider,
+      dto.externalId,
+      library,
+      override,
+    );
+    const details = read.details;
+    const seasons = await read.provider.getTvShowSeasons(
+      read.externalId,
+      override,
+    );
     if (!details.tmdbId && details.tvdbId && this.tmdb.findByExternalId) {
       const cross = await this.tmdb.findByExternalId(
         'tvdb',
@@ -265,6 +289,92 @@ export class MediaImportService {
       libraryId,
       addedByUserId,
     );
+  }
+
+  /**
+   * Read a title through the provider the destination library prefers.
+   *
+   * A search answers from whichever provider is configured globally, and the library is only
+   * picked afterwards, so importing what the search returned wrote TMDB rows into a TVDB
+   * library — episode lists from one provider, titles from the other. The ids the first
+   * provider knew are kept, so nothing loses its cross-reference.
+   *
+   * Falls back to the provider that found the title (with a warning) when the preferred one
+   * is unavailable or holds no id for this work: an import that still happens beats none.
+   */
+  private async readForLibrary(
+    type: MediaType,
+    found: IMetadataProvider,
+    externalId: string,
+    library: Library | null,
+    override?: MetadataLanguageOverride,
+  ): Promise<{
+    provider: IMetadataProvider;
+    externalId: string;
+    details: MetadataDetails;
+  }> {
+    const details =
+      type === MediaType.MOVIE
+        ? await found.getMovieDetails(externalId, override)
+        : await found.getTvShowDetails(externalId, override);
+    const keep = { provider: found, externalId, details };
+
+    const pref = library?.preferredProvider;
+    if (!pref || pref === found.name) return keep;
+    if (!this.providerRegistry.isAvailable(pref)) {
+      this.log.warn(
+        `import: library prefers ${pref} but it is not available (no API key?) — ` +
+          `importing "${details.title}" from ${found.name}`,
+      );
+      return keep;
+    }
+
+    const target = this.providerRegistry.get(pref)!;
+    const targetId = await this.crossReferenceId(target, details, override);
+    if (!targetId) {
+      this.log.warn(
+        `import: no ${pref} id for "${details.title}" (cross-reference failed) — ` +
+          `importing from ${found.name}`,
+      );
+      return keep;
+    }
+
+    const preferred =
+      type === MediaType.MOVIE
+        ? await target.getMovieDetails(targetId, override)
+        : await target.getTvShowDetails(targetId, override);
+    this.log.log(
+      `import: "${details.title}" read from ${pref} (id=${targetId}) — library preference`,
+    );
+    return {
+      provider: target,
+      externalId: targetId,
+      details: {
+        ...preferred,
+        tmdbId: preferred.tmdbId || details.tmdbId,
+        tvdbId: preferred.tvdbId ?? details.tvdbId,
+        imdbId: preferred.imdbId ?? details.imdbId,
+      },
+    };
+  }
+
+  /** The id `target` knows this work by: its own id off the details, else an IMDB lookup. */
+  private async crossReferenceId(
+    target: IMetadataProvider,
+    details: MetadataDetails,
+    override?: MetadataLanguageOverride,
+  ): Promise<string | null> {
+    if (target.name === 'tmdb' && details.tmdbId) return String(details.tmdbId);
+    if (target.name === 'tvdb' && details.tvdbId) return String(details.tvdbId);
+    if (details.imdbId && target.findByExternalId) {
+      const cross = await target.findByExternalId(
+        'imdb',
+        details.imdbId,
+        override,
+      );
+      if (cross) return cross.id;
+    }
+    return null;
   }
 
   async create(dto: CreateMediaDto): Promise<Media> {


### PR DESCRIPTION
## Problem

Adding a series to a library whose `preferredProvider` is TVDB still produced TMDB metadata.

Both import entry points read from whichever provider found the title:

- `importFromTmdb` (request approval, `/api/media/import/tmdb`) hardcodes `this.tmdb`.
- `importMedia` (`/api/media/import`, the add modal) uses `dto.provider`, which the client copies off the search result — and the search resolves its provider from the global default, since the destination library is only picked *afterwards* in the modal.

The library preference was consulted only later, by `resolveProviderForMedia` during a refresh. So a fresh series held TMDB episode lists and TMDB titles in a TVDB library, and stayed that way until the next refresh — or a manual re-identify.

## Change

New `readForLibrary(type, found, externalId, library, override)`, used by both entry points: it reads the details from the provider that found the title, and when the destination library prefers another one, cross-references the id (the details' own id, else an IMDB lookup) and re-reads details + seasons from the preferred provider. Every id the first provider knew is carried over, so `tmdbId`, `tvdbId` and `imdbId` all land on the row and nothing loses its cross-reference.

Falls back to the provider that found the title, with a warning naming the reason, when the preferred one is unavailable (no API key) or holds no id for the work — an import that happens beats none.

## Tests

`media-import.library-provider.spec.ts`: a TMDB hit is read from TVDB when the library prefers it (both ids kept), no preference stays on the finding provider, and both fallbacks (provider unavailable, no cross-reference) warn and still import. Full backend suite green: 1653 tests.