### PR TITLE
fix(release-scoring): refuse a sequel, another year, or a multi-film pack

### DIFF
--- a/backend/src/common/release-scoring/release-rejection.helper.spec.ts
+++ b/backend/src/common/release-scoring/release-rejection.helper.spec.ts
@@ -236,6 +236,100 @@ describe('resolveSearchTitles + titleMatchesExpectation', () => {
   });
 });
 
+/**
+ * The title check is a token-inclusion test, so a sequel passes it: every token of the title we
+ * asked for is there, the release simply says more. That is how a sequel with the most seeders
+ * came out first for the film it is a sequel of.
+ */
+describe('computeRejections — the wrong work under the right title', () => {
+  const reject = (
+    releaseTitle: string,
+    expectedTitle: string | string[] = ['Nova Skyline', 'La voix du succès'],
+    expectedYear: number | null = 2012,
+    scope: { expectedSeason?: number; expectedEpisode?: number } = {},
+  ) =>
+    computeRejections({
+      qualityId: 1,
+      allowed: new Set([1]),
+      languageId: 1,
+      allowedLangs: new Set<number>(),
+      isBlocklisted: false,
+      sizeBytes: 0,
+      runtimeMinutes: 112,
+      sizeByQuality: new Map(),
+      seeders: 10,
+      sourceId: 0,
+      sourceMinSeeders: new Map(),
+      releaseTitle,
+      expectedTitle,
+      expectedYear,
+      ...scope,
+    }).map((r) => r.code);
+
+  it('VERDICT: refuses a sequel of the film that was asked for', () => {
+    expect(reject('Nova.Skyline.2.2015.1080p.BluRay.x264-GRP')).toEqual([
+      'SEQUEL_MISMATCH',
+      'YEAR_MISMATCH',
+    ]);
+  });
+
+  it('VERDICT: refuses a multi-film pack when one film was asked for', () => {
+    expect(reject('Nova.Skyline.Collection.(2012-2017).MULTi.1080p.BluRay.x264-GRP')).toEqual([
+      'COLLECTION_PACK',
+    ]);
+  });
+
+  it.each([
+    'Nova.Skyline.2012.1080p.BluRay.DD.7.1.x265-GRP',
+    'Nova Skyline (2012) 1080p BrRip x264 GRP',
+    'Nova-Skyline-(2012)[1080p-BDRip--Original-Auds-]',
+    'La.voix.du.succes.(2012).[1080p].MULTI.VF2.Bluray.x264-GRP',
+    'Nova.Skyline.2012.UNRATED.1080p',
+  ])('takes the film that was asked for — %s', (title) => {
+    expect(reject(title)).toEqual([]);
+  });
+
+  it('VERDICT: takes its own release for a media whose title ends in a number', () => {
+    expect(reject('Nova.Skyline.2.2015.1080p.BluRay.x264-GRP', ['Nova Skyline 2'], 2015)).toEqual(
+      [],
+    );
+    // …and still refuses the film it is a sequel of.
+    expect(reject('Nova.Skyline.2012.1080p.BluRay', ['Nova Skyline 2'], 2015)).toEqual([
+      'YEAR_MISMATCH',
+    ]);
+  });
+
+  it('judges no year on a release that states none', () => {
+    expect(reject('Nova.Skyline.1080p.BluRay.x264-GRP')).toEqual([]);
+  });
+
+  it('allows a year one off, which a staggered release date produces', () => {
+    expect(reject('Nova.Skyline.2013.1080p.BluRay')).toEqual([]);
+    expect(reject('Nova.Skyline.2014.1080p.BluRay')).toEqual(['YEAR_MISMATCH']);
+  });
+
+  it('reads a resolution or a codec as neither a year nor a sequel number', () => {
+    expect(reject('Nova.Skyline.2012.2160p.x264.DDP5.1.HDR10')).toEqual([]);
+  });
+
+  it('VERDICT: leaves a title that is itself a year, or itself a pack word, alone', () => {
+    expect(reject('2012.2009.1080p.BluRay', ['2012'], 2009)).toEqual([]);
+    expect(reject('The.Collection.2012.1080p', ['The Collection'], 2012)).toEqual([]);
+  });
+
+  it('takes a season pack for a season-scoped search, pack word and all', () => {
+    expect(
+      reject('Nova.Skyline.Complete.Collection.1080p', ['Nova Skyline'], null, {
+        expectedSeason: 4,
+      }),
+    ).toEqual([]);
+  });
+
+  it('says nothing about a release the title check already refused', () => {
+    expect(reject('Other.Show.2.2015.1080p')).toEqual(['TITLE_MISMATCH', 'YEAR_MISMATCH']);
+  });
+});
+
 describe('computeRejections — episode targeting', () => {
   const reject = (releaseTitle: string, expectedSeason?: number, expectedEpisode?: number) =>
     computeRejections({

--- a/backend/src/common/release-scoring/release-rejection.helper.ts
+++ b/backend/src/common/release-scoring/release-rejection.helper.ts
@@ -339,6 +339,10 @@ function significantTokens(tokens: string[]): string[] {
 export interface TitleExpectationIndex {
   /** Significant tokens per readable reading; empty when nothing in the expectation is comparable. */
   readings: string[][];
+  /** Number-like tokens the expected titles carry themselves, single characters included — those
+   *  are dropped from `readings`, so a title ending in a number would otherwise
+   *  read as a sequel of itself. */
+  numbers: Set<string>;
   /** True when the expectation list was empty, which matches anything. */
   vacuous: boolean;
 }
@@ -348,20 +352,102 @@ export function indexTitleExpectations(expected: string | string[]): TitleExpect
   const candidates = (Array.isArray(expected) ? expected : [expected]).filter(
     (s): s is string => !!s && s.trim().length > 0,
   );
-  if (!candidates.length) return { readings: [], vacuous: true };
+  if (!candidates.length) return { readings: [], numbers: new Set(), vacuous: true };
   const readings: string[][] = [];
+  const numbers = new Set<string>();
   for (const cand of candidates) {
     for (const reading of titleReadings(cand)) {
+      for (const token of reading) {
+        if (/^\d+$/.test(token)) numbers.add(token);
+      }
       const tokens = significantTokens(reading);
       if (tokens.length) readings.push(tokens);
     }
   }
-  return { readings, vacuous: false };
+  return { readings, numbers, vacuous: false };
 }
 
 /** The release side of the same comparison, hoisted so it is computed once per release title. */
 export function releaseTitleTokens(releaseTitle: string): ReadonlySet<string> {
   return new Set(titleReadings(releaseTitle).flat());
+}
+
+/** Ordered readings of a release title — the sequel check needs what follows the expected
+ *  title, which a token set cannot say. */
+function releaseTitleReadings(releaseTitle: string): string[][] {
+  return titleReadings(releaseTitle);
+}
+
+/** A number a sequel wears: `2`…`99`, or a roman numeral. `v` and `x` are left out — alone they
+ *  read as a title word far more often than as a number. */
+const SEQUEL_NUMBER = /^([2-9]|[1-9]\d|ii|iii|iv|vi|vii|viii|ix)$/;
+
+/** Words that name a multi-film pack rather than a film. */
+const COLLECTION_WORD =
+  /^(collection|collections|duology|trilogy|quadrilogy|tetralogy|pentalogy|hexalogy|anthology|saga|filmography)$/;
+
+/** Index of the release token right after the expected title's last token, matching the expected
+ *  tokens in order but tolerating anything between them (a release keeps stopwords the expectation
+ *  dropped). Null when this reading does not carry the whole expectation. */
+function tokenAfterExpectation(release: string[], expected: string[]): number | null {
+  let at = 0;
+  for (const token of expected) {
+    const found = release.indexOf(token, at);
+    if (found === -1) return null;
+    at = found + 1;
+  }
+  return at;
+}
+
+/**
+ * The number this release appends to the title we asked for — `Nova Skyline 2` against
+ * `Nova Skyline`. That is another film, and the token-inclusion check cannot see it: every
+ * token of the expectation is there, the release simply says more.
+ *
+ * Null as soon as one reading of one expected title carries no such number, so a media whose own
+ * title ends in a number, and an alternative title that matches cleanly, both stay untouched.
+ */
+export function appendedSequelNumber(
+  releaseTitle: string,
+  index: TitleExpectationIndex,
+): string | null {
+  if (index.vacuous || !index.readings.length) return null;
+  let found: string | null = null;
+  for (const release of releaseTitleReadings(releaseTitle)) {
+    for (const expected of index.readings) {
+      const at = tokenAfterExpectation(release, expected);
+      if (at === null) continue;
+      const next = release[at];
+      if (
+        next === undefined ||
+        !SEQUEL_NUMBER.test(next) ||
+        expected.includes(next) ||
+        index.numbers.has(next)
+      ) {
+        return null;
+      }
+      found ??= next;
+    }
+  }
+  return found;
+}
+
+/** The pack word this release wears, when the title we asked for does not wear it itself. */
+export function collectionPackWord(
+  releaseTitle: string,
+  index: TitleExpectationIndex,
+): string | null {
+  const expected = new Set(index.readings.flat());
+  for (const token of releaseTitleReadings(releaseTitle).flat()) {
+    if (COLLECTION_WORD.test(token) && !expected.has(token)) return token;
+  }
+  return null;
+}
+
+/** Years a release title states. `1080p`, `x264` and `DDP5.1` never read as one — the word
+ *  boundary after four digits is what rules them out. */
+export function releaseYears(releaseTitle: string): number[] {
+  return [...releaseTitle.matchAll(/\b(?:19|20)\d{2}\b/g)].map((m) => Number(m[0]));
 }
 
 export function matchesIndexedExpectation(
@@ -439,15 +525,43 @@ export function computeRejections(opts: {
   /** From `want.minResolution`: the resolution already on disk when the profile allows only a
    *  resolution upgrade. 0 or absent means the rule does not apply. */
   minResolution?: number;
+  /** Release year of the media. A release stating another year names another work — the
+   *  token-inclusion title check cannot tell `Nova Skyline 2 2015` from `Nova Skyline`. */
+  expectedYear?: number | null;
 }): ReleaseRejection[] {
   const out: ReleaseRejection[] = [];
 
-  if (
-    opts.expectedTitle &&
-    opts.releaseTitle &&
-    !titleMatchesExpectation(opts.releaseTitle, opts.expectedTitle)
-  ) {
-    out.push({ code: 'TITLE_MISMATCH' });
+  if (opts.expectedTitle && opts.releaseTitle) {
+    const index = indexTitleExpectations(opts.expectedTitle);
+    if (!matchesIndexedExpectation(releaseTitleTokens(opts.releaseTitle), index)) {
+      out.push({ code: 'TITLE_MISMATCH' });
+    } else {
+      // Everything below only applies to a release that already passed as this title: they name
+      // what a token-inclusion check cannot see — what the release says *beyond* the expectation.
+      const sequel = appendedSequelNumber(opts.releaseTitle, index);
+      if (sequel !== null) {
+        out.push({ code: 'SEQUEL_MISMATCH', params: { number: sequel } });
+      }
+      // A pack of films answers a request for one of them by fetching all of them. Left alone for
+      // a season-scoped search, where a pack is exactly what is wanted.
+      const pack = opts.expectedSeason == null || opts.expectedEpisode != null
+        ? collectionPackWord(opts.releaseTitle, index)
+        : null;
+      if (pack !== null) {
+        out.push({ code: 'COLLECTION_PACK', params: { word: pack } });
+      }
+    }
+  }
+
+  // A release that states no year is not judged on one: most name theirs, some never do.
+  if (opts.releaseTitle && opts.expectedYear) {
+    const years = releaseYears(opts.releaseTitle);
+    if (years.length && !years.some((y) => Math.abs(y - opts.expectedYear!) <= 1)) {
+      out.push({
+        code: 'YEAR_MISMATCH',
+        params: { expected: opts.expectedYear, actual: years.join(', ') },
+      });
+    }
   }
 
   if (
@@ -729,6 +843,8 @@ export async function scoreAndSortReleases(
     /** From `want.minResolution`: the resolution already on disk when the profile only allows a
      *  resolution upgrade. 0 or absent means the rule does not apply. */
     minResolution?: number;
+    /** Release year of the media — a release naming another year names another work. */
+    expectedYear?: number | null;
   },
   deps: ReleaseScorerDeps,
 ): Promise<ScoredRelease[]> {
@@ -763,6 +879,7 @@ export async function scoreAndSortReleases(
         expectedSeason: opts.expectedSeason,
         expectedEpisode: opts.expectedEpisode,
         minResolution: opts.minResolution,
+        expectedYear: opts.expectedYear,
       });
       return {
         ...r,

--- a/backend/src/modules/plugins/catalog/catalog.spec.ts
+++ b/backend/src/modules/plugins/catalog/catalog.spec.ts
@@ -223,6 +223,41 @@ describe('filterCatalog()', () => {
     expect(result.plugins[0].hidden?.count).toBe(1);
   });
 
+  /**
+   * An admin who turns the compatibility check off is asking to see versions this core's
+   * version range refuses — never versions whose protocol or archive it cannot handle.
+   */
+  describe('with the fliks range check disabled', () => {
+    const opts = { skipFliksRange: true };
+
+    it('VERDICT: offers a version whose fliks range excludes this core', () => {
+      const tooNew = version({ fliks: '>=5.0.0 <6.0.0' });
+      const result = filterCatalog(document({ versions: [tooNew] }), SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1', opts);
+      expect(result.plugins[0].installable).toEqual([tooNew]);
+      expect(result.plugins[0].hidden).toBeNull();
+    });
+
+    it('VERDICT: still hides a pluginApi mismatch — the RPC protocol is not a preference', () => {
+      const mismatched = version({ pluginApi: PLUGIN_API_VERSION + 1 });
+      const result = filterCatalog(document({ versions: [mismatched] }), SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1', opts);
+      expect(result.plugins[0].installable).toEqual([]);
+      expect(result.plugins[0].hidden?.count).toBe(1);
+    });
+
+    it('still hides a version whose archive could never be verified', () => {
+      const unsigned = version({ sha256: '0'.repeat(64) });
+      const result = filterCatalog(document({ versions: [unsigned] }), SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1', opts);
+      expect(result.plugins[0].installable).toEqual([]);
+    });
+
+    it('keeps the oldest-to-newest order the callers read as "newest last"', () => {
+      const older = version({ version: '1.0.0', fliks: '>=5.0.0 <6.0.0' });
+      const newer = version({ version: '2.0.0' });
+      const result = filterCatalog(document({ versions: [newer, older] }), SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1', opts);
+      expect(result.plugins[0].installable.map((v) => v.version)).toEqual(['1.0.0', '2.0.0']);
+    });
+  });
+
   it('separates installable and hidden versions of the same plugin', () => {
     const ok = version({ version: '1.0.0' });
     const tooNew = version({ version: '2.0.0', fliks: '>=5.0.0 <6.0.0' });

--- a/backend/src/modules/plugins/catalog/catalog.ts
+++ b/backend/src/modules/plugins/catalog/catalog.ts
@@ -128,7 +128,8 @@ export interface FilteredCatalogEntry {
   kind: PluginKind;
   logo?: string;
   /** Only versions installable on this core build, oldest to newest, so the last entry is the one
-   *  to offer as an update. A caller iterating this list cannot offer an incompatible version. */
+   *  to offer as an update. A caller iterating this list cannot offer an incompatible version —
+   *  unless the admin turned the `fliks` range check off, which widens what lands here. */
   installable: CatalogVersionEntry[];
   /** Null when nothing is hidden. A plugin with an empty `installable` list still
    *  appears in the result, carrying this instead — never a bare empty page. */
@@ -159,10 +160,15 @@ function hasVerifiableArchive(v: CatalogVersionEntry): boolean {
   return typeof sha256 === 'string' && SHA256_PATTERN.test(sha256) && sha256 !== PLACEHOLDER_SHA256;
 }
 
-function isInstallable(v: CatalogVersionEntry, supportedApiVersions: readonly number[], fliksVersion: string): boolean {
+function isInstallable(
+  v: CatalogVersionEntry,
+  supportedApiVersions: readonly number[],
+  fliksVersion: string,
+  skipFliksRange: boolean,
+): boolean {
   return (
     supportedApiVersions.includes(v.pluginApi) &&
-    semver.satisfies(fliksRangeVersion(fliksVersion), v.fliks) &&
+    (skipFliksRange || semver.satisfies(fliksRangeVersion(fliksVersion), v.fliks)) &&
     hasVerifiableArchive(v)
   );
 }
@@ -190,14 +196,21 @@ export function filterCatalog(
   document: CatalogDocument,
   supportedApiVersions: readonly number[],
   fliksVersion: string,
+  /** The admin opted out of the `fliks` range check. The `pluginApi` check stays: that one is
+   *  the RPC protocol itself, and a mismatch is not something a warning can survive. */
+  opts: { skipFliksRange?: boolean } = {},
 ): FilteredCatalog {
+  const skipFliksRange = opts.skipFliksRange ?? false;
   return {
     denyList: document.denyList ?? [],
     plugins: document.plugins.map((entry) => {
       const installable: CatalogVersionEntry[] = [];
       const hidden: CatalogVersionEntry[] = [];
       for (const version of entry.versions) {
-        (isInstallable(version, supportedApiVersions, fliksVersion) ? installable : hidden).push(version);
+        (isInstallable(version, supportedApiVersions, fliksVersion, skipFliksRange)
+          ? installable
+          : hidden
+        ).push(version);
       }
       // A catalogue document lists versions in whatever order it likes; consumers read the last as newest.
       installable.sort((a, b) => semver.compare(a.version, b.version));

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -583,6 +583,9 @@ export class FliksHostImpl implements PluginHostApi {
         expectedTitle: expectedTitles,
         expectedSeason: p.seasonNumber,
         expectedEpisode: p.episodeNumber,
+        // A series' year is its first-aired year, which says nothing about a later season's
+        // releases — only a movie's year identifies the work a release must be.
+        expectedYear: media.type === MediaType.MOVIE ? media.year : null,
         // Recomputed here rather than sent by the caller: only core can map a quality to a
         // resolution, and the profile's "upgrade resolution only" toggle had no enforcement
         // anywhere after the acquisition split.

--- a/backend/src/modules/plugins/plugin-catalog-client.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-catalog-client.service.spec.ts
@@ -60,8 +60,11 @@ function fakePackageRepo(rows: PluginPackage[] = []) {
   return { find: jest.fn(async () => rows), save: jest.fn(async (row: PluginPackage) => row) };
 }
 
-function fakeRegistry() {
-  return { revoke: jest.fn(async () => undefined) };
+function fakeRegistry(skipCompatibilityCheck = false) {
+  return {
+    revoke: jest.fn(async () => undefined),
+    skipCompatibilityCheck: jest.fn(async () => skipCompatibilityCheck),
+  };
 }
 
 /** Routes a GET by URL suffix — `catalog.json` and `catalog.json.sig` never collide since
@@ -194,6 +197,34 @@ describe('PluginCatalogClientService', () => {
     const catalog = source.cachedCatalog as { plugins: { installable: unknown[]; hidden: { count: number; minFliksVersion: string } }[] };
     expect(catalog.plugins[0].installable).toEqual([]);
     expect(catalog.plugins[0].hidden).toEqual({ count: 1, minFliksVersion: '5.0.0' });
+  });
+
+  /**
+   * The cached blob is filtered under whichever value the setting held at refresh time, and every
+   * reader downstream — the catalogue page, the install gate, the auto-update job — trusts it. A
+   * refresh that ignored the setting is what would leave an admin who turned the check off still
+   * looking at the narrow list.
+   */
+  it('VERDICT: caches an out-of-range version as installable when the compatibility check is disabled', async () => {
+    const { privateKey, rawPublicKey } = generateTestKeypair();
+    const doc = catalogWith({ fliks: '>=5.0.0 <6.0.0' });
+    const bytes = Buffer.from(JSON.stringify(doc), 'utf8');
+    const sig = Buffer.from(signManifestBase64(privateKey, bytes), 'utf8');
+    axios.defaults.adapter = adapterFor({ 'catalog.json.sig': sig, 'catalog.json': bytes });
+
+    const repo = repoStub();
+    const service = new PluginCatalogClientService(
+      repo as never,
+      fakePackageRepo() as never,
+      fakeRegistry(true) as never,
+    );
+    const source = fakeSource({ publicKey: rawPublicKey });
+
+    await service.refreshSource(source);
+
+    const catalog = source.cachedCatalog as { plugins: { installable: unknown[]; hidden: unknown }[] };
+    expect(catalog.plugins[0].installable).toHaveLength(1);
+    expect(catalog.plugins[0].hidden).toBeNull();
   });
 
   it('stops and marks failed an installed package a landed revocation denies, immediately — not on next reboot', async () => {

--- a/backend/src/modules/plugins/plugin-catalog-client.service.ts
+++ b/backend/src/modules/plugins/plugin-catalog-client.service.ts
@@ -124,7 +124,15 @@ export class PluginCatalogClientService implements OnApplicationBootstrap {
       return this.fail(source, 'malformed-catalog', 'catalog signature verified but the document did not parse');
     }
 
-    const filtered: FilteredCatalog = filterCatalog(document, SUPPORTED_PLUGIN_API_VERSIONS, CURRENT_FLIKS_VERSION);
+    // Read per refresh, not once at boot: flipping the setting and refreshing is how an admin
+    // makes the wider list appear, and this cached blob is what every reader downstream trusts —
+    // the catalogue page and the install gate alike.
+    const filtered: FilteredCatalog = filterCatalog(
+      document,
+      SUPPORTED_PLUGIN_API_VERSIONS,
+      CURRENT_FLIKS_VERSION,
+      { skipFliksRange: await this.registry.skipCompatibilityCheck() },
+    );
     const signedByKeyId = trust.signedByKeyId ?? null;
     source.cachedCatalog = { ...filtered, signedByKeyId } as unknown as Record<string, unknown>;
     source.lastRefreshedAt = new Date();

--- a/backend/src/modules/plugins/plugin-install.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-install.service.spec.ts
@@ -206,6 +206,7 @@ describe('PluginInstallService', () => {
       fakePluginJobsService() as never,
       fakeScheduledJobRegistry() as never,
       fakeCountsCache() as never,
+      { get: async () => null } as never,
     );
     staging = new PluginStagingService();
     pluginDb = fakePluginDb();

--- a/backend/src/modules/plugins/plugin-registry.service.jobs.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.jobs.spec.ts
@@ -70,6 +70,7 @@ function makeService(startResult?: PluginProcessStartResult, publishedJobNames: 
     pluginJobs,
     scheduledJobs as never,
     fakeCountsCache() as never,
+    { get: async () => null } as never,
   );
   return { service, registry, pluginJobs };
 }

--- a/backend/src/modules/plugins/plugin-registry.service.permissions.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.permissions.spec.ts
@@ -39,6 +39,7 @@ function makeService(): PluginRegistryService {
     fakePluginJobsService() as never,
     fakeScheduledJobRegistry() as never,
     fakeCountsCache() as never,
+    { get: async () => null } as never,
   );
 }
 

--- a/backend/src/modules/plugins/plugin-registry.service.player.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.player.spec.ts
@@ -38,6 +38,7 @@ function makeService(): PluginRegistryService {
     fakePluginJobsService() as never,
     fakeScheduledJobRegistry() as never,
     fakeCountsCache() as never,
+    { get: async () => null } as never,
   );
 }
 

--- a/backend/src/modules/plugins/plugin-registry.service.release-picker.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.release-picker.spec.ts
@@ -51,6 +51,7 @@ function makeService(): PluginRegistryService {
     fakePluginJobsService() as never,
     fakeScheduledJobRegistry() as never,
     fakeCountsCache() as never,
+    { get: async () => null } as never,
   );
 }
 

--- a/backend/src/modules/plugins/plugin-registry.service.routes.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.routes.spec.ts
@@ -40,6 +40,7 @@ function makeService(startResult?: PluginProcessStartResult): PluginRegistryServ
     fakePluginJobsService() as never,
     fakeScheduledJobRegistry() as never,
     fakeCountsCache() as never,
+    { get: async () => null } as never,
   );
 }
 

--- a/backend/src/modules/plugins/plugin-registry.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.spec.ts
@@ -1,5 +1,6 @@
 jest.mock('./supervisor/pid-file', () => ({ sweepOrphans: jest.fn() }));
 
+import { Logger } from '@nestjs/common';
 import { PluginRegistryService } from './plugin-registry.service';
 import { PLUGIN_UID_MIN } from './supervisor/spawn-plan';
 import { PluginPackage } from './entities/plugin-package.entity';
@@ -61,6 +62,8 @@ function makeService(
   rows: PluginPackage[] = [],
   processResult: PluginProcessStartResult = { ok: true },
   sources: Array<{ enabled: boolean; cachedCatalog: Record<string, unknown> | null }> = [],
+  /** Stored app settings the service reads — only `plugins.skip_compatibility_check` so far. */
+  settings: Record<string, string> = {},
 ) {
   const repo = repoMock(rows);
   // The shared helper honours `where`, so the enabled-only filter is the code's job, not the mock's.
@@ -76,6 +79,7 @@ function makeService(
     pluginJobs as never,
     fakeScheduledJobRegistry() as never,
     fakeCountsCache() as never,
+    { get: async (key: string) => settings[key] ?? null } as never,
   );
   return { service, repo, sourceRepo, registrationRepo, processService, pluginJobs };
 }
@@ -350,6 +354,37 @@ describe('PluginRegistryService.register()', () => {
       reason: 'incompatible-fliks',
       detail: expect.any(String),
     });
+  });
+
+  /**
+   * The range check is the one an admin can waive: it says this build was not tested here, not
+   * that it cannot speak the protocol. Waiving it must still leave the reason in the log.
+   */
+  it('VERDICT: registers an out-of-range plugin when the compatibility check is disabled', async () => {
+    const manifest = minimalDataManifest({ fliks: '>=99.0.0' });
+    const pkg = makePackage(manifest);
+    const { service } = makeService([], { ok: true }, [], {
+      'plugins.skip_compatibility_check': 'true',
+    });
+    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+    const result = await service.register(pkg);
+
+    expect(result.ok).toBe(true);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('compatibility check is disabled'));
+    warn.mockRestore();
+  });
+
+  it('an api mismatch is refused even with the compatibility check disabled', async () => {
+    const manifest = minimalDataManifest({ fliks: COMPATIBLE_RANGE, pluginApi: 99 });
+    const pkg = makePackage(manifest);
+    const { service } = makeService([], { ok: true }, [], {
+      'plugins.skip_compatibility_check': 'true',
+    });
+
+    const result = await service.register(pkg);
+
+    expect(result).toMatchObject({ ok: false, reason: 'incompatible-api' });
   });
 
   describe('process tier', () => {

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -19,6 +19,7 @@ import { getPluginsSocketDir } from '../../common/constants/paths';
 import { PluginCountsCacheService } from './host/plugin-counts-cache.service';
 import { allocateChildUid } from './supervisor/spawn-plan';
 import { arePluginsDisabled, FLIKS_PLUGINS_DISABLED_ENV } from '../../common/constants/plugin-flags';
+import { SettingsService } from '../settings/settings.service';
 import {
   SUPPORTED_PLUGIN_API_VERSIONS,
   fliksRangeVersion,
@@ -170,6 +171,10 @@ function formFieldKeys(pages: ConfigPage[]): ReadonlySet<string> {
   return keys;
 }
 
+/** Turns the manifest's `fliks` range from a gate into a warning, at load and in the catalogue
+ *  alike. Off unless the value is the explicit `'true'` the settings dialog writes. */
+export const PLUGIN_SKIP_COMPATIBILITY_SETTING = 'plugins.skip_compatibility_check';
+
 @Injectable()
 export class PluginRegistryService implements OnModuleInit {
   private readonly logger = new Logger(PluginRegistryService.name);
@@ -200,7 +205,13 @@ export class PluginRegistryService implements OnModuleInit {
     private readonly pluginJobs: PluginJobsService,
     private readonly scheduledJobs: ScheduledJobRegistry,
     private readonly countsCache: PluginCountsCacheService,
+    private readonly settings: SettingsService,
   ) {}
+
+  /** Read live, never cached: an admin flipping it expects the next load to obey it. */
+  async skipCompatibilityCheck(): Promise<boolean> {
+    return (await this.settings.get(PLUGIN_SKIP_COMPATIBILITY_SETTING)) === 'true';
+  }
 
   async onModuleInit(): Promise<void> {
     // Kills a plugin child leaked by a previous crash before anything new claims its socket path.
@@ -268,10 +279,14 @@ export class PluginRegistryService implements OnModuleInit {
       );
     }
     if (!semver.satisfies(fliksRangeVersion(CURRENT_FLIKS_VERSION), manifest.fliks)) {
-      return this.fail(
-        pkg.pluginId,
-        'incompatible-fliks',
-        `manifest requires fliks "${manifest.fliks}", running ${CURRENT_FLIKS_VERSION}`,
+      const detail = `manifest requires fliks "${manifest.fliks}", running ${CURRENT_FLIKS_VERSION}`;
+      if (!(await this.skipCompatibilityCheck())) {
+        return this.fail(pkg.pluginId, 'incompatible-fliks', detail);
+      }
+      // Loading anyway is the admin's explicit choice, and the reason it broke has to be in the
+      // log before the plugin starts calling host methods that may no longer exist.
+      this.logger.warn(
+        `${pkg.pluginId}: ${detail} — loading anyway, the compatibility check is disabled`,
       );
     }
 

--- a/backend/src/modules/plugins/plugin-registry.service.webhooks.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.webhooks.spec.ts
@@ -39,6 +39,7 @@ function makeService(): PluginRegistryService {
     fakePluginJobsService() as never,
     fakeScheduledJobRegistry() as never,
     fakeCountsCache() as never,
+    { get: async () => null } as never,
   );
 }
 

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1080,7 +1080,10 @@
       "TITLE_MISMATCH": "Titel passt nicht zum Medium",
       "EPISODE_MISMATCH": "Release passt nicht zu {{expected}} (gefunden: {{actual}})",
       "FULL_SEASON_FOR_EPISODE": "Komplette Staffel, aber nur {{expected}} wird benötigt",
-      "RESOLUTION_NOT_UPGRADED": "Keine Auflösungsverbesserung ({{actual}}p, mehr als {{min}}p nötig)"
+      "RESOLUTION_NOT_UPGRADED": "Keine Auflösungsverbesserung ({{actual}}p, mehr als {{min}}p nötig)",
+      "SEQUEL_MISMATCH": "Fortsetzung {{number}}, nicht der gesuchte Film",
+      "YEAR_MISMATCH": "Jahr {{actual}}, erwartet {{expected}}",
+      "COLLECTION_PACK": "Mehrfilm-Paket ({{word}})"
     },
     "like": "Gefällt mir",
     "metadata_group": "Metadaten",

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2259,7 +2259,9 @@
         "install": "Installieren",
         "no_installable": "Keine installierbare Version",
         "switch_to": "Auf {{version}} aktualisieren",
-        "update_keeps_data": "Deine Einstellungen bleiben erhalten."
+        "update_keeps_data": "Deine Einstellungen bleiben erhalten.",
+        "pick_version": "Version auswählen",
+        "version_installed": "v{{version}} installiert"
       },
       "status_disabled": "Deaktiviert",
       "status_unavailable": "Nicht verfügbar",
@@ -2269,7 +2271,11 @@
         "subtitle": "Wie Fliks installierte Plugins verwaltet.",
         "auto_update": "Plugins automatisch aktualisieren",
         "auto_update_hint": "Standardmäßig aktiviert. Installiert einmal täglich, nach dem Aktualisieren der Quellen, die neueste angebotene Version eines installierten Plugins. Unbeaufsichtigt wird nur ein Archiv installiert, das der Quellkatalog signiert hat; alles andere braucht weiterhin deine Bestätigung.",
-        "saved": "Plugin-Einstellungen gespeichert"
+        "saved": "Plugin-Einstellungen gespeichert",
+        "skip_compatibility": "Kompatibilitätsprüfung deaktivieren",
+        "skip_compatibility_hint": "Standardmäßig deaktiviert. Prüft die Version eines Plugins nicht mehr gegen diese Fliks-Version, weder bei der Installation noch beim Laden: ein ungetesteter Build läuft dann, und eine erwartete Host-Methode existiert womöglich nicht. Die Prüfung der Plugin-API bleibt aktiv — sie ist das Protokoll selbst. Beim Aktivieren wird jede Quelle aktualisiert, damit die erweiterte Versionsliste erscheint.",
+        "allow_older_versions": "Installation älterer Versionen erlauben",
+        "allow_older_versions_hint": "Standardmäßig deaktiviert. Ergänzt jeden Installations- und Aktualisierungsknopf im Katalog um eine Versionsauswahl mit dem, was die Quelle anbietet — alle Versionen oder nur die kompatiblen, je nach Option darüber."
       }
     }
   },

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2273,9 +2273,9 @@
         "auto_update_hint": "Standardmäßig aktiviert. Installiert einmal täglich, nach dem Aktualisieren der Quellen, die neueste angebotene Version eines installierten Plugins. Unbeaufsichtigt wird nur ein Archiv installiert, das der Quellkatalog signiert hat; alles andere braucht weiterhin deine Bestätigung.",
         "saved": "Plugin-Einstellungen gespeichert",
         "skip_compatibility": "Kompatibilitätsprüfung deaktivieren",
-        "skip_compatibility_hint": "Standardmäßig deaktiviert. Prüft die Version eines Plugins nicht mehr gegen diese Fliks-Version, weder bei der Installation noch beim Laden: ein ungetesteter Build läuft dann, und eine erwartete Host-Methode existiert womöglich nicht. Die Prüfung der Plugin-API bleibt aktiv — sie ist das Protokoll selbst. Beim Aktivieren wird jede Quelle aktualisiert, damit die erweiterte Versionsliste erscheint.",
+        "skip_compatibility_hint": "Installiert und lädt eine Plugin-Version auch dann, wenn sie diese Fliks-Version nicht als unterstützt angibt. Die Prüfung der Plugin-API gilt weiterhin.",
         "allow_older_versions": "Installation älterer Versionen erlauben",
-        "allow_older_versions_hint": "Standardmäßig deaktiviert. Ergänzt jeden Installations- und Aktualisierungsknopf im Katalog um eine Versionsauswahl mit dem, was die Quelle anbietet — alle Versionen oder nur die kompatiblen, je nach Option darüber."
+        "allow_older_versions_hint": "Ergänzt die Installations- und Aktualisierungsknöpfe im Katalog um eine Versionsauswahl."
       }
     }
   },

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2300,9 +2300,9 @@
         "auto_update_hint": "On by default. Once a day, after the sources are refreshed, installs the newest version each source offers for an installed plugin. Only an archive signed by the source catalogue is installed unattended: anything else still needs your acknowledgement.",
         "saved": "Plugin settings saved",
         "skip_compatibility": "Disable the compatibility check",
-        "skip_compatibility_hint": "Off by default. Stops checking a plugin version against this Fliks version, at install and at load: an untested build then runs, and a host method it expects may simply not exist. The plugin API check stays enforced — that one is the protocol itself. Turning this on refreshes every source so the wider version list appears.",
+        "skip_compatibility_hint": "Installs and loads a plugin version even when it does not declare support for this Fliks version. The plugin API check still applies.",
         "allow_older_versions": "Allow installing older versions",
-        "allow_older_versions_hint": "Off by default. Adds a version picker next to each catalogue install and update button, listing what the source offers — every version, or only the compatible ones, depending on the setting above."
+        "allow_older_versions_hint": "Adds a version picker next to the catalogue's install and update buttons."
       }
     }
   },

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2286,7 +2286,9 @@
         "install": "Install",
         "no_installable": "No installable version",
         "switch_to": "Update to {{version}}",
-        "update_keeps_data": "Your settings are kept."
+        "update_keeps_data": "Your settings are kept.",
+        "pick_version": "Choose a version",
+        "version_installed": "v{{version}} installed"
       },
       "status_disabled": "Disabled",
       "status_unavailable": "Unavailable",
@@ -2296,7 +2298,11 @@
         "subtitle": "How Fliks manages installed plugins.",
         "auto_update": "Update plugins automatically",
         "auto_update_hint": "On by default. Once a day, after the sources are refreshed, installs the newest version each source offers for an installed plugin. Only an archive signed by the source catalogue is installed unattended: anything else still needs your acknowledgement.",
-        "saved": "Plugin settings saved"
+        "saved": "Plugin settings saved",
+        "skip_compatibility": "Disable the compatibility check",
+        "skip_compatibility_hint": "Off by default. Stops checking a plugin version against this Fliks version, at install and at load: an untested build then runs, and a host method it expects may simply not exist. The plugin API check stays enforced — that one is the protocol itself. Turning this on refreshes every source so the wider version list appears.",
+        "allow_older_versions": "Allow installing older versions",
+        "allow_older_versions_hint": "Off by default. Adds a version picker next to each catalogue install and update button, listing what the source offers — every version, or only the compatible ones, depending on the setting above."
       }
     }
   },

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1088,7 +1088,10 @@
       "TITLE_MISMATCH": "Title does not match the media",
       "EPISODE_MISMATCH": "Release does not match {{expected}} (found {{actual}})",
       "FULL_SEASON_FOR_EPISODE": "Full season, but only {{expected}} is wanted",
-      "RESOLUTION_NOT_UPGRADED": "Not a resolution upgrade ({{actual}}p, needs above {{min}}p)"
+      "RESOLUTION_NOT_UPGRADED": "Not a resolution upgrade ({{actual}}p, needs above {{min}}p)",
+      "SEQUEL_MISMATCH": "Sequel {{number}}, not the film wanted",
+      "YEAR_MISMATCH": "Year {{actual}}, expected {{expected}}",
+      "COLLECTION_PACK": "Multi-film pack ({{word}})"
     },
     "like": "Like",
     "metadata_group": "Metadata",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2273,9 +2273,9 @@
         "auto_update_hint": "Activado por defecto. Una vez al día, tras actualizar las fuentes, instala la versión más reciente ofrecida para un plugin instalado. Solo se instala sin intervención un archivo firmado por el catálogo de la fuente: el resto requiere tu confirmación.",
         "saved": "Ajustes de plugins guardados",
         "skip_compatibility": "Desactivar la comprobación de compatibilidad",
-        "skip_compatibility_hint": "Desactivado por defecto. Deja de comprobar la versión de un plugin frente a esta versión de Fliks, ni al instalar ni al cargar: se ejecuta entonces una compilación no probada y un método del host que espera puede no existir. La comprobación de la API de plugins sigue aplicándose: esa es el protocolo en sí. Al activarlo se refrescan todas las fuentes para que aparezca la lista ampliada.",
+        "skip_compatibility_hint": "Instala y carga una versión de plugin aunque no declare compatibilidad con esta versión de Fliks. La comprobación de la API de plugins sigue aplicándose.",
         "allow_older_versions": "Permitir instalar versiones anteriores",
-        "allow_older_versions_hint": "Desactivado por defecto. Añade un selector de versión junto a cada botón de instalación y actualización del catálogo, con lo que ofrece la fuente: todas las versiones o solo las compatibles, según la opción anterior."
+        "allow_older_versions_hint": "Añade un selector de versión junto a los botones de instalación y actualización del catálogo."
       }
     }
   },

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1080,7 +1080,10 @@
       "TITLE_MISMATCH": "El título no coincide con el medio",
       "EPISODE_MISMATCH": "La release no corresponde a {{expected}} (encontrado {{actual}})",
       "FULL_SEASON_FOR_EPISODE": "Temporada completa, pero solo se necesita {{expected}}",
-      "RESOLUTION_NOT_UPGRADED": "No mejora la resolución ({{actual}}p, se necesita más de {{min}}p)"
+      "RESOLUTION_NOT_UPGRADED": "No mejora la resolución ({{actual}}p, se necesita más de {{min}}p)",
+      "SEQUEL_MISMATCH": "Secuela {{number}}, no la película buscada",
+      "YEAR_MISMATCH": "Año {{actual}}, esperado {{expected}}",
+      "COLLECTION_PACK": "Pack de varias películas ({{word}})"
     },
     "like": "Me gusta",
     "metadata_group": "Metadatos",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2259,7 +2259,9 @@
         "install": "Instalar",
         "no_installable": "Sin versión instalable",
         "switch_to": "Actualizar a {{version}}",
