### PR TITLE
feat(media-detail): polish the season episode row

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -196,6 +196,8 @@
     "title": "Anzeige",
     "home_background": "Hintergrundbild auf der Startseite",
     "home_background_hint": "Zeigt ein Poster im Vollbild hinter den Bereichen der Startseite an.",
+    "gray_unreleased": "Unveröffentlichte Folgen ausgrauen",
+    "gray_unreleased_hint": "Zeigt das Standbild in Schwarz-Weiß, bis die Folge ausgestrahlt wird.",
     "language": "App-Sprache",
     "language_auto": "System",
     "language_hint": "Sprache der Oberfläche. Standardmäßig die deines Browsers oder Systems."

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -201,6 +201,8 @@
     "title": "Display",
     "home_background": "Background image on home",
     "home_background_hint": "Shows a full-screen poster behind the home sections.",
+    "gray_unreleased": "Grey out unreleased episodes",
+    "gray_unreleased_hint": "Shows the still in black and white until the episode airs.",
     "language": "Application language",
     "language_auto": "System",
     "language_hint": "Interface language. Defaults to your browser or system language."

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -196,6 +196,8 @@
     "title": "Pantalla",
     "home_background": "Imagen de fondo en el inicio",
     "home_background_hint": "Muestra un póster a pantalla completa detrás de las secciones del inicio.",
+    "gray_unreleased": "Episodios no estrenados en blanco y negro",
+    "gray_unreleased_hint": "Muestra la imagen en blanco y negro hasta que se emita el episodio.",
     "language": "Idioma de la aplicación",
     "language_auto": "Sistema",
     "language_hint": "Idioma de la interfaz. Por defecto, el de tu navegador o sistema."

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -201,6 +201,8 @@
     "title": "Affichage",
     "home_background": "Image de fond sur l'accueil",
     "home_background_hint": "Affiche une affiche en plein écran derrière les sections de l'accueil.",
+    "gray_unreleased": "Épisodes non sortis en noir et blanc",
+    "gray_unreleased_hint": "Affiche l'image en noir et blanc tant que l'épisode n'est pas diffusé.",
     "language": "Langue de l'application",
     "language_auto": "Système",
     "language_hint": "Langue de l'interface. Par défaut, celle de votre navigateur ou de votre système."

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -196,6 +196,8 @@
     "title": "Visualizzazione",
     "home_background": "Immagine di sfondo nella home",
     "home_background_hint": "Mostra un poster a schermo intero dietro le sezioni della home.",
+    "gray_unreleased": "Episodi non ancora usciti in bianco e nero",
+    "gray_unreleased_hint": "Mostra l'immagine in bianco e nero finché l'episodio non va in onda.",
     "language": "Lingua dell'app",
     "language_auto": "Sistema",
     "language_hint": "Lingua dell'interfaccia. Per impostazione predefinita, quella del browser o del sistema."

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -196,6 +196,8 @@
     "title": "Visualização",
     "home_background": "Imagem de fundo no início",
     "home_background_hint": "Mostra um poster em ecrã inteiro atrás das secções do início.",
+    "gray_unreleased": "Episódios por estrear a preto e branco",
+    "gray_unreleased_hint": "Mostra a imagem a preto e branco até o episódio ser emitido.",
     "language": "Idioma da aplicação",
     "language_auto": "Sistema",
     "language_hint": "Idioma da interface. Por predefinição, o do seu navegador ou sistema."

--- a/client/src/app/core/services/display-settings.service.ts
+++ b/client/src/app/core/services/display-settings.service.ts
@@ -7,6 +7,8 @@ export interface DisplaySettings {
   onlyMyRequests: boolean;
   /** UI language override (ISO 639-1). Empty = follow the browser/OS language. */
   language: string;
+  /** Desaturate the still of an episode that hasn't aired yet. */
+  grayUnreleased: boolean;
 }
 
 const STORAGE_KEY = 'display.settings';
