### PR TITLE
fix(subtitles): scroll the modal action row instead of wrapping it

### DIFF
--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -5,13 +5,14 @@
     <section class="space-y-3">
       <div class="flex flex-wrap items-center justify-between gap-2">
         @if (canManage()) {
-          <!-- Wraps rather than overflowing: the three labels don't fit one
-               phone-width line, and an overflow here scrolls the whole modal. -->
-          <div class="flex flex-wrap justify-end gap-2 ml-auto">
+          <!-- The three labels don't fit one phone-width line. `min-w-0` keeps
+               the overflow inside this row, so it scrolls on its own instead of
+               dragging the whole dialog sideways. -->
+          <div class="flex gap-2 ml-auto min-w-0 max-w-full overflow-x-auto py-0.5">
             @if (hasMissing()) {
               <button
                 type="button"
-                class="btn btn-ghost btn-sm"
+                class="btn btn-ghost btn-sm shrink-0"
                 [disabled]="searchDisabled() || subtitleActionBusy()"
                 [attr.title]="
                   searchDisabled() ? ('media_detail.subtitles_need_episode_file' | translate) : null
@@ -34,7 +35,7 @@
               />
               <button
                 type="button"
-                class="btn btn-ghost btn-sm"
+                class="btn btn-ghost btn-sm shrink-0"
                 [disabled]="searchDisabled() || subtitleActionBusy()"
                 [attr.title]="
                   searchDisabled() ? ('media_detail.subtitles_need_episode_file' | translate) : null
@@ -47,7 +48,7 @@
             }
             <button
               type="button"
-              class="btn btn-primary btn-sm"
+              class="btn btn-primary btn-sm shrink-0"
               [disabled]="searchDisabled() || subtitleActionBusy()"
               [attr.title]="
                 searchDisabled() ? ('media_detail.subtitles_need_episode_file' | translate) : null


### PR DESCRIPTION
Follow-up to #1114, which fixed the phone-width overflow by wrapping the row. Wrapping
works but spends a second line at the top of the dialog; scrolling the row keeps the
buttons on one line.

`min-w-0` is the load-bearing part: the row is a flex item, and its default `min-width:
auto` refuses to shrink below its content, so `overflow-x-auto` alone would leave the
dialog scrolling sideways exactly as before.

Measured at 360 px against the built stylesheet:

| element | clientW | scrollW | |
|---|---|---|---|
| button row | 282 | 356 | scrolls on its own |
| outer row | 282 | 282 | overflow stays contained |
| `.modal-box` | 330 | 330 | dialog never drags sideways |

Row height back to 34 px (one line) from 68 px (wrapped).

## Testing

Both layouts measured in headless Chromium against the real built CSS at 360 px, numbers
above. `ng build` clean, full client suite green (551 tests, 66 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)