### PR TITLE
chore(client): clear the front-end build warnings

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -19,6 +19,7 @@
           "options": {
             "browser": "src/main.ts",
             "tsConfig": "tsconfig.app.json",
+            "allowedCommonJsDependencies": ["shaka-player"],
             "assets": [
               {
                 "glob": "**/*",

--- a/client/src/app/features/search/search.html
+++ b/client/src/app/features/search/search.html
@@ -159,7 +159,7 @@
             @if (state.discoveryRecommendations().length) {
               <app-horizontal-scroller [title]="'search.discover_suggestions' | translate" class="block">
                 @for (rec of state.discoveryRecommendations(); track rec.media.id) {
-                  <app-media-card class="shrink-0 w-28 sm:w-32 lg:w-40" [imageUrl]="rec.media.posterUrl" [title]="rec.media.title" [subtitle]="'' + (rec.media.year ?? '')" [link]="recLink(rec)" [status]="rec.media.available ? null : 'missing'" [playable]="rec.media.available" />
+                  <app-media-card class="shrink-0 w-28 sm:w-32 lg:w-40" [imageUrl]="rec.media.posterUrl" [title]="rec.media.title" [subtitle]="'' + rec.media.year" [link]="recLink(rec)" [status]="rec.media.available ? null : 'missing'" [playable]="rec.media.available" />
                 }
               </app-horizontal-scroller>
             } @else {

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -13,7 +13,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { MediaService, Media, SearchParams } from '../../core/services/api/media.service';
@@ -44,7 +44,7 @@ import { UserAvatarComponent } from '../../shared/components/user-avatar/user-av
 
 @Component({
   selector: 'app-search',
-  imports: [UserAvatarComponent, FormsModule, TranslateModule, RouterLink, NgTemplateOutlet, MediaCardComponent, HorizontalScrollerComponent, DropdownMenuComponent, LucideSearch, LucideX, LucideSettings, ModalHeaderComponent],
+  imports: [UserAvatarComponent, FormsModule, TranslateModule, NgTemplateOutlet, MediaCardComponent, HorizontalScrollerComponent, DropdownMenuComponent, LucideSearch, LucideX, LucideSettings, ModalHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './search.html',
 })


### PR DESCRIPTION
Both `ng build` configurations now come out clean. None of the three warnings was
load-bearing, but they made a build log noisy enough that a new one would go unnoticed.

| Warning | Fix |
|---|---|
| `NG8102` — dead `??` in `search.html` | `rec.media.year` is typed `number`, so `?? ''` could never fire. Dropped. |
| `NG8113` — `RouterLink` unused by `SearchComponent` | No `routerLink` anywhere in `search.html`. Removed from the imports and the module import. |
| `shaka-player` is not ESM (production only) | Shaka ships UMD only — `module` and `exports` are both null in its package.json, so there is no ESM entry to switch to. Added to `allowedCommonJsDependencies`, which is the option for exactly this. |

## Testing

`ng build` clean on both `development` and `production`, no warnings on either. Full
client suite green (548 tests, 65 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)