### PR TITLE
fix(bottom-sheet): keep the host out of an enclosing modal's grid

### DIFF
--- a/client/src/app/shared/components/bottom-sheet.ts
+++ b/client/src/app/shared/components/bottom-sheet.ts
@@ -19,6 +19,11 @@ import { TABBABLE_SELECTOR } from '../../core/services/focusable.constants';
   selector: 'app-bottom-sheet',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  // Same reason as `app-popover-menu`: the backdrop and sheet are
+  // `position: fixed`, so the host needs no box — and left with one it becomes
+  // a stray grid item in a parent like daisyUI's `.modal` (display: grid),
+  // adding a row that pushes the modal-box off-centre and covers the backdrop.
+  styles: [':host { display: contents; }'],
   template: `
     @if (visible()) {
       <!-- Backdrop — CSS @starting-style handles the fade-in declaratively


### PR DESCRIPTION
## Symptoms

Opening the *Actions* sheet from a row of the subtitles modal on mobile:

1. the modal, centred until then, jumped upward;
2. it stayed up after the sheet was dismissed;
3. tapping below it no longer closed it.

## Cause

`app-popover-menu` reparents its host into the open `<dialog>` on every open — `showModal()`
puts the dialog in the browser top layer, above every z-index, so a menu mounted at the app
root would otherwise render behind it. It already carries `:host { display: contents }` so
the relocated host doesn't disturb the dialog's layout, and the comment there names this
exact hazard.

Its `app-bottom-sheet` child had no such rule. daisyUI's `.modal` is
`display: grid; align-items: center`, and **both** `.modal-box` and `.modal-backdrop` are
pinned to `grid-row-start: 1`. The sheet host, blockified as a grid item, auto-placed into a
**row 2**:

- the grid now has two rows, so the vertically centred box rises by half the new row — (1);
- `.modal-backdrop` covers row 1 only, so the area below the box is no longer the
  close-on-click form and taps there reach the bare `<dialog>` — (3);
- the sheet stays mounted after dismissal to play its slide-down exit, so the row (and both
  effects) outlive it — (2).

Measured in headless Chromium against the built stylesheet, dialog centred in a 494 px
viewport:

| `app-bottom-sheet` | `.modal-box` centre | viewport centre |
|---|---|---|
| default (grid item) | 141 | 247 |
| `display: contents` | 247 | 247 |

## Fix

`:host { display: contents }` on `BottomSheetComponent`, mirroring `app-popover-menu`. The
backdrop and the sheet are both `position: fixed`, so the host never needed a box.

The other consumers (`dropdown-menu`, the four player-controls sheets) are unaffected —
none relied on the host generating a box, and all its children are fixed.

## Testing

Both layouts measured in headless Chromium against the real built CSS, numbers above.
`ng build` clean, full client suite green (551 tests, 66 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)