### PR TITLE
fix(home): don't morph an unrelated poster when opening a recent request

### DIFF
--- a/client/src/app/features/requests/request-card/request-card.ts
+++ b/client/src/app/features/requests/request-card/request-card.ts
@@ -13,6 +13,7 @@ import { RequestPosterComponent } from '../request-poster';
 import { RequestStatusBadgeComponent } from '../request-status-badge/request-status-badge.component';
 import { FliksRequestRow } from '../../../core/services/api/requests.service';
 import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
+import { clearPosterStamps } from '../../../shared/utils/view-transition';
 
 /**
  * Compact request card for the home "Demandes récentes" scroller: a fanart
@@ -73,6 +74,10 @@ export class RequestCardComponent {
    *  their own action without also navigating. */
   protected onCardActivate(event?: Event): void {
     event?.preventDefault();
+    // This card has no poster to morph from, so drop whatever card was stamped
+    // last — otherwise the media page animates in from an unrelated card that
+    // happens to show the same title.
+    clearPosterStamps();
     void this.router.navigate(this.mediaLink());
   }
 

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -13,6 +13,7 @@ import { IdentifyModalService } from '../../../core/services/identify-modal.serv
 import { TrackingModalService } from '../../../core/services/tracking-modal.service';
 import { CardActionsDirective } from '../../directives/card-actions.directive';
 import { SpoilerDirective } from '../../directives/spoiler.directive';
+import { stampPoster } from '../../utils/view-transition';
 import { CardAction, CardActionsService } from '../../../core/services/card-actions.service';
 import { AddToPlaylistService } from '../../../core/services/add-to-playlist.service';
 import { RecommendService } from '../../../core/services/recommend.service';