-        "update_keeps_data": "Se conservan tus ajustes."
+        "update_keeps_data": "Se conservan tus ajustes.",
+        "pick_version": "Elegir una versión",
+        "version_installed": "v{{version}} instalada"
       },
       "status_disabled": "Desactivado",
       "status_unavailable": "No disponible",
@@ -2269,7 +2271,11 @@
         "subtitle": "Gestión de los plugins instalados por Fliks.",
         "auto_update": "Actualizar los plugins automáticamente",
         "auto_update_hint": "Activado por defecto. Una vez al día, tras actualizar las fuentes, instala la versión más reciente ofrecida para un plugin instalado. Solo se instala sin intervención un archivo firmado por el catálogo de la fuente: el resto requiere tu confirmación.",
-        "saved": "Ajustes de plugins guardados"
+        "saved": "Ajustes de plugins guardados",
+        "skip_compatibility": "Desactivar la comprobación de compatibilidad",
+        "skip_compatibility_hint": "Desactivado por defecto. Deja de comprobar la versión de un plugin frente a esta versión de Fliks, ni al instalar ni al cargar: se ejecuta entonces una compilación no probada y un método del host que espera puede no existir. La comprobación de la API de plugins sigue aplicándose: esa es el protocolo en sí. Al activarlo se refrescan todas las fuentes para que aparezca la lista ampliada.",
+        "allow_older_versions": "Permitir instalar versiones anteriores",
+        "allow_older_versions_hint": "Desactivado por defecto. Añade un selector de versión junto a cada botón de instalación y actualización del catálogo, con lo que ofrece la fuente: todas las versiones o solo las compatibles, según la opción anterior."
       }
     }
   },

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2300,9 +2300,9 @@
         "auto_update_hint": "Activé par défaut. Une fois par jour, après le rafraîchissement des sources, installe la version la plus récente proposée pour un plugin installé. Seule une archive signée par le catalogue de la source est installée sans intervention : le reste demande toujours une validation.",
         "saved": "Paramètres des plugins enregistrés",
         "skip_compatibility": "Désactiver la vérification de compatibilité",
