### PR TITLE
feat(plugins): let a table row open its media and explain itself

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -247,12 +247,32 @@ export interface TableColumn {
   detailField?: string;
   /** Title of that dialog. Falls back to the column's own `labelKey`. */
   detailTitleKey?: string;
+  /** Turns the cell into a link running this core action against its row. Same closed
+   *  vocabulary as a row action's `actionId`, and the same fail-closed rule: an id core does not
+   *  recognise, or a row the action cannot resolve, renders plain text rather than a dead link. */
+  linkActionId?: TableRowActionId;
   /** Names a 0–100 field on the row; a badged cell then fills left-to-right with it and appends
    *  the percent. A moving value belongs inside the badge naming what is moving — as its own
    *  column it costs width and reads as unrelated to the state beside it. Ignored on a cell that
    *  declares no `badges`, and on a row whose named field is not a number. */
   progressField?: string;
 }
+
+/**
+ * One line of a `detail` row action's dialog. A plain field renders its value; `kind: 'link'`
+ * renders `textKey` as an anchor to the URL the row holds under `key`, which core refuses
+ * unless it is `http:` or `https:` — the value comes from an indexer, not from the manifest.
+ * A field whose row value is empty is skipped, so one dialog serves rows of differing shape.
+ */
+export type TableDetailField =
+  | {
+      kind?: 'value';
+      key: string;
+      labelKey: string;
+      format?: 'date' | 'bytes' | 'percent' | 'speed';
+      labelKeys?: Record<string, string>;
+    }
+  | { kind: 'link'; key: string; labelKey: string; textKey: string };
 
 /** One `rowActions[]` visibility clause, read off the row itself: the action renders only when
  *  the row's `key` holds one of `in`. Pausing a paused download is not an action, it is a button
@@ -355,6 +375,16 @@ export interface TableConfigPage extends ConfigPageBase {
         kind: 'action';
         labelKey: string;
         actionId: TableRowActionId;
+        when?: WhenPredicate[];
+        visibleWhen?: TableRowCondition;
+      }
+    /** Opens a dialog of declared fields read off the row. Needs no route: everything it shows
+     *  is already on the row the table loaded. */
+    | {
+        kind: 'detail';
+        labelKey: string;
+        titleKey?: string;
+        fields: TableDetailField[];
         when?: WhenPredicate[];
         visibleWhen?: TableRowCondition;
       }

--- a/client/src/app/features/plugin-view/plugin-view.spec.ts
+++ b/client/src/app/features/plugin-view/plugin-view.spec.ts
@@ -426,6 +426,64 @@ describe('PluginViewComponent', () => {
     http.verify();
   });
 
