### PR TITLE
feat(plugins): let a table row action address its own row

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -247,6 +247,19 @@ export interface TableColumn {
   detailField?: string;
   /** Title of that dialog. Falls back to the column's own `labelKey`. */
   detailTitleKey?: string;
+  /** Names a 0–100 field on the row; a badged cell then fills left-to-right with it and appends
+   *  the percent. A moving value belongs inside the badge naming what is moving — as its own
+   *  column it costs width and reads as unrelated to the state beside it. Ignored on a cell that
+   *  declares no `badges`, and on a row whose named field is not a number. */
+  progressField?: string;
+}
+
+/** One `rowActions[]` visibility clause, read off the row itself: the action renders only when
+ *  the row's `key` holds one of `in`. Pausing a paused download is not an action, it is a button
+ *  that fails. Distinct from `when`, which reads the viewer rather than the row. */
+export interface TableRowCondition {
+  key: string;
+  in: (string | number | boolean)[];
 }
 
 /** One proxied route lists instances, another lists the implementations and their fields. */
@@ -328,10 +341,39 @@ export interface TableConfigPage extends ConfigPageBase {
   list: string;
   columns: TableColumn[];
   filters?: TableFilter[];
+  /**
+   * `when` gates on the viewer (the same closed predicate vocabulary `ui.contributions[]` uses —
+   * a mutating action names the permission its route is declared under, so the button is absent
+   * rather than answering 403); `visibleWhen` gates on the row. Both are presentation only:
+   * the route behind the button is CASL-guarded regardless.
+   *
+   * A `proxy` path may carry `:id`, substituted with the row's own `id` before the request fires.
+   */
   rowActions?: (
-    | { kind: 'route'; labelKey: string; path: string }
-    | { kind: 'action'; labelKey: string; actionId: TableRowActionId }
-    | { kind: 'proxy'; labelKey: string; method: 'POST' | 'DELETE'; path: string; confirmKey?: string }
+    | { kind: 'route'; labelKey: string; path: string; when?: WhenPredicate[]; visibleWhen?: TableRowCondition }
+    | {
+        kind: 'action';
+        labelKey: string;
+        actionId: TableRowActionId;
+        when?: WhenPredicate[];
+        visibleWhen?: TableRowCondition;
+      }
+    | {
+        kind: 'proxy';
+        labelKey: string;
+        method: 'POST' | 'DELETE';
+        path: string;
+        confirmKey?: string;
+        /** Renders a checkbox inside that confirmation and sends its state as the query
+         *  parameter `param`. Needs `confirmKey`: a toggle with no dialog to sit in never
+         *  renders, and would silently send its default. */
+        confirmToggle?: { labelKey: string; param: string };
+        /** Danger styling on the button — a destructive row action must not look like the
+         *  two beside it. */
+        tone?: 'default' | 'danger';
+        when?: WhenPredicate[];
+        visibleWhen?: TableRowCondition;
+      }
   )[];
   defaultSortKey?: string;
   /** `list` answers `{data,total,page,pageSize}` rather than a bare array — a

--- a/client/src/app/core/services/confirmation.service.ts
+++ b/client/src/app/core/services/confirmation.service.ts
@@ -12,8 +12,16 @@ export interface ConfirmOptions {
   variant?: ConfirmVariant;
 }
 
+/** A confirm carrying one checkbox — a decision the confirmation itself has to capture,
+ *  since it changes what the confirmed action does rather than whether it runs. */
+export interface ConfirmToggleOptions extends ConfirmOptions {
+  toggleLabel: string;
+  toggleDefault?: boolean;
+}
+
 interface InternalConfirmState extends ConfirmOptions {
   alertOnly: boolean;
+  toggleLabel?: string;
   resolve: (value: boolean | null) => void;
 }
 
@@ -27,6 +35,21 @@ export class ConfirmationService {
         ...options,
         alertOnly: false,
         resolve: (v) => resolve(v === true),
+      });
+    });
+  }
+
+  /** The checkbox's live state while a `confirmWithToggle` dialog is open. */
+  readonly toggle = signal(false);
+
+  /** Cancelling reports the toggle's state anyway; every caller ignores it when `ok` is false. */
+  confirmWithToggle(options: ConfirmToggleOptions): Promise<{ ok: boolean; toggle: boolean }> {
+    this.toggle.set(options.toggleDefault ?? false);
+    return new Promise((resolve) => {
+      this.state.set({
+        ...options,
+        alertOnly: false,
+        resolve: (v) => resolve({ ok: v === true, toggle: this.toggle() }),
       });
     });
   }

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -6,6 +6,10 @@ import { firstValueFrom } from 'rxjs';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { LucideTriangleAlert } from '@lucide/angular';
 import { PluginUiRegistryService } from '../../core/plugin-ui/plugin-ui-registry.service';
