### PR TITLE
fix(media-detail): close the highlighted card border and keep the current season in the row

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -59,6 +59,8 @@ export function loadPersistedState(): Promise<unknown> {
     .catch(() => undefined);
 }
 
+const EPISODE_PATH = 'series/:id/episode/:episodeId';
+
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
@@ -70,7 +72,22 @@ export const appConfig: ApplicationConfig = {
       withInMemoryScrolling({ scrollPositionRestoration: 'top' }),
       // Poster→hero morph. Off on Capacitor: its WebView never completes a snapshot
       // capture for a launch-created document, so every navigation waits Chrome's 4s timeout.
-      ...(Capacitor.isNativePlatform() ? [] : [withViewTransitions()]),
+      ...(Capacitor.isNativePlatform()
+        ? []
+        : [
+            withViewTransitions({
+              // Episode → episode: the cross-fade keeps the old page (and its scroll
+              // offset) on screen, so the jump to top only lands once it ends.
+              onViewTransitionCreated: ({ transition, from, to }) => {
+                if (
+                  from.routeConfig?.path === EPISODE_PATH &&
+                  to.routeConfig?.path === EPISODE_PATH
+                ) {
+                  transition.skipTransition();
+                }
+              },
+            }),
+          ]),
     ),
     { provide: RouteReuseStrategy, useExisting: CachingReuseStrategy },
     provideHttpClient(

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -97,14 +97,14 @@
           />
         }
 
-        @if (otherSeasons().length) {
+        @if (seasonsRow().length > 1) {
           <div class="divider my-6"></div>
           <app-collapsible-section
             [heading]="'media_detail.other_seasons_of' | translate: { title: m.title }"
             persistKey="otherSeasons"
           >
             <app-horizontal-scroller>
-              @for (other of otherSeasons(); track other.id) {
+              @for (other of seasonsRow(); track other.id) {
                 <app-media-card
                   class="shrink-0 w-28 sm:w-32 lg:w-40"
                   [aspect]="'portrait'"
@@ -115,6 +115,7 @@
                   [replaceUrl]="true"
                   [interactiveWatched]="true"
                   [status]="seasonFullyWatched(other) ? 'watched' : null"
+                  [highlighted]="other.id === focusedSeason()?.id"
                   (watchedToggled)="onToggleSeasonWatched(m.id, other, $event)"
                 />
               }

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -466,16 +466,16 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   });
 
   /**
-   * Sibling seasons rendered as cards under the "more from season N" row on
-   * the episode detail page. Hides the currently-focused season and any
-   * empty season (no episodes → no link target).
+   * Seasons rendered as cards under the "more from season N" row on the
+   * episode detail page. Keeps the focused season in place — highlighted, so
+   * the row doubles as a position indicator. Empty seasons drop out: no
+   * episodes, no link target.
    */
-  readonly otherSeasons = computed<Season[]>(() => {
+  readonly seasonsRow = computed<Season[]>(() => {
     const m = this.media();
-    const focused = this.focusedSeason();
-    if (!m?.seasons || !focused) return [];
+    if (!m?.seasons || !this.focusedSeason()) return [];
     return m.seasons
-      .filter((s) => s.id !== focused.id && (s.episodes?.length ?? 0) > 0)
+      .filter((s) => (s.episodes?.length ?? 0) > 0)
       .slice()
       .sort((a, b) => a.seasonNumber - b.seasonNumber);
   });

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -27,7 +27,7 @@
         #cardImg
         [cachedSrc]="_img()! | resolveUrl:'thumb'"
         [alt]="_title()"
-        class="w-full h-full object-cover select-none rounded-lg"
+        class="w-full h-full object-cover select-none"
         style="-webkit-user-drag: none; user-drag: none;"
         draggable="false"
         [appSpoiler]="spoiler()"


### PR DESCRIPTION
## Highlighted card border had a gap in every corner

The card `<img>` carried its own `rounded-lg`. It is drawn at the full outer
radius, while `border-2` shrinks the figure's inner radius by 2px — the two
curves diverge and the `bg-base-300` behind shows through at each corner. Most
visible on the open episode, the only card that gets `[highlighted]`.

The figure already clips its children with `overflow-hidden rounded-lg`, so the
img needs no radius of its own. Dropping it makes the image follow the border's
inner radius exactly.

## Jump to top lagged when opening another episode

Episode → episode navigation ran the root cross-fade from `withViewTransitions`.
The outgoing snapshot is pinned to the viewport at its outgoing scroll offset, so
the router's scroll-to-top had already happened underneath by the time the fade
ended — it read as a slow scroll.

That transition morphs nothing between two episodes: `media-card` deliberately
skips poster stamping for episode links, so it is a bare fade. Skipped via
`onViewTransitionCreated`, matched on the route config path so only
episode → episode is affected. Series → episode and episode → series keep their
poster morph.

Not addressed here: the browser's own smooth-scroll duration is distance-derived
and has no CSS knob, so the remaining animation is whatever the engine picks.
Changing it needs a custom `ViewportScroller` with a hand-rolled tween, which is
not worth it.

## "Other seasons" row skipped the season being watched

The row filtered out the focused season, so it gave no sense of where you were in
the series. It now lists every non-empty season, with the current one highlighted
the same way the current episode is, and renders only when there is more than one
season to show.

## Test

- `npx tsc -p tsconfig.app.json --noEmit` — clean
- `npx ng build --configuration development` — clean
- `npx ng test --include='**/media-card.spec.ts'` — 30 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)