### PR TITLE
fix(card-actions): pad the top of the actions panel header

### DIFF
--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
@@ -27,7 +27,7 @@
               [style.aspect-ratio]="imageAspect() === 'landscape' ? '16 / 9' : '2 / 3'" />
           }
           <div class="min-w-0">
-            <div class="text-sm font-semibold line-clamp-2">{{ title() }}</div>
+            <div class="text-sm font-bold line-clamp-2">{{ title() }}</div>
             @if (subtitle()) {
               <div class="text-xs text-base-content/60 line-clamp-2">{{ subtitle() }}</div>
             }

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
@@ -17,7 +17,9 @@
   } @else {
     <div [class.panel-slide-back]="slide() === 'back'">
       @if (title()) {
-        <div class="flex items-start gap-3 px-2 pb-3 mb-1 border-b border-base-content/10">
+        <!-- pt matches the pb: the panel's own p-2 alone left the header
+             crowding the top edge. -->
+        <div class="flex items-start gap-3 px-2 pt-2 pb-3 mb-1 border-b border-base-content/10">
           @if (imageUrl(); as img) {
             <img [cachedSrc]="img | resolveUrl" alt="" loading="lazy"
               class="shrink-0 rounded object-cover bg-base-300"


### PR DESCRIPTION
The titled header of an actions menu (e.g. *Anglais* above *Visualiser* / *Télécharger* on
a subtitle row) sat too close to the panel's top edge: the block had `pb-3 mb-1` and no top
padding, so the popover's own `p-2` was the only gap — 8 px above against 16 px below.

Now `pt-2`, which balances it in both presentations: 16 px above the title in the desktop
dropdown, 12 px in the mobile sheet where the drag handle already contributes 4 px. The
title also goes from `font-semibold` to `font-bold` — at semibold it read as one more row
of the menu rather than its heading.

## Scope

This is the generic component, so the one edit covers every action menu in the app — media
cards, the media detail header and the subtitle rows all go through
`CardActionsService.register()` and render in this single panel.

The sibling `app-popover-menu` consumers were checked for the same defect and none has it:
`select-picker`'s title block already carries a symmetric `py-2`, `multi-select`'s pinned
filter has `pt-2`, and `dropdown-menu` renders no header at all. So there was nothing to
hoist further up into `popover-menu` itself.

## Testing

`ng build` clean, full client suite green (551 tests, 66 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)