### PR TITLE
fix(releases): keep the tracker page through a manual grab

### DIFF
--- a/client/src/app/features/media-detail/media-detail-release-picker.service.ts
+++ b/client/src/app/features/media-detail/media-detail-release-picker.service.ts
@@ -7,6 +7,9 @@ import type { ReleasePickerPair, ReleasePickerRoutes } from '@fliks/plugin-contr
 export interface MovieRelease {
   title: string;
   downloadUrl: string;
+  /** The tracker's own page for this release, when the feed named one. Distinct from
+   *  `downloadUrl`, which is the indexer's API endpoint and carries its key. */
+  infoUrl?: string;
   qualityId: number;
   qualityName: string;
   rank: number;
@@ -35,6 +38,8 @@ interface GrabBody {
   sourceId?: number;
   /** Manual override for a release the profile would otherwise reject — never sent for an allowed grab. */
   force?: boolean;
+  /** Echoed back from the search hit: the plugin cannot recover it from `downloadUrl`. */
+  infoUrl?: string;
 }
 
 interface RouteParams {

--- a/client/src/app/features/media-detail/media-detail-release.utils.spec.ts
+++ b/client/src/app/features/media-detail/media-detail-release.utils.spec.ts
@@ -53,3 +53,14 @@ describe('isUnprofiledReleaseError', () => {
     expect(isUnprofiledReleaseError(undefined)).toBe(false);
   });
 });
+
+describe('releaseGrabBody — the tracker page', () => {
+  it('VERDICT: echoes the search hit back, since the grab route cannot derive it from downloadUrl', () => {
+    const body = releaseGrabBody(makeRelease({ infoUrl: 'https://tracker.example/details/42' }));
+    expect(body.infoUrl).toBe('https://tracker.example/details/42');
+  });
+
+  it('sends no key at all for a hit whose feed named no page', () => {
+    expect('infoUrl' in releaseGrabBody(makeRelease({}))).toBe(false);
+  });
+});

--- a/client/src/app/features/media-detail/media-detail-release.utils.ts
+++ b/client/src/app/features/media-detail/media-detail-release.utils.ts
@@ -19,11 +19,16 @@ export function isUnprofiledReleaseError(err: unknown): boolean {
 
 /** A release outside the profile can still be grabbed by hand — `force` tells the
  *  plugin to skip the allowed-quality guard it enforces for an unattended grab. */
-export function releaseGrabBody(r: MovieRelease): { downloadUrl: string; sourceTitle: string; sourceId: number; force?: true } {
+export function releaseGrabBody(
+  r: MovieRelease,
+): { downloadUrl: string; sourceTitle: string; sourceId: number; infoUrl?: string; force?: true } {
   return {
     downloadUrl: r.downloadUrl,
     sourceTitle: r.title,
     sourceId: r.sourceId,
+    // The search hit carries the tracker's page; the grab route cannot derive it from
+    // `downloadUrl`, so a manual grab that dropped it recorded a row with no link.
+    ...(r.infoUrl ? { infoUrl: r.infoUrl } : {}),
     ...(r.allowed ? {} : { force: true }),
   };
 }


### PR DESCRIPTION
A grab from the release picker recorded a history row with no indexer link, so the Info dialog showed nothing where the link belongs — reported after a fresh grab, which is what makes it a bug rather than the expected gap on rows predating the column.

The search hit already carries `infoUrl` (the plugin's `toWireRelease` spreads it), and the picker already receives it. `releaseGrabBody` simply dropped it. The plugin cannot recover it on its own: `downloadUrl` is the indexer's **API endpoint**, not a browsable page, and it carries the API key.

The body now echoes it back.

## The round trip is a trust boundary
By the time `infoUrl` comes back it is user-supplied, and it ends up in an `href`. The plugin refuses anything that is not an absolute `http:`/`https:` URL before storing it, so garbage never reaches the column. Core refuses it again at render time (#1142), which is belt and braces on purpose: the client that sent it is not the client that produced it.

## Verification
- Client: the body carries the URL when the hit has one, and omits the key entirely when it does not.
- Plugin: an http URL is forwarded; `javascript:`, a non-URL, `ftp:` and an empty string are all dropped.
- Client suite green, plugin 389 passed (the one known failure is the `>=3.7.0` range check awaiting the core release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)