-        "skip_compatibility_hint": "Désactivé par défaut. Ne vérifie plus la version d'un plugin face à cette version de Fliks, ni à l'installation ni au chargement : un build non testé s'exécute alors, et une méthode hôte qu'il attend peut tout simplement ne pas exister. La vérification de l'API plugin reste appliquée — celle-là est le protocole lui-même. Activer cette option rafraîchit chaque source pour faire apparaître la liste élargie.",
+        "skip_compatibility_hint": "Installe et charge une version de plugin même si elle ne déclare pas prendre en charge cette version de Fliks. La vérification de l'API plugin s'applique toujours.",
         "allow_older_versions": "Autoriser l'installation d'anciennes versions",
-        "allow_older_versions_hint": "Désactivé par défaut. Ajoute un sélecteur de version à côté des boutons d'installation et de mise à jour du catalogue, listant ce que la source propose — toutes les versions, ou seulement les compatibles, selon l'option ci-dessus."
+        "allow_older_versions_hint": "Ajoute un sélecteur de version à côté des boutons d'installation et de mise à jour du catalogue."
       }
     }
   },

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1088,7 +1088,10 @@
       "TITLE_MISMATCH": "Titre ne correspond pas au média",
       "EPISODE_MISMATCH": "La release ne correspond pas à {{expected}} (trouvé {{actual}})",
       "FULL_SEASON_FOR_EPISODE": "Saison complète alors que seul {{expected}} est voulu",
