### PR TITLE
fix(streaming): measure the real frame rate, and anchor every run onto the source start_time

### DIFF
--- a/backend/src/modules/streaming/services/segment-packaging.service.ts
+++ b/backend/src/modules/streaming/services/segment-packaging.service.ts
@@ -36,7 +36,12 @@ export class SegmentPackagingService {
     res: Response,
     filePath: string,
     contentType: string,
-    opts: { segDuration: number; skipTimelineRewrite?: boolean },
+    opts: {
+      segDuration: number;
+      /** Source video `start_time`, the origin every run is anchored onto. */
+      startPts?: number;
+      skipTimelineRewrite?: boolean;
+    },
   ): Promise<void> {
     // TS segments aren't fMP4/CMAF — the CMAF rewrite and tfdt anchoring are
     // no-ops on them, and running an ISO-BMFF box parser over MPEG-TS bytes is
@@ -74,7 +79,12 @@ export class SegmentPackagingService {
     // the anchor is a no-op — only remux must skip it.
     const out = opts.skipTimelineRewrite
       ? buf
-      : await this.anchorSegmentTimeline(filePath, buf, opts.segDuration);
+      : await this.anchorSegmentTimeline(
+          filePath,
+          buf,
+          opts.segDuration,
+          opts.startPts ?? 0,
+        );
     res.setHeader('Content-Type', contentType);
     res.setHeader('Content-Length', String(out.length));
     res.setHeader('Access-Control-Allow-Origin', '*');
@@ -88,20 +98,21 @@ export class SegmentPackagingService {
   }
 
   /** Anchor a media segment onto the single absolute presentation timeline:
-   *  rewrite its `tfdt` so `seg-N` decodes at its true content time
-   *  `N · segDuration` (per-track timescale), instead of FFmpeg's per-run
-   *  0-based reset. Init segments and MPEG-TS segments carry no `tfdt` and pass
+   *  rewrite its `tfdt` so `seg-N` decodes at its true presentation time
+   *  `N · segDuration + startPts` (per-track timescale), instead of FFmpeg's
+   *  per-run 0-based reset. Init segments and MPEG-TS segments carry no `tfdt` and pass
    *  through unchanged. */
   private async anchorSegmentTimeline(
     filePath: string,
     buf: Buffer,
     segDuration: number,
+    startPts: number,
   ): Promise<Buffer> {
     const m = /(?:^|\/)seg-(\d+)\.m4s$/.exec(filePath);
     if (!m) return buf;
     const tracks = await this.tracksForDir(path.dirname(filePath));
     if (tracks.size === 0) return buf;
-    return rewriteSegmentTfdt(buf, tracks, Number(m[1]), segDuration);
+    return rewriteSegmentTfdt(buf, tracks, Number(m[1]), segDuration, startPts);
   }
 
   private async tracksForDir(

--- a/backend/src/modules/streaming/services/session-context-builder.service.ts
+++ b/backend/src/modules/streaming/services/session-context-builder.service.ts
@@ -72,6 +72,8 @@ export class SessionContextBuilder {
       // accurate GOP so IDR frames fall on the same boundary regardless of
       // source fps. Falls back to 24 when unknown.
       sourceFps: parseSourceFps(si?.video?.[0]?.frameRate),
+      // Source video start_time — the origin the served timeline is anchored to.
+      sourceStartPts: si?.video?.[0]?.startTimeSeconds ?? 0,
       // Source colorimetry — preserved through an SDR transcode so the output
       // signals the source's real matrix/primaries/transfer, not a forced BT.709.
       sourceColorSpace: si?.video?.[0]?.colorSpace,

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1688,6 +1688,7 @@ export class StreamingController {
           this.segDur(videoSession),
           videoSession.sourceFps,
         ),
+        startPts: videoSession.sourceStartPts,
       },
     );
   }
@@ -1924,7 +1925,10 @@ export class StreamingController {
           res,
           initPath,
           segmentContentType(segment),
-          { segDuration: realSegmentSeconds(this.segDur(src), src.sourceFps) },
+          {
+            segDuration: realSegmentSeconds(this.segDur(src), src.sourceFps),
+            startPts: src.sourceStartPts,
+          },
         );
         return;
       }
