### PR TITLE
feat(releases): stop offering releases better than the profile allows

### DIFF
--- a/backend/src/common/release-scoring/release-rejection.helper.spec.ts
+++ b/backend/src/common/release-scoring/release-rejection.helper.spec.ts
@@ -490,3 +490,41 @@ describe('computeRejections — resolution upgrade only', () => {
     expect(codes('Show.S01E01.1080p.BluRay.x264', undefined)).toEqual([]);
   });
 });
+
+describe('computeRejections — above the profile vs merely outside it', () => {
+  // 12 WEBDL-720p (45), 16 WEBDL-1080p (62), 18 Bluray-1080p (68), 19 Remux-1080p (72).
+  const codeFor = (qualityId: number, allowed: number[]) =>
+    computeRejections({
+      qualityId,
+      allowed: new Set(allowed),
+      languageId: 1,
+      allowedLangs: new Set<number>(),
+      isBlocklisted: false,
+      sizeBytes: 0,
+      runtimeMinutes: 112,
+      sizeByQuality: new Map(),
+      seeders: 10,
+      sourceId: 0,
+      sourceMinSeeders: new Map(),
+    }).map((r) => r.code);
+
+  it('VERDICT: a quality better than every allowed one is ABOVE, not merely NOT_ALLOWED', () => {
+    expect(codeFor(19, [16, 18])).toEqual(['QUALITY_ABOVE_PROFILE']);
+  });
+
+  it('VERDICT: a quality below the profile stays NOT_ALLOWED, so the picker keeps offering it', () => {
+    expect(codeFor(12, [16, 18])).toEqual(['QUALITY_NOT_ALLOWED']);
+  });
+
+  it('ranks, not ids: a lower id outranking the profile still reads as above it', () => {
+    expect(codeFor(18, [16])).toEqual(['QUALITY_ABOVE_PROFILE']);
+  });
+
+  it('an allowed quality is rejected by neither', () => {
+    expect(codeFor(16, [16, 18])).toEqual([]);
+  });
+
+  it('an empty profile rejects everything as outside it — nothing to be above', () => {
+    expect(codeFor(19, [])).toEqual(['QUALITY_NOT_ALLOWED']);
+  });
+});

--- a/backend/src/common/release-scoring/release-rejection.helper.ts
+++ b/backend/src/common/release-scoring/release-rejection.helper.ts
@@ -486,6 +486,19 @@ export function titleMatchesExpectation(
   return matchesIndexedExpectation(releaseTitleTokens(releaseTitle), index, whenUnreadable);
 }
 