-      "RESOLUTION_NOT_UPGRADED": "Pas une montée de résolution ({{actual}}p, il faut plus de {{min}}p)"
+      "RESOLUTION_NOT_UPGRADED": "Pas une montée de résolution ({{actual}}p, il faut plus de {{min}}p)",
+      "SEQUEL_MISMATCH": "Suite {{number}}, pas le film voulu",
+      "YEAR_MISMATCH": "Année {{actual}}, attendue {{expected}}",
+      "COLLECTION_PACK": "Pack multi-films ({{word}})"
     },
     "like": "J’aime",
     "metadata_group": "Métadonnées",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2286,7 +2286,9 @@
         "install": "Installer",
         "no_installable": "Aucune version installable",
         "switch_to": "Mettre à jour en {{version}}",
-        "update_keeps_data": "Vos réglages sont conservés."
+        "update_keeps_data": "Vos réglages sont conservés.",
+        "pick_version": "Choisir une version",
+        "version_installed": "v{{version}} installé"
       },
       "status_disabled": "Désactivé",
       "status_unavailable": "Indisponible",
@@ -2296,7 +2298,11 @@
         "subtitle": "Gestion des plugins installés par Fliks.",
         "auto_update": "Mettre à jour automatiquement les plugins",
         "auto_update_hint": "Activé par défaut. Une fois par jour, après le rafraîchissement des sources, installe la version la plus récente proposée pour un plugin installé. Seule une archive signée par le catalogue de la source est installée sans intervention : le reste demande toujours une validation.",
