### PR TITLE
feat(releases): list only the qualities the profile allows

### DIFF
--- a/backend/src/common/release-scoring/release-rejection.helper.spec.ts
+++ b/backend/src/common/release-scoring/release-rejection.helper.spec.ts
@@ -491,7 +491,7 @@ describe('computeRejections — resolution upgrade only', () => {
   });
 });
 
-describe('computeRejections — above the profile vs merely outside it', () => {
+describe('computeRejections — the quality profile', () => {
   // 12 WEBDL-720p (45), 16 WEBDL-1080p (62), 18 Bluray-1080p (68), 19 Remux-1080p (72).
   const codeFor = (qualityId: number, allowed: number[]) =>
     computeRejections({
@@ -508,23 +508,16 @@ describe('computeRejections — above the profile vs merely outside it', () => {
       sourceMinSeeders: new Map(),
     }).map((r) => r.code);
 
-  it('VERDICT: a quality better than every allowed one is ABOVE, not merely NOT_ALLOWED', () => {
-    expect(codeFor(19, [16, 18])).toEqual(['QUALITY_ABOVE_PROFILE']);
-  });
-
-  it('VERDICT: a quality below the profile stays NOT_ALLOWED, so the picker keeps offering it', () => {
-    expect(codeFor(12, [16, 18])).toEqual(['QUALITY_NOT_ALLOWED']);
-  });
-
-  it('ranks, not ids: a lower id outranking the profile still reads as above it', () => {
-    expect(codeFor(18, [16])).toEqual(['QUALITY_ABOVE_PROFILE']);
-  });
-
-  it('an allowed quality is rejected by neither', () => {
+  it('an allowed quality is not rejected on quality', () => {
     expect(codeFor(16, [16, 18])).toEqual([]);
   });
 
-  it('an empty profile rejects everything as outside it — nothing to be above', () => {
-    expect(codeFor(19, [])).toEqual(['QUALITY_NOT_ALLOWED']);
+  it('VERDICT: membership, not a ceiling — above and below the profile read alike', () => {
+    expect(codeFor(19, [16, 18])).toEqual(['QUALITY_NOT_ALLOWED']);
+    expect(codeFor(12, [16, 18])).toEqual(['QUALITY_NOT_ALLOWED']);
+  });
+
+  it('an empty profile allows nothing', () => {
+    expect(codeFor(16, [])).toEqual(['QUALITY_NOT_ALLOWED']);
   });
 });

--- a/backend/src/common/release-scoring/release-rejection.helper.ts
+++ b/backend/src/common/release-scoring/release-rejection.helper.ts
@@ -475,19 +475,6 @@ export function titleMatchesExpectation(
   return matchesIndexedExpectation(releaseTitleTokens(releaseTitle), index, whenUnreadable);
 }
 
-/**
- * Better than everything the profile allows, as opposed to merely outside it. The picker hides
- * these rows instead of offering them for a forced grab: a 2160p remux under a 1080p profile is
- * not a fallback anyone wants, while a 720p one under the same profile still is.
- */
-function rankExceedsProfile(qualityId: number, allowed: Set<number>): boolean {
-  const rank = getAppQualityById(qualityId)?.rank;
-  if (rank == null || allowed.size === 0) return false;
-  let best = 0;
-  for (const id of allowed) best = Math.max(best, getAppQualityById(id)?.rank ?? 0);
-  return rank > best;
-}
-
 /** `S04E03`, `S04`, or `?` — the display params of an EPISODE_MISMATCH. */
 function formatSeasonEpisode(
   season: number | null | undefined,
@@ -603,11 +590,7 @@ export function computeRejections(opts: {
   }
 
   if (!opts.allowed.has(opts.qualityId)) {
-    out.push({
-      code: rankExceedsProfile(opts.qualityId, opts.allowed)
-        ? 'QUALITY_ABOVE_PROFILE'
-        : 'QUALITY_NOT_ALLOWED',
-    });
+    out.push({ code: 'QUALITY_NOT_ALLOWED' });
   }
 
   // "Upgrade resolution only": the profile refuses a same-resolution tier hop, so a 1080p Bluray

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1089,7 +1089,6 @@
     "confirm_delete_subtitle": "Diesen Untertitel löschen?",
     "rejection": {
       "QUALITY_NOT_ALLOWED": "Qualität außerhalb des Profils",
-      "QUALITY_ABOVE_PROFILE": "Qualität über dem Profil",
       "LANGUAGE_NOT_ALLOWED": "Sprache außerhalb des Profils",
       "BLOCKLISTED": "Release blockiert",
       "SIZE_TOO_LOW": "Größe zu niedrig\n({{actual}} MB < {{min}} MB)",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1097,7 +1097,6 @@
     "confirm_delete_subtitle": "Delete this subtitle?",
     "rejection": {
       "QUALITY_NOT_ALLOWED": "Quality outside profile",
-      "QUALITY_ABOVE_PROFILE": "Quality above profile",
       "LANGUAGE_NOT_ALLOWED": "Language outside profile",
       "BLOCKLISTED": "Blocked release",
       "SIZE_TOO_LOW": "Size too low\n({{actual}} MB < {{min}} MB)",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1089,7 +1089,6 @@
     "confirm_delete_subtitle": "¿Eliminar este subtítulo?",
     "rejection": {
       "QUALITY_NOT_ALLOWED": "Calidad fuera del perfil",
-      "QUALITY_ABOVE_PROFILE": "Calidad superior al perfil",
       "LANGUAGE_NOT_ALLOWED": "Idioma fuera del perfil",
       "BLOCKLISTED": "Release bloqueada",
       "SIZE_TOO_LOW": "Tamaño demasiado bajo\n({{actual}} MB < {{min}} MB)",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1097,7 +1097,6 @@
     "confirm_delete_subtitle": "Supprimer ce sous-titre ?",
     "rejection": {
       "QUALITY_NOT_ALLOWED": "Qualité hors profil",
-      "QUALITY_ABOVE_PROFILE": "Qualité au-dessus du profil",
       "LANGUAGE_NOT_ALLOWED": "Langue hors profil",
       "BLOCKLISTED": "Release bloquée",
       "SIZE_TOO_LOW": "Taille trop faible\n({{actual}} MB < {{min}} MB)",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1089,7 +1089,6 @@
     "confirm_delete_subtitle": "Eliminare questo sottotitolo?",
     "rejection": {
       "QUALITY_NOT_ALLOWED": "Qualità fuori profilo",
-      "QUALITY_ABOVE_PROFILE": "Qualità superiore al profilo",
       "LANGUAGE_NOT_ALLOWED": "Lingua fuori profilo",
       "BLOCKLISTED": "Release bloccata",
       "SIZE_TOO_LOW": "Dimensione troppo bassa\n({{actual}} MB < {{min}} MB)",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1089,7 +1089,6 @@
     "confirm_delete_subtitle": "Eliminar esta legenda?",
     "rejection": {
       "QUALITY_NOT_ALLOWED": "Qualidade fora do perfil",
-      "QUALITY_ABOVE_PROFILE": "Qualidade acima do perfil",
       "LANGUAGE_NOT_ALLOWED": "Idioma fora do perfil",
       "BLOCKLISTED": "Release bloqueada",
       "SIZE_TOO_LOW": "Tamanho demasiado baixo\n({{actual}} MB < {{min}} MB)",

--- a/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.spec.ts
+++ b/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.spec.ts
@@ -261,35 +261,46 @@ describe('ReleasesModalComponent — per-indexer tabs', () => {
   });
 });
 
-describe('ReleasesModalComponent — releases above the profile', () => {
-  const above = (sourceId: number, title: string): MovieRelease => ({
+describe('ReleasesModalComponent — only what the profile allows', () => {
+  const outside = (sourceId: number, title: string, code: string): MovieRelease => ({
     ...release(sourceId, title),
     allowed: false,
-    rejections: [{ code: 'QUALITY_ABOVE_PROFILE' }],
+    rejections: [{ code }],
   });
 
-  it('VERDICT: never lists a release better than the profile allows', async () => {
+  it('VERDICT: a quality above the profile is never listed', async () => {
     const fixture = await createFixture({
-      releases: [release(1, 'in-profile'), above(1, 'remux')],
+      releases: [release(1, 'in-profile'), outside(1, 'remux-2160p', 'QUALITY_NOT_ALLOWED')],
     });
     expect(fixture.componentInstance.visibleReleases().map((r) => r.title)).toEqual(['in-profile']);
   });
 
-  it("VERDICT: the tab counts drop it too — a count that promises a row the list hides is a bug", async () => {
+  it('VERDICT: a quality below it is not a fallback either — membership, not a ceiling', async () => {
     const fixture = await createFixture({
-      releases: [release(1, 'in-profile'), above(1, 'remux'), above(2, 'remux-2')],
+      releases: [release(1, 'in-profile'), outside(1, 'sd-720p', 'QUALITY_NOT_ALLOWED')],
+    });
+    expect(fixture.componentInstance.visibleReleases().map((r) => r.title)).toEqual(['in-profile']);
+  });
+
+  it('the tab counts drop them too — a count that promises a hidden row is a bug', async () => {
+    const fixture = await createFixture({
+      releases: [
+        release(1, 'in-profile'),
+        outside(1, 'remux', 'QUALITY_NOT_ALLOWED'),
+        outside(2, 'sd', 'QUALITY_NOT_ALLOWED'),
+      ],
       indexers: ROSTER,
     });
     expect(fixture.componentInstance.tabs().map((t) => t.count)).toEqual([1, 1, null, 0]);
   });
 
-  it('keeps a release merely outside the profile — it is still grabbable by hand', async () => {
-    const outside: MovieRelease = {
-      ...release(1, 'below'),
-      allowed: false,
-      rejections: [{ code: 'QUALITY_NOT_ALLOWED' }],
+  it('a release the profile allows but something else rejects still shows, to be forced by hand', async () => {
+    const seedless: MovieRelease = {
+      ...release(1, 'few-seeders'),
+      allowed: true,
+      rejections: [{ code: 'MIN_SEEDERS', params: { actual: 0, min: 5 } }],
     };
-    const fixture = await createFixture({ releases: [outside] });
-    expect(fixture.componentInstance.visibleReleases().map((r) => r.title)).toEqual(['below']);
+    const fixture = await createFixture({ releases: [seedless] });
+    expect(fixture.componentInstance.visibleReleases().map((r) => r.title)).toEqual(['few-seeders']);
   });
 });

--- a/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.ts
+++ b/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.ts
@@ -79,11 +79,15 @@ export class ReleasesModalComponent {
     if (active !== null && !roster.some((ix) => ix.id === active)) this.activeTab.set(null);
   });
 
-  /** Everything the picker will ever show. A release better than the profile allows is dropped
-   *  here rather than in the row list, so a tab's count can never promise rows it then hides. */
-  private readonly offered = computed(() =>
-    this.releases().filter((r) => !r.rejections.some((x) => x.code === 'QUALITY_ABOVE_PROFILE')),
-  );
+  /**
+   * Everything the picker will ever show: the profile's allowed qualities exactly — not a
+   * ceiling. A release above them is not wanted and one below them is not a fallback, so
+   * neither is listed. Other rejections (size, seeders, language, blocklist) still show, and
+   * still confirm before grabbing: those are judgements, this one is the profile itself.
+   *
+   * Filtered here rather than in the row list, so a tab's count can never promise rows it hides.
+   */
+  private readonly offered = computed(() => this.releases().filter((r) => r.allowed));
 
   readonly tabs = computed<TabView[]>(() => {
     const roster = this.indexers();


### PR DESCRIPTION
Supersedes #1134. The release picker now shows **only** releases whose quality is in the profile's allowed set — membership, not a ceiling.

## The rule
| Release | Before #1134 | After #1134 | Now |
|---|---|---|---|
| Quality in the profile | listed | listed | **listed** |
| Quality above the profile | listed, rejected | hidden | **hidden** |
| Quality below the profile | listed, rejected | listed, rejected | **hidden** |

A quality above the profile is not wanted; a quality below it is not a fallback. Neither belongs in a list read to pick something to grab.

The filter is `r.allowed` — the field `scoreAndSortReleases` already sets from `allowed.has(qualityId)` — applied once into `offered()`, feeding both the tab counts and the row list. Filtering only the list would leave a per-indexer tab advertising rows it then refuses to show.

## `QUALITY_ABOVE_PROFILE` is removed
#1134 split the quality rejection so the picker could hide "above" and keep "below". With both hidden that split has **zero consumers**: no surface renders either code, and `formatRejectionForLog` is called from nowhere in this repo or in the download plugin. It goes, and takes with it a per-release scan of the allowed set that ran on the scoring hot path for nothing. Its six translations go too.

## What still shows
Every other rejection — `SIZE_TOO_LOW`, `MIN_SEEDERS`, `LANGUAGE_NOT_ALLOWED`, `BLOCKLISTED`, `TITLE_MISMATCH`, … — still lists, and still confirms before grabbing. Those are judgements an operator may reasonably override on a given night. The quality profile is not one of them.

## Verification
- Backend **1832 passed**, client **611 passed**; both typechecks clean.
- Client tests cover above-hidden, below-hidden, tab counts agreeing with the rows, and a profile-allowed release rejected for seeders still being offered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)