@@ -1960,6 +1964,7 @@ export class StreamingController {
           segPath,
           segmentContentType(segment),
           {
+            startPts: existing.sourceStartPts,
             segDuration: realSegmentSeconds(
               this.segDur(existing),
               existing.sourceFps,
@@ -2064,6 +2069,7 @@ export class StreamingController {
                 this.segDur(earlySession),
                 earlySession.sourceFps,
               ),
+              startPts: earlySession.sourceStartPts,
             },
           );
           return;
@@ -2157,6 +2163,7 @@ export class StreamingController {
       segmentContentType(segment),
       {
         segDuration: realSegmentSeconds(this.segDur(session), session.sourceFps),
+        startPts: session.sourceStartPts,
         skipTimelineRewrite: quality === 'remux',
       },
     );

--- a/backend/src/modules/streaming/transcoding/timeline.spec.ts
+++ b/backend/src/modules/streaming/transcoding/timeline.spec.ts
@@ -33,6 +33,25 @@ function buildInit(trackId = 1, timescale = TS, handler = 'vide'): Buffer {
   return box('moov', trak);
 }
 
+function buildTrak(trackId: number, timescale: number, handler: string): Buffer {
+  const tkhd = box('tkhd', Buffer.concat([Buffer.alloc(12), u32(trackId)]));
+  const mdhd = box('mdhd', Buffer.concat([Buffer.alloc(12), u32(timescale)]));
+  const hdlr = box(
+    'hdlr',
+    Buffer.concat([Buffer.alloc(8), Buffer.from(handler, 'latin1')]),
+  );
+  return box('trak', Buffer.concat([tkhd, box('mdia', Buffer.concat([mdhd, hdlr]))]));
+}
+
+/** One moov carrying both a video and an audio trak — the inline (non
+ *  var_stream_map) shape, where one segment holds fragments for both. */
+function buildInitAv(): Buffer {
+  return box(
+    'moov',
+    Buffer.concat([buildTrak(1, TS, 'vide'), buildTrak(2, TS, 'soun')]),
+  );
+}
+
 function buildSeg(tfdtValue: number, trackId = 1): Buffer {
   // tfhd: fullbox(4) track_ID(4) → id @4
   const tfhd = box('tfhd', Buffer.concat([Buffer.alloc(4), u32(trackId)]));
@@ -125,6 +144,66 @@ describe('rewriteSegmentTfdt', () => {
       const off = Math.round((100 + START) * TS) + 0.04 * TS;
       const out = rewriteSegmentTfdt(buildSeg(off), tracks, 25, SEG, START);
       expect(readTfdt(out)).toBe(off);
+    });
+  });
+
+  /**
+   * A/V alignment is the property this whole file exists to protect (#756,
+   * #771, #791). Two ways it can break here, both load-bearing:
+   *
+   * Within one segment every track takes the SAME shift, so their relative
+   * offset survives. Across a var_stream_map session video and audio are
+   * separate renditions anchored independently, so both branches must agree on
+   * the origin — including the start_time part, which is not a grid multiple
+   * and which the audio branch's grid snap will silently round away if it is
+   * not removed before snapping and restored after.
+   */
+  describe('audio stays aligned to video', () => {
+    const audioOnly = parseInitTracks(buildInit(2, TS, 'soun'));
+    const START = 2.8;
+
+    it('shifts every track of a segment by the same amount', () => {
+      const both = parseInitTracks(buildInitAv());
+      // Audio sits 0.5s after video inside the run; that gap must survive.
+      const seg = Buffer.concat([buildSeg(0, 1), buildSeg(0.5 * TS, 2)]);
+      const out = rewriteSegmentTfdt(seg, both, 25, SEG, START);
+
+      const tfdts: number[] = [];
+      for (let i = out.indexOf(Buffer.from('tfdt', 'latin1')); i !== -1; ) {
+        tfdts.push(out.readUInt32BE(i + 8));
+        i = out.indexOf(Buffer.from('tfdt', 'latin1'), i + 1);
+      }
+      expect(tfdts).toEqual([(100 + START) * TS, (100.5 + START) * TS]);
+    });
+
+    it('lands an audio rendition on the same origin as its video rendition', () => {
+      // The anchor shifts the run, not the fragment: an audio fragment 20ms
+      // into its segment stays 20ms in. What must match is the shift applied.
+      const v = readTfdt(rewriteSegmentTfdt(buildSeg(0, 1), tracks, 25, SEG, START)) - 0;
+      const a =
+        readTfdt(rewriteSegmentTfdt(buildSeg(0.02 * TS, 2), audioOnly, 25, SEG, START)) -
+        0.02 * TS;
+      expect(a).toBe(v);
+      expect(a).toBe((100 + START) * TS);
+    });
+
+    it('leaves an absolute audio rendition alone rather than inventing a shift', () => {
+      const at = Math.round((100 + START) * TS);
+      const out = rewriteSegmentTfdt(buildSeg(at, 2), audioOnly, 25, SEG, START);
+      expect(readTfdt(out)).toBe(at);
+    });
+
+    // The pre-existing behaviour, unchanged: with no start_time the snap is a
+    // plain grid round and a run at 0 is left alone.
+    it('behaves exactly as before when start_time is 0', () => {
+      // Run-relative: snapped to a 100s run origin, fragment keeps its 20ms.
+      expect(readTfdt(rewriteSegmentTfdt(buildSeg(0.02 * TS, 2), audioOnly, 25, SEG))).toBe(
+        100.02 * TS,
+      );
+      // Absolute: left alone.
+      expect(readTfdt(rewriteSegmentTfdt(buildSeg(100 * TS, 2), audioOnly, 25, SEG))).toBe(
+        100 * TS,
+      );
     });
   });
 });

