### PR TITLE
fix(downloads): show download progress to everyone who can see the media

### DIFF
--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -149,7 +149,7 @@ interface Harness {
     emitDomain: jest.Mock;
     emitRaw: jest.Mock;
   };
-  sseAudience: { recipientsForMedia: jest.Mock };
+  sseAudience: { recipientsForMedia: jest.Mock; viewersForMedia: jest.Mock };
   countsCache: PluginCountsCacheService;
 }
 
@@ -191,7 +191,10 @@ function makeHarness(pluginId: string | null = 'test.plugin'): Harness {
     emitDomain: jest.fn(),
     emitRaw: jest.fn(),
   };
-  const sseAudience = { recipientsForMedia: jest.fn().mockResolvedValue([9]) };
+  const sseAudience = {
+    recipientsForMedia: jest.fn().mockResolvedValue([9]),
+    viewersForMedia: jest.fn().mockResolvedValue([9]),
+  };
   const countsCache = new PluginCountsCacheService();
 
   // Fakes stand in for 19 constructor params — a plain unit test of the class,
@@ -1779,7 +1782,7 @@ describe('FliksHostImpl', () => {
 
     it('emits nothing when the audience is empty', async () => {
       const h = makeHarness();
-      h.sseAudience.recipientsForMedia.mockResolvedValue([]);
+      h.sseAudience.viewersForMedia.mockResolvedValue([]);
       await h.host['progress.set']({
         mediaId: 1,
         ref: 'r',

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -1074,7 +1074,9 @@ export class FliksHostImpl implements PluginHostApi {
     state: DownloadProgressState;
   }): Promise<void> {
     const media = await this.mediaRepo.findOne({ where: { id: p.mediaId } });
-    const recipients = await this.sseAudience.recipientsForMedia(p.mediaId);
+    // Progress is passive page state, not a notification: everyone who can open
+    // the media's page sees it, not just whoever requested the title.
+    const recipients = await this.sseAudience.viewersForMedia(p.mediaId);
     if (!recipients.length) return;
     this.events.emitToUsers(recipients, {
       type: 'download.progress',

--- a/backend/src/modules/plugins/host/plugin-host-binding.service.spec.ts
+++ b/backend/src/modules/plugins/host/plugin-host-binding.service.spec.ts
@@ -109,7 +109,10 @@ function makeStack() {
       emitDomain: jest.fn(),
       emitRaw: jest.fn(),
     },
-    { recipientsForMedia: jest.fn().mockResolvedValue([]) },
+    {
+      recipientsForMedia: jest.fn().mockResolvedValue([]),
+      viewersForMedia: jest.fn().mockResolvedValue([]),
+    },
     countsCache,
   ) as FliksHostImpl;
 

--- a/backend/src/modules/requests/request-lifecycle.service.spec.ts
+++ b/backend/src/modules/requests/request-lifecycle.service.spec.ts
@@ -17,6 +17,7 @@ describe('RequestLifecycleService onMediaRemoved (kind-aware)', () => {
       {} as never,
       { subscribe: jest.fn() } as never,
       {} as never,
+      { viewersForMedia: jest.fn(async () => []) } as never,
     );
   });
 
@@ -90,6 +91,7 @@ describe('RequestLifecycleService onMediaImported — acquisition announcement',
       { envelopeCovers: jest.fn(async () => opts.covers) } as never,
       events as never,
       {} as never,
+      { viewersForMedia: jest.fn(async () => []) } as never,
     );
     return { service, events, requestRepo };
   }

--- a/backend/src/modules/requests/request-lifecycle.service.ts
+++ b/backend/src/modules/requests/request-lifecycle.service.ts
@@ -16,6 +16,7 @@ import { MediaService } from '../media/media.service';
 import { onDiskEpisodeNumbers } from '../media/episode-coverage.util';
 import { ProfilesService } from '../profiles/profiles.service';
 import { EventsService } from '../scheduler/events.service';
+import { SseAudienceService } from '../scheduler/sse-audience.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { User } from '../users/entities/user.entity';
 import {
@@ -64,6 +65,7 @@ export class RequestLifecycleService
     private readonly profiles: ProfilesService,
     private readonly events: EventsService,
     private readonly notifications: NotificationsService,
+    private readonly sseAudience: SseAudienceService,
   ) {}
 
   onModuleInit(): void {
@@ -211,15 +213,10 @@ export class RequestLifecycleService
           mediaType: r.mediaType,
         });
       }
-      // Push a 0% progress event to the requesters so the bar + PROCESSING
-      // state appear immediately, without waiting for the next poll tick.
-      const userIds = [
-        ...new Set(
-          touched
-            .map((r) => r.userId)
-            .filter((id): id is number => id != null),
-        ),
-      ];
+      // Push a 0% progress event so the bar + PROCESSING state appear
+      // immediately, without waiting for the next poll tick. Same audience as
+      // the plugin's own ticks — everyone who can open the media's page.
+      const userIds = await this.sseAudience.viewersForMedia(mediaId);
       if (userIds.length) {
         this.events.emitToUsers(userIds, {
           type: 'download.progress',

--- a/backend/src/modules/scheduler/events.module.ts
+++ b/backend/src/modules/scheduler/events.module.ts
@@ -5,10 +5,12 @@ import { SseAudienceService } from './sse-audience.service';
 import { DownloadProgressCacheService } from './download-progress-cache.service';
 import { FliksRequest } from '../requests/entities/request.entity';
 import { User } from '../users/entities/user.entity';
+import { Media } from '../media/entities/media.entity';
+import { LibraryUserAccess } from '../libraries/entities/library-user-access.entity';
 
 @Global()
 @Module({
-  imports: [TypeOrmModule.forFeature([FliksRequest, User])],
+  imports: [TypeOrmModule.forFeature([FliksRequest, User, Media, LibraryUserAccess])],
   providers: [EventsService, SseAudienceService, DownloadProgressCacheService],
   exports: [EventsService, SseAudienceService],
 })

--- a/backend/src/modules/scheduler/sse-audience.service.spec.ts
+++ b/backend/src/modules/scheduler/sse-audience.service.spec.ts
@@ -1,0 +1,71 @@
+import { SseAudienceService } from './sse-audience.service';
+
+/**
+ * `viewersForMedia` is the audience for download progress: passive page state
+ * the whole household sees, unlike `recipientsForMedia`'s requester-scoped
+ * toasts. It must mirror LibrariesService' access rule — admins and `manage:all`
+ * see every library, everyone else needs a grant on the media's own library.
+ */
+describe('SseAudienceService.viewersForMedia', () => {
+  const user = (id: number, over: Partial<Record<string, unknown>> = {}) => ({
+    id,
+    isAdmin: false,
+    enabled: true,
+    permissions: [],
+    ...over,
+  });
+
+  function makeService(opts: {
+    users: unknown[];
+    libraryId: number | null;
+    grantedUserIds: number[];
+  }) {
+    const mediaRepo = {
+      findOne: jest.fn(async () => ({
+        id: 1,
+        library: opts.libraryId == null ? null : { id: opts.libraryId },
+      })),
+    };
+    const userRepo = { find: jest.fn(async () => opts.users) };
+    const accessRepo = {
+      find: jest.fn(async () => opts.grantedUserIds.map((id) => ({ userId: id }))),
+    };
+    return new SseAudienceService(
+      {} as never,
+      userRepo as never,
+      mediaRepo as never,
+      accessRepo as never,
+    );
+  }
+
+  it('includes a granted user who never requested the media', async () => {
+    const service = makeService({
+      users: [user(1), user(2)],
+      libraryId: 7,
+      grantedUserIds: [2],
+    });
+    await expect(service.viewersForMedia(1)).resolves.toEqual([2]);
+  });
+
+  it('always includes admins and manage:all, grant or not', async () => {
+    const service = makeService({
+      users: [
+        user(1, { isAdmin: true }),
+        user(2, { permissions: ['manage:all'] }),
+        user(3),
+      ],
+      libraryId: 7,
+      grantedUserIds: [],
+    });
+    await expect(service.viewersForMedia(1)).resolves.toEqual([1, 2]);
+  });
+
+  it('falls back to full-library users when the media has no library', async () => {
+    const service = makeService({
+      users: [user(1, { isAdmin: true }), user(2)],
+      libraryId: null,
+      grantedUserIds: [2],
+    });
+    await expect(service.viewersForMedia(1)).resolves.toEqual([1]);
+  });
+});

--- a/backend/src/modules/scheduler/sse-audience.service.ts
+++ b/backend/src/modules/scheduler/sse-audience.service.ts
@@ -3,6 +3,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { FliksRequest } from '../requests/entities/request.entity';
 import { User } from '../users/entities/user.entity';
+import { Media } from '../media/entities/media.entity';
+import { LibraryUserAccess } from '../libraries/entities/library-user-access.entity';
 
 /**
  * Resolves which users should receive a media-scoped SSE toast (import done,
@@ -18,7 +20,46 @@ export class SseAudienceService {
     private readonly requestRepo: Repository<FliksRequest>,
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
+    @InjectRepository(Media)
+    private readonly mediaRepo: Repository<Media>,
+    @InjectRepository(LibraryUserAccess)
+    private readonly accessRepo: Repository<LibraryUserAccess>,
   ) {}
+
+  /**
+   * Everyone allowed to open the media's page, for passive state the whole
+   * household should see — download progress on a media detail header. Unlike
+   * {@link recipientsForMedia} this is not narrowed to the requesters: a user
+   * who didn't ask for a title still watches it download.
+   */
+  async viewersForMedia(mediaId: number | null): Promise<number[]> {
+    if (mediaId == null) return this.adminIds();
+    const media = await this.mediaRepo.findOne({
+      where: { id: mediaId },
+      relations: ['library'],
+    });
+    const libraryId = media?.library?.id ?? null;
+    const users = await this.userRepo.find({
+      where: { enabled: true },
+      relations: ['userRole'],
+    });
+    if (libraryId == null) {
+      return users.filter((u) => this.hasEveryLibrary(u)).map((u) => u.id);
+    }
+    const granted = new Set(
+      (
+        await this.accessRepo.find({ where: { library: { id: libraryId } } })
+      ).map((a) => a.userId),
+    );
+    return users
+      .filter((u) => this.hasEveryLibrary(u) || granted.has(u.id))
+      .map((u) => u.id);
+  }
+
+  /** Same rule as LibrariesService.getAccessibleLibraryIds' fast path. */
+  private hasEveryLibrary(user: User): boolean {
+    return user.isAdmin || user.permissions.includes('manage:all');
+  }
 
   async recipientsForMedia(mediaId: number | null): Promise<number[]> {
     if (mediaId != null) {

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -47,6 +47,8 @@
           [fanartUrl]="ep.stillUrl ?? m.fanartUrl ?? null"
           [posterUrl]="ep.stillUrl ?? m.fanartUrl ?? null"
           [posterMode]="'still'"
+          [badge]="episodeHeaderBadge()"
+          (openDownloadDetail)="openDownloadDetailModal()"
           [spoilerImage]="episodeSpoilerImage()"
           [spoilerOverview]="episodeSpoilerOverview()"
           [backRoute]="episodeSeriesRoute()"

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -199,6 +199,27 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       clickable: d.isClickable && !this.tv.isTv(),
     };
   });
+
+  /** Same badge on the episode page, narrowed to that episode's own torrent
+   *  (or the season pack that carries it). */
+  readonly episodeHeaderBadge = computed<MediaInfoHeaderBadge | null>(() => {
+    const ep = this.focusedEpisode();
+    const season = this.focusedSeason();
+    if (!ep || !season) return null;
+    const d = describeBadge(this.activeDownload(), {
+      monitored: ep.monitored,
+      downloaded: ep.hasFile,
+      seasonFilter: [season.seasonNumber],
+      episodeFilter: ep.episodeNumber,
+    });
+    if (!d.labelKey) return null;
+    return {
+      labelKey: d.labelKey,
+      percent: d.percent,
+      badgeClass: d.badgeClass,
+      clickable: d.isClickable && !this.tv.isTv(),
+    };
+  });
   private readonly downloadModal = viewChild<DownloadQualityModalComponent>('downloadModal');
   private readonly downloadDetailModal =
     viewChild<DownloadDetailModalComponent>('downloadDetailModal');

--- a/client/src/app/shared/utils/download-format.ts
+++ b/client/src/app/shared/utils/download-format.ts
@@ -177,12 +177,19 @@ function fallbackDescriptor(
 function collectLeaves(
   progress: MediaDownloadProgress,
   seasonFilter?: number[],
+  episodeFilter?: number,
 ): DownloadLeaf[] {
   if (!progress.seasons) return [];
   const out: DownloadLeaf[] = [];
   for (const [seasonNumber, sp] of progress.seasons) {
     if (seasonFilter?.length && !seasonFilter.includes(seasonNumber)) continue;
-    for (const leaf of sp.leaves.values()) out.push(leaf);
+    for (const [key, leaf] of sp.leaves) {
+      // A season pack carries the episode too, so it counts in an episode scope.
+      if (episodeFilter != null && key !== episodeFilter && key !== 'PACK') {
+        continue;
+      }
+      out.push(leaf);
+    }
   }
   return out;
 }
@@ -196,13 +203,26 @@ function collectLeaves(
  */
 export function describeBadge(
   progress: MediaDownloadProgress | null,
-  opts: { monitored: boolean; downloaded: boolean; seasonFilter?: number[] },
+  opts: {
+    monitored: boolean;
+    downloaded: boolean;
+    seasonFilter?: number[];
+    /** Narrow to one episode — its own torrent, or a pack that contains it. */
+    episodeFilter?: number;
+  },
 ): DownloadBadgeDescriptor {
   if (!progress) return fallbackDescriptor(opts.monitored, opts.downloaded);
 
   let fold: LeafFold;
-  if (progress.seasons && opts.seasonFilter?.length) {
-    const leaves = collectLeaves(progress, opts.seasonFilter);
+  if (
+    progress.seasons &&
+    (opts.seasonFilter?.length || opts.episodeFilter != null)
+  ) {
+    const leaves = collectLeaves(
+      progress,
+      opts.seasonFilter,
+      opts.episodeFilter,
+    );
     if (!leaves.length) {
       return fallbackDescriptor(opts.monitored, opts.downloaded);
     }


### PR DESCRIPTION
## Why

The progress badge on a media page (and on a home *Recent requests* card) is fed by
`download.progress` SSE events. Their audience was resolved by
`SseAudienceService.recipientsForMedia` — **the users who requested the title**, falling
back to admins only when nobody had requested it.

So a film someone else requested downloaded in complete silence for everyone but that one
account: the header badge stayed on *Monitored* for the whole transfer, and the home
request badge never filled either.

The plumbing was otherwise complete — plugin → host → SSE → `DownloadProgressService` →
`describeBadge` — only the audience was wrong.

## What

**Audience.** `download.progress` now resolves through a new `viewersForMedia`: every
enabled account that can open the media's page, mirroring
`LibrariesService.getAccessibleLibraryIds` — admins and `manage:all` see every library,
everyone else needs a grant on the media's own library. A media with no library falls back
to the full-library accounts.

`recipientsForMedia` is untouched and still serves the media toasts (import done, import
failed, stalled torrent removed). Those are notifications: broadcasting them to the
household would be spam.

The 0% seed emitted when a request flips to PROCESSING moved to the same audience, so the
badge appears immediately for everyone rather than only for the requester.

**Episode pages.** The episode header passed no `[badge]` at all, so an episode download
was invisible there. It now gets the same badge, scoped to that episode: its own torrent,
or the season pack that carries it (`describeBadge` gained an `episodeFilter`).

The home *Recent requests* card needed no change — it already routes through
`RequestStatusBadgeComponent` → `describeBadge`, so it was failing for this same reason and
is fixed by the audience change.

## Testing

- New `sse-audience.service.spec.ts` covers the three branches of the access rule: a
  granted non-requester is included, admins and `manage:all` are always in, and a
  library-less media falls back to full-library accounts.
- Full backend suite green (1797 tests, 162 files) — the existing host specs were updated
  to stub the new method, and the one asserting an empty audience now drives it through
  `viewersForMedia`.
- `ng build` clean, full client suite green (548 tests, 65 files).
- Not yet observed against a live download on a running stack; the wiring is verified by
  tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)