### PR TITLE
fix(plugins): translate a plugin message that names one of its own keys

### DIFF
--- a/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.html
+++ b/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.html
@@ -63,7 +63,7 @@
           class="flex min-h-64 flex-col items-center justify-center gap-3 pt-16 pb-10 text-center"
         >
           <span class="loading loading-spinner loading-lg text-base-content/40"></span>
-          <p class="max-w-sm text-sm text-base-content/60">
+          <p class="max-w-sm text-base-content/60">
             {{ 'media_detail.releases_searching' | translate }}
           </p>
         </div>

--- a/client/src/app/shared/components/data-table/data-table.spec.ts
+++ b/client/src/app/shared/components/data-table/data-table.spec.ts
@@ -2,7 +2,7 @@ import { WritableSignal, provideZonelessChangeDetection, signal } from '@angular
 import { TestBed } from '@angular/core/testing';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
-import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { TranslateLoader, TranslateService, provideTranslateService } from '@ngx-translate/core';
 import { Subject, of } from 'rxjs';
 import { vi } from 'vitest';
 import { DataTableComponent } from './data-table';
@@ -787,5 +787,38 @@ describe('DataTableComponent — a cell that links', () => {
   it('a column declaring no linkActionId never links', async () => {
     const fixture = await createComponent({ http: { get: () => of([]) }, resolveAction: () => vi.fn() });
     expect(fixture.componentInstance.cellLink({ key: 'name', labelKey: 'x' }, { id: 1 })).toBeUndefined();
+  });
+});
+
+describe('DataTableComponent — a plugin message that is an i18n key', () => {
+  // `detailField` and a `detail` field both carry whatever the plugin put on the row: sometimes
+  // one of its own keys, sometimes raw text from a filesystem or an HTTP client.
+  const TRANSLATED = 'plugin.msg.removed';
+  const COL: TableColumn = { key: 'status', labelKey: 'x.status', detailField: 'statusMessage' };
+
+  async function withTranslation(row: TableRow) {
+    const fixture = await createComponent({ http: { get: () => of([row]) }, columns: [COL] });
+    // `instant` echoes an unknown key back, which is what the fallback keys off.
+    const translate = TestBed.inject(TranslateService);
+    translate.setTranslation('en', { [TRANSLATED]: 'Removed by an operator' }, true);
+    return fixture;
+  }
+
+  it('VERDICT: renders the declared wording, not the raw key', async () => {
+    const row = { id: 1, status: 'failed', statusMessage: TRANSLATED };
+    const fixture = await withTranslation(row);
+    expect(fixture.componentInstance.detailText(COL, row)).toBe('Removed by an operator');
+  });
+
+  it('leaves raw text alone — a filesystem error is not a key', async () => {
+    const row = { id: 1, status: 'failed', statusMessage: 'ENOENT: no such file' };
+    const fixture = await withTranslation(row);
+    expect(fixture.componentInstance.detailText(COL, row)).toBe('ENOENT: no such file');
+  });
+
+  it('a row with no message opens nothing', async () => {
+    const row = { id: 1, status: 'failed', statusMessage: '' };
+    const fixture = await withTranslation(row);
+    expect(fixture.componentInstance.detailText(COL, row)).toBe('');
   });
 });

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -313,7 +313,8 @@ export class DataTableComponent implements OnInit {
         if (href) lines.push({ labelKey: field.labelKey, text: this.translate.instant(field.textKey), href });
         continue;
       }
-      lines.push({ labelKey: field.labelKey, text: this.subValueText(field, value) });
+      const text = this.subValueText(field, value);
+      lines.push({ labelKey: field.labelKey, text: field.format ? text : this.resolveMessage(text) });
     }
     return lines;
   }
@@ -330,11 +331,23 @@ export class DataTableComponent implements OnInit {
     return typeof value === 'number' ? Math.round(value) : null;
   }
 
+  /**
+   * A message a plugin puts on a row is sometimes one of its own i18n keys ("removed by an
+   * operator") and sometimes raw text from whatever it talks to (a filesystem error). A key
+   * resolves through the plugin's manifest dictionary, merged into the active language at boot;
+   * anything else is shown as it came, which is the same fallback the provider pages use.
+   */
+  private resolveMessage(text: string): string {
+    const translated = this.translate.instant(text);
+    return translated === text ? text : translated;
+  }
+
   /** The row's detail text for this column, or '' when there is none to open. A cell only
    *  becomes a button when it has something to show. */
   detailText(col: TableColumn, row: TableRow): string {
     if (!col.detailField) return '';
-    return String(row[col.detailField] ?? '').trim();
+    const raw = String(row[col.detailField] ?? '').trim();
+    return raw ? this.resolveMessage(raw) : '';
   }
 
   openDetail(col: TableColumn, row: TableRow): void {


### PR DESCRIPTION
`statusMessage` on a plugin table row carries two different kinds of value:

- one of the plugin's **own i18n keys** — `download.queue.removed_by_user`, `download.download_clients.block.reason`
- **raw text** from whatever the plugin talks to — `ENOENT: no such file or directory, lstat '/downloads/…'`

The table printed both verbatim, so the declared ones reached the user as a dotted key.

Both `detailField`'s dialog and a `detail` action's fields now resolve the value through the active language and **fall back to the text itself when it is not a key**. `PluginI18nService` merges each plugin's manifest dictionary into the active language at boot, so a declared key resolves like any other; `TranslateService.instant` echoes an unknown key back, which is what the fallback keys off. This is the same rule `PluginViewComponent.resolvePluginMessage` already applies to a plugin's `testConnection` result.

A `format`ted field is left alone: a date or a byte count is never a key.

Also in here, one line: the release picker's "searching…" paragraph dropped `text-sm`, which made it read smaller than everything around it.

3 tests: a declared key renders its wording, raw text is untouched, an empty message opens nothing. Client suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)