-        "saved": "Paramètres des plugins enregistrés"
+        "saved": "Paramètres des plugins enregistrés",
+        "skip_compatibility": "Désactiver la vérification de compatibilité",
+        "skip_compatibility_hint": "Désactivé par défaut. Ne vérifie plus la version d'un plugin face à cette version de Fliks, ni à l'installation ni au chargement : un build non testé s'exécute alors, et une méthode hôte qu'il attend peut tout simplement ne pas exister. La vérification de l'API plugin reste appliquée — celle-là est le protocole lui-même. Activer cette option rafraîchit chaque source pour faire apparaître la liste élargie.",
+        "allow_older_versions": "Autoriser l'installation d'anciennes versions",
+        "allow_older_versions_hint": "Désactivé par défaut. Ajoute un sélecteur de version à côté des boutons d'installation et de mise à jour du catalogue, listant ce que la source propose — toutes les versions, ou seulement les compatibles, selon l'option ci-dessus."
       }
     }
   },

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1080,7 +1080,10 @@
       "TITLE_MISMATCH": "Il titolo non corrisponde al file multimediale",
       "EPISODE_MISMATCH": "La release non corrisponde a {{expected}} (trovato {{actual}})",
       "FULL_SEASON_FOR_EPISODE": "Stagione completa, ma serve solo {{expected}}",
-      "RESOLUTION_NOT_UPGRADED": "Non migliora la risoluzione ({{actual}}p, serve più di {{min}}p)"
+      "RESOLUTION_NOT_UPGRADED": "Non migliora la risoluzione ({{actual}}p, serve più di {{min}}p)",
+      "SEQUEL_MISMATCH": "Sequel {{number}}, non il film cercato",
+      "YEAR_MISMATCH": "Anno {{actual}}, atteso {{expected}}",
+      "COLLECTION_PACK": "Pacchetto multi-film ({{word}})"
     },
     "like": "Mi piace",
     "metadata_group": "Metadati",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2273,9 +2273,9 @@
         "auto_update_hint": "Attivo per impostazione predefinita. Una volta al giorno, dopo l’aggiornamento delle sorgenti, installa la versione più recente offerta per un plugin installato. Senza intervento viene installato solo un archivio firmato dal catalogo della sorgente: il resto richiede la tua conferma.",
         "saved": "Impostazioni dei plugin salvate",
         "skip_compatibility": "Disattiva il controllo di compatibilità",
-        "skip_compatibility_hint": "Disattivato per impostazione predefinita. Non verifica più la versione di un plugin rispetto a questa versione di Fliks, né all’installazione né al caricamento: viene eseguita una build non testata e un metodo host che si aspetta potrebbe non esistere. Il controllo dell’API dei plugin resta attivo: quello è il protocollo stesso. Attivandolo, ogni sorgente viene aggiornata perché compaia l’elenco ampliato.",
+        "skip_compatibility_hint": "Installa e carica una versione di plugin anche se non dichiara il supporto per questa versione di Fliks. Il controllo dell’API dei plugin resta valido.",
         "allow_older_versions": "Consenti l’installazione di versioni precedenti",
-        "allow_older_versions_hint": "Disattivato per impostazione predefinita. Aggiunge un selettore di versione accanto a ogni pulsante di installazione e aggiornamento del catalogo, con ciò che la sorgente offre: tutte le versioni o solo quelle compatibili, secondo l’opzione sopra."
+        "allow_older_versions_hint": "Aggiunge un selettore di versione accanto ai pulsanti di installazione e aggiornamento del catalogo."
       }
     }
   },

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2259,7 +2259,9 @@
         "install": "Installa",
         "no_installable": "Nessuna versione installabile",
         "switch_to": "Aggiorna a {{version}}",
-        "update_keeps_data": "Le tue impostazioni sono conservate."
+        "update_keeps_data": "Le tue impostazioni sono conservate.",
+        "pick_version": "Scegli una versione",
+        "version_installed": "v{{version}} installata"
       },
       "status_disabled": "Disattivato",
       "status_unavailable": "Non disponibile",
@@ -2269,7 +2271,11 @@
         "subtitle": "Come Fliks gestisce i plugin installati.",
         "auto_update": "Aggiorna automaticamente i plugin",
         "auto_update_hint": "Attivo per impostazione predefinita. Una volta al giorno, dopo l’aggiornamento delle sorgenti, installa la versione più recente offerta per un plugin installato. Senza intervento viene installato solo un archivio firmato dal catalogo della sorgente: il resto richiede la tua conferma.",
-        "saved": "Impostazioni dei plugin salvate"
+        "saved": "Impostazioni dei plugin salvate",
+        "skip_compatibility": "Disattiva il controllo di compatibilità",
+        "skip_compatibility_hint": "Disattivato per impostazione predefinita. Non verifica più la versione di un plugin rispetto a questa versione di Fliks, né all’installazione né al caricamento: viene eseguita una build non testata e un metodo host che si aspetta potrebbe non esistere. Il controllo dell’API dei plugin resta attivo: quello è il protocollo stesso. Attivandolo, ogni sorgente viene aggiornata perché compaia l’elenco ampliato.",
+        "allow_older_versions": "Consenti l’installazione di versioni precedenti",
+        "allow_older_versions_hint": "Disattivato per impostazione predefinita. Aggiunge un selettore di versione accanto a ogni pulsante di installazione e aggiornamento del catalogo, con ciò che la sorgente offre: tutte le versioni o solo quelle compatibili, secondo l’opzione sopra."
       }
     }
   },

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1080,7 +1080,10 @@
       "TITLE_MISMATCH": "O título não corresponde ao media",
       "EPISODE_MISMATCH": "A release não corresponde a {{expected}} (encontrado {{actual}})",
       "FULL_SEASON_FOR_EPISODE": "Temporada completa, mas só {{expected}} é necessário",
-      "RESOLUTION_NOT_UPGRADED": "Não melhora a resolução ({{actual}}p, precisa de mais de {{min}}p)"
+      "RESOLUTION_NOT_UPGRADED": "Não melhora a resolução ({{actual}}p, precisa de mais de {{min}}p)",
+      "SEQUEL_MISMATCH": "Sequela {{number}}, não o filme pretendido",
+      "YEAR_MISMATCH": "Ano {{actual}}, esperado {{expected}}",
+      "COLLECTION_PACK": "Pacote de vários filmes ({{word}})"
     },
     "like": "Gosto",
     "metadata_group": "Metadados",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2273,9 +2273,9 @@
         "auto_update_hint": "Ativado por predefinição. Uma vez por dia, após atualizar as fontes, instala a versão mais recente oferecida para um plugin instalado. Sem intervenção só é instalado um arquivo assinado pelo catálogo da fonte: o resto continua a exigir a tua confirmação.",
         "saved": "Definições dos plugins guardadas",
         "skip_compatibility": "Desativar a verificação de compatibilidade",
-        "skip_compatibility_hint": "Desativado por predefinição. Deixa de verificar a versão de um plugin face a esta versão do Fliks, nem na instalação nem no carregamento: passa a correr uma compilação não testada e um método do host que ela espera pode não existir. A verificação da API de plugins continua a ser aplicada — essa é o próprio protocolo. Ao ativar, todas as fontes são atualizadas para aparecer a lista ampliada.",
+        "skip_compatibility_hint": "Instala e carrega uma versão de plugin mesmo que não declare suporte para esta versão do Fliks. A verificação da API de plugins continua a aplicar-se.",
         "allow_older_versions": "Permitir instalar versões anteriores",
-        "allow_older_versions_hint": "Desativado por predefinição. Adiciona um seletor de versão junto a cada botão de instalação e atualização do catálogo, com o que a fonte oferece — todas as versões ou apenas as compatíveis, conforme a opção acima."
+        "allow_older_versions_hint": "Adiciona um seletor de versão junto aos botões de instalação e atualização do catálogo."
       }
     }
   },

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2259,7 +2259,9 @@
         "install": "Instalar",
         "no_installable": "Sem versão instalável",
         "switch_to": "Atualizar para {{version}}",
-        "update_keeps_data": "As tuas configurações são mantidas."
+        "update_keeps_data": "As tuas configurações são mantidas.",
+        "pick_version": "Escolher uma versão",
+        "version_installed": "v{{version}} instalada"
       },
       "status_disabled": "Desativado",
       "status_unavailable": "Indisponível",
@@ -2269,7 +2271,11 @@
         "subtitle": "Como o Fliks gere os plugins instalados.",
         "auto_update": "Atualizar os plugins automaticamente",
         "auto_update_hint": "Ativado por predefinição. Uma vez por dia, após atualizar as fontes, instala a versão mais recente oferecida para um plugin instalado. Sem intervenção só é instalado um arquivo assinado pelo catálogo da fonte: o resto continua a exigir a tua confirmação.",
