### PR TITLE
fix(spoilers): mask the season synopsis too

### DIFF
--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -217,7 +217,11 @@
         </div>
 
         @if (selSeason.overview) {
-          <p class="text-sm text-base-content/80">{{ selSeason.overview }}</p>
+          <app-synopsis
+            [text]="selSeason.overview"
+            [spoiler]="seasonOverviewSpoiler(selSeason)"
+            textClass="text-sm text-base-content/80"
+          />
         }
       </div>
     }

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -295,6 +295,11 @@ export class MediaDetailSeasonsComponent {
     return this.spoilers.still(this.watchedEpisodeIds().has(ep.id));
   }
 
+  /** A season's synopsis gives away episodes the viewer hasn't reached yet. */
+  seasonOverviewSpoiler(season: Season): boolean {
+    return this.spoilers.overview(this.seasonFullyWatched(season));
+  }
+
   episodeOverviewSpoiler(ep: Episode): boolean {
     return this.spoilers.overview(this.watchedEpisodeIds().has(ep.id));
   }


### PR DESCRIPTION
Follow-up to #1108.

The season header renders the season's own synopsis, which summarises episodes the viewer
hasn't reached — it spoils exactly the way an episode synopsis does, and it was left
unmasked.

It now uses `seasonFullyWatched` as the predicate: masked until every episode of that
season that is on disk has been watched, and revealed on click like the rest.

Rendering it through the shared `app-synopsis` component rather than a bare `<p>` avoids a
second copy of the tooltip wrapper, and it picks up the clamp + show-more toggle the other
synopses already have.

## Testing

`ng build` clean, full client suite green (548 tests, 65 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)