### PR TITLE
fix(streaming): stop the subtitle-guard spec from typing its subject as never

### DIFF
--- a/backend/src/modules/streaming/subtitle-extract-guards.spec.ts
+++ b/backend/src/modules/streaming/subtitle-extract-guards.spec.ts
@@ -3,9 +3,9 @@ import * as os from 'os';
 import * as path from 'path';
 import { SubtitleStreamService } from './subtitle-stream.service';
 
-type Svc = SubtitleStreamService & {
-  assertExtracted(tmpPath: string): Promise<void>;
-};
+/** `assertExtracted` is private, so intersecting it with the class collapses to `never`.
+ *  The spec only ever calls that one method — name it alone and cast through `unknown`. */
+type Svc = { assertExtracted(tmpPath: string): Promise<void> };
 
 const svc = new SubtitleStreamService(
   null as never,
@@ -13,7 +13,7 @@ const svc = new SubtitleStreamService(
   null as never,
   null as never,
   null as never,
-) as Svc;
+) as unknown as Svc;
 
 describe('subtitle extraction guards', () => {
   let dir: string;


### PR DESCRIPTION
`npx tsc --noEmit` has failed on `main` since 611af9f0 with three errors, all in one file:

```
subtitle-extract-guards.spec.ts(36,22): error TS2339: Property 'assertExtracted' does not exist on type 'never'.
  The intersection 'Svc' was reduced to 'never' because property 'assertExtracted' exists in
  multiple constituents and is private in some.
```

`assertExtracted` is `private` on `SubtitleStreamService`, so `SubtitleStreamService & { assertExtracted(...) }` is uninhabitable and TypeScript reduces it to `never` — after which every call in the spec fails.

The spec reaches for that one method and nothing else, so it now names just that method and casts through `unknown`, instead of restating a class it never uses. The three tests are unchanged and still pass; they were running fine under Jest's transpile-only path, which is why this went unnoticed.

`npx tsc --noEmit` on `backend/` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)