@@ -15,6 +17,7 @@ const DEFAULTS: DisplaySettings = {
   homeBackground: true,
   onlyMyRequests: false,
   language: '',
+  grayUnreleased: true,
 };
 
 @Injectable({ providedIn: 'root' })

--- a/client/src/app/core/services/scroll-memory.service.ts
+++ b/client/src/app/core/services/scroll-memory.service.ts
@@ -43,7 +43,7 @@ export class ScrollMemoryService {
     const y = this.positions.get(key);
     if (!y) return;
     afterNextRender(() => {
-      window.scrollTo(0, y);
+      window.scrollTo({ top: y, left: 0, behavior: 'instant' });
     }, { injector });
   }
 

--- a/client/src/app/features/app-settings/display-settings/display-settings.html
+++ b/client/src/app/features/app-settings/display-settings/display-settings.html
@@ -22,5 +22,12 @@
       [label]="'display_settings.home_background' | translate"
       [hint]="'display_settings.home_background_hint' | translate"
     />
+
+    <app-toggle-field
+      [value]="grayUnreleased()"
+      (valueChange)="onGrayUnreleasedChange($event)"
+      [label]="'display_settings.gray_unreleased' | translate"
+      [hint]="'display_settings.gray_unreleased_hint' | translate"
+    />
   </div>
 </div>