+import { evaluateWhen } from '../../core/plugin-ui/when-evaluator';
+import { AuthService } from '../../core/services/auth.service';
+import { TvService } from '../../core/services/tv.service';
+import { DeviceService } from '../../core/services/device.service';
 import { SettingsApiService } from '../../core/services/api/settings-api.service';
 import { ToastService } from '../../core/services/toast.service';
 import { NavbarService } from '../../core/services/navbar.service';
@@ -123,6 +127,9 @@ export class PluginViewComponent implements OnDestroy {
   private readonly translate = inject(TranslateService);
   private readonly router = inject(Router);
   private readonly toast = inject(ToastService);
+  private readonly auth = inject(AuthService);
+  private readonly tv = inject(TvService);
+  private readonly device = inject(DeviceService);
 
   // Angular reuses this component across param changes on the same route
   // config (same wildcard path, different pluginId/view) — read reactively.
@@ -338,9 +345,23 @@ export class PluginViewComponent implements OnDestroy {
       }));
   }
 
-  /** Only `kind: 'proxy'` carries a plugin-relative path — `route`/`action` resolve in-app. */
+  /**
+   * Only `kind: 'proxy'` carries a plugin-relative path — `route`/`action` resolve in-app.
+   *
+   * `when` is evaluated here rather than in `<app-data-table>`: it reads the viewer, and a
+   * generic table has no business knowing about permissions. The row-scoped `visibleWhen`
+   * rides through untouched — only the table holds a row.
+   */
   tableRowActions(view: TableView): RowAction[] {
-    return (view.rowActions ?? []).map((a) => (a.kind === 'proxy' ? { ...a, path: this.resourceUrl(a.path) } : a));
+    const ctx = {
+      isAdmin: this.auth.user()?.isAdmin ?? false,
+      hasPermission: (p: string) => this.auth.hasPermission(p),
+      isTv: this.tv.isTv(),
+      isTouch: this.device.isTouch(),
+    };
+    return (view.rowActions ?? [])
+      .filter((a) => evaluateWhen(a.when, ctx))
+      .map((a) => (a.kind === 'proxy' ? { ...a, path: this.resourceUrl(a.path) } : a));
   }
 
   tableListActions(view: TableView): ListAction[] {

--- a/client/src/app/shared/components/confirmation-modal.html
+++ b/client/src/app/shared/components/confirmation-modal.html
@@ -2,6 +2,17 @@
   <div class="modal-box">
     <app-modal-header [title]="title()" />
     <p class="py-4 whitespace-pre-line">{{ message() }}</p>
+    @if (toggleLabel(); as tl) {
+      <label class="label cursor-pointer justify-start gap-3 pb-4">
+        <input
+          type="checkbox"
+          class="checkbox checkbox-sm"
+          [checked]="confirmService.toggle()"
+          (change)="confirmService.toggle.set($any($event.target).checked)"
+        />
+        <span class="label-text">{{ tl }}</span>
+      </label>
+    }
     <app-modal-footer>
       @if (dismissLabel(); as dl) {
         <button class="btn btn-ghost" (click)="confirmService.dismiss()">{{ dl }}</button>

--- a/client/src/app/shared/components/confirmation-modal.ts
+++ b/client/src/app/shared/components/confirmation-modal.ts
@@ -36,6 +36,7 @@ export class ConfirmationModalComponent {
   readonly variant = computed(() => this.confirmService.state()?.variant ?? 'default');
 
   readonly alertOnly = computed(() => this.confirmService.state()?.alertOnly ?? false);
+  readonly toggleLabel = computed(() => this.confirmService.state()?.toggleLabel ?? null);
   readonly dismissLabel = computed(() => this.confirmService.state()?.dismissLabel ?? null);
 
   readonly confirmBtnClass = computed(() => {

--- a/client/src/app/shared/components/data-table/data-table.html
+++ b/client/src/app/shared/components/data-table/data-table.html
@@ -134,9 +134,11 @@
                           }
                         </button>
                       } @else if (badgeClass(col, row[col.key]); as badge) {
-                        <span class="badge badge-sm" [class]="badge">{{
-                          cellLabel(col, row[col.key])
-                        }}</span>
+                        <app-progress-badge
+                          [label]="cellLabel(col, row[col.key])"
+                          [percent]="cellProgress(col, row)"
+                          [badgeClass]="badge"
+                        />
                       } @else {
                         {{ cellLabel(col, row[col.key]) }}
                       }
@@ -169,6 +171,7 @@
                     <button
                       type="button"
                       class="btn btn-ghost btn-xs"
+                      [class.text-error]="item.action.kind === 'proxy' && item.action.tone === 'danger'"
                       (click)="item.run()"
                       [disabled]="
                         busy() ===

--- a/client/src/app/shared/components/data-table/data-table.spec.ts
+++ b/client/src/app/shared/components/data-table/data-table.spec.ts
@@ -31,6 +31,7 @@ async function createComponent(opts: {
   refreshMs?: number;
   refreshOn?: string[];
   sseEvent?: WritableSignal<{ type: string } | null>;
+  confirmation?: unknown;
 }) {
   TestBed.configureTestingModule({
     providers: [
@@ -41,7 +42,13 @@ async function createComponent(opts: {
       }),
       { provide: HttpClient, useValue: opts.http as unknown as HttpClient },
       { provide: Router, useValue: { navigateByUrl: vi.fn() } },
-      { provide: ConfirmationService, useValue: { confirm: () => Promise.resolve(true) } },
+      {
+        provide: ConfirmationService,
+        useValue: opts.confirmation ?? {
+          confirm: () => Promise.resolve(true),
+          confirmWithToggle: () => Promise.resolve({ ok: true, toggle: true }),
+        },
+      },
       {
         provide: SseService,
         useValue: { lastEvent: opts.sseEvent ?? signal(null) } as unknown as SseService,
@@ -569,5 +576,137 @@ describe('DataTableComponent — the spinner always comes down', () => {
     await table.loadRows({ silent: true });
 
     expect(table.loading()).toBe(false);
+  });
+});
+
+describe('DataTableComponent — row-scoped proxy actions', () => {
+  const ROW = { id: 7, name: 'A', state: 'active' };
+
+  it('VERDICT: substitutes :id with the row it sits on — a shared path would hit one row for all', async () => {
+    const del = vi.fn(() => of({}));
+    const fixture = await createComponent({
+      http: { get: () => of([ROW]), delete: del },
+      rowActions: [{ kind: 'proxy', labelKey: 'x.rm', method: 'DELETE', path: '/api/p/queue/:id' }],
+    });
+    await fixture.componentInstance.visibleActions(ROW)[0].run();
+    expect(del).toHaveBeenCalledWith('/api/p/queue/7');
+  });
+
+  it('renders an action whose visibleWhen matches the row', async () => {
+    const fixture = await createComponent({
+      http: { get: () => of([ROW]) },
+      rowActions: [
+        {
+          kind: 'proxy',
+          labelKey: 'x.pause',
+          method: 'POST',
+          path: '/api/p/queue/:id/pause',
+          visibleWhen: { key: 'state', in: ['active', 'stalled'] },
+        },
+      ],
+    });
+    expect(fixture.componentInstance.visibleActions(ROW).length).toBe(1);
+  });
+
+  it('VERDICT: hides it when the row is in another state — pausing a paused row is a button that fails', async () => {
+    const fixture = await createComponent({
+      http: { get: () => of([{ ...ROW, state: 'paused' }]) },
+      rowActions: [
+        {
+          kind: 'proxy',
+          labelKey: 'x.pause',
+          method: 'POST',
+          path: '/api/p/queue/:id/pause',
+          visibleWhen: { key: 'state', in: ['active', 'stalled'] },
+        },
+      ],
+    });
+    expect(fixture.componentInstance.visibleActions({ ...ROW, state: 'paused' })).toEqual([]);
+  });
+
+  it('fails closed on a condition naming a field the row does not carry', async () => {
+    const fixture = await createComponent({
+      http: { get: () => of([ROW]) },
+      rowActions: [
+        {
+          kind: 'proxy',
+          labelKey: 'x.pause',
+          method: 'POST',
+          path: '/api/p/queue/:id/pause',
+          visibleWhen: { key: 'nosuchfield', in: ['active'] },
+        },
+      ],
+    });
+    expect(fixture.componentInstance.visibleActions(ROW)).toEqual([]);
+  });
+});
+
+describe('DataTableComponent — a confirmation that carries a decision', () => {
+  const ROW = { id: 7, name: 'A' };
+  const REMOVE: RowAction = {
+    kind: 'proxy',
+    labelKey: 'x.rm',
+    method: 'DELETE',
+    path: '/api/p/queue/:id',
+    confirmKey: 'x.confirm_rm',
+    confirmToggle: { labelKey: 'x.delete_files', param: 'deleteFiles' },
+  };
+
+  it("VERDICT: sends the checkbox's answer, not its default", async () => {
+    const del = vi.fn(() => of({}));
+    const fixture = await createComponent({
+      http: { get: () => of([ROW]), delete: del },
+      rowActions: [REMOVE],
+      confirmation: { confirmWithToggle: () => Promise.resolve({ ok: true, toggle: false }) },
+    });
+    await fixture.componentInstance.visibleActions(ROW)[0].run();
+    expect(del).toHaveBeenCalledWith('/api/p/queue/7?deleteFiles=false');
+  });
+
+  it('calls nothing when the confirmation is declined', async () => {
+    const del = vi.fn(() => of({}));
+    const fixture = await createComponent({
+      http: { get: () => of([ROW]), delete: del },
+      rowActions: [REMOVE],
+      confirmation: { confirmWithToggle: () => Promise.resolve({ ok: false, toggle: true }) },
+    });
+    await fixture.componentInstance.visibleActions(ROW)[0].run();
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it('a toggle declared without a confirmKey is dropped rather than sent silently', async () => {
+    const del = vi.fn(() => of({}));
+    const fixture = await createComponent({
+      http: { get: () => of([ROW]), delete: del },
+      rowActions: [{ ...REMOVE, confirmKey: undefined }],
+    });
+    await fixture.componentInstance.visibleActions(ROW)[0].run();
+    expect(del).toHaveBeenCalledWith('/api/p/queue/7');
+  });
+});
+
+describe('DataTableComponent — progress inside a badge', () => {
+  const COL: TableColumn = {
+    key: 'state',
+    labelKey: 'x.state',
+    badges: { active: 'info' },
+    progressField: 'progress',
+  };
+
+  it('rounds the named field into a 0–100 fill', async () => {
+    const fixture = await createComponent({ http: { get: () => of([]) } });
+    expect(fixture.componentInstance.cellProgress(COL, { id: 1, state: 'active', progress: 47.4 })).toBe(47);
+  });
+
+  it('VERDICT: a row reporting no number stays flat — an unreachable client is not 0%', async () => {
+    const fixture = await createComponent({ http: { get: () => of([]) } });
+    expect(fixture.componentInstance.cellProgress(COL, { id: 1, state: 'active', progress: null })).toBeNull();
+  });
+
+  it('a column declaring no progressField never fills', async () => {
+    const fixture = await createComponent({ http: { get: () => of([]) } });
+    expect(
+      fixture.componentInstance.cellProgress({ key: 'state', labelKey: 'x.state' }, { id: 1, progress: 50 }),
+    ).toBeNull();
   });
 });

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -19,6 +19,7 @@ import { formatBytes, formatSpeed } from '../../utils/download-format';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { SseService } from '../../../core/services/sse.service';
 import { PaginationComponent } from '../pagination/pagination';
+import { ProgressBadgeComponent } from '../progress-badge/progress-badge.component';
 import {
   BadgeTone,
   CellValue,
@@ -28,6 +29,7 @@ import {
   TableColumn,
   TableFilter,
   TableRow,
+  TableRowCondition,
   TableSubValue,
 } from './data-table.types';
 import { ModalHeaderComponent } from '../modal-header';
@@ -67,6 +69,7 @@ const BADGE_CLASSES: Readonly<Record<BadgeTone, string>> = {
     TranslateModule,
     LocaleDatePipe,
     PaginationComponent,
+    ProgressBadgeComponent,
   ],
   providers: [LocaleDatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -275,6 +278,14 @@ export class DataTableComponent implements OnInit {
     return BADGE_CLASSES[tone] ?? BADGE_CLASSES.ghost;
   }
 
+  /** The 0–100 fill for a badged cell that declares `progressField`, or null to render the
+   *  badge flat. A row reporting no number yet (an unreachable client) is not 0%. */
+  cellProgress(col: TableColumn, row: TableRow): number | null {
+    if (!col.progressField) return null;
+    const value = row[col.progressField];
+    return typeof value === 'number' ? Math.round(value) : null;
+  }
+
   /** The row's detail text for this column, or '' when there is none to open. A cell only
    *  becomes a button when it has something to show. */
   detailText(col: TableColumn, row: TableRow): string {
@@ -335,10 +346,24 @@ export class DataTableComponent implements OnInit {
     });
   }
 
+  /** A declared `visibleWhen` read off the row. Absent means "always"; a clause naming a field
+   *  the row does not carry hides the action, since an unreadable condition is not a met one. */
+  private rowAllows(condition: TableRowCondition | undefined, row: TableRow): boolean {
+    if (!condition) return true;
+    if (!(condition.key in row)) return false;
+    return condition.in.includes(row[condition.key] ?? null);
+  }
+
+  /** A `proxy` path may carry `:id` — the row's own, never the declared pattern. */
+  private rowPath(path: string, row: TableRow): string {
+    return path.replace(':id', encodeURIComponent(String(row.id)));
+  }
+
   /** Drops any `action`-kind entry whose actionId the host doesn't recognise. */
   visibleActions(row: TableRow): { action: RowAction; run: () => void | Promise<void> }[] {
     const result: { action: RowAction; run: () => void | Promise<void> }[] = [];
     for (const action of this.rowActions()) {
+      if (!this.rowAllows(action.visibleWhen, row)) continue;
       if (action.kind === 'action') {
         const handler = this.resolveAction()(action.actionId, row);
         if (handler) result.push({ action, run: handler });
@@ -358,12 +383,18 @@ export class DataTableComponent implements OnInit {
 
   private async runProxy(
     row: TableRow,
-    action: { kind: 'proxy'; method: 'POST' | 'DELETE'; path: string; confirmKey?: string },
+    action: Extract<RowAction, { kind: 'proxy' }>,
   ): Promise<void> {
+    // Keyed on the declared path, which is what the template's disabled check compares against.
     this.busy.set(`${row.id}:${action.path}`);
     try {
-      if (await this.runHttpAction(action.method, action.path, action.confirmKey))
-        await this.loadRows();
+      const ran = await this.runHttpAction(
+        action.method,
+        this.rowPath(action.path, row),
+        action.confirmKey,
+        action.confirmToggle,
+      );
+      if (ran) await this.loadRows();
     } catch {
       // handled by the global error interceptor
     } finally {
@@ -384,13 +415,27 @@ export class DataTableComponent implements OnInit {
     }
   }
 
-  /** Returns false without calling anything when the user declines the confirm — not an error. */
+  /** Returns false without calling anything when the user declines the confirm — not an error.
+   *  A `confirmToggle` rides along as a query param, so its answer reaches the route that acts
+   *  on it rather than being decided again server-side. Declared without a `confirmKey` it is
+   *  dropped: there is no dialog to render it in, and sending its default silently is worse. */
   private async runHttpAction(
     method: 'POST' | 'DELETE',
     path: string,
     confirmKey?: string,
+    toggle?: { labelKey: string; param: string },
   ): Promise<boolean> {
-    if (confirmKey) {
+    let url = path;
+    if (confirmKey && toggle) {
+      const { ok, toggle: checked } = await this.confirmation.confirmWithToggle({
+        title: this.translate.instant('common.confirm'),
+        message: this.translate.instant(confirmKey),
+        variant: 'danger',
+        toggleLabel: this.translate.instant(toggle.labelKey),
+      });
+      if (!ok) return false;
+      url = `${path}${path.includes('?') ? '&' : '?'}${toggle.param}=${checked}`;
+    } else if (confirmKey) {
       const ok = await this.confirmation.confirm({
         title: this.translate.instant('common.confirm'),
         message: this.translate.instant(confirmKey),
@@ -398,7 +443,7 @@ export class DataTableComponent implements OnInit {
       });
       if (!ok) return false;
     }
-    await firstValueFrom(method === 'POST' ? this.http.post(path, {}) : this.http.delete(path));
+    await firstValueFrom(method === 'POST' ? this.http.post(url, {}) : this.http.delete(url));
     return true;
   }
 }

--- a/client/src/app/shared/components/data-table/data-table.types.ts
+++ b/client/src/app/shared/components/data-table/data-table.types.ts
@@ -37,6 +37,14 @@ export interface TableColumn {
   detailField?: string;
   /** Title of that dialog; falls back to the column's `labelKey`. */
   detailTitleKey?: string;
+  /** Names a 0–100 field on the row; a badged cell fills with it and appends the percent. */
+  progressField?: string;
+}
+
+/** One `rowActions[]` visibility clause read off the row — `when` reads the viewer instead. */
+export interface TableRowCondition {
+  key: string;
+  in: CellValue[];
 }
 
 /** `TableConfigPage.filters[]` — value sent to `list` as a query param named by `key`. */
@@ -64,9 +72,19 @@ export interface PagedResult<T> {
  * — a plugin row invoking a flow it doesn't own.
  */
 export type RowAction =
-  | { kind: 'route'; labelKey: string; path: string }
-  | { kind: 'action'; labelKey: string; actionId: string }
-  | { kind: 'proxy'; labelKey: string; method: 'POST' | 'DELETE'; path: string; confirmKey?: string };
+  | { kind: 'route'; labelKey: string; path: string; visibleWhen?: TableRowCondition }
+  | { kind: 'action'; labelKey: string; actionId: string; visibleWhen?: TableRowCondition }
+  | {
+      kind: 'proxy';
+      labelKey: string;
+      method: 'POST' | 'DELETE';
+      path: string;
+      confirmKey?: string;
+      /** A checkbox inside the confirmation; its state rides along as the query param `param`. */
+      confirmToggle?: { labelKey: string; param: string };
+      tone?: 'default' | 'danger';
+      visibleWhen?: TableRowCondition;
+    };
 
 /** List-scope action (`TableConfigPage.listActions[]`) — rendered once, not per row. */
 export interface ListAction {


### PR DESCRIPTION
Groundwork for per-row controls on a plugin's `table` page (pause/resume/remove on the download queue). Nothing in core changes behaviour today — no shipped manifest declares any of it yet.

## The bug underneath
`TableConfigPage.rowActions[]` has always declared a `kind: 'proxy'` entry, but `DataTableComponent.runProxy` passed `action.path` through **verbatim**: every row fired the same URL. No manifest ever used the kind, so it was never noticed. `ProviderListComponent` does substitute `:id` on its side of the same contract — the table half was simply never finished.

## What lands
| Addition | Why it is needed rather than nice |
|---|---|
| `:id` substitution in a `proxy` path | Without it a row action cannot name its row at all. |
| `visibleWhen: { key, in }` | Reads the **row**. Offering Pause on a paused row is a button that fails. A clause naming an absent field hides the action — an unreadable condition is not a met one. |
| `when: WhenPredicate[]` | Reads the **viewer**, reusing the closed vocabulary `ui.contributions[]` already uses. Evaluated in `PluginViewComponent`, not in `<app-data-table>`: a generic shared table has no business knowing about permissions. |
| `confirmToggle: { labelKey, param }` | A checkbox inside the confirmation whose answer changes *what the action does* ("also delete the files"), sent as a query param. Dropped when declared without a `confirmKey` — sending a default from a dialog that never rendered is worse than ignoring it. |
| `TableColumn.progressField` | Fills a badged cell and appends the percent, reusing `<app-progress-badge>` from the request views. A row reporting no number renders flat: an unreachable client is not 0%. |

`ConfirmationService` grows `confirmWithToggle()` returning `{ ok, toggle }`; the existing `confirm()` / `choose()` / `alert()` are untouched.

## Not changed
`validateManifestShape` — it checks that a `table` page carries `list` and `columns`, and does not descend into either. No new refusal path.

## Verification
- 10 new `data-table` tests: `:id` substitution, `visibleWhen` match / mismatch / absent field, toggle sent as answered / declined / dropped without a confirmKey, `progressField` rounding / null / undeclared.
- Full client suite: **610 passed**.
- `npx tsc --noEmit` clean on the client; backend unchanged apart from the contract type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)