-        "saved": "Definições dos plugins guardadas"
+        "saved": "Definições dos plugins guardadas",
+        "skip_compatibility": "Desativar a verificação de compatibilidade",
+        "skip_compatibility_hint": "Desativado por predefinição. Deixa de verificar a versão de um plugin face a esta versão do Fliks, nem na instalação nem no carregamento: passa a correr uma compilação não testada e um método do host que ela espera pode não existir. A verificação da API de plugins continua a ser aplicada — essa é o próprio protocolo. Ao ativar, todas as fontes são atualizadas para aparecer a lista ampliada.",
+        "allow_older_versions": "Permitir instalar versões anteriores",
+        "allow_older_versions_hint": "Desativado por predefinição. Adiciona um seletor de versão junto a cada botão de instalação e atualização do catálogo, com o que a fonte oferece — todas as versões ou apenas as compatíveis, conforme a opção acima."
       }
     }
   },

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue-page.html
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue-page.html
@@ -4,7 +4,12 @@
     {{ 'settings.plugins.catalogue.back' | translate }}
   </a>
 
-  <app-plugin-catalogue [installedIds]="installedIds()" [installedVersions]="installedVersions()" (install)="onInspected($event)" />
+  <app-plugin-catalogue
+  [installedIds]="installedIds()"
+  [installedVersions]="installedVersions()"
+  [allowOlderVersions]="allowOlderVersions()"
+  (install)="onInspected($event)"
+/>
 </div>
 
 <app-plugin-install-consent #consentSheet (installed)="onInstalled($event)" />

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue-page.ts
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue-page.ts
@@ -10,6 +10,7 @@ import {
   PluginInspectReport,
   PluginInstallResult,
 } from '../../../../core/services/api/plugins-api.service';
+import { SettingsApiService } from '../../../../core/services/api/settings-api.service';
 import { PluginInstallConsentComponent } from '../plugin-install-consent/plugin-install-consent';
 import { PluginCatalogueComponent } from './plugin-catalogue';
 