--- a/client/src/app/features/app-settings/display-settings/display-settings.ts
+++ b/client/src/app/features/app-settings/display-settings/display-settings.ts
@@ -16,6 +16,7 @@ export class DisplaySettingsPageComponent implements OnInit {
   private readonly translate = inject(TranslateService);
 
   readonly homeBackground = signal(true);
+  readonly grayUnreleased = signal(true);
   readonly languageOptions = SUPPORTED_LOCALES;
   /** '' = follow the browser/OS language. */
   readonly language = signal('');
@@ -23,12 +24,18 @@ export class DisplaySettingsPageComponent implements OnInit {
   ngOnInit() {
     const s = this.displaySettings.get();
     this.homeBackground.set(s.homeBackground);
+    this.grayUnreleased.set(s.grayUnreleased);
     this.language.set(s.language);
   }
 
   onHomeBackgroundChange(value: boolean) {
     this.homeBackground.set(value);
     this.displaySettings.save({ homeBackground: value });
+  }
+
+  onGrayUnreleasedChange(value: boolean) {
+    this.grayUnreleased.set(value);
+    this.displaySettings.save({ grayUnreleased: value });
   }
 
   onLanguageChange(value: string) {

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -254,6 +254,7 @@
                 [clickIntent]="ep.hasFile ? 'play' : 'open'"
                 [hideCaption]="true"
                 [dimmed]="!ep.monitored"
+                [grayscale]="episodeGrayscale(ep)"
                 (clicked)="ep.hasFile && playEpisode(ep)"
                 (played)="playEpisode(ep)"
                 (watchedToggled)="toggleEpisodeWatched.emit({ episode: ep, watched: $event })"
@@ -318,6 +319,8 @@
             [playable]="ep.hasFile"
             [interactiveWatched]="ep.hasFile"
             [dimmed]="!ep.monitored"
+            [grayscale]="episodeGrayscale(ep)"
+            [highlighted]="ep.id === activeEpisodeId()"
             (played)="playEpisode(ep)"
             (watchedToggled)="toggleEpisodeWatched.emit({ episode: ep, watched: $event })"
           />

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -41,6 +41,7 @@ import {
 import {
   displayMediaFilePath,
   episodeBadgeLabel,
+  episodeUnreleased,
   filesForEpisode,
   filterSeasonEpisodesOnDisk,
   onDiskEpisodeNumbers,
@@ -51,6 +52,7 @@ import { AddToPlaylistService } from '../../../../core/services/add-to-playlist.
 import { TvService } from '../../../../core/services/tv.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { DeviceService } from '../../../../core/services/device.service';
+import { DisplaySettingsService } from '../../../../core/services/display-settings.service';
 import { LocaleDatePipe } from '../../../../core/pipes/locale-date.pipe';
 import { SeasonLabelPipe } from '../../../../core/pipes/season-label.pipe';
 import { PluginUiRegistryService } from '../../../../core/plugin-ui/plugin-ui-registry.service';
@@ -85,6 +87,7 @@ export class MediaDetailSeasonsComponent {
   readonly auth = inject(AuthService);
   private readonly device = inject(DeviceService);
   private readonly pluginUi = inject(PluginUiRegistryService);
+  private readonly displaySettings = inject(DisplaySettingsService);
   readonly media = input.required<Media>();
   readonly selectedSeason = input<Season | null>(null);
   readonly activeSeasonId = input.required<number | null>();
@@ -116,6 +119,8 @@ export class MediaDetailSeasonsComponent {
   /** Optional override for the horizontal-scroller title. Defaults to
    *  the generic "Episodes" string when null. */
   readonly sectionTitle = input<string | null>(null);
+  /** Episode the page is already showing — its card is framed instead of hidden. */
+  readonly activeEpisodeId = input<number | null>(null);
   /** Season ids the viewer has liked — drives the season heart entry. */
   readonly likedSeasonIds = input<number[]>([]);
 
@@ -283,6 +288,10 @@ export class MediaDetailSeasonsComponent {
   }
 
   episodeBadgeLabel = episodeBadgeLabel;
+  /** Grey still for an episode that hasn't aired, unless the viewer turned it off. */
+  episodeGrayscale(ep: Episode): boolean {
+    return this.displaySettings.settings().grayUnreleased && episodeUnreleased(ep);
+  }
 
   episodeRoute(ep: Episode): string[] {
     return ['/series', String(this.media().id), 'episode', String(ep.id)];

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -78,12 +78,13 @@
           (openTracking)="openTracking({ kind: 'episode', episodeId: ep.id })"
         />
 
-        @if (moreFromSeasonEpisodes().length > 0) {
+        @if (currentSeasonEpisodes().length > 1) {
           <app-media-detail-seasons
             [media]="m"
             [selectedSeason]="s"
             [activeSeasonId]="s.id"
-            [filteredEpisodes]="moreFromSeasonEpisodes()"
+            [filteredEpisodes]="currentSeasonEpisodes()"
+            [activeEpisodeId]="ep.id"
             [watchedEpisodeIds]="watchedEpisodeIds()"
             [episodeProgress]="episodeProgress()"
             [hideControls]="true"

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -437,16 +437,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   });
 
   /**
-   * Episodes shown in the "Plus de saison X" row — the focused season minus the
-   * episode already open above it: listing the active episode in its own
-   * "more from this season" row is redundant.
-   */
-  readonly moreFromSeasonEpisodes = computed<Episode[]>(() => {
-    const activeId = this.focusedEpisode()?.id;
-    return this.currentSeasonEpisodes().filter((e) => e.id !== activeId);
-  });
-
-  /**
    * Sibling seasons rendered as cards under the "more from season N" row on
    * the episode detail page. Hides the currently-focused season and any
    * empty season (no episodes → no link target).
@@ -483,26 +473,18 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * When the focused episode changes on the episode detail page, bring the
-   * "Plus de saison X" scroller to the episode AFTER the active one — the
-   * active episode is hidden from the row, so we surface what comes next.
-   * When the active episode is the season's last, scroll the row to its end
-   * instead. The setTimeout lets the card and its scroll container mount
-   * through app-media-detail-seasons → app-horizontal-scroller → ng-content
-   * before we measure — they can take a change-detection pass or two to settle.
+   * When the focused episode changes on the episode detail page, center the
+   * "Plus de saison X" scroller on its card. The setTimeout lets the card and
+   * its scroll container mount through app-media-detail-seasons →
+   * app-horizontal-scroller → ng-content before we measure — they can take a
+   * change-detection pass or two to settle.
    */
   private readonly scrollToFocusedEpisodeEffect = effect(() => {
     const active = this.focusedEpisode();
-    const eps = this.currentSeasonEpisodes();
-    if (!active || !this.episodeMode() || this.moreFromSeasonEpisodes().length === 0) {
+    if (!active || !this.episodeMode() || this.currentSeasonEpisodes().length < 2) {
       return;
     }
-    const idx = eps.findIndex((e) => e.id === active.id);
-    const next = idx >= 0 ? eps[idx + 1] : undefined;
-    setTimeout(() => {
-      if (next) this.scrollToEpisode(next.id);
-      else this.scrollToEpisodesRowEnd();
-    }, 30);
+    setTimeout(() => this.scrollToEpisode(active.id), 30);
   });
 
   private scrollToEpisode(epId: number): void {
@@ -518,20 +500,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       scroller.clientWidth / 2 +
       el.offsetWidth / 2;
     scroller.scrollTo({ left: Math.max(0, target), behavior: 'smooth' });
-  }
-
-  /** Scroll the "Plus de saison X" row to its far end — used when the active
-   *  episode (hidden from the row) is the season's last, so there is no "next"
-   *  card to center on. Anchors off the last rendered card to find the row's
-   *  scroller. */
-  private scrollToEpisodesRowEnd(): void {
-    const last = this.moreFromSeasonEpisodes().at(-1);
-    if (!last) return;
-    const el = document.getElementById(`episode-${last.id}`);
-    if (!el) return;
-    const scroller = this.findHorizontalScrollParent(el);
-    if (!scroller) return;
-    scroller.scrollTo({ left: scroller.scrollWidth, behavior: 'smooth' });
   }
 
   private findHorizontalScrollParent(el: HTMLElement): HTMLElement | null {

--- a/client/src/app/features/media-detail/media-detail.utils.ts
+++ b/client/src/app/features/media-detail/media-detail.utils.ts
@@ -96,6 +96,11 @@ export function episodeBadgeLabel(ep: Episode): string {
     : String(ep.episodeNumber);
 }
 
+/** Episode whose air date is still ahead — nothing to download yet. */
+export function episodeUnreleased(ep: Episode): boolean {
+  return !!ep.airDate && new Date(ep.airDate) > new Date();
+}
+
 /** Saisons à afficher dans les onglets : toutes, ou seulement celles avec ≥1 épisode sur disque. */
 export function seasonsVisibleWithDiskFilter(media: Media, onlyOnDisk: boolean): Season[] {
   const list = media.seasons ?? [];

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -4056,7 +4056,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     this.isLandscape.set(screen.orientation?.type?.startsWith('landscape') ?? false);
     // iOS WKWebView sometimes doesn't reflow fixed-position elements after
     // rotation, leaving the player UI oversized. Force a layout recalc.
-    window.scrollTo(0, 0);
+    window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
     document.documentElement.style.setProperty('--vh', `${window.innerHeight}px`);
     // Native subtitle bottom margin is a % of video height — reapply after
     // orientation change so the value is recalculated against the new dimensions.

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -8,6 +8,8 @@
     class="group relative bg-base-300 rounded-lg overflow-hidden shadow-md hover:shadow-xl transition-shadow cursor-pointer"
     [class.aspect-2/3]="aspect() === 'portrait'"
     [class.aspect-video]="aspect() === 'landscape'"
+    [class.border-2]="highlighted()"
+    [class.border-primary]="highlighted()"
     tabindex="0"
     role="button"
     [attr.aria-label]="_title()"
@@ -30,6 +32,7 @@
         draggable="false"
         [class.opacity-35]="imageBlurred()"
         [class.scale-105]="imageBlurred()"
+        [class.grayscale]="grayscale()"
         loading="lazy"
         decoding="async"
       />

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -89,6 +89,13 @@ export class MediaCardComponent {
    */
   readonly widthClass = input<string | null>(null);
 
+  /** Frames the card in the primary colour — marks the card as the one
+   *  the current page is already showing. */
+  readonly highlighted = input(false);
+
+  /** Desaturates the image — marks content that hasn't aired/released yet. */
+  readonly grayscale = input(false);
+
   // Image (override media.posterUrl)
   readonly imageUrl = input<string | null>(null);
   readonly imageBlurred = input(false);
@@ -279,6 +286,9 @@ export class MediaCardComponent {
     // Pointless where the router runs no transition (Capacitor) or the engine has
     // none (Chromium <111, Tizen 5.5 WebKit, webOS 5) — and it costs a querySelectorAll per click.
     if (this.isNative || !('startViewTransition' in document)) return;
+    // Episode stills never pair: the episode page stamps the SERIES id on its
+    // still, so an episode name only ever animates in or out on its own.
+    if (this.link()?.includes('episode')) return;
     const id = this.resolveMediaId();
     const img = this.imgRef()?.nativeElement;
     if (id == null || !img) return;

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -203,7 +203,7 @@
           class="w-full rounded-xl object-cover bg-base-300"
           [class.aspect-2/3]="posterMode() === 'poster'"
           [class.aspect-video]="posterMode() === 'still'"
-          [style.view-transition-name]="'media-poster-' + mediaId()"
+          [style.view-transition-name]="episodeId() ? null : 'media-poster-' + mediaId()"
         />
       } @else {
         <div

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -71,6 +71,15 @@
   background-color: rgba(29, 35, 42, 0.95);
 }
 
+/* Router scroll-to-top on navigation goes through window.scrollTo, so smooth
+   here animates the jump instead of teleporting. Scroll restores that must land
+   instantly pass behavior:'instant'. */
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+
 /* Sidebar veil when a fanart background is showing — frosted
    look without depending on Tailwind's color-mix-based
    `bg-base-100/40`. Phones/tablets/desktop: 40 % alpha. TV: a


### PR DESCRIPTION
## What

Four changes to the episode view, all from the same walkthrough.

### The active episode stays in "More from season X"
It was filtered out of its own row. Its card is now kept and framed `border-2 border-primary`, so the row's contents no longer shift under the reader when moving between episodes. The scroller centres on the active card itself, which retires the "scroll to the next episode, or to the row's end when it's the last" fallback.

### Episode stills leave the view transition
The card stamped `view-transition-name: media-poster-<episodeId>` before navigating, but the episode page stamps the **series** id on its still. The name never paired, so the image animated in or out on its own after every click — read as a random jitter. Episode links are now skipped on the card side, and the episode still drops the name on the header side. The movie/series poster morph is untouched.

### Smooth scroll-to-top on navigation
`scroll-behavior: smooth` on `html`, guarded by `prefers-reduced-motion: no-preference`. The router's `scrollPositionRestoration: 'top'` goes through `window.scrollTo`, so it picks this up for free: clicking an episode from the footer now glides to the top instead of teleporting.

Two callers must still land instantly and now say so explicitly:
- `ScrollMemoryService.restore()` — back-navigation position restore.
- the player's orientation-change layout recalc (`window.scrollTo(0, 0)` is a reflow hack there, not a scroll).

`restoreSticky()` already passed `behavior: 'instant'`; TV builds already set smooth on `html.tv-host`.

### Unreleased episodes in black and white
An episode whose `airDate` is still ahead renders its still greyscale, via a new `[grayscale]` input on `app-media-card`. Behind a Display setting, **on by default**, persisted in the existing `display.settings` key; the toggle reads a signal so it applies without a reload. Translated in the six shipped languages.

## Test

- `ng build` clean (only the two pre-existing `search` warnings).
- `ng test --include='**/media-card.spec.ts'` — 30 passed.
- Walked the episode view: active card framed and centred, no image jitter on click, smooth return to top from the footer, unreleased stills grey and the toggle flipping them live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)