### PR TITLE
refactor(progress): call a download a download, not a torrent

### DIFF
--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -1770,7 +1770,7 @@ describe('FliksHostImpl', () => {
     // The gate coalesces per torrent, not per media: every consumer keys a leaf
     // by (media, season, episode, ref), so a sibling dropped inside the window
     // is never seen at all — not late, missing, until the client sweeps it.
-    it('does not hold one torrent of a series behind another', async () => {
+    it('does not hold one download of a series behind another', async () => {
       jest.useFakeTimers();
       try {
         const h = makeHarness();
@@ -1781,7 +1781,7 @@ describe('FliksHostImpl', () => {
         await h.host['progress.set']({ mediaId: 7, seasonNumber: 1, episodeNumber: 8, ref: 'c', progress: 0.3, state: 'active' });
 
         expect(h.events.emitToUsers).toHaveBeenCalledTimes(3);
-        expect(h.events.emitToUsers.mock.calls.map((c) => c[1].hash).sort()).toEqual(['a', 'b', 'c']);
+        expect(h.events.emitToUsers.mock.calls.map((c) => c[1].ref).sort()).toEqual(['a', 'b', 'c']);
       } finally {
         jest.useRealTimers();
       }

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -1117,7 +1117,7 @@ export class FliksHostImpl implements PluginHostApi {
       mediaType: media?.type === MediaType.MOVIE ? 'movie' : 'series',
       seasonNumber: p.seasonNumber,
       episodeNumber: p.episodeNumber,
-      hash: p.ref,
+      ref: p.ref,
       progress: p.progress,
       dlspeed: p.bytesPerSecond ?? 0,
       eta: p.etaSeconds ?? 0,

--- a/backend/src/modules/scheduler/download-progress-cache.service.ts
+++ b/backend/src/modules/scheduler/download-progress-cache.service.ts
@@ -9,7 +9,7 @@ interface CachedLeaf {
   recordedAt: number;
 }
 
-// `CompletionService.processCompleted` re-emits every in-flight torrent once
+// `CompletionService.processCompleted` re-emits every in-flight download once
 // a minute — a leaf that has gone this many ticks without a refresh didn't
 // just miss one slow tick, it left the download client (stalled-removed,
 // user-deleted, media deleted, …) through a path that never reaches
@@ -24,7 +24,7 @@ const STALE_AFTER_MS = 3 * 60_000;
  * ticks sees nothing until the next one. Mirrors `PluginCountsCacheService`'s
  * shape — not persisted, a restart is a legitimate reset. `import.complete`
  * evicts a leaf immediately (the fast path); the age check in `snapshotFor`
- * is the backstop catch-all for every other way a torrent stops — it needs
+ * is the backstop catch-all for every other way a download stops — it needs
  * no list of end-events and self-heals on the next connect, no sweep timer.
  */
 @Injectable()
@@ -40,7 +40,7 @@ export class DownloadProgressCacheService {
   }
 
   private key(e: DownloadProgressEvent): string {
-    return `${e.mediaId}:${e.seasonNumber ?? ''}:${e.episodeNumber ?? ''}:${e.hash ?? ''}`;
+    return `${e.mediaId}:${e.seasonNumber ?? ''}:${e.episodeNumber ?? ''}:${e.ref ?? ''}`;
   }
 
   /** Record the latest push for its recipients. A leaf reporting done

--- a/backend/src/modules/scheduler/events.service.progress-replay.spec.ts
+++ b/backend/src/modules/scheduler/events.service.progress-replay.spec.ts
@@ -106,7 +106,7 @@ describe('EventsService — download.progress replay on connect', () => {
 });
 
 /**
- * The staleness backstop: a torrent can stop existing without ever routing
+ * The staleness backstop: a download can stop existing without ever routing
  * through `import.complete` (stalled-removed, user-deleted in the client,
  * the media itself deleted…). Without an age check, that leaf's last known
  * percent would replay forever. A fake, manually-advanced clock is injected

--- a/backend/src/modules/scheduler/events.service.ts
+++ b/backend/src/modules/scheduler/events.service.ts
@@ -75,7 +75,7 @@ export type SseEvent =
     }
   | { type: 'import.failed'; mediaId: number; title: string; error: string }
   | {
-      // Live torrent progress for an in-flight grab, delivered to the media's
+      // Live progress for an in-flight grab, delivered to the media's
       // request audience. `progress` is 0–1; `state` is core's closed
       // vocabulary (the client maps it to a label/colour). Season/episode set
       // for the matched scope of a series.
@@ -84,10 +84,11 @@ export type SseEvent =
       mediaType: 'movie' | 'series';
       seasonNumber?: number;
       episodeNumber?: number;
-      /** Torrent hash — disambiguates concurrent leaves of the same season when
-       *  the episode relation couldn't be resolved (loose episodes with no
-       *  episodeNumber would otherwise collide). */
-      hash?: string;
+      /** Opaque per-download identity, straight from `progress.set`'s `ref` — whatever the
+       *  plugin that reported it uses to tell its own downloads apart. Disambiguates concurrent
+       *  leaves of the same season when the episode relation couldn't be resolved (loose
+       *  episodes with no episodeNumber would otherwise collide). */
+      ref?: string;
       progress: number;
       dlspeed: number;
       eta: number;

--- a/backend/src/modules/scheduler/sse-audience.service.ts
+++ b/backend/src/modules/scheduler/sse-audience.service.ts
@@ -8,7 +8,7 @@ import { LibraryUserAccess } from '../libraries/entities/library-user-access.ent
 
 /**
  * Resolves which users should receive a media-scoped SSE toast (import done,
- * import failed, stalled torrent removed). The audience is the set of users who
+ * import failed, stalled download removed). The audience is the set of users who
  * requested that media. When a media has no linked requests (e.g. an admin
  * added it manually) the toast falls back to admins so library events are never
  * silently dropped.

--- a/client/src/app/core/enums/download-progress-state.enum.ts
+++ b/client/src/app/core/enums/download-progress-state.enum.ts
@@ -2,7 +2,7 @@ export type DownloadProgressState = 'queued' | 'active' | 'stalled' | 'paused' |
 
 /**
  * A leaf's phase as the UI sees it: the wire vocabulary plus `searching`, the
- * window between the user pressing grab and a torrent existing at all. Local to
+ * window between the user pressing grab and a download existing at all. Local to
  * the client — the backend never sends it, and never has to know about it.
  */
 export type ProgressPhase = DownloadProgressState | 'searching';

--- a/client/src/app/core/services/download-progress.service.spec.ts
+++ b/client/src/app/core/services/download-progress.service.spec.ts
@@ -57,8 +57,8 @@ describe('DownloadProgressService', () => {
 
   /**
    * `import.complete` is what retires a finished episode. It arrives with a
-   * season and episode number, never a torrent ref, so it has to find the leaf
-   * by the episode the leaf names — the key identifies the torrent.
+   * season and episode number, never a download ref, so it has to find the leaf
+   * by the episode the leaf names — the key identifies the download.
    */
   describe('clearMedia', () => {
     const make = () => {
@@ -67,7 +67,7 @@ describe('DownloadProgressService', () => {
     };
     const tick = (
       svc: DownloadProgressService,
-      hash: string,
+      ref: string,
       episodeNumber: number | undefined,
     ) =>
       svc.applyProgress({
@@ -75,14 +75,14 @@ describe('DownloadProgressService', () => {
         mediaType: 'series',
         seasonNumber: 1,
         episodeNumber,
-        hash,
+        ref,
         progress: 0.5,
         dlspeed: 0,
         eta: 0,
         state: 'active',
       });
 
-    it('retires the hash-keyed leaf of the imported episode', () => {
+    it('retires the ref-keyed leaf of the imported episode', () => {
       const svc = make();
       tick(svc, 'aaa', 8);
 
@@ -91,14 +91,14 @@ describe('DownloadProgressService', () => {
       expect(svc.progress().size).toBe(0);
     });
 
-    it("leaves a sibling episode's torrent alone", () => {
+    it("leaves a sibling episode's download alone", () => {
       const svc = make();
       tick(svc, 'aaa', 8);
       tick(svc, 'bbb', 9);
 
       svc.clearMedia(1, 1, 8);
 
-      expect([...svc.progress().get(1)!.seasons!.get(1)!.leaves.keys()]).toEqual(['hash:bbb']);
+      expect([...svc.progress().get(1)!.seasons!.get(1)!.leaves.keys()]).toEqual(['ref:bbb']);
     });
 
     it('retires both releases when two were racing for that episode', () => {
@@ -119,7 +119,7 @@ describe('DownloadProgressService', () => {
 
       svc.clearMedia(1, 1, 8);
 
-      expect([...svc.progress().get(1)!.seasons!.get(1)!.leaves.keys()]).toEqual(['hash:pack']);
+      expect([...svc.progress().get(1)!.seasons!.get(1)!.leaves.keys()]).toEqual(['ref:pack']);
     });
 
     it('drops the whole season when given no episode', () => {
@@ -134,7 +134,7 @@ describe('DownloadProgressService', () => {
   });
 
   /**
-   * The store is fed by events alone, so a torrent that simply stops being
+   * The store is fed by events alone, so a download that simply stops being
    * reported — deleted from the download client, or announced by a plugin too
    * old to retire it — would sit at its last percent for the life of the app.
    * The sweep is the backstop, on the same horizon the backend's replay cache
@@ -155,13 +155,13 @@ describe('DownloadProgressService', () => {
         }
       }
     };
-    const tick = (svc: DownloadProgressService, hash: string) =>
+    const tick = (svc: DownloadProgressService, ref: string) =>
       svc.applyProgress({
         mediaId: 1,
         mediaType: 'series',
         seasonNumber: 1,
         episodeNumber: 8,
-        hash,
+        ref,
         progress: 0.5,
         dlspeed: 0,
         eta: 0,
@@ -185,7 +185,7 @@ describe('DownloadProgressService', () => {
 
       sweep(svc);
 
-      expect([...svc.progress().get(1)!.seasons!.get(1)!.leaves.keys()]).toEqual(['hash:bbb']);
+      expect([...svc.progress().get(1)!.seasons!.get(1)!.leaves.keys()]).toEqual(['ref:bbb']);
     });
 
     it('drops the media once its last leaf goes quiet', () => {
@@ -221,18 +221,18 @@ describe('DownloadProgressService', () => {
    * the first. The leaf used to be keyed by episode number, so the second
    * overwrote the first and the header showed one download where there were two.
    */
-  describe('two torrents for one episode', () => {
+  describe('two downloads for one episode', () => {
     const make = () => {
       TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
       return TestBed.inject(DownloadProgressService);
     };
-    const tick = (svc: DownloadProgressService, hash: string, percent: number, state: 'active' | 'stalled' = 'active') =>
+    const tick = (svc: DownloadProgressService, ref: string, percent: number, state: 'active' | 'stalled' = 'active') =>
       svc.applyProgress({
         mediaId: 1,
         mediaType: 'series',
         seasonNumber: 1,
         episodeNumber: 8,
-        hash,
+        ref,
         progress: percent / 100,
         dlspeed: 0,
         eta: 0,
@@ -269,10 +269,10 @@ describe('DownloadProgressService', () => {
       tick(svc, 'aaa', 100);
 
       const leaves = svc.progress().get(1)!.seasons!.get(1)!.leaves;
-      expect([...leaves.keys()]).toEqual(['hash:bbb']);
+      expect([...leaves.keys()]).toEqual(['ref:bbb']);
     });
 
-    // The grab puts up a placeholder before any torrent exists; it has no ref to
+    // The grab puts up a placeholder before any download exists; it has no ref to
     // be matched on, so the first real tick has to stand in for it explicitly.
     it('supersedes the placeholder its own grab put up', () => {
       const svc = make();
@@ -281,14 +281,14 @@ describe('DownloadProgressService', () => {
       tick(svc, 'aaa', 12);
 
       const leaves = svc.progress().get(1)!.seasons!.get(1)!.leaves;
-      expect([...leaves.keys()]).toEqual(['hash:aaa']);
+      expect([...leaves.keys()]).toEqual(['ref:aaa']);
       release();
-      expect([...svc.progress().get(1)!.seasons!.get(1)!.leaves.keys()]).toEqual(['hash:aaa']);
+      expect([...svc.progress().get(1)!.seasons!.get(1)!.leaves.keys()]).toEqual(['ref:aaa']);
     });
   });
 
   /**
-   * Speed and ETA are per torrent. They used to be written onto the media
+   * Speed and ETA are per download. They used to be written onto the media
    * entry by every tick, so with concurrent episodes the figure shown was
    * whichever leaf happened to report last, not the download's.
    */
@@ -355,7 +355,7 @@ describe('DownloadProgressService', () => {
    * A series tick with no season number cannot be placed. The plugin sends one
    * for a history row that never got a season/episode id, so it is a steady
    * state — merging it onto whichever leaf happened to be alone attributed
-   * another torrent's percent to that episode, and taking the movie branch
+   * another download's percent to that episode, and taking the movie branch
    * flattened the entry and lost the season map with it.
    */
   describe('a series tick with no season', () => {
@@ -369,7 +369,7 @@ describe('DownloadProgressService', () => {
         mediaType: 'series',
         seasonNumber: 1,
         episodeNumber: 8,
-        hash: 'aaa',
+        ref: 'aaa',
         progress: 0.1,
         dlspeed: 0,
         eta: 0,
@@ -391,7 +391,7 @@ describe('DownloadProgressService', () => {
 
       unattributed(svc, 0.6);
 
-      expect(svc.progress().get(1)?.seasons?.get(1)?.leaves.get('hash:aaa')?.percent).toBe(10);
+      expect(svc.progress().get(1)?.seasons?.get(1)?.leaves.get('ref:aaa')?.percent).toBe(10);
     });
 
     it('never flattens the entry into the movie shape', () => {
@@ -413,7 +413,7 @@ describe('DownloadProgressService', () => {
   });
 
   /**
-   * The window between pressing grab and a torrent existing. Modelled as an
+   * The window between pressing grab and a download existing. Modelled as an
    * ordinary leaf so the header's season/episode scoping needs no special case
    * — and so a failed search clears with the request instead of sticking.
    */
@@ -438,30 +438,30 @@ describe('DownloadProgressService', () => {
       expect(svc.progress().size).toBe(0);
     });
 
-    // Every real tick carries a ref, so these use one: a hash-less payload is a
+    // Every real tick carries a ref, so these use one: a ref-less payload is a
     // shape production never emits, and it is exactly the shape where a guard
     // that reconstructs a key from the episode number passes by accident.
-    it('leaves a real torrent alone once it takes over', () => {
+    it('leaves a real download alone once it takes over', () => {
       const svc = make();
       const release = svc.markGrabbing(episode);
-      svc.applyProgress({ ...episode, hash: 'aaa', progress: 0.4, dlspeed: 1, eta: 2, state: 'active' });
+      svc.applyProgress({ ...episode, ref: 'aaa', progress: 0.4, dlspeed: 1, eta: 2, state: 'active' });
 
       release();
 
-      expect(svc.progress().get(1)?.seasons?.get(1)?.leaves.get('hash:aaa')).toEqual(
+      expect(svc.progress().get(1)?.seasons?.get(1)?.leaves.get('ref:aaa')).toEqual(
         expect.objectContaining({ state: 'active', percent: 40 }),
       );
     });
 
-    it('never downgrades a torrent already reporting to a search', () => {
+    it('never downgrades a download already reporting to a search', () => {
       const svc = make();
-      svc.applyProgress({ ...episode, hash: 'aaa', progress: 0.4, dlspeed: 1, eta: 2, state: 'active' });
+      svc.applyProgress({ ...episode, ref: 'aaa', progress: 0.4, dlspeed: 1, eta: 2, state: 'active' });
 
       svc.markGrabbing(episode)();
 
       const leaves = svc.progress().get(1)!.seasons!.get(1)!.leaves;
-      expect([...leaves.keys()]).toEqual(['hash:aaa']);
-      expect(leaves.get('hash:aaa')?.state).toBe('active');
+      expect([...leaves.keys()]).toEqual(['ref:aaa']);
+      expect(leaves.get('ref:aaa')?.state).toBe('active');
     });
 
     it("drops only its own leaf, not a sibling's download", () => {
@@ -471,7 +471,7 @@ describe('DownloadProgressService', () => {
         mediaType: 'series',
         seasonNumber: 1,
         episodeNumber: 3,
-        hash: 'bbb',
+        ref: 'bbb',
         progress: 0.5,
         dlspeed: 1,
         eta: 2,
@@ -481,7 +481,7 @@ describe('DownloadProgressService', () => {
       svc.markGrabbing(episode)();
 
       expect([...(svc.progress().get(1)?.seasons?.get(1)?.leaves.keys() ?? [])]).toEqual([
-        'hash:bbb',
+        'ref:bbb',
       ]);
     });
   });

--- a/client/src/app/core/services/download-progress.service.ts
+++ b/client/src/app/core/services/download-progress.service.ts
@@ -3,23 +3,22 @@ import { MediaType } from '../enums/media-type.enum';
 import { DownloadProgressState, ProgressPhase } from '../enums/download-progress-state.enum';
 import { foldLeaves } from '../../shared/utils/download-format';
 
-/** Identifies one torrent within a season. `hash:<h>` whenever the torrent has
- *  a ref — its own identity, so two releases grabbed for the *same* episode stay
- *  two leaves instead of overwriting each other. The episode number (or `'PACK'`)
- *  keys the placeholder a grab puts up before any torrent exists; the first real
- *  tick for that scope supersedes it. */
-export type LeafKey = number | 'PACK' | `hash:${string}`;
+/** Identifies one download within a season. `ref:<r>` whenever the report carries one —
+ *  its own identity, so two releases grabbed for the *same* episode stay two leaves instead
+ *  of overwriting each other. The episode number (or `'PACK'`) keys the placeholder a grab
+ *  puts up before any download exists; the first real tick for that scope supersedes it. */
+export type LeafKey = number | 'PACK' | `ref:${string}`;
 
-/** One in-flight torrent contributing to a media's download progress. */
+/** One in-flight download contributing to a media's download progress. */
 export interface DownloadLeaf {
   percent: number; // 0–100
   state: ProgressPhase;
-  /** The episode this torrent is for, when it names one. Held on the leaf
-   *  rather than in its key, which now identifies the torrent itself. */
+  /** The episode this download is for, when it names one. Held on the leaf
+   *  rather than in its key, which now identifies the download itself. */
   episodeNumber?: number;
   /** When this leaf was last reported, for the staleness sweep. */
   updatedAt?: number;
-  /** This torrent's own speed and ETA. Held per leaf because concurrent
+  /** This download's own speed and ETA. Held per leaf because concurrent
    *  episodes each have their own, and a media-level pair could only ever
    *  report whichever of them ticked last. */
   dlspeed?: number;
@@ -32,8 +31,8 @@ export interface SeasonProgress {
 
 /** Live download progress for one media, keyed by `mediaId`. For a series the
  *  `seasons` sub-map holds per-(season, leaf) progress (a leaf is a season pack
- *  or an individual episode torrent); `state`/`percent` are the folded
- *  media-level rollup. A movie has no `seasons` — its single torrent's folded
+ *  or an individual episode download); `state`/`percent` are the folded
+ *  media-level rollup. A movie has no `seasons` — its single download's folded
  *  state and percent sit directly on the entry. */
 export interface MediaDownloadProgress {
   mediaId: number;
@@ -54,7 +53,7 @@ export interface DownloadProgressEvent {
   mediaType: MediaType;
   seasonNumber?: number;
   episodeNumber?: number;
-  hash?: string;
+  ref?: string;
   progress: number; // 0–1
   dlspeed: number;
   eta: number;
@@ -67,14 +66,14 @@ export interface DownloadProgressEvent {
 const STALE_AFTER_MS = 3 * 60_000;
 const SWEEP_INTERVAL_MS = 30_000;
 
-function leafKey(episodeNumber?: number, hash?: string): LeafKey {
-  if (hash) return `hash:${hash}`;
+function leafKey(episodeNumber?: number, ref?: string): LeafKey {
+  if (ref) return `ref:${ref}`;
   return episodeNumber ?? 'PACK';
 }
 
 /** Fold every season leaf into the media-level state, percent, speed and ETA.
  *  Callers only reach here with at least one leaf, so `f.state` is never the
- *  empty sentinel. Speed sums across concurrent torrents and the ETA is the
+ *  empty sentinel. Speed sums across concurrent downloads and the ETA is the
  *  longest of them — the media is done when its slowest leaf is. */
 function rollupSeasons(seasons: Map<number, SeasonProgress>): {
   state: ProgressPhase;
@@ -110,7 +109,7 @@ export class DownloadProgressService {
 
   /**
    * Drop leaves nothing has reported in a while. The store is fed by events
-   * alone, so a torrent that stops being reported — deleted from the download
+   * alone, so a download that stops being reported — deleted from the download
    * client, or an acquisition plugin too old to announce its retirement — would
    * otherwise sit here at its last percent for the life of the app.
    *
@@ -126,7 +125,7 @@ export class DownloadProgressService {
 
     for (const [mediaId, entry] of prev) {
       if (!entry.seasons) {
-        // A movie's single torrent: the entry itself is the leaf.
+        // A movie's single download: the entry itself is the leaf.
         if ((entry.updatedAt ?? 0) < cutoff) {
           next.delete(mediaId);
           changed = true;
@@ -190,12 +189,12 @@ export class DownloadProgressService {
         const cur = next.get(e.mediaId);
         const seasons = new Map(cur?.seasons ?? []);
         const leaves = new Map(seasons.get(e.seasonNumber)?.leaves ?? []);
-        const key = leafKey(e.episodeNumber, e.hash);
+        const key = leafKey(e.episodeNumber, e.ref);
 
-        // A torrent with a ref stands in for the placeholder its grab put up
+        // A download with a ref stands in for the placeholder its grab put up
         // for the same scope, which has no identity to be matched on — on a
         // retirement as much as on a live tick.
-        if (e.hash) leaves.delete(e.episodeNumber ?? 'PACK');
+        if (e.ref) leaves.delete(e.episodeNumber ?? 'PACK');
         if (e.progress >= 1) leaves.delete(key);
         else {
           leaves.set(key, {
@@ -227,12 +226,12 @@ export class DownloadProgressService {
       // A series tick with no season number cannot be placed. The plugin sends
       // these for a history row that never got a season/episode id, so it is a
       // steady state, not a blip. Merging one onto whichever leaf happens to be
-      // alone would attribute another torrent's percent to it, and taking the
+      // alone would attribute another download's percent to it, and taking the
       // movie branch below would flatten the entry and lose the season map with
       // it. Drop it: the next attributed tick carries the same truth.
       if (e.mediaType === 'series') return next;
 
-      // Movie (single torrent — no season dimension).
+      // Movie (single download — no season dimension).
       if (e.progress >= 1) {
         next.delete(e.mediaId);
         return next;
@@ -252,14 +251,14 @@ export class DownloadProgressService {
   }
 
   /**
-   * Mark a grab as under way for a scope, before any torrent exists: the header
+   * Mark a grab as under way for a scope, before any download exists: the header
    * says "searching" from the click instead of from the download client's first
    * tick, seconds later. Returns the release to call when the request settles —
    * either way, since a failed search must not leave the badge up.
    *
    * Modelled as an ordinary leaf so scoping, folding and rendering need no
    * special case: an episode grab is keyed to that episode and stays off its
-   * siblings' pages, exactly like the torrent that replaces it.
+   * siblings' pages, exactly like the download that replaces it.
    */
   markGrabbing(e: {
     mediaId: number;
@@ -268,7 +267,7 @@ export class DownloadProgressService {
     episodeNumber?: number;
   }): () => void {
     const key = leafKey(e.episodeNumber);
-    // A torrent already reporting for this scope says strictly more than
+    // A download already reporting for this scope says strictly more than
     // "searching" — leave it, and make the release a no-op.
     if (this.leafState(e) !== undefined) return () => undefined;
 
@@ -313,8 +312,8 @@ export class DownloadProgressService {
     const cur = this.progress().get(e.mediaId);
     if (!cur) return undefined;
     if (!cur.seasons || e.seasonNumber == null) return cur.state;
-    // Matched on the leaf's own episode: the key identifies the torrent, so a
-    // live download is keyed by its hash and reconstructing a key from the
+    // Matched on the leaf's own episode: the key identifies the download, so a
+    // live download is keyed by its ref and reconstructing a key from the
     // episode number could only ever find the placeholder.
     for (const leaf of cur.seasons.get(e.seasonNumber)?.leaves.values() ?? []) {
       if (leaf.episodeNumber === e.episodeNumber) return leaf.state;

--- a/client/src/app/core/services/sse.service.ts
+++ b/client/src/app/core/services/sse.service.ts
@@ -182,7 +182,7 @@ export class SseService implements OnDestroy {
           mediaType: event['mediaType'] as MediaType,
           seasonNumber: event['seasonNumber'] as number | undefined,
           episodeNumber: event['episodeNumber'] as number | undefined,
-          hash: event['hash'] as string | undefined,
+          ref: event['ref'] as string | undefined,
           progress: Number(event['progress']),
           dlspeed: Number(event['dlspeed'] ?? 0),
           eta: Number(event['eta'] ?? 0),
@@ -197,11 +197,11 @@ export class SseService implements OnDestroy {
           event['seasonNumber'] as number | undefined,
           event['episodeNumber'] as number | undefined,
         );
-        // Import always finishes unattended (torrent completion is polled by
+        // Import always finishes unattended (completion is polled by
         // a scheduler) — no toast, just retire the live progress above.
         break;
       case 'stalled.removed':
-        // Unattended cleanup of a stalled torrent — no toast.
+        // Unattended cleanup of a stalled download — no toast.
         break;
       case 'social.followed':
         this.toast.info(

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -108,7 +108,7 @@ function readEpisodesHasFileOnlyFromStorage(): boolean {
   }
 }
 
-/** Season / episode a grab targets, matching the leaf its torrent lands under.
+/** Season / episode a grab targets, matching the leaf its download lands under.
  *  Empty for a movie, or a whole-series grab with no season scope. */
 type GrabScope = { seasonNumber?: number; episodeNumber?: number };
 
@@ -181,7 +181,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   });
 
   /**
-   * The header's download chip. One torrent shows its own state and percent;
+   * The header's download chip. One download shows its own state and percent;
    * several show how many there are and open the modal for the breakdown —
    * folding their states into one label read "stalled" for a whole show
    * whenever a single episode was, and averaged percentages that belong to
@@ -230,7 +230,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     this.media() ? this.downloadBadge() : null,
   );
 
-  /** Same chip on the episode page, narrowed to that episode's own torrents or
+  /** Same chip on the episode page, narrowed to that episode's own downloads or
    *  the season pack that carries it — a sibling episode's grab stays off it. */
   readonly episodeHeaderBadge = computed<MediaInfoHeaderBadge | null>(() => {
     const ep = this.focusedEpisode();
@@ -1180,7 +1180,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   /**
    * Run a grab with the header badge showing its search phase from the click,
    * so the user isn't left with a silent button while the indexers are queried.
-   * The badge hands over to the real torrent as soon as the first progress
+   * The badge hands over to the real download as soon as the first progress
    * event lands; on failure the phase clears with the settled request.
    */
   private async withGrabPhase<T>(
@@ -1195,7 +1195,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       const out = await run();
       // Success: the grab is real, so keep the phase up while the download
       // client's first tick makes its way over SSE. Only ever clears a leaf
-      // still marked `searching`, so a torrent that lands sooner is untouched.
+      // still marked `searching`, so a download that lands sooner is untouched.
       setTimeout(release, GRAB_HANDOFF_MS);
       return out;
     } catch (err) {
@@ -1204,7 +1204,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     }
   }
 
-  /** Grab scope for an episode id — the leaf key its torrent will land under. */
+  /** Grab scope for an episode id — the leaf key its download will land under. */
   private episodeScope(episodeId: number): GrabScope {
     for (const s of this.media()?.seasons ?? []) {
       const ep = s.episodes?.find((e) => e.id === episodeId);

--- a/client/src/app/shared/components/download-detail-modal/download-detail-modal.html
+++ b/client/src/app/shared/components/download-detail-modal/download-detail-modal.html
@@ -3,7 +3,7 @@
     <app-modal-header [title]="'media_detail.download_detail_title' | translate" />
 
     @if (progress(); as p) {
-      @if (isSingleTorrent()) {
+      @if (isSingleDownload()) {
         <div class="flex flex-col gap-1.5">
           @if (p.percent !== null) {
             <app-progress-bar [percent]="p.percent" [variant]="overallVariant()" />

--- a/client/src/app/shared/components/download-detail-modal/download-detail-modal.spec.ts
+++ b/client/src/app/shared/components/download-detail-modal/download-detail-modal.spec.ts
@@ -48,11 +48,11 @@ async function render(
 }
 
 /**
- * One torrent, one row: bar, percent, speed and ETA. There is deliberately no
+ * One download, one row: bar, percent, speed and ETA. There is deliberately no
  * rollup above them — the media-level speed was whichever leaf ticked last, and
  * a folded state read "stalled" for a whole show whenever one episode was.
  */
-describe('DownloadDetailModalComponent — one row per torrent', () => {
+describe('DownloadDetailModalComponent — one row per download', () => {
   it('gives every episode its own bar, speed and ETA', async () => {
     const f = await render([
       [1, [
@@ -81,7 +81,7 @@ describe('DownloadDetailModalComponent — one row per torrent', () => {
     expect(seven.percent).toBe(0);
   });
 
-  it('names the search, with no percentage, before a torrent exists', async () => {
+  it('names the search, with no percentage, before a download exists', async () => {
     const f = await render([[1, [[8, { state: 'searching', percent: 0 }]]]]);
     const [row] = f.componentInstance.seasonRows()[0].leaves;
 
@@ -98,7 +98,7 @@ describe('DownloadDetailModalComponent — one row per torrent', () => {
     expect(f.componentInstance.seasonRows().map((s) => s.seasonNumber)).toEqual([1, 2]);
   });
 
-  // A movie has one torrent and no season to group it under, so the headline is
+  // A movie has one download and no season to group it under, so the headline is
   // the row rather than a rollup over anything.
   it('keeps a single headline for a movie', async () => {
     TestBed.resetTestingModule();
@@ -123,7 +123,7 @@ describe('DownloadDetailModalComponent — one row per torrent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(fixture.componentInstance.isSingleTorrent()).toBe(true);
+    expect(fixture.componentInstance.isSingleDownload()).toBe(true);
     expect(fixture.componentInstance.seasonRows()).toEqual([]);
     expect(fixture.componentInstance.speedLabel()).toBe('1.0 KB/s');
   });

--- a/client/src/app/shared/components/download-detail-modal/download-detail-modal.ts
+++ b/client/src/app/shared/components/download-detail-modal/download-detail-modal.ts
@@ -23,7 +23,7 @@ interface LeafRow {
   key: string;
   labelKey: string;
   labelNumber: number | null;
-  /** Null while the release is still being searched for — there is no torrent
+  /** Null while the release is still being searched for — there is no download
    *  to be a percentage of yet. */
   percent: number | null;
   variant: ProgressVariant;
@@ -36,7 +36,7 @@ interface LeafRow {
 
 interface SeasonRow {
   seasonNumber: number;
-  /** One row per torrent. The season itself carries no folded status: with
+  /** One row per download. The season itself carries no folded status: with
    *  concurrent episodes it could only ever be a rollup that contradicts the
    *  rows under it. */
   leaves: LeafRow[];
@@ -44,10 +44,10 @@ interface SeasonRow {
 
 /**
  * Detail view behind the header / request download badge. The badge can only
- * fold several concurrent torrents into one chip; this modal is where they come
- * apart — one bar, speed and ETA per torrent, under the season it belongs to.
+ * fold several concurrent downloads into one chip; this modal is where they come
+ * apart — one bar, speed and ETA per download, under the season it belongs to.
  * No rollup above them: with concurrent episodes it could only ever be an
- * aggregate that contradicts the rows beneath it. A movie has a single torrent
+ * aggregate that contradicts the rows beneath it. A movie has a single download
  * and no season dimension, so it keeps a single headline instead.
  *
  * The parent passes its live `progress` so the modal keeps updating from SSE
@@ -65,8 +65,8 @@ export class DownloadDetailModalComponent {
 
   private readonly dialog = viewChild<ElementRef<HTMLDialogElement>>('dialog');
 
-  /** A movie's single torrent: no season to group under, so it is its own row. */
-  readonly isSingleTorrent = computed(() => !this.progress()?.seasons);
+  /** A movie's single download: no season to group under, so it is its own row. */
+  readonly isSingleDownload = computed(() => !this.progress()?.seasons);
 
   readonly overallStateLabelKey = computed(() =>
     qbStateLabelKey(this.progress()?.state ?? ''),
@@ -112,7 +112,7 @@ export class DownloadDetailModalComponent {
     return { labelKey: 'media_detail.download_pack', labelNumber: null };
   }
 
-  /** Episode order, packs last. The key identifies the torrent now, so it says
+  /** Episode order, packs last. The key identifies the download now, so it says
    *  nothing about where the row belongs in the list. */
   private leafOrder(leaf: { episodeNumber?: number }): number {
     return leaf.episodeNumber ?? Number.MAX_SAFE_INTEGER;

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -102,7 +102,7 @@ export interface MediaInfoHeaderBadge {
   percent: number | null;
   /** daisyUI colour class, e.g. `badge-info` / `badge-ghost`. */
   badgeClass: string;
-  /** Interpolation for {@link labelKey} — the torrent count, when the chip
+  /** Interpolation for {@link labelKey} — the download count, when the chip
    *  stands for several at once. */
   labelParams: Record<string, unknown> | null;
   /** When true the badge renders as a button that emits openDownloadDetail. */

--- a/client/src/app/shared/utils/download-badges.spec.ts
+++ b/client/src/app/shared/utils/download-badges.spec.ts
@@ -23,11 +23,11 @@ const series = (leaves: [number, [number | 'PACK', { state: 'active'; percent: n
 /**
  * A media can be downloading several things at once — two episodes, or a season
  * pack alongside a straggler. The header used to fold them into one chip, which
- * averaged percentages belonging to different files; each torrent now gets its
+ * averaged percentages belonging to different files; each download now gets its
  * own, so the scoped listing has to keep them apart and keep their identity.
  */
-describe('collectScopedLeaves — several torrents on one media', () => {
-  it('keeps every torrent, with the season it was found under', () => {
+describe('collectScopedLeaves — several downloads on one media', () => {
+  it('keeps every download, with the season it was found under', () => {
     const found = collectScopedLeaves(
       series([[1, [[6, { state: 'active', percent: 3 }], [8, { state: 'active', percent: 19 }]]]]),
     );

--- a/client/src/app/shared/utils/download-format.spec.ts
+++ b/client/src/app/shared/utils/download-format.spec.ts
@@ -127,7 +127,7 @@ describe('download-format', () => {
    * a season pack legitimately belongs on every episode page of that season.
    */
   describe('describeDownload — episode scope', () => {
-    // The store keys a leaf by its torrent and records the episode on the leaf,
+    // The store keys a leaf by its download and records the episode on the leaf,
     // so a fixture has to carry the attribute the scope filter reads.
     const season1 = (leaves: [number | 'PACK', DownloadLeaf][]): MediaDownloadProgress => ({
       mediaId: 2,
@@ -156,7 +156,7 @@ describe('download-format', () => {
       expect(d).toBeNull();
     });
 
-    it("reports the episode's own torrent", () => {
+    it("reports the episode's own download", () => {
       const d = describeDownload(season1([[7, leaf('active', 52)]]), {
         seasonFilter: [1],
         episodeFilter: 7,
@@ -170,9 +170,9 @@ describe('download-format', () => {
       expect(describeDownload(progress, { seasonFilter: [1], episodeFilter: 8 })?.percent).toBe(30);
     });
 
-    // Real season-pack ticks arrive with a torrent ref and no episode number,
-    // so the store keys them `hash:<ref>` — never the literal 'PACK' sentinel.
-    it('reports a hash-keyed pack on an episode page', () => {
+    // Real season-pack ticks arrive with a download ref and no episode number,
+    // so the store keys them `ref:<r>` — never the literal 'PACK' sentinel.
+    it('reports a ref-keyed pack on an episode page', () => {
       const progress: MediaDownloadProgress = {
         mediaId: 2,
         mediaType: 'series',
@@ -180,7 +180,7 @@ describe('download-format', () => {
         state: 'active',
         dlspeed: 0,
         eta: 0,
-        seasons: new Map([[1, { leaves: new Map([['hash:abc', leaf('active', 30)]]) }]]),
+        seasons: new Map([[1, { leaves: new Map([['ref:abc', leaf('active', 30)]]) }]]),
       };
       expect(describeDownload(progress, { seasonFilter: [1], episodeFilter: 7 })?.percent).toBe(30);
     });

--- a/client/src/app/shared/utils/download-format.ts
+++ b/client/src/app/shared/utils/download-format.ts
@@ -29,8 +29,8 @@ export function formatSpeed(bytesPerSec: number): string {
 }
 
 export function formatEta(seconds: number): string {
-  // qBittorrent reports 8640000s (100 days) as its "infinite" ETA sentinel for
-  // stalled / no-progress torrents — show ∞ rather than a bogus "2400h 0m".
+  // 8640000s (100 days) is the "infinite" ETA sentinel a stalled download reports —
+  // show ∞ rather than a bogus "2400h 0m".
   if (!isFinite(seconds) || seconds >= 8640000) return '∞';
   if (seconds <= 0) return '—';
   const h = Math.floor(seconds / 3600);
@@ -94,7 +94,7 @@ const STATE_RANK: Record<ProgressPhase, number> = {
   queued: 3,
   importing: 4,
   paused: 5,
-  // Last: any torrent that actually exists says more than "still looking".
+  // Last: any download that actually exists says more than "still looking".
   searching: 6,
 };
 
@@ -163,7 +163,7 @@ function fallbackDescriptor(
 }
 
 /** A leaf with the scope it was found under, for callers that render one row
- *  per torrent rather than a fold. */
+ *  per download rather than a fold. */
 export interface ScopedLeaf {
   seasonNumber: number;
   key: LeafKey;
@@ -180,7 +180,7 @@ export function collectScopedLeaves(
   for (const [seasonNumber, sp] of progress.seasons) {
     if (seasonFilter?.length && !seasonFilter.includes(seasonNumber)) continue;
     for (const [key, leaf] of sp.leaves) {
-      // Only another episode's own torrent is out of scope. A leaf naming no
+      // Only another episode's own download is out of scope. A leaf naming no
       // episode — a season pack, or one whose episode couldn't be resolved —
       // may well carry this one, so it counts.
       if (
@@ -217,7 +217,7 @@ export function describeBadge(
     monitored: boolean;
     downloaded: boolean;
     seasonFilter?: number[];
-    /** Narrow to one episode — its own torrent, or a pack that contains it. */
+    /** Narrow to one episode — its own download, or a pack that contains it. */
     episodeFilter?: number;
   },
 ): DownloadBadgeDescriptor {
@@ -228,7 +228,7 @@ export function describeBadge(
 }
 
 /**
- * The in-flight half of {@link describeBadge}: what a scope's torrents are
+ * The in-flight half of {@link describeBadge}: what a scope's downloads are
  * doing, or null when none of them are. Callers that only surface downloads
  * (the media header) use this directly — the monitored / unmonitored fallback
  * is a request-view concern and would otherwise sit on an ongoing series for
@@ -238,7 +238,7 @@ export function describeDownload(
   progress: MediaDownloadProgress | null,
   scope: {
     seasonFilter?: number[];
-    /** Narrow to one episode — its own torrent, or a pack that contains it. */
+    /** Narrow to one episode — its own download, or a pack that contains it. */
     episodeFilter?: number;
   } = {},
 ): DownloadBadgeDescriptor | null {
@@ -257,7 +257,7 @@ export function describeDownload(
     if (!leaves.length) return null;
     fold = foldLeaves(leaves);
   } else {
-    // Unscoped, or a movie's single torrent: the entry already carries the fold
+    // Unscoped, or a movie's single download: the entry already carries the fold
     // of everything under it. A series with no leaf left is nothing in flight.
     if (progress.seasons && !collectLeaves(progress).length) return null;
     fold = { state: progress.state, percent: progress.percent };


### PR DESCRIPTION
The last torrent-shaped naming in core's progress path. **No behaviour change** — the value crossing the wire is byte-identical, only its name changes.

## The lie
`PluginHostApi['progress.set']` takes `ref: string`, deliberately opaque: whatever the reporting plugin uses to tell its own downloads apart. `FliksHostService.pushProgress` then re-emitted it as `hash` on the `download.progress` SSE event, and the client keyed its leaves `` `hash:${string}` ``.

Nothing below the contract parses a torrent, talks to a tracker, or would behave one bit differently if that ref were a Usenet message id. Core simply cannot know, and the name claimed otherwise.

| | Before | After |
|---|---|---|
| SSE event field | `hash?: string` | `ref?: string` |
| Client leaf key | `` `hash:${string}` `` | `` `ref:${string}` `` |
| Detail-modal getter | `isSingleTorrent()` | `isSingleDownload()` |

`LeafKey` is an in-memory signal key with no persistence anywhere, so nothing needs migrating.

## Also the comments
Same reasoning, same files: the progress fold, the detail modal, the SSE audience and the staleness backstop all described "torrents". They describe downloads.

Left alone deliberately: `osdbHash` / `moviehash` in the subtitle scheduler (a real content hash), and the plugin-archive hashes.

## Verification
- Backend **1834 passed**, client **610 passed**.
- `npx tsc --noEmit` clean on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)