+  it('VERDICT: a row naming an episode lands on that episode, not on the series root', async () => {
+    const { fixture, http, navigateByUrl } = createComponent(
+      { pluginId: 'fliks.a', view: 'queue' },
+      {
+        hasPlugin: () => true,
+        configPage: () => ({
+          kind: 'table',
+          id: 'x',
+          labelKey: 'x.title',
+          list: '/queue',
+          columns: [{ key: 'name', labelKey: 'x.col_name', linkActionId: 'table.open-media' }],
+          rowActions: [{ kind: 'action', labelKey: 'x.open', actionId: 'table.open-media' }],
+        }),
+      },
+    );
+    fixture.detectChanges();
+    http.expectOne({ url: '/api/plugins/fliks.a/queue', method: 'GET' }).flush([
+      { id: 1, name: 'Show A - S01E02', mediaId: 42, mediaType: 'series', episodeId: 7 },
+    ]);
+    await settle(fixture);
+
+    // The title cell is the link now, so clicking it is what a user actually does.
+    const link = (Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[]).find(
+      (b) => b.textContent?.includes('Show A - S01E02'),
+    );
+    expect(link).toBeDefined();
+    link!.click();
+    expect(navigateByUrl).toHaveBeenCalledWith('/series/42/episode/7');
+    http.verify();
+  });
+
+  it('a movie row ignores any episodeId and lands on the movie page', async () => {
+    const { fixture, http, navigateByUrl } = createComponent(
+      { pluginId: 'fliks.a', view: 'queue' },
+      {
+        hasPlugin: () => true,
+        configPage: () => ({
+          kind: 'table',
+          id: 'x',
+          labelKey: 'x.title',
+          list: '/queue',
+          columns: [{ key: 'name', labelKey: 'x.col_name' }],
+          rowActions: [{ kind: 'action', labelKey: 'x.open', actionId: 'table.open-media' }],
+        }),
+      },
+    );
+    fixture.detectChanges();
+    http.expectOne({ url: '/api/plugins/fliks.a/queue', method: 'GET' }).flush([
+      { id: 1, name: 'A Film', mediaId: 9, mediaType: 'movie', episodeId: null },
+    ]);
+    await settle(fixture);
+    (Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[])
+      .find((b) => b.textContent?.includes('x.open'))!
+      .click();
+    expect(navigateByUrl).toHaveBeenCalledWith('/movies/9');
+    http.verify();
+  });
+
   it('a table `proxy` row action hits the proxied route with its declared method; a `route` row action navigates in-app unprefixed', async () => {
     const { fixture, http, navigateByUrl } = createComponent(
       { pluginId: 'fliks.a', view: 'queue' },

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -383,16 +383,25 @@ export class PluginViewComponent implements OnDestroy {
   }
 
   /** Resolves a `TableRowActionId` against its row — today only jumping to that row's own media
-   *  page via its `mediaId`/`mediaType` columns; anything else renders no button. */
+   *  page via its `mediaId`/`mediaType` columns; anything else renders no button.
+   *
+   *  A row naming an episode lands on that episode rather than on the series root: a queue row
+   *  is read to reach the thing it is downloading, and a series page does not say which. */
   tableResolveAction = (actionId: string, row: TableRow): (() => void) | undefined => {
     if (!isTableRowActionId(actionId)) return undefined;
     const id = row['mediaId'];
     const type = row['mediaType'];
     // Both columns or no button: guessing the type sends a series to a movie page.
     if (id == null || (type !== 'series' && type !== 'movie')) return undefined;
-    const base = type === 'series' ? '/series' : '/movies';
+    const episodeId = row['episodeId'];
+    const url =
+      type === 'series'
+        ? episodeId == null
+          ? `/series/${id}`
+          : `/series/${id}/episode/${episodeId}`
+        : `/movies/${id}`;
     return () => {
-      void this.router.navigateByUrl(`${base}/${id}`);
+      void this.router.navigateByUrl(url);
     };
   };
 }

--- a/client/src/app/shared/components/data-table/data-table.html
+++ b/client/src/app/shared/components/data-table/data-table.html
@@ -110,7 +110,11 @@
                       {{ cellSpeed(row[col.key]) }}
                     }
                     @default {
-                      @if (col.truncate) {
+                      @if (cellLink(col, row); as open) {
+                        <button type="button" class="link link-hover text-start" (click)="open()">
+                          {{ cellLabel(col, row[col.key]) }}
+                        </button>
+                      } @else if (col.truncate) {
                         <!-- The width cap is what makes the ellipsis appear: a table cell sizes
                              to its content otherwise, however narrow the viewport. -->
                         <span
@@ -198,6 +202,38 @@
     }
   }
 </div>
+
+@if (rowDetail(); as open) {
+  <dialog class="modal modal-open">
+    <div class="modal-box max-w-lg">
+      <app-modal-header [title]="open.titleKey | translate" (closed)="closeRowDetail()" />
+      <dl class="flex flex-col gap-3 py-2">
+        @for (line of open.lines; track line.labelKey) {
+          <div class="flex flex-col gap-0.5">
+            <dt class="text-sm text-base-content/60">{{ line.labelKey | translate }}</dt>
+            <dd class="break-words">
+              @if (line.href) {
+                <a class="link" [href]="line.href" target="_blank" rel="noopener noreferrer">{{ line.text }}</a>
+              } @else {
+                {{ line.text }}
+              }
+            </dd>
+          </div>
+        }
+      </dl>
+      <app-modal-footer>
+        <button type="button" class="btn btn-ghost" (click)="closeRowDetail()">
+          {{ 'common.close' | translate }}
+        </button>
+      </app-modal-footer>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+      <button type="button" (click)="closeRowDetail()" [attr.aria-label]="'common.close' | translate">
+        close
+      </button>
+    </form>
+  </dialog>
+}
 
 @if (detail(); as open) {
   <dialog class="modal modal-open">

--- a/client/src/app/shared/components/data-table/data-table.spec.ts
+++ b/client/src/app/shared/components/data-table/data-table.spec.ts
@@ -710,3 +710,82 @@ describe('DataTableComponent — progress inside a badge', () => {
     ).toBeNull();
   });
 });
