### PR TITLE
fix(media-detail): stop the resume bar flashing on a series page

### DIFF
--- a/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
@@ -693,4 +693,33 @@ describe('MediaInfoHeaderComponent — resume state across an episode switch', (
     expect(fixture.componentInstance.resumePositionSeconds()).toBeNull();
     expect(fixture.componentInstance.durationSeconds()).toBeNull();
   });
+
+  /** Opening a series from the home page renders the header before the parent
+   *  has resolved which episode the resume button targets. Reading the series'
+   *  own row (episode IS NULL) in that window flashed a progress bar that the
+   *  real episode then cleared. */
+  it('shows no progress on a series root until the resume episode is known', async () => {
+    const fixture = await createFixture(OWNER, {
+      mediaType: 'series',
+      selectedFileId: null,
+      monitored: true,
+      qualityProfileName: 'HD-1080p',
+      // A stale series-level row: what the header used to read and render.
+      playbackStates: {
+        0: { positionSeconds: 1200, durationSeconds: 3600, completed: false, mediaFileId: 30 },
+        3: { positionSeconds: 1992, durationSeconds: 3660, completed: false, mediaFileId: 31 },
+      },
+    });
+    expect(fixture.componentInstance.resumePositionSeconds()).toBeNull();
+
+    // The parent resolves the resume target — now the episode's own row shows.
+    fixture.componentRef.setInput('resumeEpisodeId', 3);
+    fixture.detectChanges();
+    // The fetch starts inside the effect, so let its promise chain settle
+    // before reading — `whenStable` alone doesn't track a bare promise.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.resumePositionSeconds()).toBe(1992);
+  });
 });

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -342,9 +342,12 @@ export class MediaInfoHeaderComponent {
     // playback_state row as before.
     if (this.mediaType() === 'series' && !episodeId) {
       this.watched.set(this.seriesFullyWatched());
-    } else {
-      this.playable.loadWatchedState(mediaId, episodeId).then(v => this.watched.set(v));
+      // A series' own row (episode IS NULL) is never its resume target, so
+      // reading it here only flashes a bar that the real episode then clears.
+      // The parent resolves `resumeEpisodeId` a moment later and re-runs this.
+      return;
     }
+    this.playable.loadWatchedState(mediaId, episodeId).then(v => this.watched.set(v));
 
     // Tracked read: a position queued offline shows up here as soon as it is
     // recorded, and again as soon as the flush clears it.


### PR DESCRIPTION
## Why

Opening a series (from the home page, for instance) briefly showed a progress bar that
vanished a moment later.

The header's playback effect keys on `episodeId ?? resumeEpisodeId`. On first render the
parent hasn't resolved `resumeEpisodeId` yet — it comes from `getMediaResumeInfo`, loaded
off the render path — so the key was `mediaId:0` and the header fetched the series' **own**
playback row (`episode IS NULL`). If that stale row held a position, the bar rendered from
it. Then `resumeEpisodeId` arrived, the key changed, the state reset, and the bar
disappeared.

## What

A series' media-level row is never its resume target — the header's own comment already
said as much about the label. So with no episode in scope it now settles the watched state
from `seriesFullyWatched` and stops, instead of reading a row it will discard. When the
parent resolves `resumeEpisodeId` the effect re-runs and reads that episode's row, which is
the only position that was ever meant to show.

Side effects: one fewer request per series page, and a series whose resume target never
resolves (nothing to resume) no longer shows a bar built from a stale media-level row —
that was the same bug without the flash.

Movies and episode pages are untouched: both have a real target in scope on the first run.

## Testing

New case in `media-info-header.spec.ts`: a series root with **both** a stale media-level row
and an episode row reports no resume position on first render, then picks up the episode's
1992 s once `resumeEpisodeId` resolves. It fails on the old code, which reported the
media-level position immediately.

`ng build` clean, full client suite green (549 tests, 65 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)