### PR TITLE
fix(media-info): always show the subtitle picker without the origin hint

### DIFF
--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -467,28 +467,24 @@
       @if (subtitles().length) {
         <div class="flex items-center gap-2">
           <span class="text-base-content/50">{{ 'media_info.subtitles' | translate }}</span>
-          @if (subtitles().length === 1) {
-            <span>{{ subtitles()[0].label }}</span>
-          } @else {
-            <app-dropdown-menu placement="bottom-end">
-              <button trigger type="button" class="select select-bordered select-sm w-fit text-left cursor-pointer transition-colors hover:bg-base-content/10">
-                {{ selectedSubtitle()?.head || selectedSubtitle()?.label || ('player.off' | translate) }}
-              </button>
+          <app-dropdown-menu placement="bottom-end">
+            <button trigger type="button" class="select select-bordered select-sm w-fit text-left cursor-pointer transition-colors hover:bg-base-content/10">
+              {{ selectedSubtitle()?.head || selectedSubtitle()?.label || ('player.off' | translate) }}
+            </button>
+            <app-dropdown-option
+              [head]="'player.off' | translate"
+              [selected]="!selectedSubtitleId()"
+              (click)="onSubtitleChange(null)"
+            />
+            @for (s of subtitles(); track s.id) {
               <app-dropdown-option
-                [head]="'player.off' | translate"
-                [selected]="!selectedSubtitleId()"
-                (click)="onSubtitleChange(null)"
+                [head]="s.head || s.label"
+                [sub]="s.sub"
+                [selected]="s.id === selectedSubtitleId()"
+                (click)="onSubtitleChange(s.id)"
               />
-              @for (s of subtitles(); track s.id) {
-                <app-dropdown-option
-                  [head]="s.head || s.label"
-                  [sub]="s.sub"
-                  [selected]="s.id === selectedSubtitleId()"
-                  (click)="onSubtitleChange(s.id)"
-                />
-              }
-            </app-dropdown-menu>
-          }
+            }
+          </app-dropdown-menu>
         </div>
       }
     </div>


### PR DESCRIPTION
## Problem

On the media detail header, when a title has a single subtitle track the row rendered as plain text using the full label — language plus the origin hint (`English — OCR`, `French — translated`). Two consequences:

- the origin hint leaked into the header, where only the language matters;
- with no select, there was no way to turn subtitles off before opening the player.

## Change

Drop the single-track special case: the subtitles row is always the dropdown. Its trigger shows only `head` (the language), and the `Off` option stays available whatever the track count.

The origin hint is untouched elsewhere — it still shows as the option's secondary line inside the menu, and in the subtitles modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)