### PR TITLE
feat(specials): place a special file in season 0 instead of on a real episode

### DIFF
--- a/backend/src/common/library-ingest/library-ingest.service.spec.ts
+++ b/backend/src/common/library-ingest/library-ingest.service.spec.ts
@@ -91,6 +91,20 @@ function buildMovie(over: Partial<Media> & { path: string }): Media {
   } as unknown as Media;
 }
 
+function buildSeries(over: Partial<Media> & { path: string }): Media {
+  return {
+    id: 20,
+    title: 'Nova Skyline',
+    originalTitle: undefined,
+    year: 2025,
+    type: MediaType.SERIES,
+    tmdbId: undefined,
+    library: { id: 10 },
+    folderName: 'Nova Skyline',
+    ...over,
+  } as unknown as Media;
+}
+
 describe('LibraryIngestService.ingest', () => {
   let srcDir: string;
 
@@ -107,7 +121,10 @@ describe('LibraryIngestService.ingest', () => {
     const srcFile = path.join(srcDir, 'Lonely.Harbor.2021.mkv');
     fs.writeFileSync(srcFile, 'x'.repeat(4096));
 
-    const media = buildMovie({ id: 7, path: '/library/movies/Lonely Harbor (2021)' });
+    const media = buildMovie({
+      id: 7,
+      path: '/library/movies/Lonely Harbor (2021)',
+    });
     h.mediaRepo.findOne.mockResolvedValue(media);
 
     const existingRow = {
@@ -186,5 +203,52 @@ describe('LibraryIngestService.ingest', () => {
     expect(h.logger.warn).toHaveBeenCalledWith(
       'Ingest[Coral Drift]: post-import enrichment failed — ffprobe crashed',
     );
+  });
+
+  /**
+   * A special's number is nowhere in its filename — only its title is. Without the title
+   * match the file imports as season 1 episode 1 (or not at all).
+   */
+  it('VERDICT: places a special with no numbering into season 0 by its title', async () => {
+    const h = buildHarness();
+    const srcFile = path.join(
+      srcDir,
+      'Nova.Skyline.Behind.The.Scenes.1080p.WEB-DL.mkv',
+    );
+    fs.writeFileSync(srcFile, 'z'.repeat(2048));
+
+    h.mediaRepo.findOne.mockResolvedValue(
+      buildSeries({ id: 20, path: '/library/tv/Nova Skyline' }),
+    );
+    h.seasonRepo.findOne.mockResolvedValue({
+      id: 900,
+      seasonNumber: 0,
+      episodes: [
+        { id: 9001, episodeNumber: 1, title: 'Teaser', airDate: null },
+        {
+          id: 9002,
+          episodeNumber: 2,
+          title: 'Behind the Scenes',
+          airDate: null,
+        },
+      ],
+    });
+
+    const result = await h.service.ingest({
+      mediaId: 20,
+      files: [{ path: srcFile }],
+      transfer: 'copy',
+      fallbackQuality: 'WEBDL-1080p',
+      sourceLabel: 'Nova Skyline',
+    });
+
+    expect(h.seasonRepo.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { media: { id: 20 }, seasonNumber: 0 },
+      }),
+    );
+    expect(result.imported[0].file.relativePath).toContain('Season 00');
+    expect(result.imported[0].file.relativePath).toContain('S00E02');
+    expect(h.episodeRepo.update).toHaveBeenCalledWith(9002, { hasFile: true });
   });
 });

--- a/backend/src/common/library-ingest/library-ingest.service.ts
+++ b/backend/src/common/library-ingest/library-ingest.service.ts
@@ -136,7 +136,7 @@ export class LibraryIngestService {
 
       if (media.type !== MediaType.MOVIE) {
         const epNums =
-          this.naming.parseEpisodeNumbers(sourceBase) ??
+          this.naming.parseEpisodeNumbers(sourceBase, file.path) ??
           (req.releaseName ? this.naming.parseEpisodeNumbers(req.releaseName) : null);
         seasonNumber = epNums?.season;
         episodeNumber = epNums?.episode;
@@ -175,6 +175,28 @@ export class LibraryIngestService {
                 await this.episodeRepo.save(episode);
               }
             }
+          }
+        } else {
+          // No numbering at all: the name may still carry a special's title, which is the
+          // only thing a special is identifiable by. No title match means no link.
+          const season = await this.seasonRepo.findOne({
+            where: { media: { id: media.id }, seasonNumber: 0 },
+            relations: ['episodes'],
+          });
+          const episode = this.naming.matchSpecialByTitle(
+            sourceBase,
+            season?.episodes ?? [],
+          );
+          if (season && episode) {
+            seasonId = season.id;
+            seasonNumber = 0;
+            episodeNumber = episode.episodeNumber;
+            episodeId = episode.id;
+            episodeTitle = episode.title ?? undefined;
+            airDate = episode.airDate ?? undefined;
+            this.logger.log(
+              `Ingest[${req.sourceLabel}]: "${sourceBase}" → special S00E${String(episode.episodeNumber).padStart(2, '0')} "${episode.title ?? ''}" matched by title`,
+            );
           }
         }
         if (isSeasonPack) {

--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -207,10 +207,14 @@ export class DiskImportService {
       if (linkedSet.has(path.resolve(abs))) continue;
 
       const filename = path.basename(abs);
-      const epNums = this.naming.parseEpisodeNumbers(filename);
+      const epNums = this.naming.parseEpisodeNumbers(filename, abs);
       // Skip files whose inferred type the library doesn't accept (e.g. a
       // series file under a movies-only library) — they can't be re-linked here.
-      const inferredType = epNums ? MediaType.SERIES : MediaType.MOVIE;
+      // A special carries no numbering, so its own markers are what make it a series file.
+      const inferredType =
+        epNums || this.naming.isSpecialFile(abs)
+          ? MediaType.SERIES
+          : MediaType.MOVIE;
       if (!mediaTypes.includes(inferredType)) continue;
       orphanCount++;
 
@@ -408,14 +412,19 @@ export class DiskImportService {
                   episode: f.episodeNumber,
                   episodeEnd: f.episodeEnd ?? null,
                 }
-              : this.naming.parseEpisodeNumbers(filename);
+              : this.naming.parseEpisodeNumbers(filename, f.filePath);
           if (!epNums) {
-            errors.push(`${filename}: no SxxEyy pattern found`);
-            continue;
+            const special = await this.matchSpecialFile(media.id, f.filePath);
+            if (!special) {
+              errors.push(`${filename}: no SxxEyy pattern found`);
+              continue;
+            }
+            episodeId = special.id;
+          } else {
+            const ep = await this.mediaService.ensureSeriesEpisode(media, epNums);
+            episodeId = ep.episodeId ?? undefined;
+            slotCreated ||= ep.created;
           }
-          const ep = await this.mediaService.ensureSeriesEpisode(media, epNums);
-          episodeId = ep.episodeId ?? undefined;
-          slotCreated ||= ep.created;
         }
         entries.push({
           filePath: f.filePath,
@@ -703,12 +712,19 @@ export class DiskImportService {
     }
 
     const { quality } = parseReleaseQuality(filename);
-    const epNums = this.naming.parseEpisodeNumbers(filename);
+    const epNums = this.naming.parseEpisodeNumbers(filename, filePath);
     const extractedTitle = this.extractTitle(filename);
     const matched = matchMedia(extractedTitle, allMedia);
 
     let episodeId: number | null = null;
     let episodeTitle: string | null = null;
+    let special: Episode | null = null;
+
+    if (matched?.type === 'series' && !epNums) {
+      special = await this.matchSpecialFile(matched.id, filePath);
+      episodeId = special?.id ?? null;
+      episodeTitle = special?.title ?? null;
+    }
 
     if (matched?.type === 'series' && epNums) {
       let season = await this.seasonRepo.findOne({
@@ -754,8 +770,8 @@ export class DiskImportService {
       size,
       qualityName: quality.name,
       qualityId: quality.id,
-      seasonNumber: epNums?.season ?? null,
-      episodeNumber: epNums?.episode ?? null,
+      seasonNumber: epNums?.season ?? (special ? 0 : null),
+      episodeNumber: epNums?.episode ?? special?.episodeNumber ?? null,
       mediaId: matched?.id ?? null,
       mediaTitle: matched?.title ?? null,
       mediaYear: matched?.year ?? null,
@@ -764,6 +780,25 @@ export class DiskImportService {
       episodeTitle,
       existingQuality: null,
     };
+  }
+
+  /**
+   * A file that names itself a special but no episode number: match it against the season-0
+   * rows by title. Never creates a row — an unplaceable special stays unmatched rather than
+   * taking a number, which would attach it to the wrong one.
+   */
+  private async matchSpecialFile(
+    mediaId: number,
+    filePath: string,
+  ): Promise<Episode | null> {
+    const season = await this.seasonRepo.findOne({
+      where: { media: { id: mediaId }, seasonNumber: 0 },
+      relations: ['episodes'],
+    });
+    return this.naming.matchSpecialByTitle(
+      path.basename(filePath),
+      season?.episodes ?? [],
+    );
   }
 
   private extractTitle(filename: string): string {

--- a/backend/src/modules/media/media-service/media-rescan.service.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.ts
@@ -186,17 +186,20 @@ export class MediaRescanService {
     let episodeId: number | null = null;
     let created = false;
     if (media.type === MediaType.SERIES) {
-      const epNums = p.epNums ?? this.naming.parseEpisodeNumbers(filename);
+      const epNums = p.epNums ?? this.naming.parseEpisodeNumbers(filename, absPath);
       if (!epNums) {
-        return { error: 'no SxxEyy pattern found' };
+        const special = await this.matchSpecialFile(media.id, absPath);
+        if (!special) return { error: 'no SxxEyy pattern found' };
+        episodeId = special.id;
+      } else {
+        const { ep, created: c } = await this.ensureSeasonAndEpisode(
+          media,
+          epNums,
+          media.id,
+        );
+        episodeId = ep?.id ?? null;
+        created = c;
       }
-      const { ep, created: c } = await this.ensureSeasonAndEpisode(
-        media,
-        epNums,
-        media.id,
-      );
-      episodeId = ep?.id ?? null;
-      created = c;
     }
 
     let size = 0;
@@ -546,7 +549,7 @@ export class MediaRescanService {
       // (e.g. "S07E11-E12.mkv" already imported as E11 gets endEpisodeNumber
       // set retroactively).
       if (media.type === MediaType.SERIES) {
-        const epNums = this.naming.parseEpisodeNumbers(filename);
+        const epNums = this.naming.parseEpisodeNumbers(filename, absPath);
         if (epNums && dbFile.episodeId == null) {
           try {
             const { ep, created } = await this.ensureSeasonAndEpisode(
@@ -576,6 +579,14 @@ export class MediaRescanService {
               `Rescan[media #${mediaId}]: failed to create season/episode for refresh "${normPath}"`,
               err instanceof Error ? err.stack : err,
             );
+          }
+        } else if (!epNums && dbFile.episodeId == null) {
+          const special = await this.matchSpecialFile(mediaId, absPath);
+          if (special) {
+            dbFile.episode = special;
+            await this.mediaFileRepo.save(dbFile);
+            await this.episodeRepo.update(special.id, { hasFile: true });
+            updated++;
           }
         } else if (epNums?.episodeEnd != null && dbFile.episodeId != null) {
           // Already-linked file: retroactively apply the range on its Episode.
@@ -667,7 +678,7 @@ export class MediaRescanService {
       // Try to match episode for series — create season/episode on the fly if missing
       let episodeId: number | undefined;
       if (media.type === MediaType.SERIES) {
-        const epNums = this.naming.parseEpisodeNumbers(filename);
+        const epNums = this.naming.parseEpisodeNumbers(filename, absPath);
         if (epNums) {
           try {
             const { ep, created } = await this.ensureSeasonAndEpisode(
@@ -684,10 +695,15 @@ export class MediaRescanService {
             );
           }
         } else {
-          this.log.warn(
-            `Rescan[media #${mediaId}]: series file name has no SxxEyy pattern — "${filename}" (skipped, alien file in series folder)`,
-          );
-          continue;
+          const special = await this.matchSpecialFile(mediaId, absPath);
+          if (special) {
+            episodeId = special.id;
+          } else {
+            this.log.warn(
+              `Rescan[media #${mediaId}]: series file name has no SxxEyy pattern — "${filename}" (skipped, alien file in series folder)`,
+            );
+            continue;
+          }
         }
       }
 
@@ -829,6 +845,32 @@ export class MediaRescanService {
    * episode when the freshly-parsed filename reveals it's a multi-episode
    * file (e.g. "S07E11-E12.mkv" originally indexed as E11 only).
    */
+  /**
+   * A file that names itself a special but no episode number: match it against the season-0
+   * rows by title. Never creates a row — an unplaceable special stays unmatched rather than
+   * taking a number, which would attach it to the wrong one.
+   */
+  private async matchSpecialFile(
+    mediaId: number,
+    absPath: string,
+  ): Promise<Episode | null> {
+    const season = await this.seasonRepo.findOne({
+      where: { media: { id: mediaId }, seasonNumber: 0 },
+      relations: ['episodes'],
+    });
+    const ep = this.naming.matchSpecialByTitle(
+      path.basename(absPath),
+      season?.episodes ?? [],
+    );
+    if (ep) {
+      this.log.log(
+        `Rescan[media #${mediaId}]: matched special S00E${String(ep.episodeNumber).padStart(2, '0')} ` +
+          `"${ep.title ?? ''}" by title — "${path.basename(absPath)}"`,
+      );
+    }
+    return ep;
+  }
+
   private async ensureSeasonAndEpisode(
     media: Media,
     epNums: {

--- a/backend/src/modules/scheduler/naming.service.spec.ts
+++ b/backend/src/modules/scheduler/naming.service.spec.ts
@@ -671,4 +671,125 @@ describe('NamingService', () => {
       expect(svc.parseEpisodeNumbers('')).toBeNull();
     });
   });
+  /**
+   * A special carries no reliable episode number: the loose patterns would hand it the first
+   * number they find, which is a real episode of season 1. Season 0 or nothing.
+   */
+  describe('parseEpisodeNumbers — specials', () => {
+    const svc = buildService();
+
+    it('reads an explicit S00Exx as season 0', () => {
+      expect(
+        svc.parseEpisodeNumbers('Nova.Skyline.S00E03.Backstage.mkv'),
+      ).toEqual({
+        season: 0,
+        episode: 3,
+        episodeEnd: undefined,
+      });
+    });
+
+    it.each([
+      ['[Grp] Nova Skyline - OVA - 01 [1080p].mkv', 1],
+      ['Nova.Skyline.SP02.Prologue.mkv', 2],
+      ['Nova Skyline Special 3 1080p.mkv', 3],
+    ])(
+      'VERDICT: gives a numbered special to season 0 — %s',
+      (name, episode) => {
+        expect(svc.parseEpisodeNumbers(name)).toEqual({ season: 0, episode });
+      },
+    );
+
+    it.each([
+      'Nova.Skyline.S01E00.Recap.1080p.WEB-DL.mkv',
+      'Nova.Skyline.2x00.Recap.mkv',
+      '[Grp] Nova Skyline - 05.5 [SP] [1080p].mkv',
+      'Nova.Skyline.Special.Winter.1080p.mkv',
+    ])('VERDICT: refuses to number an unplaceable special — %s', (name) => {
+      expect(svc.parseEpisodeNumbers(name)).toBeNull();
+    });
+
+    it('VERDICT: a Specials folder blocks a loose number from taking a real episode', () => {
+      expect(
+        svc.parseEpisodeNumbers(
+          'Nova Skyline - 05.mkv',
+          '/medias/tv/Nova Skyline/Specials/Nova Skyline - 05.mkv',
+        ),
+      ).toBeNull();
+      // Same file under a numbered season keeps its episode.
+      expect(
+        svc.parseEpisodeNumbers(
+          'Nova Skyline - 05.mkv',
+          '/medias/tv/Nova Skyline/Season 01/Nova Skyline - 05.mkv',
+        ),
+      ).toEqual({ season: 1, episode: 5, episodeEnd: undefined });
+    });
+
+    it('still trusts an explicit SxxExx whose episode title says "special"', () => {
+      expect(
+        svc.parseEpisodeNumbers(
+          'Nova.Skyline.S01E05.The.Winter.Special.1080p.mkv',
+        ),
+      ).toEqual({ season: 1, episode: 5, episodeEnd: undefined });
+    });
+  });
+
+  describe('isSpecialFile', () => {
+    const svc = buildService();
+
+    it.each([
+      '/medias/tv/Nova Skyline/Specials/Backstage.mkv',
+      '/medias/tv/Nova Skyline/Season 00/Nova - Winter.mkv',
+      'Nova.Skyline.S01E00.Recap.mkv',
+      '[Grp] Nova Skyline - 05.5 [SP].mkv',
+      'Nova.Skyline.NCED.mkv',
+    ])('flags %s', (p) => expect(svc.isSpecialFile(p)).toBe(true));
+
+    it.each([
+      '/medias/tv/Nova Skyline/Season 01/Nova.Skyline.S01E05.mkv',
+      'Nova.Skyline.S02E10.1080p.WEB-DL.mkv',
+    ])('leaves %s alone', (p) => expect(svc.isSpecialFile(p)).toBe(false));
+  });
+
+  /** The number lives nowhere in the name — only the title does. */
+  describe('matchSpecialByTitle', () => {
+    const svc = buildService();
+    const specials = [
+      { title: 'Behind the Scenes', episodeNumber: 1 },
+      { title: 'The Making Of', episodeNumber: 2 },
+      { title: 'Making', episodeNumber: 3 },
+      { title: 'Spécial Hiver', episodeNumber: 4 },
+      { title: null, episodeNumber: 5 },
+    ];
+
+    it('VERDICT: prefers the longest title match, not the first that fits', () => {
+      expect(
+        svc.matchSpecialByTitle(
+          'Nova - The Making Of - 1080p.WEB-DL.mkv',
+          specials,
+        )?.episodeNumber,
+      ).toBe(2);
+    });
+
+    it('ignores punctuation, case and accents', () => {
+      expect(
+        svc.matchSpecialByTitle(
+          'Nova.Skyline.SPECIAL.HIVER.1080p.mkv',
+          specials,
+        )?.episodeNumber,
+      ).toBe(4);
+      expect(
+        svc.matchSpecialByTitle('Nova.Behind.the.scenes.1080p.mkv', specials)
+          ?.episodeNumber,
+      ).toBe(1);
+    });
+
+    it('VERDICT: returns null rather than guessing when no title is in the name', () => {
+      expect(
+        svc.matchSpecialByTitle(
+          'Nova.Skyline.Unknown.Extra.1080p.mkv',
+          specials,
+        ),
+      ).toBeNull();
+    });
+  });
 });

--- a/backend/src/modules/scheduler/naming.service.ts
+++ b/backend/src/modules/scheduler/naming.service.ts
@@ -21,6 +21,35 @@ const DEFAULT_FORMATS: NamingFormats = {
   seasonFolder: 'Season {season:00}',
 };
 
+/** `OVA 02`, `SP01`, `Special 3`, `NCED 1` — the marker owns the number that follows it. */
+const NUMBERED_SPECIAL =
+  /(?:^|[^a-z0-9])(?:specials?|ova|oav|ovd|sp|ncop|nced)[ ._-]*(\d{1,2})(?![0-9])/i;
+
+/** The same markers standing alone — no number to take. `sp` is left out: too short to
+ *  tell apart from a release tag without a number bound to it. */
+const SPECIAL_TOKEN =
+  /(?:^|[^a-z0-9])(?:specials?|ova|oav|ovd|ncop|nced)(?:[^a-z0-9]|$)/i;
+
+/** A `Specials` / `Season 00` folder anywhere in the path. */
+const SPECIALS_FOLDER =
+  /(?:^|[\\/])(?:specials?|(?:season|saison)[ ._-]*0+)(?:[\\/])/i;
+
+/** The `.5` interstitial anime uses for a special between two episodes. */
+const DECIMAL_EPISODE = /(?:^|[^0-9])\d{1,3}\.5(?:[^0-9]|$)/;
+
+/** `S01E00` / `1x00`: a special the release names by its parent season, not by its number. */
+const EPISODE_ZERO = /(?:[Ss](\d{1,2})[ ._-]*[Ee]|(\d{1,2})[xX])0+(?![0-9])/;
+
+/** Same treatment on both sides of a title comparison: accents, case and punctuation gone. */
+function normalizeTitle(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
 @Injectable()
 export class NamingService {
   constructor(private readonly dataSource: DataSource) {}
@@ -209,6 +238,9 @@ export class NamingService {
    */
   parseEpisodeNumbers(
     sourceTitle: string,
+    /** Full path when the caller has one: a `Specials` folder is a season-0 signal the
+     *  filename alone does not carry. Only read for that — never parsed for numbers. */
+    filePath?: string,
   ): { season: number; episode: number; episodeEnd?: number } | null {
     // Normalize separators: dots/underscores → spaces (but keep S01E01 intact)
     const normalized = sourceTitle
@@ -221,6 +253,9 @@ export class NamingService {
       episode: number;
       /** Group index of the range-end number (only the multi-episode regex has one). */
       episodeEnd?: number;
+      /** The name states its season and episode. The looser patterns below guess from any
+       *  number they find, which is why a marked special must not trust them. */
+      explicit?: boolean;
     }[] = [
       // ---- Standard S01E01 patterns ----
 
@@ -232,18 +267,24 @@ export class NamingService {
         season: 1,
         episode: 2,
         episodeEnd: 3,
+        explicit: true,
       },
 
       // S01E01 standard (most common)
-      { re: /[Ss](\d{1,2})\s*[Ee](\d{1,3})/, season: 1, episode: 2 },
+      { re: /[Ss](\d{1,2})\s*[Ee](\d{1,3})/, season: 1, episode: 2, explicit: true },
 
       // S01.E01 / S01 E01 / S01_E01
-      { re: /[Ss](\d{1,2})\s*[.\- _][Ee](\d{1,3})/, season: 1, episode: 2 },
+      {
+        re: /[Ss](\d{1,2})\s*[.\- _][Ee](\d{1,3})/,
+        season: 1,
+        episode: 2,
+        explicit: true,
+      },
 
       // ---- Cross/x notation ----
 
       // 1x05 / 01x05
-      { re: /(\d{1,2})[xX](\d{2,3})/, season: 1, episode: 2 },
+      { re: /(\d{1,2})[xX](\d{2,3})/, season: 1, episode: 2, explicit: true },
 
       // ---- Bare season + episode (no letter prefix) ----
 
@@ -267,16 +308,30 @@ export class NamingService {
       { re: /[Ee](\d{2,3})(?:[^a-zA-Z\d]|$)/, season: -1, episode: 1 },
     ];
 
+    // A special names its own number, so `Show - OVA - 01` is S00E01 and never S01E01.
+    const numberedSpecial = sourceTitle.match(NUMBERED_SPECIAL);
+    if (numberedSpecial) {
+      const episode = parseInt(numberedSpecial[1], 10);
+      if (episode >= 1) return { season: 0, episode };
+    }
+    const special = this.isSpecialFile(filePath ?? sourceTitle);
+
     for (const {
       re,
       season: sIdx,
       episode: eIdx,
       episodeEnd: endIdx,
+      explicit,
     } of patterns) {
       const m = normalized.match(re) ?? sourceTitle.match(re);
       if (!m) continue;
       const episode = parseInt(m[eIdx], 10);
+      // `SxxE00` states a special without stating which one; a looser pattern would only
+      // find an unrelated number, so stop here and let the caller match it by title.
+      if (explicit && episode === 0) return null;
       if (!Number.isFinite(episode) || episode < 1) continue;
+      // Same reason, for a name that only carries a marker: no number here is trustworthy.
+      if (special && !explicit) return null;
 
       let episodeEnd: number | undefined;
       if (endIdx != null && m[endIdx] != null) {
@@ -294,6 +349,53 @@ export class NamingService {
     }
 
     return null;
+  }
+
+  /**
+   * Whether this path names a special: a `Specials` folder, an `OVA`/`SP`/`NCED` marker, a
+   * `.5` interstitial, or a `SxxE00` numbering. Accepts a full path — the folder counts.
+   */
+  isSpecialFile(pathOrName: string): boolean {
+    return (
+      SPECIALS_FOLDER.test(pathOrName) ||
+      SPECIAL_TOKEN.test(pathOrName) ||
+      NUMBERED_SPECIAL.test(pathOrName) ||
+      DECIMAL_EPISODE.test(pathOrName) ||
+      EPISODE_ZERO.test(pathOrName)
+    );
+  }
+
+  /**
+   * The season-0 episode whose title the filename contains. Longest title wins at equal
+   * position, so "The Making Of" beats "Making" on the same file.
+   *
+   * This is how a special with no usable numbering gets placed: its number lives nowhere in
+   * the name, only its title does. No match means the file stays unmatched — guessing a
+   * number would attach it to the wrong special.
+   */
+  matchSpecialByTitle<T extends { title?: string | null }>(
+    filename: string,
+    specials: T[],
+  ): T | null {
+    const haystack = normalizeTitle(
+      path.basename(filename, path.extname(filename)),
+    );
+    let best: { position: number; length: number; special: T } | null = null;
+    for (const special of specials) {
+      const needle = normalizeTitle(special.title ?? '');
+      // A two-letter title would match half the release names on disk.
+      if (needle.length < 4) continue;
+      const position = haystack.indexOf(needle);
+      if (position < 0) continue;
+      if (
+        !best ||
+        position < best.position ||
+        (position === best.position && needle.length > best.length)
+      ) {
+        best = { position, length: needle.length, special };
+      }
+    }
+    return best?.special ?? null;
   }
 
   /**


### PR DESCRIPTION
## Problem

With season 0 finally in the database (#1100), the file matcher still could not place a special — and worse, it mis-placed some. Measured on the real parser before this change:

```
{"season":0,"episode":1}  <- Show.S00E01.Behind.The.Scenes.1080p.WEB-DL.mkv   ok
null                      <- Show.S01E00.Recap.1080p.WEB-DL.mkv
null                      <- Show.Special.Christmas.1080p.WEB-DL.mkv
{"season":1,"episode":1}  <- [Grp] Show - OVA - 01 [1080p].mkv                wrong
{"season":1,"episode":5}  <- [Grp] Show - 05.5 [SP] [1080p].mkv               wrong
null                      <- Show - SP01 - Prologue.mkv
null                      <- Specials/Show - Making Of.mkv
```

The two wrong lines are the real damage: the cascade falls through to loose patterns that take *any* number in the name, so an OVA and a `.5` interstitial each claimed an existing episode of season 1 — the wrong file linked to a real episode, which is worse than no match.

## Change

**Parsing** (`NamingService`)

- A marker owns the number that follows it: `OVA 01`, `SP01`, `Special 3`, `NCED 1` → season 0, that number. Checked before the cascade, so it can never become S01E01.
- A special with no usable number is refused instead of guessed — `SxxE00`, `1x00`, a `.5` interstitial, a bare `OVA`/`Specials` marker, or a `Specials` / `Season 00` folder. The four explicit `SxxExx` patterns are flagged `explicit` and keep full trust, so `S01E05.The.Winter.Special.mkv` is still episode 5.
- `parseEpisodeNumbers` takes an optional full path, read *only* for that folder signal — never parsed for numbers.
- `isSpecialFile(path)` and `matchSpecialByTitle(filename, specials)` are public: the second is the placement rule, since a special's number lives nowhere in its name and only its title does. Normalized on both sides (accents, case, punctuation), earliest position then longest title wins, titles under 4 characters ignored, no match returns null.

**Every file → episode path** falls back to that title match when numbering yields nothing, and links without ever creating a row: library rescan (3 call sites), orphan scan + relink, download ingest. A special also counts as a series file when the orphan scan infers a type, so it is no longer skipped as a movie in a series-only library.

## Tests

`naming.service.spec.ts`: numbered specials land in season 0; the four unplaceable shapes return null; an explicit `SxxExx` with "special" in the episode title is untouched; a `Specials` folder blocks a loose number while the same file under `Season 01` keeps its episode; title matching handles accents/case/punctuation, prefers the longest title, and returns null rather than guessing.

`library-ingest.service.spec.ts`: a special with no numbering is placed in season 0 by title, named `S00E02` under `Season 00`, with `hasFile` set on the matched row.

Full backend suite green: 161 suites, 1772 tests. `tsc --noEmit` clean.