+/**
+ * Better than everything the profile allows, as opposed to merely outside it. The picker hides
+ * these rows instead of offering them for a forced grab: a 2160p remux under a 1080p profile is
+ * not a fallback anyone wants, while a 720p one under the same profile still is.
+ */
+function rankExceedsProfile(qualityId: number, allowed: Set<number>): boolean {
+  const rank = getAppQualityById(qualityId)?.rank;
+  if (rank == null || allowed.size === 0) return false;
+  let best = 0;
+  for (const id of allowed) best = Math.max(best, getAppQualityById(id)?.rank ?? 0);
+  return rank > best;
+}
+
 /** `S04E03`, `S04`, or `?` — the display params of an EPISODE_MISMATCH. */
 function formatSeasonEpisode(
   season: number | null | undefined,
@@ -601,7 +614,11 @@ export function computeRejections(opts: {
   }
 
   if (!opts.allowed.has(opts.qualityId)) {
-    out.push({ code: 'QUALITY_NOT_ALLOWED' });
+    out.push({
+      code: rankExceedsProfile(opts.qualityId, opts.allowed)
+        ? 'QUALITY_ABOVE_PROFILE'
+        : 'QUALITY_NOT_ALLOWED',
+    });
   }
 
   // "Upgrade resolution only": the profile refuses a same-resolution tier hop, so a 1080p Bluray

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1089,6 +1089,7 @@
     "confirm_delete_subtitle": "Diesen Untertitel löschen?",
     "rejection": {
       "QUALITY_NOT_ALLOWED": "Qualität außerhalb des Profils",
+      "QUALITY_ABOVE_PROFILE": "Qualität über dem Profil",
       "LANGUAGE_NOT_ALLOWED": "Sprache außerhalb des Profils",
       "BLOCKLISTED": "Release blockiert",
       "SIZE_TOO_LOW": "Größe zu niedrig\n({{actual}} MB < {{min}} MB)",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1097,6 +1097,7 @@
     "confirm_delete_subtitle": "Delete this subtitle?",
     "rejection": {
       "QUALITY_NOT_ALLOWED": "Quality outside profile",
+      "QUALITY_ABOVE_PROFILE": "Quality above profile",
       "LANGUAGE_NOT_ALLOWED": "Language outside profile",
       "BLOCKLISTED": "Blocked release",
       "SIZE_TOO_LOW": "Size too low\n({{actual}} MB < {{min}} MB)",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1089,6 +1089,7 @@
     "confirm_delete_subtitle": "¿Eliminar este subtítulo?",
     "rejection": {
       "QUALITY_NOT_ALLOWED": "Calidad fuera del perfil",
+      "QUALITY_ABOVE_PROFILE": "Calidad superior al perfil",
       "LANGUAGE_NOT_ALLOWED": "Idioma fuera del perfil",
       "BLOCKLISTED": "Release bloqueada",
       "SIZE_TOO_LOW": "Tamaño demasiado bajo\n({{actual}} MB < {{min}} MB)",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1097,6 +1097,7 @@
     "confirm_delete_subtitle": "Supprimer ce sous-titre ?",
     "rejection": {
       "QUALITY_NOT_ALLOWED": "Qualité hors profil",
+      "QUALITY_ABOVE_PROFILE": "Qualité au-dessus du profil",
       "LANGUAGE_NOT_ALLOWED": "Langue hors profil",
       "BLOCKLISTED": "Release bloquée",
       "SIZE_TOO_LOW": "Taille trop faible\n({{actual}} MB < {{min}} MB)",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1089,6 +1089,7 @@
     "confirm_delete_subtitle": "Eliminare questo sottotitolo?",
     "rejection": {
       "QUALITY_NOT_ALLOWED": "Qualità fuori profilo",
+      "QUALITY_ABOVE_PROFILE": "Qualità superiore al profilo",
       "LANGUAGE_NOT_ALLOWED": "Lingua fuori profilo",
       "BLOCKLISTED": "Release bloccata",
       "SIZE_TOO_LOW": "Dimensione troppo bassa\n({{actual}} MB < {{min}} MB)",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1089,6 +1089,7 @@
     "confirm_delete_subtitle": "Eliminar esta legenda?",
     "rejection": {
       "QUALITY_NOT_ALLOWED": "Qualidade fora do perfil",
+      "QUALITY_ABOVE_PROFILE": "Qualidade acima do perfil",
       "LANGUAGE_NOT_ALLOWED": "Idioma fora do perfil",
       "BLOCKLISTED": "Release bloqueada",
       "SIZE_TOO_LOW": "Tamanho demasiado baixo\n({{actual}} MB < {{min}} MB)",

--- a/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.spec.ts
+++ b/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.spec.ts
@@ -260,3 +260,36 @@ describe('ReleasesModalComponent — per-indexer tabs', () => {
     expect(fixture.nativeElement.querySelector('svg[lucideSearchX]')).not.toBeNull();
   });
 });
+
+describe('ReleasesModalComponent — releases above the profile', () => {
+  const above = (sourceId: number, title: string): MovieRelease => ({
+    ...release(sourceId, title),
+    allowed: false,
+    rejections: [{ code: 'QUALITY_ABOVE_PROFILE' }],
+  });
+
+  it('VERDICT: never lists a release better than the profile allows', async () => {
+    const fixture = await createFixture({
+      releases: [release(1, 'in-profile'), above(1, 'remux')],
+    });
+    expect(fixture.componentInstance.visibleReleases().map((r) => r.title)).toEqual(['in-profile']);
+  });
+
+  it("VERDICT: the tab counts drop it too — a count that promises a row the list hides is a bug", async () => {
+    const fixture = await createFixture({
+      releases: [release(1, 'in-profile'), above(1, 'remux'), above(2, 'remux-2')],
+      indexers: ROSTER,
+    });
+    expect(fixture.componentInstance.tabs().map((t) => t.count)).toEqual([1, 1, null, 0]);
+  });
+
+  it('keeps a release merely outside the profile — it is still grabbable by hand', async () => {
+    const outside: MovieRelease = {
+      ...release(1, 'below'),
+      allowed: false,
+      rejections: [{ code: 'QUALITY_NOT_ALLOWED' }],
+    };
+    const fixture = await createFixture({ releases: [outside] });
+    expect(fixture.componentInstance.visibleReleases().map((r) => r.title)).toEqual(['below']);
+  });
+});

--- a/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.ts
+++ b/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.ts
@@ -79,18 +79,24 @@ export class ReleasesModalComponent {
     if (active !== null && !roster.some((ix) => ix.id === active)) this.activeTab.set(null);
   });
 
+  /** Everything the picker will ever show. A release better than the profile allows is dropped
+   *  here rather than in the row list, so a tab's count can never promise rows it then hides. */
+  private readonly offered = computed(() =>
+    this.releases().filter((r) => !r.rejections.some((x) => x.code === 'QUALITY_ABOVE_PROFILE')),
+  );
+
   readonly tabs = computed<TabView[]>(() => {
     const roster = this.indexers();
     if (!roster.length) return [];
     const counts = new Map<number, number>();
-    for (const r of this.releases()) counts.set(r.sourceId, (counts.get(r.sourceId) ?? 0) + 1);
+    for (const r of this.offered()) counts.set(r.sourceId, (counts.get(r.sourceId) ?? 0) + 1);
     // `count: null` is the spinner slot — a tab still working. Tous spins for as long as any
     // indexer does, so the whole strip follows one rule instead of the header carrying its own.
     return [
       {
         id: null,
         label: '',
-        count: this.loading() ? null : this.releases().length,
+        count: this.loading() ? null : this.offered().length,
         state: 'all' as const,
       },
       ...roster.map((ix) => ({
@@ -106,7 +112,7 @@ export class ReleasesModalComponent {
    *  per-indexer tab is a filter over it, so neither sorts anything client-side. */
   readonly visibleReleases = computed(() => {
     const tab = this.activeTab();
-    const all = this.releases();
+    const all = this.offered();
     return tab === null ? all : all.filter((r) => r.sourceId === tab);
   });
 


### PR DESCRIPTION
The release picker listed every rejected release, so a 1080p profile still showed 2160p remuxes one confirm click away from a forced grab — rows nobody wants, crowding out the ones that are actually grabbable.

The distinction that was missing: a quality **below** the profile is a legitimate fallback and must stay listed; a quality **above** it is not.

## Core tells the two apart
Only core resolves the quality profile, so only core can rank a release against it. `computeRejections` now splits the verdict:

- `QUALITY_ABOVE_PROFILE` — outranks every allowed quality (compared on `rank`, not on id, so `Bluray-1080p` under a WEB-DL-only profile reads as above it).
- `QUALITY_NOT_ALLOWED` — outside the profile but not better than it. Unchanged behaviour.

**No field was added to `ScoredRelease`**, only a new value for an existing `code` string. The download plugin's `check-contract-drift` diffs field names, so it stays green and the plugin needs no release for this.

Auto-grab is unaffected: these releases already carried a rejection, and `pickRelease` only tests `rejections.length > 0`.

## The client drops them in one place
`ReleasesModalComponent` filters once, into a private `offered()` consumed by **both** the tab counts and the row list. Filtering only the list would leave a per-indexer tab advertising "12" and then rendering 7.

## Verification
- 5 backend tests on the above/below/at/empty-profile boundaries: 53 passed.
- 3 client tests, including that the tab counts drop the same rows: 20 passed.
- `npx tsc --noEmit` clean on the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)