@@ -22,6 +23,7 @@ import { PluginCatalogueComponent } from './plugin-catalogue';
 })
 export class PluginCataloguePageComponent implements OnInit {
   private readonly api = inject(PluginsApiService);
+  private readonly settings = inject(SettingsApiService);
   private readonly registry = inject(PluginUiRegistryService);
   private readonly translate = inject(TranslateService);
   private readonly toast = inject(ToastService);
@@ -29,11 +31,23 @@ export class PluginCataloguePageComponent implements OnInit {
   private readonly consentSheet = viewChild<PluginInstallConsentComponent>('consentSheet');
 
   private readonly rows = signal<PluginSummary[]>([]);
+  /** `plugins.allow_older_versions` — read here so the grid stays input-driven. */
+  readonly allowOlderVersions = signal(false);
   readonly installedIds = computed(() => new Set(this.rows().map((r) => r.pluginId)));
   readonly installedVersions = computed(() => new Map(this.rows().map((r) => [r.pluginId, r.version])));
 
   ngOnInit(): void {
     this.reload();
+    void this.loadOlderVersionsSetting();
+  }
+
+  private async loadOlderVersionsSetting(): Promise<void> {
+    try {
+      const row = await this.settings.get('plugins.allow_older_versions');
+      this.allowOlderVersions.set(row?.value === 'true');
+    } catch {
+      this.allowOlderVersions.set(false);
+    }
   }
 
   async reload(): Promise<void> {

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.html
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.html
@@ -43,26 +43,71 @@
 
           <div class="mt-auto pt-2 flex items-center justify-between">
             <span class="text-xs text-base-content/40 truncate">{{ row.sourceUrl }}</span>
-            @if (!isInstalled(row.plugin.id)) {
-              @if (row.latestVersion) {
-                <button type="button" class="btn btn-primary btn-xs shrink-0" [disabled]="isInspecting(row)" (click)="installLatest(row)">
+            @if (!row.plugin.installable.length) {
+              <span class="text-xs text-base-content/40 shrink-0">{{ 'settings.plugins.catalogue.no_installable' | translate }}</span>
+            } @else if (!allowOlderVersions()) {
+              @if (!isInstalled(row.plugin.id)) {
+                <button type="button" class="btn btn-primary btn-xs shrink-0" [disabled]="isInspecting(row)" (click)="installVersion(row, primaryVersion(row))">
                   @if (isInspecting(row)) {
                     <span class="loading loading-spinner loading-xs"></span>
                   }
                   {{ 'settings.plugins.catalogue.install' | translate }}
                 </button>
-              } @else {
-                <span class="text-xs text-base-content/40 shrink-0">{{ 'settings.plugins.catalogue.no_installable' | translate }}</span>
+              } @else if (updateTarget(row); as version) {
+                <div class="flex flex-col items-end gap-0.5 shrink-0">
+                  <button type="button" class="btn btn-primary btn-xs" [disabled]="isInspecting(row)" (click)="installVersion(row, version)">
+                    @if (isInspecting(row)) {
+                      <span class="loading loading-spinner loading-xs"></span>
+                    }
+                    {{ 'settings.plugins.catalogue.switch_to' | translate: { version: version } }}
+                  </button>
+                  <span class="text-[0.7rem] text-base-content/50">{{ 'settings.plugins.catalogue.update_keeps_data' | translate }}</span>
+                </div>
               }
-            } @else if (updateTarget(row); as version) {
+            } @else {
+              <!-- Split button: the left half is the action, the right half every other version
+                   the source offers. Nothing to update to leaves the left half stating what runs. -->
               <div class="flex flex-col items-end gap-0.5 shrink-0">
-                <button type="button" class="btn btn-primary btn-xs" [disabled]="isInspecting(row)" (click)="installLatest(row)">
-                  @if (isInspecting(row)) {
-                    <span class="loading loading-spinner loading-xs"></span>
-                  }
-                  {{ 'settings.plugins.catalogue.switch_to' | translate: { version: version } }}
-                </button>
-                <span class="text-[0.7rem] text-base-content/50">{{ 'settings.plugins.catalogue.update_keeps_data' | translate }}</span>
+                <div class="flex items-stretch">
+                  <button type="button" class="btn btn-primary btn-xs rounded-r-none"
+                    [disabled]="isInspecting(row) || !primaryVersion(row)"
+                    (click)="installVersion(row, primaryVersion(row))">
+                    @if (isInspecting(row)) {
+                      <span class="loading loading-spinner loading-xs"></span>
+                    }
+                    @if (primaryVersion(row); as version) {
+                      @if (isInstalled(row.plugin.id)) {
+                        {{ 'settings.plugins.catalogue.switch_to' | translate: { version: version } }}
+                      } @else {
+                        {{ 'settings.plugins.catalogue.install' | translate }}
+                      }
+                    } @else {
+                      {{ 'settings.plugins.catalogue.version_installed' | translate: { version: installedVersion(row) } }}
+                    }
+                  </button>
+                  <app-dropdown-menu placement="bottom-end" class="contents">
+                    <button trigger type="button"
+                      class="btn btn-primary btn-xs rounded-l-none border-l border-primary-content/25 px-1"
+                      [disabled]="isInspecting(row)"
+                      [attr.aria-label]="'settings.plugins.catalogue.pick_version' | translate">
+                      <svg lucideChevronDown class="h-3 w-3"></svg>
+                    </button>
+                    <p class="px-3 py-2 text-xs text-base-content/50">{{ 'settings.plugins.catalogue.pick_version' | translate }}</p>
+                    @for (entry of versionsFor(row); track entry.version) {
+                      <button type="button" class="btn btn-ghost btn-sm w-full justify-between font-normal"
+                        [disabled]="entry.version === installedVersion(row)"
+                        (click)="installVersion(row, entry.version)">
+                        <span>{{ entry.version }}</span>
+                        @if (entry.version === installedVersion(row)) {
+                          <span class="badge badge-success badge-xs">{{ 'settings.plugins.catalogue.installed' | translate }}</span>
+                        }
+                      </button>
+                    }
+                  </app-dropdown-menu>
+                </div>
+                @if (isInstalled(row.plugin.id)) {
+                  <span class="text-[0.7rem] text-base-content/50">{{ 'settings.plugins.catalogue.update_keeps_data' | translate }}</span>
+                }
               </div>
             }
           </div>

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.html
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.html
@@ -65,36 +65,37 @@
                 </div>
               }
             } @else {
-              <!-- Split button: the left half is the action, the right half every other version
-                   the source offers. Nothing to update to leaves the left half stating what runs. -->
+              <!-- daisyUI split button: `join` owns the seam (its radii beat `.btn`'s), and the
+                   dropdown wraps both halves so the panel anchors to them. -->
               <div class="flex flex-col items-end gap-0.5 shrink-0">
-                <div class="flex items-stretch">
-                  <button type="button" class="btn btn-primary btn-xs rounded-r-none"
-                    [disabled]="isInspecting(row) || !primaryVersion(row)"
-                    (click)="installVersion(row, primaryVersion(row))">
-                    @if (isInspecting(row)) {
-                      <span class="loading loading-spinner loading-xs"></span>
-                    }
-                    @if (primaryVersion(row); as version) {
-                      @if (isInstalled(row.plugin.id)) {
-                        {{ 'settings.plugins.catalogue.switch_to' | translate: { version: version } }}
-                      } @else {
-                        {{ 'settings.plugins.catalogue.install' | translate }}
+                <div class="dropdown dropdown-end">
+                  <div class="join">
+                    <button type="button" class="btn btn-primary btn-xs join-item"
+                      [disabled]="isInspecting(row) || !primaryVersion(row)"
+                      (click)="installVersion(row, primaryVersion(row))">
+                      @if (isInspecting(row)) {
+                        <span class="loading loading-spinner loading-xs"></span>
                       }
-                    } @else {
-                      {{ 'settings.plugins.catalogue.version_installed' | translate: { version: installedVersion(row) } }}
-                    }
-                  </button>
-                  <app-dropdown-menu placement="bottom-end" class="contents">
-                    <button trigger type="button"
-                      class="btn btn-primary btn-xs rounded-l-none border-l border-primary-content/25 px-1"
+                      @if (primaryVersion(row); as version) {
+                        @if (isInstalled(row.plugin.id)) {
+                          {{ 'settings.plugins.catalogue.switch_to' | translate: { version: version } }}
+                        } @else {
+                          {{ 'settings.plugins.catalogue.install' | translate }}
+                        }
+                      } @else {
+                        {{ 'settings.plugins.catalogue.version_installed' | translate: { version: installedVersion(row) } }}
+                      }
+                    </button>
+                    <button appDropdownToggle type="button" class="btn btn-primary btn-xs join-item px-1.5"
                       [disabled]="isInspecting(row)"
                       [attr.aria-label]="'settings.plugins.catalogue.pick_version' | translate">
                       <svg lucideChevronDown class="h-3 w-3"></svg>
                     </button>
+                  </div>
+                  <div class="dropdown-content bg-base-200 rounded-box shadow-xl min-w-52 max-h-[70vh] p-1 z-[101] overflow-y-auto">
                     <p class="px-3 py-2 text-xs text-base-content/50">{{ 'settings.plugins.catalogue.pick_version' | translate }}</p>
                     @for (entry of versionsFor(row); track entry.version) {
-                      <button type="button" class="btn btn-ghost btn-sm w-full justify-between font-normal"
+                      <button type="button" class="dropdown-item justify-between"
                         [disabled]="entry.version === installedVersion(row)"
                         (click)="installVersion(row, entry.version)">
                         <span>{{ entry.version }}</span>
@@ -103,7 +104,7 @@
                         }
                       </button>
                     }
-                  </app-dropdown-menu>
+                  </div>
                 </div>
                 @if (isInstalled(row.plugin.id)) {
                   <span class="text-[0.7rem] text-base-content/50">{{ 'settings.plugins.catalogue.update_keeps_data' | translate }}</span>

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.spec.ts
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.spec.ts
@@ -32,7 +32,7 @@ async function settle(fixture: ComponentFixture<unknown>) {
   fixture.detectChanges();
 }
 
-async function createComponent(installed: [string, string][]) {
+async function createComponent(installed: [string, string][], allowOlderVersions = false) {
   TestBed.configureTestingModule({
     providers: [
       provideZonelessChangeDetection(),
@@ -48,6 +48,7 @@ async function createComponent(installed: [string, string][]) {
   const fixture = TestBed.createComponent(PluginCatalogueComponent);
   fixture.componentRef.setInput('installedIds', new Set(installed.map(([id]) => id)));
   fixture.componentRef.setInput('installedVersions', new Map(installed));
+  fixture.componentRef.setInput('allowOlderVersions', allowOlderVersions);
   fixture.detectChanges();
   http.expectOne({ url: '/api/plugins/sources', method: 'GET' }).flush([{ id: 1, url: 'https://src', enabled: true }]);
   await settle(fixture);
@@ -119,5 +120,63 @@ describe('PluginCatalogueComponent — what a card states', () => {
     expect(fixture.componentInstance.installedVersion(fixture.componentInstance.rows()[0])).toBeNull();
     expect(text(fixture)).not.toContain('settings.plugins.catalogue.installed_version');
     expect(fixture.nativeElement.querySelector('.badge-info')).toBeNull();
+  });
+});
+
+/**
+ * With older versions allowed, the action and the version list are one control: the left half
+ * acts, the right half lists what the source offers. A plugin already on the newest version has
+ * nothing to act on, so the left half states what runs instead of offering an update.
+ */
+describe('PluginCatalogueComponent — the version picker', () => {
+  afterEach(() => TestBed.inject(HttpTestingController).verify());
+
+  function versionButtons(fixture: ComponentFixture<unknown>): string[] {
+    return Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('.dropdown-content button'),
+    ).map((b) => b.querySelector('span')?.textContent?.trim() ?? '');
+  }
+
+  it('offers no picker at all while the setting is off', async () => {
+    const { fixture } = await createComponent([['fliks.acme', '1.0.0']]);
+    expect(fixture.nativeElement.querySelector('.dropdown-content')).toBeNull();
+  });
+
+  it('VERDICT: lists every version the source offers, newest first', async () => {
+    const { fixture } = await createComponent([['fliks.acme', '1.0.0']], true);
+    expect(versionButtons(fixture)).toEqual(['1.1.0', '1.0.0']);
+  });
+
+  it('VERDICT: states the running version on the left half when nothing is newer', async () => {
+    const { fixture } = await createComponent([['fliks.acme', '1.1.0']], true);
+    const row = fixture.componentInstance.rows()[0];
+
+    expect(fixture.componentInstance.primaryVersion(row)).toBeNull();
+    expect(buttonLabels(fixture).join(' ')).toContain('settings.plugins.catalogue.version_installed');
+    // …and the picker is still there, which is the only way back to an older build.
+    expect(versionButtons(fixture)).toEqual(['1.1.0', '1.0.0']);
+  });
+
+  it('VERDICT: installs the version picked, not the newest', async () => {
+    const { fixture, http } = await createComponent([['fliks.acme', '1.1.0']], true);
+    const older = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLButtonElement>('.dropdown-content button'),
+    ).find((b) => b.textContent?.includes('1.0.0'));
+
+    older!.click();
+    await settle(fixture);
+
+    const req = http.expectOne({ url: '/api/plugins/sources/1/inspect', method: 'POST' });
+    expect(req.request.body).toEqual({ pluginId: 'fliks.acme', version: '1.0.0' });
+    req.flush({ pluginId: 'fliks.acme', version: '1.0.0' });
+    await settle(fixture);
+  });
+
+  it('leaves the installed version unpickable', async () => {
+    const { fixture } = await createComponent([['fliks.acme', '1.1.0']], true);
+    const installed = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLButtonElement>('.dropdown-content button'),
+    ).find((b) => b.textContent?.includes('1.1.0'));
+    expect(installed!.disabled).toBe(true);
   });
 });

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.ts
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.ts
@@ -7,7 +7,7 @@ import {
   PluginInspectReport,
   PluginsApiService,
 } from '../../../../core/services/api/plugins-api.service';
-import { DropdownMenuComponent } from '../../../../shared/components/dropdown-menu';
+import { DropdownToggleDirective } from '../../../../shared/directives/dropdown-toggle.directive';
 
 interface CatalogueRow {
   sourceId: number;
@@ -21,7 +21,7 @@ interface CatalogueRow {
 /** What every cached catalog offers, merged across sources. */
 @Component({
   selector: 'app-plugin-catalogue',
-  imports: [TranslateModule, DropdownMenuComponent, LucideChevronDown],
+  imports: [TranslateModule, DropdownToggleDirective, LucideChevronDown],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugin-catalogue.html',
 })

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.ts
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.ts
@@ -1,6 +1,13 @@
 import { ChangeDetectionStrategy, Component, OnInit, inject, input, output, signal } from '@angular/core';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { CatalogPluginEntry, PluginInspectReport, PluginsApiService } from '../../../../core/services/api/plugins-api.service';
+import { LucideChevronDown } from '@lucide/angular';
+import {
+  CatalogPluginEntry,
+  CatalogVersionEntry,
+  PluginInspectReport,
+  PluginsApiService,
+} from '../../../../core/services/api/plugins-api.service';
+import { DropdownMenuComponent } from '../../../../shared/components/dropdown-menu';
 
 interface CatalogueRow {
   sourceId: number;
@@ -14,7 +21,7 @@ interface CatalogueRow {
 /** What every cached catalog offers, merged across sources. */
 @Component({
   selector: 'app-plugin-catalogue',
-  imports: [TranslateModule],
+  imports: [TranslateModule, DropdownMenuComponent, LucideChevronDown],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugin-catalogue.html',
 })
@@ -26,6 +33,10 @@ export class PluginCatalogueComponent implements OnInit {
   /** Installed version per plugin id — what makes "already installed" and "out of date"
    *  distinguishable on a card. */
   readonly installedVersions = input<ReadonlyMap<string, string>>(new Map());
+  /** `plugins.allow_older_versions`: off, a card installs the newest and nothing else; on, it
+   *  splits into an action and a version picker. The list itself is whatever the source cached —
+   *  which the compatibility setting has already widened or narrowed. */
+  readonly allowOlderVersions = input(false);
 
   /** A version was inspected and staged; the parent owns the consent sheet and opens it with this report. */
   readonly install = output<PluginInspectReport>();
@@ -97,12 +108,23 @@ export class PluginCatalogueComponent implements OnInit {
     (event.target as HTMLImageElement).style.display = 'none';
   }
 
-  async installLatest(row: CatalogueRow): Promise<void> {
-    if (!row.latestVersion) return;
-    const key = `${row.sourceId}:${row.plugin.id}:${row.latestVersion}`;
-    this.inspectingKey.set(key);
+  /** What the version picker lists, newest first — a version list is read top down. */
+  versionsFor(row: CatalogueRow): CatalogVersionEntry[] {
+    return [...row.plugin.installable].reverse();
+  }
+
+  /** The version the button's left half acts on: the update target, else the newest for a plugin
+   *  that is absent. Null once the newest is already running — the half then only states it. */
+  primaryVersion(row: CatalogueRow): string | null {
+    if (!this.isInstalled(row.plugin.id)) return row.latestVersion;
+    return this.updateTarget(row);
+  }
+
+  async installVersion(row: CatalogueRow, version: string | null): Promise<void> {
+    if (!version) return;
+    this.inspectingKey.set(`${row.sourceId}:${row.plugin.id}:${version}`);
     try {
-      const report = await this.api.inspectFromCatalog(row.sourceId, row.plugin.id, row.latestVersion);
+      const report = await this.api.inspectFromCatalog(row.sourceId, row.plugin.id, version);
       this.install.emit(report);
     } catch {
       // The global error interceptor already toasts the server's message; a second one here
@@ -112,7 +134,8 @@ export class PluginCatalogueComponent implements OnInit {
     }
   }
 
+  /** Any version of this card being staged, so both halves disable together. */
   isInspecting(row: CatalogueRow): boolean {
-    return this.inspectingKey() === `${row.sourceId}:${row.plugin.id}:${row.latestVersion}`;
+    return this.inspectingKey()?.startsWith(`${row.sourceId}:${row.plugin.id}:`) ?? false;
   }
 }

--- a/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.html
+++ b/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.html
@@ -14,13 +14,27 @@
         <span class="loading loading-spinner loading-lg"></span>
       </div>
     } @else {
-      <div class="mt-6">
+      <div class="mt-6 flex flex-col gap-4">
         <app-toggle-field
           [value]="autoUpdate()"
           (valueChange)="toggleAutoUpdate($event)"
           [disabled]="saving()"
           [label]="'settings.plugins.settings.auto_update' | translate"
           [hint]="'settings.plugins.settings.auto_update_hint' | translate"
+        />
+        <app-toggle-field
+          [value]="skipCompatibility()"
+          (valueChange)="toggleSkipCompatibility($event)"
+          [disabled]="saving()"
+          [label]="'settings.plugins.settings.skip_compatibility' | translate"
+          [hint]="'settings.plugins.settings.skip_compatibility_hint' | translate"
+        />
+        <app-toggle-field
+          [value]="allowOlderVersions()"
+          (valueChange)="toggleAllowOlderVersions($event)"
+          [disabled]="saving()"
+          [label]="'settings.plugins.settings.allow_older_versions' | translate"
+          [hint]="'settings.plugins.settings.allow_older_versions_hint' | translate"
         />
       </div>
     }

--- a/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.spec.ts
+++ b/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.spec.ts
@@ -1,0 +1,88 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { PluginSettingsComponent } from './plugin-settings';
+import { ToastService } from '../../../../core/services/toast.service';
+
+/** Lets the promise chain inside the component advance between two flushes. */
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+/**
+ * The catalogue reads what a source's last refresh cached, and that cache was filtered under
+ * whichever value the compatibility setting had at the time. Saving the toggle without
+ * refreshing leaves the admin looking at the old, narrower list and no way to tell why.
+ */
+describe('PluginSettingsComponent — disabling the compatibility check', () => {
+  function setup() {
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideTranslateService({
+          lang: 'en',
+          loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+        }),
+        { provide: ToastService, useValue: { success: () => undefined } },
+      ],
+    });
+    const http = TestBed.inject(HttpTestingController);
+    const component = TestBed.createComponent(PluginSettingsComponent).componentInstance;
+    return { component, http };
+  }
+
+  it('VERDICT: refreshes every source so the wider version list appears', async () => {
+    const { component, http } = setup();
+    const done = component.toggleSkipCompatibility(true);
+
+    http
+      .expectOne({ url: '/api/settings/plugins.skip_compatibility_check', method: 'PUT' })
+      .flush({ key: 'plugins.skip_compatibility_check', value: 'true' });
+    await tick();
+    http.expectOne({ url: '/api/plugins/sources', method: 'GET' }).flush([{ id: 1 }, { id: 2 }]);
+    await tick();
+    http.expectOne({ url: '/api/plugins/sources/1/refresh', method: 'POST' }).flush({ ok: true });
+    http.expectOne({ url: '/api/plugins/sources/2/refresh', method: 'POST' }).flush({ ok: true });
+    await done;
+
+    expect(component.skipCompatibility()).toBe(true);
+    http.verify();
+  });
+
+  it('VERDICT: reverts the toggle and refreshes nothing when the write fails', async () => {
+    const { component, http } = setup();
+    const done = component.toggleSkipCompatibility(true);
+
+    http
+      .expectOne({ url: '/api/settings/plugins.skip_compatibility_check', method: 'PUT' })
+      .flush({ message: 'nope' }, { status: 500, statusText: 'Server Error' });
+    await done;
+
+    expect(component.skipCompatibility()).toBe(false);
+    // No source call at all: the value the catalogue would be filtered under never changed.
+    http.verify();
+  });
+
+  it('a source that fails to refresh does not fail the toggle', async () => {
+    const { component, http } = setup();
+    const done = component.toggleSkipCompatibility(true);
+
+    http
+      .expectOne({ url: '/api/settings/plugins.skip_compatibility_check', method: 'PUT' })
+      .flush({ key: 'plugins.skip_compatibility_check', value: 'true' });
+    await tick();
+    http.expectOne({ url: '/api/plugins/sources', method: 'GET' }).flush([{ id: 1 }]);
+    await tick();
+    http
+      .expectOne({ url: '/api/plugins/sources/1/refresh', method: 'POST' })
+      .flush({ message: 'unreachable' }, { status: 502, statusText: 'Bad Gateway' });
+    await done;
+
+    expect(component.skipCompatibility()).toBe(true);
+    expect(component.saving()).toBe(false);
+    http.verify();
+  });
+});

--- a/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.ts
+++ b/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
+  WritableSignal,
   inject,
   signal,
   viewChild,
@@ -10,12 +11,17 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { LucideX } from '@lucide/angular';
 import { ToggleFieldComponent } from '../../../../shared/components/forms/toggle-field/toggle-field';
 import { SettingsApiService } from '../../../../core/services/api/settings-api.service';
+import { PluginsApiService } from '../../../../core/services/api/plugins-api.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { ModalHeaderComponent } from '../../../../shared/components/modal-header';
 import { ModalFooterComponent } from '../../../../shared/components/modal-footer';
 
 /** Mirrors the backend's `PLUGIN_AUTO_UPDATE_SETTING`. */
 const AUTO_UPDATE_KEY = 'plugins.auto_update';
+/** Mirrors the backend's `PLUGIN_SKIP_COMPATIBILITY_SETTING`. */
+const SKIP_COMPATIBILITY_KEY = 'plugins.skip_compatibility_check';
+/** Read by the catalogue alone: it decides whether a card offers other versions to pick. */
+const ALLOW_OLDER_VERSIONS_KEY = 'plugins.allow_older_versions';
 
 @Component({
   selector: 'app-plugin-settings',
@@ -25,6 +31,7 @@ const AUTO_UPDATE_KEY = 'plugins.auto_update';
 })
 export class PluginSettingsComponent {
   private readonly settings = inject(SettingsApiService);
+  private readonly plugins = inject(PluginsApiService);
   private readonly translate = inject(TranslateService);
   private readonly toast = inject(ToastService);
 
@@ -32,6 +39,9 @@ export class PluginSettingsComponent {
 
   /** On unless the stored value is the explicit 'false' — mirrors the backend's own reading. */
   readonly autoUpdate = signal(true);
+  /** Both off unless the stored value is the explicit 'true' — same reading as the backend. */
+  readonly skipCompatibility = signal(false);
+  readonly allowOlderVersions = signal(false);
   readonly loading = signal(true);
   readonly saving = signal(false);
 
@@ -40,10 +50,18 @@ export class PluginSettingsComponent {
     this.dialogRef().nativeElement.showModal();
     this.loading.set(true);
     try {
-      const row = await this.settings.get(AUTO_UPDATE_KEY);
-      this.autoUpdate.set(row?.value !== 'false');
+      const [auto, skip, older] = await Promise.all([
+        this.settings.get(AUTO_UPDATE_KEY),
+        this.settings.get(SKIP_COMPATIBILITY_KEY),
+        this.settings.get(ALLOW_OLDER_VERSIONS_KEY),
+      ]);
+      this.autoUpdate.set(auto?.value !== 'false');
+      this.skipCompatibility.set(skip?.value === 'true');
+      this.allowOlderVersions.set(older?.value === 'true');
     } catch {
       this.autoUpdate.set(true);
+      this.skipCompatibility.set(false);
+      this.allowOlderVersions.set(false);
     } finally {
       this.loading.set(false);
     }
@@ -54,14 +72,45 @@ export class PluginSettingsComponent {
   }
 
   async toggleAutoUpdate(next: boolean): Promise<void> {
-    const previous = this.autoUpdate();
-    this.autoUpdate.set(next);
+    await this.persist(AUTO_UPDATE_KEY, next, this.autoUpdate);
+  }
+
+  /**
+   * The catalogue reads what a source's last refresh cached, and that cache was filtered under
+   * whichever value this had at the time. Refreshing every source is what makes the wider (or
+   * narrower) version list appear without waiting for the nightly job.
+   */
+  async toggleSkipCompatibility(next: boolean): Promise<void> {
+    if (!(await this.persist(SKIP_COMPATIBILITY_KEY, next, this.skipCompatibility))) return;
     this.saving.set(true);
     try {
-      await this.settings.set(AUTO_UPDATE_KEY, String(next));
+      const sources = await this.plugins.listSources();
+      await Promise.all(sources.map((s) => this.plugins.refreshSource(s.id).catch(() => null)));
+    } finally {
+      this.saving.set(false);
+    }
+  }
+
+  async toggleAllowOlderVersions(next: boolean): Promise<void> {
+    await this.persist(ALLOW_OLDER_VERSIONS_KEY, next, this.allowOlderVersions);
+  }
+
+  /** False when the write failed, so a caller does not act on a value the server refused. */
+  private async persist(
+    key: string,
+    next: boolean,
+    flag: WritableSignal<boolean>,
+  ): Promise<boolean> {
+    const previous = flag();
+    flag.set(next);
+    this.saving.set(true);
+    try {
+      await this.settings.set(key, String(next));
       this.toast.success(this.translate.instant('settings.plugins.settings.saved'));
+      return true;
     } catch {
-      this.autoUpdate.set(previous);
+      flag.set(previous);
+      return false;
     } finally {
       this.saving.set(false);
     }


### PR DESCRIPTION
## Problem

Reported from production: for a 2012 film, the **first** release offered was its 2015 sequel.

The title filter is a token-inclusion test — every token of the title asked for must appear in the release, and what the release says *beyond* that is never read ([`matchesIndexedExpectation`](backend/src/common/release-scoring/release-rejection.helper.ts#L367-L377)). A sequel contains every token of its predecessor, so it collects no rejection at all; having the most seeders in the batch, the relevance sort put it on top. Nothing compared the year either: `computeRejections` received the title, season, episode, resolution, languages and sizes, but never the media's year.

## Change

Three rules, all evaluated only for a release that already passed as this title, so they cannot mask a plain `TITLE_MISMATCH`:

- **`SEQUEL_MISMATCH`** — a number the release appends right after the expected title. Matched by walking the release's ordered tokens for the expected ones (stopwords the expectation dropped are tolerated in between) and reading what follows. The expectation's own numbers are now indexed separately from its significant tokens — those drop single characters, so without it a media whose title ends in `2` would read as a sequel of itself. `v` and `x` alone are deliberately not read as numerals: they are title words far more often than numbers.
- **`YEAR_MISMATCH`** — the release states one or more years and none is within ±1 of the media's (a staggered release date routinely shifts it by one). A release stating no year is not judged on one. Movies only: a series' first-aired year says nothing about a later season's releases. `1080p`, `x264` and `DDP5.1` never read as years — the word boundary after four digits rules them out.
- **`COLLECTION_PACK`** — a pack word (`collection`, `duology`, `trilogy`, `anthology`, `saga`, …) that the expected title does not carry itself, so a film actually named `The Collection` is untouched. Not applied to a season-scoped search, where a pack is exactly what is wanted.

Nothing in the sort changed: a rejected release already sinks below every clean one.

## Measured on the reported batch

Run through the real parser with the reported release names (placeholders here, real strings used locally):

| Release | Before | After |
|---|---|---|
| `… 2 2015 1080p BluRay x264` | accepted, **first** | `SEQUEL_MISMATCH`, `YEAR_MISMATCH` |
| `… Collection (2012-2017) MULTi 1080p` | accepted | `COLLECTION_PACK` |
| `… 3 2017 2160p WEB-DL` | accepted | `SEQUEL_MISMATCH`, `YEAR_MISMATCH` |
| `… 2012 1080p BluRay x265` | accepted | accepted |
| `… (2012) 1080p BrRip x264` | accepted | accepted |
| localized title + original in parentheses, 2012 | accepted | accepted |
| `…-(2012)[1080p-BDRip--Original-Auds-]` | accepted | accepted |

And the cases these rules must not break: a media whose own title ends in a number takes its own release; a title that *is* a year (`2012`, 2009) and a title containing `Collection` both still match; `2160p` / `x264` / `DDP5.1` read as neither year nor sequel number.

## Tests

12 new cases in `release-rejection.helper.spec.ts` covering each rule, each false-positive guard, the ±1 tolerance, the no-year case and the season-pack exemption. Backend 1794 tests / 161 suites, client 544, both `tsc --noEmit` clean. The three codes are translated in the six locales.