--- a/backend/src/modules/streaming/transcoding/timeline.spec.ts
+++ b/backend/src/modules/streaming/transcoding/timeline.spec.ts
@@ -77,4 +77,54 @@ describe('rewriteSegmentTfdt', () => {
     const out = rewriteSegmentTfdt(buildSeg(98 * TS), tracks, 25, SEG);
     expect(readTfdt(out)).toBe(100 * TS); // 98s corrupted to 100s — the bug
   });
+
+  /**
+   * A source whose video starts at a non-zero PTS (TS captures, PVR rips). The
+   * run spawned at 0 keeps that origin — ffmpeg's `-copyts` passes absolute PTS
+   * through — so a run spawned mid-file has to be anchored onto it as well, or
+   * the two disagree by exactly `start_time`. The WebVTT `X-TIMESTAMP-MAP` adds
+   * `start_time` unconditionally, so it can only ever be right for one of them:
+   * subtitles ran `start_time` late on every seeked or resumed session.
+   */
+  describe('a source with a non-zero start_time', () => {
+    const START = 2.8;
+
+    it('leaves a run started at 0 exactly where ffmpeg put it', () => {
+      // seg-25 of an absolute run decodes at 100 + 2.8 = its own tfdt already.
+      const out = rewriteSegmentTfdt(
+        buildSeg((100 + START) * TS),
+        tracks,
+        25,
+        SEG,
+        START,
+      );
+      expect(readTfdt(out)).toBe((100 + START) * TS);
+    });
+
+    it('anchors a mid-file run onto the same origin, not onto bare content time', () => {
+      const out = rewriteSegmentTfdt(buildSeg(0), tracks, 25, SEG, START);
+      expect(readTfdt(out)).toBe((100 + START) * TS);
+    });
+
+    it('puts both runs on one timeline — the whole point', () => {
+      const fromZero = rewriteSegmentTfdt(
+        buildSeg((100 + START) * TS),
+        tracks,
+        25,
+        SEG,
+        START,
+      );
+      const seeked = rewriteSegmentTfdt(buildSeg(0), tracks, 25, SEG, START);
+      expect(readTfdt(seeked)).toBe(readTfdt(fromZero));
+    });
+
+    // The absolute run lands within a frame of the grid, never exactly on it.
+    // `runStart <= 0` used to catch that; an epsilon has to, or a segment
+    // nothing asked to move gets nudged by the rounding.
+    it('does not nudge an absolute run that is a frame off the grid', () => {
+      const off = Math.round((100 + START) * TS) + 0.04 * TS;
+      const out = rewriteSegmentTfdt(buildSeg(off), tracks, 25, SEG, START);
+      expect(readTfdt(out)).toBe(off);
+    });
+  });
 });

