### PR TITLE
feat(acquisition): hand the episode title down with the target

### DIFF
--- a/backend/src/common/plugin-contract/host-methods.ts
+++ b/backend/src/common/plugin-contract/host-methods.ts
@@ -42,6 +42,9 @@ export interface AcquisitionTarget {
     number: number;
     endNumber: number | null;
     airDate: string | null;
+    /** The only handle on a special: season 0 is never published as `S00Exx`, so a plugin
+     *  searching one has to query the episode title. Null when the provider has none. */
+    title: string | null;
   };
 }
 

--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -332,6 +332,7 @@ describe('FliksHostImpl', () => {
       expect(result?.episode).toEqual({
         id: 100,
         number: 1,
+        title: 'Pilot',
         endNumber: null,
         airDate: '2020-01-01',
       });
@@ -391,6 +392,47 @@ describe('FliksHostImpl', () => {
 
       expect(seen).toHaveLength(4);
       expect(seen[0].season).toBeUndefined();
+    });
+
+    /**
+     * A special is never published as `S00Exx`, so its title is the only query that can find
+     * it. The plugin cannot invent one — it has to come down with the target.
+     */
+    it('VERDICT: carries the episode title so a special can be searched by name', async () => {
+      const h = makeHarness();
+      const series = makeMedia({ id: 2, type: MediaType.SERIES });
+      const specials = makeSeason({ id: 20, mediaId: 2, seasonNumber: 0 });
+      const special = makeEpisode({
+        id: 201,
+        season: specials,
+        episodeNumber: 3,
+        title: 'Behind the Scenes',
+      });
+
+      h.acquisitionCandidates.listMovieTargets.mockResolvedValue([]);
+      h.acquisitionCandidates.listEpisodeTargets.mockResolvedValue([
+        { media: series, season: specials, episode: special, files: [] },
+      ]);
+      h.acquisitionCandidates.groupIntoSeasonPacks.mockResolvedValue([]);
+      h.autoGrab.classifyForSearch.mockReturnValue({
+        mode: 'missing',
+        minRankExclusive: 0,
+        maxRankInclusive: 10,
+      });
+
+      const page = await h.host['acquisition.candidates']({
+        availableOn: '2099-01-01',
+        limit: 10,
+      });
+
+      expect(page.items[0].episode).toEqual({
+        id: 201,
+        number: 3,
+        endNumber: null,
+        airDate: '2020-01-01',
+        title: 'Behind the Scenes',
+      });
+      expect(page.items[0].season?.number).toBe(0);
     });
 
     // The pack used to be the only candidate for its season, so nothing was left to fall back

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -237,6 +237,7 @@ export class FliksHostImpl implements PluginHostApi {
         number: episode.episodeNumber,
         endNumber: episode.endEpisodeNumber,
         airDate: episode.airDate ?? null,
+        title: episode.title ?? null,
       };
     }
     return target;
@@ -1224,6 +1225,7 @@ export class FliksHostImpl implements PluginHostApi {
       number: t.episode.episodeNumber,
       endNumber: t.episode.endEpisodeNumber,
       airDate: t.episode.airDate ?? null,
+      title: t.episode.title ?? null,
     };
     return target;
   }


### PR DESCRIPTION
## Problem

Specials can be monitored since #1100 and placed on disk since #1102, but they can never be *found*.

`AcquisitionTarget.episode` carried `{ id, number, endNumber, airDate }`. A plugin searching a season-0 episode has only the series title and the numbers, so the best query it can build is `S00E03` — a form nothing publishes. Every episode search for season 0 fans out over every enabled indexer and consumes the search budget for a guaranteed empty answer.

The one handle on a special is its episode title (`Behind the Scenes`), and that never left core.

## Change

- `AcquisitionTarget.episode` gains `title: string | null` (`backend/src/common/plugin-contract/host-methods.ts`).
- Both builders populate it: the episode-scoped `media.acquisitionContext` lookup (which the manual release picker goes through) and `buildFromEpisodeTarget` behind `acquisition.candidates`. `listEpisodeTargets` already selected `ep.title`, so there is no extra query.

Additive on the contract: a plugin that ignores the field behaves exactly as it does today. The matching plugin-side search lands separately in `fk-plugin-download`.

## Tests

`fliks-host.service.spec.ts`: a season-0 candidate carries its title down with `season.number === 0`; the existing episode-scoped context assertion now pins the title too. 161 suites / 1773 tests pass; `tsc --noEmit` clean.