+
+describe('DataTableComponent — the detail row action', () => {
+  const ROW = {
+    id: 7,
+    name: 'A',
+    quality: 'WEBDL-1080p',
+    infoUrl: 'https://tracker.example/details/42',
+    empty: '',
+  };
+  const DETAIL: RowAction = {
+    kind: 'detail',
+    labelKey: 'x.info',
+    titleKey: 'x.info_title',
+    fields: [
+      { key: 'quality', labelKey: 'x.quality' },
+      { key: 'empty', labelKey: 'x.empty' },
+      { kind: 'link', key: 'infoUrl', labelKey: 'x.indexer', textKey: 'x.open_on_indexer' },
+    ],
+  };
+
+  const openDetail = async (row: TableRow, action: RowAction = DETAIL) => {
+    const fixture = await createComponent({ http: { get: () => of([row]) }, rowActions: [action] });
+    await fixture.componentInstance.visibleActions(row)[0].run();
+    return fixture.componentInstance.rowDetail()!;
+  };
+
+  it('opens a dialog titled by titleKey, skipping fields the row leaves empty', async () => {
+    const open = await openDetail(ROW);
+    expect(open.titleKey).toBe('x.info_title');
+    expect(open.lines.map((l) => l.labelKey)).toEqual(['x.quality', 'x.indexer']);
+  });
+
+  it('anchors a link field to the row url', async () => {
+    const open = await openDetail(ROW);
+    expect(open.lines.find((l) => l.labelKey === 'x.indexer')?.href).toBe(
+      'https://tracker.example/details/42',
+    );
+  });
+
+  it('VERDICT: refuses a non-http url — a row value is indexer data, not manifest data', async () => {
+    // eslint-disable-next-line no-script-url
+    const open = await openDetail({ ...ROW, infoUrl: 'javascript:alert(1)' });
+    expect(open.lines.map((l) => l.labelKey)).toEqual(['x.quality']);
+  });
+
+  it('refuses a value that is not a url at all', async () => {
+    const open = await openDetail({ ...ROW, infoUrl: 'not a url' });
+    expect(open.lines.map((l) => l.labelKey)).toEqual(['x.quality']);
+  });
+});
+
+describe('DataTableComponent — a cell that links', () => {
+  const COL: TableColumn = { key: 'name', labelKey: 'x.name', linkActionId: 'table.open-media' };
+
+  it('renders a handler when core resolves the action for the row', async () => {
+    const run = vi.fn();
+    const fixture = await createComponent({
+      http: { get: () => of([{ id: 1, name: 'A' }]) },
+      columns: [COL],
+      resolveAction: () => run,
+    });
+    fixture.componentInstance.cellLink(COL, { id: 1, name: 'A' })!();
+    expect(run).toHaveBeenCalled();
+  });
+
+  it('VERDICT: plain text when the row cannot resolve it, never a dead link', async () => {
+    const fixture = await createComponent({
+      http: { get: () => of([{ id: 1, name: 'A' }]) },
+      columns: [COL],
+      resolveAction: () => undefined,
+    });
+    expect(fixture.componentInstance.cellLink(COL, { id: 1, name: 'A' })).toBeUndefined();
+  });
+
+  it('a column declaring no linkActionId never links', async () => {
+    const fixture = await createComponent({ http: { get: () => of([]) }, resolveAction: () => vi.fn() });
+    expect(fixture.componentInstance.cellLink({ key: 'name', labelKey: 'x' }, { id: 1 })).toBeUndefined();
+  });
+});

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -27,6 +27,7 @@ import {
   PagedResult,
   RowAction,
   TableColumn,
+  TableDetailField,
   TableFilter,
   TableRow,
   TableRowCondition,
@@ -115,6 +116,12 @@ export class DataTableComponent implements OnInit {
 
   /** The open detail dialog's title key and text, or null when it is closed. */
   readonly detail = signal<{ titleKey: string; text: string } | null>(null);
+
+  /** The open `detail` row action's dialog: its title and the lines that had a value. */
+  readonly rowDetail = signal<{
+    titleKey: string;
+    lines: { labelKey: string; text: string; href?: string }[];
+  } | null>(null);
 
   readonly page = signal(1);
   readonly total = signal(0);
@@ -278,6 +285,43 @@ export class DataTableComponent implements OnInit {
     return BADGE_CLASSES[tone] ?? BADGE_CLASSES.ghost;
   }
 
+  /** A URL a row supplies is indexer data, not manifest data: anything but http(s) — a
+   *  `javascript:` payload above all — renders as plain text instead of an anchor. */
+  private safeHref(value: CellValue): string | undefined {
+    if (typeof value !== 'string' || !value) return undefined;
+    try {
+      const url = new URL(value);
+      return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** A cell's link handler, or undefined when the column declares none, the id is unknown, or
+   *  this row cannot resolve it — the cell is then plain text, never a dead link. */
+  cellLink(col: TableColumn, row: TableRow): (() => void) | undefined {
+    return col.linkActionId ? this.resolveAction()(col.linkActionId, row) : undefined;
+  }
+
+  private detailLines(fields: readonly TableDetailField[], row: TableRow) {
+    const lines: { labelKey: string; text: string; href?: string }[] = [];
+    for (const field of fields) {
+      const value = row[field.key];
+      if (value === null || value === undefined || value === '') continue;
+      if (field.kind === 'link') {
+        const href = this.safeHref(value);
+        if (href) lines.push({ labelKey: field.labelKey, text: this.translate.instant(field.textKey), href });
+        continue;
+      }
+      lines.push({ labelKey: field.labelKey, text: this.subValueText(field, value) });
+    }
+    return lines;
+  }
+
+  closeRowDetail(): void {
+    this.rowDetail.set(null);
+  }
+
   /** The 0–100 fill for a badged cell that declares `progressField`, or null to render the
    *  badge flat. A row reporting no number yet (an unreachable client) is not 0%. */
   cellProgress(col: TableColumn, row: TableRow): number | null {
@@ -367,6 +411,15 @@ export class DataTableComponent implements OnInit {
       if (action.kind === 'action') {
         const handler = this.resolveAction()(action.actionId, row);
         if (handler) result.push({ action, run: handler });
+      } else if (action.kind === 'detail') {
+        result.push({
+          action,
+          run: () =>
+            this.rowDetail.set({
+              titleKey: action.titleKey ?? action.labelKey,
+              lines: this.detailLines(action.fields, row),
+            }),
+        });
       } else if (action.kind === 'route') {
         result.push({
           action,

--- a/client/src/app/shared/components/data-table/data-table.types.ts
+++ b/client/src/app/shared/components/data-table/data-table.types.ts
@@ -39,7 +39,20 @@ export interface TableColumn {
   detailTitleKey?: string;
   /** Names a 0–100 field on the row; a badged cell fills with it and appends the percent. */
   progressField?: string;
+  /** Turns the cell into a link running this core action against its row. */
+  linkActionId?: string;
 }
+
+/** One line of a `detail` dialog. `kind: 'link'` anchors `textKey` to the URL under `key`. */
+export type TableDetailField =
+  | {
+      kind?: 'value';
+      key: string;
+      labelKey: string;
+      format?: 'date' | 'bytes' | 'percent' | 'speed';
+      labelKeys?: Record<string, string>;
+    }
+  | { kind: 'link'; key: string; labelKey: string; textKey: string };
 
 /** One `rowActions[]` visibility clause read off the row — `when` reads the viewer instead. */
 export interface TableRowCondition {
@@ -74,6 +87,13 @@ export interface PagedResult<T> {
 export type RowAction =
   | { kind: 'route'; labelKey: string; path: string; visibleWhen?: TableRowCondition }
   | { kind: 'action'; labelKey: string; actionId: string; visibleWhen?: TableRowCondition }
+  | {
+      kind: 'detail';
+      labelKey: string;
+      titleKey?: string;
+      fields: TableDetailField[];
+      visibleWhen?: TableRowCondition;
+    }
   | {
       kind: 'proxy';
       labelKey: string;


### PR DESCRIPTION
Three additions to the `table` view kind. Nothing changes today: no shipped manifest declares any of them yet. The download queue is the consumer, in a companion plugin PR.

### `TableColumn.linkActionId`
Turns a cell into a link running a core action against its row, so the **title** is what you click to reach the thing the row is about. Reuses `TableRowActionId` and the same fail-closed rule as a row action: an unknown id, or a row the action cannot resolve, renders plain text rather than a dead link.

### `table.open-media` resolves an episode
A row carrying `episodeId` with `mediaType: 'series'` now navigates to `/series/:id/episode/:episodeId` instead of `/series/:id`. A queue row is read to reach the thing being downloaded, and a series root does not say which episode that is. A movie row ignores `episodeId` entirely.

### A `detail` row action
Opens a dialog of declared fields read straight off the row. It needs **no route**: the table already loaded everything it shows.

```ts
{ kind: 'detail', labelKey, titleKey?, fields: [
    { key: 'quality', labelKey: '…' },
    { kind: 'link', key: 'infoUrl', labelKey: '…', textKey: '…' },
] }
```

A field the row leaves empty is skipped, so one declaration serves rows of differing shape (a movie row and an episode row, a finished grab and a running one).

**The link field is a trust boundary.** Its URL comes from an indexer, not from the manifest, so core parses it and refuses anything but `http:` / `https:` before it reaches an `href`. A `javascript:` URL in an anchor is a script the viewer runs. Anchors carry `target="_blank" rel="noopener noreferrer"`.

## Verification
10 new tests: dialog title and empty-field skipping, the link anchor, and both refusals (`javascript:` and a non-URL); `cellLink` resolving, failing closed, and absent. Plus the episode and movie routing cases.

Client suite **623 passed**, backend typecheck clean, `manifest-shape` / `api-compatibility` green (the validator does not descend into columns, so no new refusal path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)