### PR TITLE
fix(desktop): make a playback glitch diagnosable, and leave the buffering state

### DIFF
--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -94,6 +94,9 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
    *  end is detected from that property. Guards against mpv re-sending the
    *  property-change so the end-vs-failure decision runs once. */
   private sawEof = false;
+  /** mpv's own `pause` property, so leaving a cache stall can restore the state
+   *  the user actually left playback in rather than assuming `playing`. */
+  private paused = false;
   private duration = 0;
   private cacheEnd = 0;
   /** Last `time-pos` seen; compared against `duration` when `eof-reached` fires
@@ -356,10 +359,18 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
         }
         break;
       case 'pause':
-        this.emit('stateChanged', { state: data ? 'paused' : 'playing' });
+        this.paused = data === true;
+        this.emit('stateChanged', { state: this.paused ? 'paused' : 'playing' });
         break;
       case 'paused-for-cache':
-        if (data) this.emit('stateChanged', { state: 'buffering' });
+        // Both edges. Emitting only the rising one left the UI reporting
+        // `buffering` for the rest of the session: mpv resumes on its own once
+        // the cache refills and never re-sends `pause`, so nothing followed to
+        // clear it. The falling edge restores the state the user left playback
+        // in, not an assumed `playing`.
+        this.emit('stateChanged', {
+          state: data ? 'buffering' : this.paused ? 'paused' : 'playing',
+        });
         break;
       case 'track-list':
         this.emit('tracksChanged', mapTrackList((data as MpvTrack[]) ?? []));

--- a/desktop/src/main/window/player-session.ts
+++ b/desktop/src/main/window/player-session.ts
@@ -243,9 +243,20 @@ export class PlayerSession {
       // every segment URL, and this write is synchronous on the main thread.
       if (/^\[(error|fatal|warn)\]/.test(s)) appendLog(`[mpv] ${s.trimEnd()}`);
     });
-    mpv.on('exit', (e) => console.error('[mpv] process exit', JSON.stringify(e)));
+    // A packaged GUI build has no console, so anything that only reaches
+    // `console.*` is unretrievable in the field. These four are what separate a
+    // playback glitch's causes from one another — an `error` followed by a
+    // `firstFrame` is a re-open, a lone `buffering` is a cache underrun, and
+    // neither is an event below the IPC layer — so they go to the file too.
+    // Deliberately not `timeUpdate`: it fires several times a second.
+    mpv.on('exit', (e) => {
+      const line = `[mpv] process exit ${JSON.stringify(e)}`;
+      console.error(line);
+      appendLog(line);
+    });
     mpv.on('stateChanged', (p) => {
       console.log('[player] state:', p.state);
+      appendLog(`[player] state: ${p.state}`);
       setPlaybackKeepAwake(keepAwakeForState(p.state));
       this.emit({ type: 'stateChanged', payload: p });
     });
@@ -256,6 +267,7 @@ export class PlayerSession {
     });
     mpv.on('firstFrame', () => {
       console.log('[player] firstFrame');
+      appendLog('[player] firstFrame');
       setPlaybackKeepAwake(true);
       // Now that playback owns the window, paint the frame black: a video gap
       // (decoder re-init on a seek) then reads as loading, not a brand flash.
@@ -264,6 +276,7 @@ export class PlayerSession {
     });
     mpv.on('error', (p) => {
       console.log('[player] error:', JSON.stringify(p));
+      appendLog(`[player] error: ${JSON.stringify(p)}`);
       setPlaybackKeepAwake(false);
       this.emit({ type: 'error', payload: p });
     });


### PR DESCRIPTION
Two defects found while investigating sub-second black-with-audio-cut flashes on the Windows desktop app. Neither is confirmed as *the* cause — 0 of 8 hypotheses survived adversarial verification — but both are real on their own, and the first is why the bug could not be diagnosed at all.

## 1. The diagnostic was being generated and thrown away

`FLIKS_MPV_LOGLEVEL=v` has been the Windows default since #786, but its output reached only `process.stderr`, and the player's own events (`state:`, `error:`, `firstFrame`, `process exit`) were `console.log`. **A packaged GUI build has no console**, so none of it was retrievable. `desktop.log` — described in `log-file.ts` as "the only retrievable diagnostic on a packaged build" — kept `^\[(error|fatal|warn)\]` from mpv and nothing from the player.

A field report of a playback glitch was therefore undiagnosable by construction.

Those four events now reach the file too. They are what separates the candidate causes:

| in `desktop.log` | means |
|---|---|
| `[player] error:` then `[player] firstFrame` | the client re-opened the stream (`stop` + `loadfile`) — payload carries mpv's error code |
| `[player] state: buffering` alone | mpv paused itself on a cache underrun — different bug |
| `[mpv] process exit` | the subprocess died |
| none of them | the event is below the IPC layer |

`timeUpdate` is deliberately excluded: it fires several times a second and `appendLog` is synchronous on the main thread.

## 2. `paused-for-cache` never released the buffering state

`mpv-player.ts` handled the rising edge only:

```ts
case 'paused-for-cache':
  if (data) this.emit('stateChanged', { state: 'buffering' });
```

mpv resumes on its own once the cache refills and does not re-send `pause`, so nothing followed to clear it — the UI stayed in `buffering` for the rest of the session after any cache stall. The sibling `case 'pause'` three lines up handles both edges correctly.

Both edges now emit, and the falling one restores the state the user actually left playback in: mpv's `pause` property is tracked, so a stall that happens while paused doesn't resume the UI behind the user's back.

## Not included

The third finding — that **every reconnect option we set is inert on Windows direct play** — is left alone deliberately. `MPV_STREAM_OPTIONS` puts `reconnect=1, reconnect_on_network_error=1, …` on `demuxer-lavf-o`, which only reaches a URL opened by *lavf*; Windows direct play goes through mpv's **curl** stream backend (corroborated by `mpv-player.ts:279-284`, which classifies errors on `curl`/`tls` prefixes). It is the most credible candidate for the reported symptom, but the fix changes the network stack on the one platform that already has a parked TLS bug, and it needs a Windows box to verify. Not shipping that blind.

## Test

`npm run typecheck` and `npm run build` clean. The desktop package has no test suite; neither change is verifiable without a Windows build, and change 1 is inert until an incident occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)