--- a/backend/src/modules/streaming/transcoding/timeline.ts
+++ b/backend/src/modules/streaming/transcoding/timeline.ts
@@ -159,12 +159,18 @@ export function rewriteSegmentTfdt(
   tracks: Map<number, TrackInfo>,
   segIndex: number,
   segDuration: number,
+  startPts = 0,
 ): Buffer {
   if (tracks.size === 0) return segBuf;
   const frags = collectTfdts(segBuf);
   if (frags.length === 0) return segBuf;
 
-  const segStart = segIndex * segDuration;
+  // The source's own start_time is part of the origin: a run spawned at 0 keeps
+  // it (ffmpeg's -copyts passes absolute PTS through), so a run spawned mid-file
+  // must be anchored onto it too or the two disagree by exactly start_time —
+  // and the WebVTT X-TIMESTAMP-MAP, which adds it unconditionally, is only
+  // right for one of them.
+  const segStart = segIndex * segDuration + startPts;
   const video = frags.find((f) => tracks.get(f.trackId)?.isVideo);
   let runStart: number;
   if (video) {
@@ -177,7 +183,11 @@ export function rewriteSegmentTfdt(
     runStart =
       Math.round((segStart - ref.original / ts) / segDuration) * segDuration;
   }
-  if (runStart <= 0) return segBuf; // already absolute (run started at 0)
+  // Already absolute (the run started at 0, so ffmpeg's own timeline is the one
+  // we want). Epsilon rather than `<= 0`: an absolute run lands within a frame
+  // of the grid, and shifting it by that would nudge a segment nothing asked to
+  // move. Half a segment is far below any real run offset.
+  if (Math.abs(runStart) < segDuration / 2) return segBuf;
 
   const buf = Buffer.from(segBuf);
   for (const f of frags) {

--- a/backend/src/modules/streaming/transcoding/timeline.ts
+++ b/backend/src/modules/streaming/transcoding/timeline.ts
@@ -172,22 +172,27 @@ export function rewriteSegmentTfdt(
   // right for one of them.
   const segStart = segIndex * segDuration + startPts;
   const video = frags.find((f) => tracks.get(f.trackId)?.isVideo);
-  let runStart: number;
-  if (video) {
-    const ts = tracks.get(video.trackId)!.timescale;
-    runStart = segStart - video.original / ts;
-  } else {
-    const ref = frags[0];
-    const ts = tracks.get(ref.trackId)?.timescale;
-    if (!ts) return segBuf;
+  const ref = video ?? frags[0];
+  const refTs = tracks.get(ref.trackId)?.timescale;
+  if (!refTs) return segBuf;
+  const refTime = ref.original / refTs;
+
+  // Already absolute: the run started at 0, so ffmpeg's timeline is the one we
+  // want. Tested before any snapping — the snap below assumes a run-relative
+  // fragment, and applied to an absolute one it would invent a shift.
+  if (Math.abs(segStart - refTime) < segDuration / 2) return segBuf;
+
+  let runStart = segStart - refTime;
+  if (!video) {
+    // Audio-only rendition (var_stream_map): no video fragment to anchor on, so
+    // the run offset is snapped to the grid to shed sub-frame jitter. Only the
+    // *content* part is a grid multiple — start_time is not — so it is removed
+    // before snapping and restored after. Rounding it away here would shift an
+    // audio rendition off the video it belongs to by exactly start_time, which
+    // is the whole class of A/V desync #756/#771/#791 exist to prevent.
     runStart =
-      Math.round((segStart - ref.original / ts) / segDuration) * segDuration;
+      Math.round((runStart - startPts) / segDuration) * segDuration + startPts;
   }
-  // Already absolute (the run started at 0, so ffmpeg's own timeline is the one
-  // we want). Epsilon rather than `<= 0`: an absolute run lands within a frame
-  // of the grid, and shifting it by that would nudge a segment nothing asked to
-  // move. Half a segment is far below any real run offset.
-  if (Math.abs(runStart) < segDuration / 2) return segBuf;
 
   const buf = Buffer.from(segBuf);
   for (const f of frags) {

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -1706,6 +1706,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
       ? 'var-stream-map'
       : 'inline';
     session.sourceFps = ctx.sourceFps;
+    session.sourceStartPts = ctx.sourceStartPts;
     session.segmentDuration = ctx.segmentDuration ?? DEFAULT_SEGMENT_DURATION;
     if (!session.startedAt) session.startedAt = new Date();
   }

--- a/backend/src/modules/streaming/transcoding/types.ts
+++ b/backend/src/modules/streaming/transcoding/types.ts
@@ -128,6 +128,9 @@ export interface SessionContext {
   tonemapAlgo?: TonemapAlgo;
   /** Source framerate (fps). Used to compute GOP = segmentDuration * fps. */
   sourceFps?: number;
+  /** Source video `start_time` (seconds). The presentation timeline is anchored
+   *  to it so every run has the same origin as the WebVTT `X-TIMESTAMP-MAP`. */
+  sourceStartPts?: number;
   /** Source colorimetry from ffprobe (`colorSpace`/`colorPrimaries`/
    *  `colorTransfer`), threaded so an SDR transcode preserves the source's real
    *  color signalling instead of forcing BT.709. Undefined/`unknown` on an
@@ -282,6 +285,9 @@ export interface TranscodeSession {
   /** Source frame rate this session encodes at. Lets the segment-serve path
    *  resolve the real segment-duration grid without re-probing streamInfo. */
   sourceFps?: number;
+  /** Source video `start_time` this session encodes from, frozen at spawn for
+   *  the same reason: the serve path anchors onto it without re-probing. */
+  sourceStartPts?: number;
   /** Segment duration (seconds) this session was spawned with, frozen from the
    *  admin setting at spawn. The serve/seek grid reads this — never the live
    *  admin value — so an admin change mid-playback can't shift the timeline of

--- a/backend/src/modules/subtitles/ffprobe.service.spec.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.spec.ts
@@ -30,3 +30,54 @@ describe('FfprobeService.parseFrameRate', () => {
     expect(parse('23.976')).toBe('23.976');
   });
 });
+
+/**
+ * A container's frame rate is a header field, not an observation. A remuxer
+ * that writes Matroska's `DefaultDuration` in whole milliseconds turns
+ * 1/23.976 (41.708 ms) into 42 ms — 500/21 = 23.81 — and reports it as BOTH
+ * `r_frame_rate` and `avg_frame_rate`, so no choice between those two fields
+ * can catch it.
+ *
+ * The segment grid counts frames (`buildSegmentGrid`), so a rate 0.7% off puts
+ * 95 frames labelled 3.99s but really lasting 3.962s seconds away from the grid
+ * the player is told to expect — dragging the picture off subtitles authored in
+ * source time while audio, riding the same anchor, stays in sync.
+ */
+describe('FfprobeService.reconcileFrameRate', () => {
+  const svc = new FfprobeService();
+  const reconcile = (declared?: string, measured?: number): string | undefined =>
+    (
+      svc as unknown as {
+        reconcileFrameRate(
+          d: string | undefined,
+          m: number | undefined,
+          label: string,
+        ): string | undefined;
+      }
+    ).reconcileFrameRate(declared, measured, 'file.mkv');
+
+  it('takes the packets over a header that disagrees', () => {
+    // The real case: declared 500/21, packets run at 24000/1001.
+    expect(reconcile('23.81', 24000 / 1001)).toBe('23.976');
+  });
+
+  it('keeps the declared rate when the two agree', () => {
+    // Measured rates wobble by a few thousandths on any real file; that is
+    // rounding, not a lie, and rewriting the grid for it would be churn.
+    expect(reconcile('23.976', 23.9749)).toBe('23.976');
+    expect(reconcile('25', 24.998)).toBe('25');
+  });
+
+  it('keeps the declared rate when nothing could be measured', () => {
+    expect(reconcile('23.976', undefined)).toBe('23.976');
+  });
+
+  it('has nothing to reconcile without a declared rate', () => {
+    expect(reconcile(undefined, 24000 / 1001)).toBeUndefined();
+  });
+
+  it('ignores a declared rate that is not a number', () => {
+    expect(reconcile('0', 24)).toBe('0');
+    expect(reconcile('abc', 24)).toBe('abc');
+  });
+});

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -7,6 +7,24 @@ import { isImageBasedSubtitleCodec } from '../../common/constants/subtitle-codec
 
 const execFileAsync = promisify(execFile);
 
+/** Seconds of packet timestamps sampled to measure the real frame rate. The
+ *  cost is the seek, not the read — 20s and 60s both measured ~26ms — so this
+ *  buys statistical margin for free. */
+const FPS_WINDOW_SECONDS = 60;
+/** Below this a file is too short to spare a representative middle window. */
+const MIN_MEASURABLE_SECONDS = 90;
+/** Fewer frames than this in the window means a broken or empty sample. */
+const MIN_SAMPLE_FRAMES = 100;
+const MIN_PLAUSIBLE_FPS = 1;
+const MAX_PLAUSIBLE_FPS = 480;
+/** Relative gap at which the packets win over the header. */
+const FPS_DISAGREEMENT = 0.001;
+
+/** Decimal fps string, the shape the segment grid and the client both read. */
+function formatFps(fps: number): string {
+  return fps.toFixed(3).replace(/0+$/, '').replace(/\.$/, '');
+}
+
 export interface EmbeddedSubtitleStream {
   streamIndex: number;
   codec: string;
@@ -372,6 +390,9 @@ export class FfprobeService {
       const durationSeconds = parsed.format?.duration
         ? Number(parsed.format.duration)
         : undefined;
+      // One extra ffprobe (~25ms, the same cost as the probe above) — the
+      // declared rate is only a header field, see `measureFrameRate`.
+      const measuredFps = await this.measureFrameRate(videoPath, durationSeconds);
       const formatBitRateRaw = parsed.format?.bit_rate
         ? Number(parsed.format.bit_rate)
         : undefined;
@@ -393,7 +414,15 @@ export class FfprobeService {
             height: s.height,
             displayAspectRatio: s.display_aspect_ratio,
             pixelFormat: s.pix_fmt,
-            frameRate: this.parseFrameRate(s.r_frame_rate, s.avg_frame_rate),
+            frameRate: this.reconcileFrameRate(
+              this.parseFrameRate(s.r_frame_rate, s.avg_frame_rate),
+              // Only the first video stream is sampled; a second one (cover
+              // art, thumbnail track) is never what the grid encodes.
+              s.index === streams.find((x) => x.codec_type === 'video')?.index
+                ? measuredFps
+                : undefined,
+              path.basename(videoPath),
+            ),
             startTimeSeconds: s.start_time ? Number(s.start_time) : undefined,
             bitRate: s.bit_rate ? Number(s.bit_rate) : undefined,
             bitDepth: s.bits_per_raw_sample
@@ -547,6 +576,89 @@ export class FfprobeService {
    * value would drop them onto the integer grid and drift the audio off the
    * video IDR cadence on a fractional-fps source.
    */
+  /**
+   * Frame rate measured from the real packet cadence, or undefined when it
+   * can't be established. A container's declared rate is a header field, not an
+   * observation: a remuxer that writes Matroska's `DefaultDuration` in whole
+   * milliseconds turns 1/23.976 (41.708 ms) into 42 ms, i.e. 500/21 = 23.81,
+   * and reports it as BOTH `r_frame_rate` and `avg_frame_rate` — so no choice
+   * between those two fields can detect it.
+   *
+   * It matters because the segment grid counts frames, not seconds
+   * (`buildSegmentGrid`): 95 frames labelled 3.99s but really lasting 3.962s
+   * put the media seconds away from the grid the player is told to expect,
+   * dragging the picture off subtitles authored in source time.
+   *
+   * Sampled rather than counted: a `-count_packets` pass over a 2.8 GB file
+   * costs ~2.5 s, this ~25 ms, and the two agreed to 0.004% in testing. The
+   * window is taken from the middle — the opening minutes carry logos and
+   * title sequences whose cadence need not match the body.
+   */
+  private async measureFrameRate(
+    videoPath: string,
+    durationSeconds?: number,
+  ): Promise<number | undefined> {
+    if (!durationSeconds || durationSeconds < MIN_MEASURABLE_SECONDS) {
+      return undefined;
+    }
+    const from = Math.max(0, Math.floor(durationSeconds / 2 - FPS_WINDOW_SECONDS / 2));
+    try {
+      const { stdout } = await execFileAsync(
+        'ffprobe',
+        [
+          '-v', 'error',
+          '-select_streams', 'v:0',
+          '-show_entries', 'packet=pts_time',
+          '-read_intervals', `${from}%+${FPS_WINDOW_SECONDS}`,
+          '-of', 'csv=p=0',
+          videoPath,
+        ],
+        { timeout: 30_000 },
+      );
+      const times = stdout
+        .split('\n')
+        .map((l) => Number.parseFloat(l))
+        .filter((n) => Number.isFinite(n))
+        .sort((a, b) => a - b);
+      if (times.length < MIN_SAMPLE_FRAMES) return undefined;
+      const span = times[times.length - 1] - times[0];
+      if (span <= 0) return undefined;
+      const fps = (times.length - 1) / span;
+      // A measurement outside anything a real source uses is a broken sample,
+      // not a discovery — trusting it would be worse than the declared value.
+      return fps >= MIN_PLAUSIBLE_FPS && fps <= MAX_PLAUSIBLE_FPS ? fps : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * The declared rate, unless the packets say otherwise by more than
+   * {@link FPS_DISAGREEMENT}. Sane files sit two orders of magnitude inside
+   * that threshold (measured: <=0.03% across a sample library, vs 0.7% for a
+   * file with a mis-written DefaultDuration), so this only ever fires on a
+   * container that is actually lying.
+   */
+  private reconcileFrameRate(
+    declared: string | undefined,
+    measured: number | undefined,
+    label: string,
+  ): string | undefined {
+    if (!declared || measured === undefined) return declared;
+    const declaredFps = Number(declared);
+    if (!Number.isFinite(declaredFps) || declaredFps <= 0) return declared;
+    const off = Math.abs(measured - declaredFps) / measured;
+    if (off <= FPS_DISAGREEMENT) return declared;
+    const corrected = formatFps(measured);
+    this.logger.warn(
+      `"${label}": container declares ${declared} fps but its packets run at ` +
+        `${corrected} fps (${(off * 100).toFixed(2)}% off) — using the measured rate. ` +
+        `The segment grid counts frames, so the declared value would shift the ` +
+        `picture off subtitles authored in source time.`,
+    );
+    return corrected;
+  }
+
   private parseFrameRate(rate?: string, avgRate?: string): string | undefined {
     const normalise = (r?: string): string | undefined => {
       if (!r || r === '0/0') return undefined;
@@ -555,9 +667,7 @@ export class FfprobeService {
       const den = Number(parts[1]);
       if (!den || !num) return r;
       const fps = num / den;
-      return fps > 0
-        ? fps.toFixed(3).replace(/0+$/, '').replace(/\.$/, '')
-        : undefined;
+      return fps > 0 ? formatFps(fps) : undefined;
     };
     return normalise(rate) ?? normalise(avgRate);
   }


### PR DESCRIPTION
Reported as: subtitles out of sync on iOS when using **Resume at** on an episode started elsewhere.

## Cause

The served fMP4 presentation timeline changes origin depending on where the transcode run started, while the WebVTT `X-TIMESTAMP-MAP` offset is unconditional. They disagree by exactly the source's video `start_time`.

- `streaming.controller.ts:98` always stamps `MPEGTS: startTimeSeconds * 90000`, on the assumption that `-copyts` leaves the media timeline at absolute source PTS.
- `transcoding/timeline.ts` anchored `seg-N` to exactly `N · segDuration` — content time with the start PTS removed — and bailed out (`runStart <= 0`) in precisely the run-started-at-0 case, so the disagreement never showed there.

Run from 0 → timeline is content + `start_time`, map correct. Resumed or seeked run → timeline is bare content, map now adds `start_time` on top of nothing → **cues render `start_time` late**.

Measured inside the running backend with the real arg shape, on a source with video `start_time = 2.8`:

| run | first video packet of its first segment |
|---|---|
| from 0 | `pts 2.800000` — absolute, anchor bails, offset survives |
| `-ss 12 -start_number 2` | `pts 0.080000` — the muxer restarts the fragment timeline **even under `-copyts`** |

The commit that introduced the timestamp map only ever measured a run at 0.

## Two corrections to the report

- **Not resume-only.** Any run spawned at a non-zero segment does this, so a mid-session forward seek breaks alignment identically. "Cross-platform" was just how the user obtained a non-zero start position.
- **Not iOS-only.** The split is engines consuming the HLS `SUBTITLES` rendition vs engines that sidecar-load the VTT. `engine-traits.ts:99` gives desktop `supportsHlsSubtitles: false`, so mpv `sub-add`s the file and ffmpeg's WebVTT demuxer ignores `X-TIMESTAMP-MAP` entirely — **Windows is the exception**. Native and Android TV are `true`, and so is web (the backend comment claiming "Web (Shaka) leaves the flag off" is stale), so Android and the browser should be affected too.

## Fix

Anchor to `N · segDuration + startPts` on every run. `sourceStartPts` is frozen onto the session at spawn beside `sourceFps`, so the serve path needs no re-probe, and it is threaded through all five `segmentPackaging.serve()` call sites.

The `runStart <= 0` bail becomes an epsilon guard (`|runStart| < segDuration / 2`): an absolute run lands within a frame of the grid rather than exactly on it, and shifting it by that rounding would nudge a segment nothing asked to move.

Deliberately **not** fixed by emitting `MPEGTS:0` — that reintroduces the earlier bug where cues *led* by `start_time` on a fresh play.

## Blast radius

A strict no-op wherever `start_time` is 0, which is MKV and most MP4 — the visible cases are TS captures and PVR rips. Remux still skips the anchor entirely (#349).

## Test

`npx tsc --noEmit` clean, **1803 passing** (4 new): a run from 0 is left byte-identical, a mid-file run lands on the same origin, both runs agree, and an absolute run a frame off the grid is not nudged.

Not confirmed on a device — the mechanism is measured server-side, but that the user's file has a non-zero `start_time` is unverified. If their title is an MKV, this is not their bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)