### PR TITLE
fix(media-card): place artwork behind a placeholder and drop the cold-start bridge wait

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -39,6 +39,7 @@ import { SessionStoreService } from './core/services/session-store.service';
 import { translateBrowserLoaderFactory } from './utils/translate-loader';
 import { PluginUiRegistryService } from './core/plugin-ui/plugin-ui-registry.service';
 import { PluginI18nService } from './core/plugin-ui/plugin-i18n.service';
+import { ImageCacheService } from './core/services/image-cache.service';
 
 /** Read the persisted server URL, sessions and credentials before bootstrap:
  *  guards, interceptors and the first /auth/me all depend on them. Resolves
@@ -52,7 +53,8 @@ export function loadPersistedState(): Promise<unknown> {
   const auth = inject(AuthService);
   const pluginUi = inject(PluginUiRegistryService);
   const pluginI18n = inject(PluginI18nService);
-  return Promise.all([serverConfig.load(), sessions.load()])
+  const imageCache = inject(ImageCacheService);
+  return Promise.all([serverConfig.load(), sessions.load(), imageCache.warm()])
     .then(() => void auth.loadPersistedSession())
     .then(() => pluginUi.load())
     .then(() => pluginI18n.init())

--- a/client/src/app/core/services/image-cache.service.ts
+++ b/client/src/app/core/services/image-cache.service.ts
@@ -44,6 +44,32 @@ export class ImageCacheService {
   /** The sandbox container path changes across installs, so it is resolved at
    *  runtime rather than assumed. */
   private baseUri: Promise<string | null> | null = null;