@@ -294,12 +295,7 @@ export class MediaCardComponent {
     const id = this.resolveMediaId();
     const img = this.imgRef()?.nativeElement;
     if (id == null || !img) return;
-    document
-      .querySelectorAll<HTMLImageElement>('img[style*="view-transition-name"]')
-      .forEach((el) => {
-        if (el !== img) el.style.viewTransitionName = '';
-      });
-    img.style.viewTransitionName = `media-poster-${id}`;
+    stampPoster(img, id);
   }
   protected readonly _playable = computed(() => {
     if (this.playable()) return true;

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -5,11 +5,13 @@
     <section class="space-y-3">
       <div class="flex flex-wrap items-center justify-between gap-2">
         @if (canManage()) {
-          <div class="flex gap-2 ml-auto">
+          <!-- Wraps rather than overflowing: the three labels don't fit one
+               phone-width line, and an overflow here scrolls the whole modal. -->
+          <div class="flex flex-wrap justify-end gap-2 ml-auto">
             @if (hasMissing()) {
               <button
                 type="button"
-                class="btn btn-ghost btn-sm shrink-0"
+                class="btn btn-ghost btn-sm"
                 [disabled]="searchDisabled() || subtitleActionBusy()"
                 [attr.title]="
                   searchDisabled() ? ('media_detail.subtitles_need_episode_file' | translate) : null
@@ -32,7 +34,7 @@
               />
               <button
                 type="button"
-                class="btn btn-ghost btn-sm shrink-0"
+                class="btn btn-ghost btn-sm"
                 [disabled]="searchDisabled() || subtitleActionBusy()"
                 [attr.title]="
                   searchDisabled() ? ('media_detail.subtitles_need_episode_file' | translate) : null
@@ -45,7 +47,7 @@
             }
             <button
               type="button"
-              class="btn btn-primary btn-sm shrink-0"
+              class="btn btn-primary btn-sm"
               [disabled]="searchDisabled() || subtitleActionBusy()"
               [attr.title]="
                 searchDisabled() ? ('media_detail.subtitles_need_episode_file' | translate) : null

--- a/client/src/app/shared/utils/view-transition.spec.ts
+++ b/client/src/app/shared/utils/view-transition.spec.ts
@@ -1,0 +1,39 @@
+import { clearPosterStamps, stampPoster } from './view-transition';
+
+/** The stamp deliberately outlives the click that set it (the back transition
+ *  reads it again), so the regressions worth guarding are both about a STALE
+ *  stamp pairing the destination poster with the wrong card. */
+describe('view-transition poster stamps', () => {
+  function img(): HTMLImageElement {
+    const el = document.createElement('img');
+    document.body.appendChild(el);
+    return el;
+  }
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('leaves only the newly stamped image named', () => {
+    const first = img();
+    const second = img();
+
+    stampPoster(first, 7);
+    expect(first.style.viewTransitionName).toBe('media-poster-7');
+
+    stampPoster(second, 9);
+    expect(second.style.viewTransitionName).toBe('media-poster-9');
+    // Same media in two rows would otherwise abort the transition on a
+    // duplicate name; a different media would animate from the wrong card.
+    expect(first.style.viewTransitionName).toBe('');
+  });
+
+  it('clears every stamp for a navigation that owns no poster', () => {
+    const card = img();
+    stampPoster(card, 7);
+
+    clearPosterStamps();
+
+    expect(card.style.viewTransitionName).toBe('');
+  });
+});

--- a/client/src/app/shared/utils/view-transition.ts
+++ b/client/src/app/shared/utils/view-transition.ts
@@ -1,0 +1,21 @@
+/**
+ * Poster morph between a media card and the media page.
+ *
+ * The stamp has to survive past the click — the browser snapshots on the next
+ * tick, and the back transition reads it again — so it is never cleared on a
+ * timer, only replaced. That makes a stale stamp the hazard: a navigation
+ * started from anything but a card would otherwise pair the destination poster
+ * with whatever card was stamped last. Those callers clear it instead.
+ */
+export function clearPosterStamps(except?: HTMLElement): void {
+  document
+    .querySelectorAll<HTMLElement>('img[style*="view-transition-name"]')
+    .forEach((el) => {
+      if (el !== except) el.style.viewTransitionName = '';
+    });
+}
+
+export function stampPoster(img: HTMLElement, mediaId: number): void {
+  clearPosterStamps(img);
+  img.style.viewTransitionName = `media-poster-${mediaId}`;
+}


### PR DESCRIPTION
Two unrelated UI fixes.

## 1. Wrong poster morph from a recent request

Clicking a card in home's *Recent requests* animated the media page in from a **different**
card — the recommendations row, when it happened to show the same title.

`MediaCardComponent` stamps `view-transition-name: media-poster-<id>` on its `<img>` at
click time, and deliberately leaves it there: the back transition (detail → card) needs the
name present at snapshot time, and clearing it on a timer killed that animation. A stale
stamp is the cost of that, and it only bites a navigation started from something that isn't
a media card — which is exactly what the request card is. The browser found the leftover
name and paired it with the destination poster.

The request card has no poster to morph from, so it now clears the stamps before
navigating: the media page just appears, no animation. The stamp/clear pair moved into
`shared/utils/view-transition.ts` — the same hazard applies to any future non-card entry
point, and the "wipe the others first" rule now lives with the stamp instead of inside the
card.

## 2. Subtitle modal overflows on a phone

With *Rechercher manquants*, *Importer* and *Rechercher* all visible, the action row didn't
fit and put a horizontal scrollbar on the whole dialog. The row was `flex` with no wrap and
`shrink-0` on every button.

Measured at 360 px against the built stylesheet:

| | container | buttons span | scrollW / clientW |
|---|---|---|---|
| before | 31 → 299 | 31 → **370** | 356 / 282 — overflow |
| after | 31 → 299 | 57 → 299 | 282 / 282 — fits |

It now wraps onto two lines, right-aligned as before.

## Testing

- New `view-transition.spec.ts`: stamping a second image clears the first (the
  duplicate-name abort and the wrong-card pairing), and `clearPosterStamps()` wipes a stamp
  left by a card.
- Overflow fix verified by measuring both layouts in headless Chromium against the real
  built CSS at 360 px, numbers above.
- `ng build` clean, full client suite green (551 tests, 66 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)