### PR TITLE
feat(subtitles): bleed the table to the modal edges on a phone

### DIFF
--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -2,7 +2,9 @@
   <div class="modal-box w-11/12 max-w-5xl">
     <app-modal-header [title]="'media_detail.edit_subtitles' | translate" />
 
-    <section class="space-y-3">
+    <!-- On a phone the table band runs into the footer, whose own top border
+         closes it; -mb-6 cancels the footer bar's 1.5rem top margin. -->
+    <section class="space-y-3 -mb-6 sm:mb-0">
       <div class="flex flex-wrap items-center justify-between gap-2">
         @if (canManage()) {
           <!-- The three labels don't fit one phone-width line. `min-w-0` keeps

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -68,7 +68,11 @@
       } @else if (rows().length === 0) {
         <p class="text-sm text-base-content/50">{{ 'media_detail.no_subtitles' | translate }}</p>
       } @else {
-        <div class="rounded-lg border border-base-200 overflow-x-auto">
+        <!-- Phone only: -mx-6 cancels the modal-box's 1.5rem padding so the
+             rule reaches both edges, like the header and footer bars. Top rule
+             only — the footer's own border closes the band. From sm it goes
+             back to an inset, rounded card. -->
+        <div class="-mx-6 border-t border-base-200 overflow-x-auto sm:mx-0 sm:rounded-lg sm:border">
           <table class="table">
             <thead>
               <tr>
@@ -197,6 +201,12 @@
         }
       }
     </section>
+
+    <app-modal-footer>
+      <form method="dialog">
+        <button class="btn">{{ 'common.close' | translate }}</button>
+      </form>
+    </app-modal-footer>
   </div>
 
   <form method="dialog" class="modal-backdrop">

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -71,10 +71,10 @@
         <p class="text-sm text-base-content/50">{{ 'media_detail.no_subtitles' | translate }}</p>
       } @else {
         <!-- Phone only: -mx-6 cancels the modal-box's 1.5rem padding so the
-             rule reaches both edges, like the header and footer bars. Top rule
-             only — the footer's own border closes the band. From sm it goes
-             back to an inset, rounded card. -->
-        <div class="-mx-6 border-t border-base-200 overflow-x-auto sm:mx-0 sm:rounded-lg sm:border">
+             table reaches both edges, like the header and footer bars. No
+             border of its own — the header and footer rules frame it. From sm
+             it goes back to an inset, rounded card. -->
+        <div class="-mx-6 overflow-x-auto sm:mx-0 sm:rounded-lg sm:border sm:border-base-200">
           <table class="table">
             <thead>
               <tr>


### PR DESCRIPTION
**Not for merge yet — for visual review.**

At phone width the subtitles table sat inset inside the `.modal-box`'s 1.5rem of side
padding, spending it on a grid that already has to scroll sideways. It now bleeds to both
edges and runs straight into the footer, the way the releases modal's body does with its
`p-0` box + `sm:px-6`.

- `-mx-6` cancels the box's side padding exactly (`.modal-box` padding is `calc(0.25rem * 6)`).
- No border and no rounding at all on a phone — the header and footer rules already frame
  the band. `sm:mx-0 sm:rounded-lg sm:border` restores the inset card from `sm` up, so
  nothing changes on desktop.
- `-mb-6` on the section cancels the footer bar's 1.5rem top margin, so the table meets the
  footer instead of floating above it.
- The dialog gains the **Close** button the releases modal has. `app-modal-footer` without
  `flush` already bleeds out of a padded box via `.modal-footer-bar`, so no extra plumbing.

Measured against the built stylesheet, phone branch (base classes, no `sm:`):

| | |
|---|---|
| table container edges | `18..697` — identical to `.modal-box` |
| borders / radius | none |
| gap between table and footer | **0.0 px** |
| footer bottom vs box bottom | `219` / `219` |

The first cell's text sits 8px inside the modal's own text column — the table's cell padding
is 1rem against the box's 1.5rem. Left as is; say the word if you want them aligned.

## Testing

`ng build` clean, full client suite green (551 tests, 66 files). Geometry measured in
headless Chromium against the real built CSS. Not yet eyeballed on a real phone — that's
what this PR is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)