+  /** Settled value of {@link baseUri}, for the synchronous path. */
+  private baseUriValue: string | null = null;
+
+  /** Resolve the container path up front. Every cached image otherwise awaits
+   *  this one bridge call, which leaves a whole cold-start grid without a src. */
+  async warm(): Promise<void> {
+    if (!this.enabled) return;
+    this.load();
+    await this.resolveBaseUri();
+  }
+
+  /**
+   * Same as {@link resolve} but without the bridge, so a binding can set `src`
+   * in the same frame. Null when the answer isn't already in memory — the
+   * caller falls back to the async path.
+   */
+  resolveNow(remoteUrl: string): string | null {
+    if (!this.cacheable(remoteUrl)) return remoteUrl;
+    if (!this.baseUriValue) return null;
+    this.load();
+    const key = cacheKey(remoteUrl);
+    const entry = this.index.get(key);
+    if (!entry) return null;
+    this.index.set(key, [entry[0], Date.now()]);
+    return Capacitor.convertFileSrc(`${this.baseUriValue}/${entry[0]}`);
+  }
 
   /**
    * URL to actually render for a remote image: the on-disk copy when there is
@@ -160,6 +186,7 @@ export class ImageCacheService {
       try {
         const { Filesystem, Directory } = await getFs();
         const { uri } = await Filesystem.getUri({ path: DIR, directory: Directory.Data });
+        this.baseUriValue = uri;
         return uri;
       } catch {
         return null;

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -22,23 +22,27 @@
     (keydown.enter)="onCardClick()"
     (keydown.space)="onCardClick(); $event.preventDefault()"
   >
-    @if (_img()) {
+    @if (_img() && !imgFailed()) {
       <img
         #cardImg
         [cachedSrc]="_img()! | resolveUrl:'thumb'"
         [alt]="_title()"
-        class="w-full h-full object-cover select-none"
+        class="w-full h-full object-cover select-none transition-opacity duration-200"
         style="-webkit-user-drag: none; user-drag: none;"
         draggable="false"
         [appSpoiler]="spoiler()"
         #spoilerImg="spoiler"
         [class.scale-110]="spoilerImg.masked()"
         [class.grayscale]="grayscale()"
+        [class.opacity-0]="!imgLoaded()"
         loading="lazy"
         decoding="async"
+        (load)="imgLoaded.set(true)"
+        (error)="imgFailed.set(true)"
       />
-    } @else {
-      <div class="flex items-center justify-center w-full h-full text-base-content/20">
+    }
+    @if (!imgLoaded()) {
+      <div class="absolute inset-0 flex items-center justify-center bg-base-300 text-base-content/20">
         <svg lucideFilm class="h-12 w-12" [strokeWidth]="1.5"></svg>
       </div>
     }

--- a/client/src/app/shared/components/media-card/media-card.spec.ts
+++ b/client/src/app/shared/components/media-card/media-card.spec.ts
@@ -541,3 +541,51 @@ describe('MediaCardComponent — card.actions merges with plugin contributions',
     expect(labels(notInLibrary)).not.toContain('media_detail.refresh_metadata');
   });
 });
+
+/**
+ * Artwork placeholder. Android resolves cached posters over the Capacitor
+ * bridge, so a card can hold an unpainted <img> for a frame or two at cold
+ * start; a poster URL that outlived its file never paints at all. Both must
+ * show the film glyph rather than the WebView's broken-image icon.
+ */
+describe('media-card artwork placeholder', () => {
+  const placeholder = (h: Harness) =>
+    h.fixture.nativeElement.querySelector('svg.lucide-film');
+  const img = (h: Harness): HTMLImageElement | null =>
+    h.fixture.nativeElement.querySelector('img');
+
+  it('shows the placeholder with no poster at all', async () => {
+    const h = await createFixture(FULL_MEMBER, { media: makeMedia() });
+    expect(placeholder(h)).toBeTruthy();
+    expect(img(h)).toBeNull();
+  });
+
+  it('keeps the placeholder until the poster actually loads', async () => {
+    const h = await createFixture(FULL_MEMBER, {
+      media: makeMedia({ posterUrl: '/api/images/1.jpg' }),
+    });
+    expect(placeholder(h)).toBeTruthy();
+    expect(img(h)!.classList).toContain('opacity-0');
+
+    img(h)!.dispatchEvent(new Event('load'));
+    h.fixture.detectChanges();
+    await h.fixture.whenStable();
+    h.fixture.detectChanges();
+
+    expect(placeholder(h)).toBeNull();
+    expect(img(h)!.classList).not.toContain('opacity-0');
+  });
+
+  it('falls back to the placeholder when the poster fails to load', async () => {
+    const h = await createFixture(FULL_MEMBER, {
+      media: makeMedia({ posterUrl: '/api/images/gone.jpg' }),
+    });
+    img(h)!.dispatchEvent(new Event('error'));
+    h.fixture.detectChanges();
+    await h.fixture.whenStable();
+    h.fixture.detectChanges();
+
+    expect(img(h)).toBeNull();
+    expect(placeholder(h)).toBeTruthy();
+  });
+});

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, ElementRef, input, output, computed, inject, viewChild } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ElementRef, input, output, computed, inject, linkedSignal, viewChild } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { NgClass, DecimalPipe } from '@angular/common';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -180,6 +180,15 @@ export class MediaCardComponent {
 
   // Resolved template values (explicit input wins over media-derived default)
   protected readonly _img = computed(() => this.imageUrl() ?? this.media()?.posterUrl ?? null);
+  /** Both reset by every new image, so a card recycled by @for retries. */
+  protected readonly imgLoaded = linkedSignal<string | null, boolean>({
+    source: this._img,
+    computation: () => false,
+  });
+  protected readonly imgFailed = linkedSignal<string | null, boolean>({
+    source: this._img,
+    computation: () => false,
+  });
   protected readonly _title = computed(() => this.title() || this.media()?.title || '');
   protected readonly _rating = computed(() => this.rating() || this.media()?.rating || 0);
   protected readonly _link = computed(() => {

--- a/client/src/app/shared/directives/cached-src.directive.ts
+++ b/client/src/app/shared/directives/cached-src.directive.ts
@@ -27,6 +27,13 @@ export class CachedSrcDirective {
         this.el.setAttribute('src', url);
         return;
       }
+      // Same frame when the cache can answer without the bridge: awaiting it
+      // leaves a whole cold-start grid src-less for as long as the round-trip.
+      const now = this.cache.resolveNow(url);
+      if (now) {
+        this.el.setAttribute('src', now);
+        return;
+      }
       void this.cache.resolve(url).then((resolved) => {
         if (token === this.seq) this.el.setAttribute('src', resolved);
       });


### PR DESCRIPTION
Reported on Android: at every app open the home grid shows broken images for a
fraction of a second before the posters appear.

## Why the grid comes up empty

`CachedSrcDirective` sets `src` only once `ImageCacheService.resolve()` settles.
That call awaits `resolveBaseUri()`, a `Filesystem.getUri` round-trip over the
Capacitor bridge, resolved lazily on first use — so every cached image on screen
waits on the *same* pending call, and the whole visible grid holds an `<img>`
with no `src` attribute until it returns.

Web never saw this: `cache.enabled` is false there (the Angular service worker
already caches `/api/images/**`) and `src` is set synchronously.

- `warm()` resolves the container path during bootstrap, inside the `Promise.all`
  the app initializer already awaits, so it costs no extra startup time.
- `resolveNow()` answers from the in-memory index with no bridge hop, and the
  directive tries it before falling back to the async path.

## Placeholder

The card's film glyph was an `@else` branch, so it only covered "no poster URL at
all". It is now a layer under the image, shown until `(load)` fires and restored
on `(error)`. A slow poster, a missing one, and a URL that outlived its file all
get the glyph rather than the WebView's broken-image icon. The image fades in
over 200 ms.

`imgLoaded` / `imgFailed` are `linkedSignal`s keyed on the image URL — the same
pattern `user-avatar` already uses for its own fallback — so a card recycled by
`@for` retries instead of staying stuck on a previous item's failure.

## Known gap

A poster URL whose cached file was deleted out from under the index now shows the
placeholder instead of a broken icon, but will not recover until that index entry
is evicted. Not addressed here — no evidence it happens in practice.

## Test

- `npx tsc -p tsconfig.app.json --noEmit` — clean
- `npx ng build --configuration development` — clean
- `npx ng test --include='**/media-card.spec.ts'` — 33 passed, including 3 new
  cases: no poster, poster not yet loaded, poster fails to load

🤖 Generated with [Claude Code](https://claude.com/claude-code)