### PR TITLE
refactor(progress): make a download's absence expressible

### DIFF
--- a/backend/src/common/plugin-contract/host-methods.ts
+++ b/backend/src/common/plugin-contract/host-methods.ts
@@ -83,15 +83,6 @@ export type AcquisitionEvent =
       episodeNumber?: number;
     }
   | {
-      type: 'acquisition.progress';
-      mediaId: number;
-      ref: string;
-      progress: number;
-      etaSeconds: number | null;
-      /** Closed vocabulary — see `progress.set`'s `state` below. */
-      state: 'queued' | 'active' | 'stalled' | 'paused' | 'importing';
-    }
-  | {
       type: 'acquisition.imported';
       mediaId: number;
       seasonNumber?: number;
@@ -263,19 +254,32 @@ export interface PluginHostApi {
   }) => Promise<void>;
 
   /**
-   * Live acquisition progress. Plugin pushes; core emits the reserved
-   * `download.progress` SSE type, coalesced to one emission per media per second: pushing faster
-   * is allowed, and the last value of a window is the one that goes out.
+   * Live acquisition progress, as the complete set for one media. Plugin pushes; core emits the
+   * reserved `download.progress` SSE type, coalesced to one emission per media per second:
+   * pushing faster is allowed, and the last value of a window is the one that goes out.
+   *
+   * `downloads` is a replacement, never a delta: whatever is absent from it is retired, and an
+   * empty array retires the media outright. That is the whole point of the shape. A per-download
+   * push cannot express absence, so every consumer had to infer a removal from a compensating
+   * event or a timeout, and every new way to remove a download reopened the same gap.
+   *
+   * The caller must therefore only push a set it fully enumerated. A download client that could
+   * not be reached is not evidence that its torrents are gone: skip the push for that tick rather
+   * than assert a set that is missing them.
    */
   'progress.set': (p: {
     mediaId: number;
-    seasonNumber?: number;
-    episodeNumber?: number;
-    ref: string;
-    progress: number;
-    bytesPerSecond?: number;
-    etaSeconds?: number;
-    state: 'queued' | 'active' | 'stalled' | 'paused' | 'importing';
+    downloads: {
+      /** Stable identity for one download within the media, opaque to core. */
+      ref: string;
+      seasonNumber?: number;
+      episodeNumber?: number;
+      /** 0 to 1. */
+      progress: number;
+      bytesPerSecond?: number;
+      etaSeconds?: number;
+      state: 'queued' | 'active' | 'stalled' | 'paused' | 'importing';
+    }[];
   }) => Promise<void>;
 
   // Group E — config (2)

--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { FliksHostImpl } from './fliks-host.service';
 import { PluginCountsCacheService } from './plugin-counts-cache.service';
+import { DownloadProgressCacheService } from '../../scheduler/download-progress-cache.service';
 import {
   MediaStatus,
   MediaType,
@@ -151,6 +152,7 @@ interface Harness {
   };
   sseAudience: { recipientsForMedia: jest.Mock; viewersForMedia: jest.Mock };
   countsCache: PluginCountsCacheService;
+  progressCache: DownloadProgressCacheService;
 }
 
 function makeHarness(pluginId: string | null = 'test.plugin'): Harness {
@@ -196,6 +198,7 @@ function makeHarness(pluginId: string | null = 'test.plugin'): Harness {
     viewersForMedia: jest.fn().mockResolvedValue([9]),
   };
   const countsCache = new PluginCountsCacheService();
+  const progressCache = new DownloadProgressCacheService();
 
   // Fakes stand in for 19 constructor params — a plain unit test of the class,
   // not a DI-resolved instance (the DI graph itself is proven by the boot check).
@@ -220,11 +223,13 @@ function makeHarness(pluginId: string | null = 'test.plugin'): Harness {
     events,
     sseAudience,
     countsCache,
+    progressCache,
   ) as FliksHostImpl;
 
   return {
     host,
     countsCache,
+    progressCache,
     mediaRepo,
     seasonRepo,
     episodeRepo,
@@ -1611,33 +1616,18 @@ describe('FliksHostImpl', () => {
         expect.objectContaining({
           type: 'download.progress',
           mediaId: 1,
-          seasonNumber: 4,
-          episodeNumber: 8,
-          progress: 0,
-          state: 'queued',
+          downloads: [
+            expect.objectContaining({ seasonNumber: 4, episodeNumber: 8, progress: 0, state: 'queued' }),
+          ],
         }),
       );
     });
 
-    it('handles queue.changed and the batched acquisition.progress variant', async () => {
+    it('handles a batched queue.changed', async () => {
       const h = makeHarness();
       h.mediaRepo.findOne.mockResolvedValue(makeMedia());
-      await h.host['events.publish']([
-        { type: 'acquisition.queue.changed' },
-        {
-          type: 'acquisition.progress',
-          mediaId: 1,
-          ref: 'r1',
-          progress: 0.5,
-          etaSeconds: 30,
-          state: 'active',
-        },
-      ]);
+      await h.host['events.publish']([{ type: 'acquisition.queue.changed' }]);
       expect(h.events.emit).toHaveBeenCalledWith({ type: 'queue.updated' });
-      expect(h.events.emitToUsers).toHaveBeenCalledWith(
-        [9],
-        expect.objectContaining({ type: 'download.progress' }),
-      );
     });
   });
 
@@ -1749,51 +1739,48 @@ describe('FliksHostImpl', () => {
       );
       await h.host['progress.set']({
         mediaId: 1,
-        seasonNumber: 1,
-        episodeNumber: 2,
-        ref: 'torrent-hash',
-        progress: 0.42,
-        bytesPerSecond: 1000,
-        state: 'active',
+        downloads: [
+          { ref: 'torrent-hash', seasonNumber: 1, episodeNumber: 2, progress: 0.42, bytesPerSecond: 1000, state: 'active' },
+        ],
       });
       expect(h.events.emitToUsers).toHaveBeenCalledWith(
         [9],
         expect.objectContaining({
           type: 'download.progress',
           mediaType: 'series',
-          progress: 0.42,
-          dlspeed: 1000,
+          downloads: [
+            expect.objectContaining({ ref: 'torrent-hash', progress: 0.42, dlspeed: 1000 }),
+          ],
         }),
       );
     });
 
-    // The gate coalesces per torrent, not per media: every consumer keys a leaf
-    // by (media, season, episode, ref), so a sibling dropped inside the window
-    // is never seen at all — not late, missing, until the client sweeps it.
-    it('does not hold one download of a series behind another', async () => {
-      jest.useFakeTimers();
-      try {
-        const h = makeHarness();
-        h.mediaRepo.findOne.mockResolvedValue(makeMedia({ type: MediaType.SERIES }));
+    // Coalescing per media loses nothing now: a push already carries the media's whole set, so
+    // the last one in a window states every sibling the earlier ones did.
+    it('VERDICT: one emission carries every download of the media', async () => {
+      const h = makeHarness();
+      h.mediaRepo.findOne.mockResolvedValue(makeMedia({ type: MediaType.SERIES }));
 
-        await h.host['progress.set']({ mediaId: 7, seasonNumber: 1, episodeNumber: 6, ref: 'a', progress: 0.1, state: 'active' });
-        await h.host['progress.set']({ mediaId: 7, seasonNumber: 1, episodeNumber: 7, ref: 'b', progress: 0.2, state: 'active' });
-        await h.host['progress.set']({ mediaId: 7, seasonNumber: 1, episodeNumber: 8, ref: 'c', progress: 0.3, state: 'active' });
+      await h.host['progress.set']({
+        mediaId: 7,
+        downloads: [
+          { ref: 'a', seasonNumber: 1, episodeNumber: 6, progress: 0.1, state: 'active' },
+          { ref: 'b', seasonNumber: 1, episodeNumber: 7, progress: 0.2, state: 'active' },
+          { ref: 'c', seasonNumber: 1, episodeNumber: 8, progress: 0.3, state: 'active' },
+        ],
+      });
 
-        expect(h.events.emitToUsers).toHaveBeenCalledTimes(3);
-        expect(h.events.emitToUsers.mock.calls.map((c) => c[1].ref).sort()).toEqual(['a', 'b', 'c']);
-      } finally {
-        jest.useRealTimers();
-      }
+      expect(h.events.emitToUsers).toHaveBeenCalledTimes(1);
+      expect(h.events.emitToUsers.mock.calls[0][1].downloads.map((d: { ref: string }) => d.ref)).toEqual(['a', 'b', 'c']);
     });
 
-    it('coalesces to one emission per torrent per second, and the trailing one carries the latest', async () => {
+    it('coalesces to one emission per media per second, and the trailing one carries the latest', async () => {
       jest.useFakeTimers();
       try {
         const h = makeHarness();
         h.mediaRepo.findOne.mockResolvedValue(makeMedia({ type: MediaType.SERIES }));
         const push = (progress: number) =>
-          h.host['progress.set']({ mediaId: 7, ref: 'r', progress, state: 'active' });
+          h.host['progress.set']({ mediaId: 7, downloads: [{ ref: 'r', progress, state: 'active' }] });
 
         await push(0.1);
         await push(0.2);
@@ -1804,7 +1791,7 @@ describe('FliksHostImpl', () => {
         expect(h.events.emitToUsers).toHaveBeenCalledTimes(2);
         expect(h.events.emitToUsers).toHaveBeenLastCalledWith(
           [9],
-          expect.objectContaining({ progress: 0.3 }),
+          expect.objectContaining({ downloads: [expect.objectContaining({ progress: 0.3 })] }),
         );
       } finally {
         jest.useRealTimers();
@@ -1816,8 +1803,8 @@ describe('FliksHostImpl', () => {
       try {
         const h = makeHarness();
         h.mediaRepo.findOne.mockResolvedValue(makeMedia({ type: MediaType.SERIES }));
-        await h.host['progress.set']({ mediaId: 1, ref: 'r', progress: 0.1, state: 'active' });
-        await h.host['progress.set']({ mediaId: 2, ref: 'r', progress: 0.1, state: 'active' });
+        await h.host['progress.set']({ mediaId: 1, downloads: [{ ref: 'r', progress: 0.1, state: 'active' }] });
+        await h.host['progress.set']({ mediaId: 2, downloads: [{ ref: 'r', progress: 0.1, state: 'active' }] });
         expect(h.events.emitToUsers).toHaveBeenCalledTimes(2);
       } finally {
         jest.useRealTimers();
@@ -1829,9 +1816,7 @@ describe('FliksHostImpl', () => {
       h.sseAudience.viewersForMedia.mockResolvedValue([]);
       await h.host['progress.set']({
         mediaId: 1,
-        ref: 'r',
-        progress: 0.1,
-        state: 'active',
+        downloads: [{ ref: 'r', progress: 0.1, state: 'active' }],
       });
       expect(h.events.emitToUsers).not.toHaveBeenCalled();
     });

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -53,27 +53,19 @@ import {
 } from '../../../common/release-scoring';
 import { parseSeasonEpisode } from '../../../common/release-parsing';
 import { PluginCountsCacheService } from './plugin-counts-cache.service';
+import { DownloadProgressCacheService } from '../../scheduler/download-progress-cache.service';
 import { PLUGIN_HOST_PLUGIN_ID } from './plugin-host.constants';
 import { PluginHostContext } from './plugin-host-context';
 import { DownloadProgressState } from '../../../common/constants/download-progress-state';
 
-/** One gate per leaf, matching how every consumer identifies one — the replay
- *  cache's own key and the client's leaf key. */
-function progressGateKey(p: {
-  mediaId: number;
-  seasonNumber?: number;
-  episodeNumber?: number;
-  ref?: string;
-}): string {
-  return `${p.mediaId}:${p.seasonNumber ?? ''}:${p.episodeNumber ?? ''}:${p.ref ?? ''}`;
-}
-
-/** The rate `progress.set` promises: at most one SSE emission per torrent per second. */
+/** The rate `progress.set` promises: at most one SSE emission per media per second. */
 const PROGRESS_MIN_INTERVAL_MS = 1_000;
+
+type ProgressSet = Parameters<PluginHostApi['progress.set']>[0];
 
 interface ProgressGate {
   lastEmitMs: number;
-  pending: Parameters<PluginHostApi['progress.set']>[0] | null;
+  pending: ProgressSet | null;
   timer: NodeJS.Timeout | null;
 }
 
@@ -130,6 +122,7 @@ export class FliksHostImpl implements PluginHostApi {
     private readonly events: EventsService,
     private readonly sseAudience: SseAudienceService,
     private readonly countsCache: PluginCountsCacheService,
+    private readonly progressCache: DownloadProgressCacheService,
   ) {}
 
   private readonly logger = new Logger(FliksHostImpl.name);
@@ -918,16 +911,32 @@ export class FliksHostImpl implements PluginHostApi {
           // a pack shows on every episode page of the season.
           episodeNumber: event.episodeNumber,
         });
-        // Put the download badge up on the grab rather than on the client's
-        // next poll tick, which can be a minute out. Same push the ticks
-        // themselves use, so the media type and audience are resolved
-        // identically and the first real tick simply supersedes this.
+        // Put the download badge up on the grab rather than on the client's next poll tick,
+        // which can be a minute out. Added to the media's last known set rather than replacing
+        // it: a push states the whole set, so announcing this grab alone would retire whatever
+        // else the media already had in flight. The first real snapshot supersedes it.
         await this.pushProgress({
           mediaId: event.mediaId,
-          seasonNumber: event.seasonNumber,
-          episodeNumber: event.episodeNumber,
-          progress: 0,
-          state: 'queued',
+          downloads: [
+            ...(this.progressCache.current(event.mediaId)?.downloads ?? []).map((d) => ({
+              ref: d.ref,
+              seasonNumber: d.seasonNumber,
+              episodeNumber: d.episodeNumber,
+              progress: d.progress,
+              bytesPerSecond: d.dlspeed,
+              etaSeconds: d.eta,
+              state: d.state,
+            })),
+            {
+              // No download exists yet, so there is no identity to carry: the scope is the only
+              // thing that names this placeholder, and the first real snapshot drops it.
+              ref: `pending:${event.seasonNumber ?? ''}:${event.episodeNumber ?? ''}`,
+              seasonNumber: event.seasonNumber,
+              episodeNumber: event.episodeNumber,
+              progress: 0,
+              state: 'queued' as const,
+            },
+          ],
         });
         return;
       case 'acquisition.imported': {
@@ -985,15 +994,6 @@ export class FliksHostImpl implements PluginHostApi {
         this.events.emit({ type: 'queue.updated' });
         return;
       }
-      case 'acquisition.progress':
-        await this.pushProgress({
-          mediaId: event.mediaId,
-          ref: event.ref,
-          progress: event.progress,
-          etaSeconds: event.etaSeconds ?? undefined,
-          state: event.state,
-        });
-        return;
     }
   }
 
@@ -1046,23 +1046,14 @@ export class FliksHostImpl implements PluginHostApi {
   // D5 — progress.set
   // ===========================================================================
 
-  private async progressSet(p: {
-    mediaId: number;
-    seasonNumber?: number;
-    episodeNumber?: number;
-    ref: string;
-    progress: number;
-    bytesPerSecond?: number;
-    etaSeconds?: number;
-    state: DownloadProgressState;
-  }): Promise<void> {
-    const key = progressGateKey(p);
+  private async progressSet(p: ProgressSet): Promise<void> {
+    // One gate per media, because a media's set is now what a push carries: coalescing per
+    // download would let a window drop the very push that shrank the set.
+    const key = String(p.mediaId);
     const gate = this.progressGates.get(key);
     const now = Date.now();
     if (gate && now - gate.lastEmitMs < PROGRESS_MIN_INTERVAL_MS) {
-      // Newest wins — for this leaf. Coalescing per media would drop every
-      // sibling torrent of a season reported in the same window, and the
-      // consumers key per leaf, so a dropped one is never seen at all.
+      // Newest wins, and nothing is lost by it: each push already carries the media's whole set.
       gate.pending = p;
       if (!gate.timer) {
         gate.timer = setTimeout(
@@ -1088,7 +1079,7 @@ export class FliksHostImpl implements PluginHostApi {
     gate.pending = null;
     if (!pending) {
       // Idle for a whole window: drop the gate so the map cannot grow with
-      // every torrent ever seen.
+      // every media ever seen.
       this.progressGates.delete(key);
       return;
     }
@@ -1096,16 +1087,7 @@ export class FliksHostImpl implements PluginHostApi {
     void this.pushProgress(pending);
   }
 
-  private async pushProgress(p: {
-    mediaId: number;
-    seasonNumber?: number;
-    episodeNumber?: number;
-    ref?: string;
-    progress: number;
-    bytesPerSecond?: number;
-    etaSeconds?: number;
-    state: DownloadProgressState;
-  }): Promise<void> {
+  private async pushProgress(p: ProgressSet): Promise<void> {
     const media = await this.mediaRepo.findOne({ where: { id: p.mediaId } });
     // Progress is passive page state, not a notification: everyone who can open
     // the media's page sees it, not just whoever requested the title.
@@ -1115,13 +1097,15 @@ export class FliksHostImpl implements PluginHostApi {
       type: 'download.progress',
       mediaId: p.mediaId,
       mediaType: media?.type === MediaType.MOVIE ? 'movie' : 'series',
-      seasonNumber: p.seasonNumber,
-      episodeNumber: p.episodeNumber,
-      ref: p.ref,
-      progress: p.progress,
-      dlspeed: p.bytesPerSecond ?? 0,
-      eta: p.etaSeconds ?? 0,
-      state: p.state,
+      downloads: p.downloads.map((d) => ({
+        ref: d.ref,
+        seasonNumber: d.seasonNumber,
+        episodeNumber: d.episodeNumber,
+        progress: d.progress,
+        dlspeed: d.bytesPerSecond ?? 0,
+        eta: d.etaSeconds ?? 0,
+        state: d.state,
+      })),
     });
   }
 

--- a/backend/src/modules/plugins/host/plugin-host-binding.service.spec.ts
+++ b/backend/src/modules/plugins/host/plugin-host-binding.service.spec.ts
@@ -263,7 +263,7 @@ describe('PluginHostBindingService', () => {
       'notifications.dispatch': { event: 'grab.started', payload: {} },
       'counts.set': { key: 'k', value: 1 },
       'events.emitOwn': { type: 't', payload: {}, audience: 'all' },
-      'progress.set': { mediaId: 1, ref: 'r', progress: 0, state: 'active' },
+      'progress.set': { mediaId: 1, downloads: [{ ref: 'r', progress: 0, state: 'active' }] },
       'config.get': {},
       'config.set': { key: 'k', value: 'v' },
     };

--- a/backend/src/modules/scheduler/download-progress-cache.service.ts
+++ b/backend/src/modules/scheduler/download-progress-cache.service.ts
@@ -3,80 +3,86 @@ import type { SseEvent } from './events.service';
 
 type DownloadProgressEvent = Extract<SseEvent, { type: 'download.progress' }>;
 
-interface CachedLeaf {
+interface CachedMedia {
   event: DownloadProgressEvent;
   recipients: readonly number[];
   recordedAt: number;
 }
 
-// `CompletionService.processCompleted` re-emits every in-flight download once
-// a minute — a leaf that has gone this many ticks without a refresh didn't
-// just miss one slow tick, it left the download client (stalled-removed,
-// user-deleted, media deleted, …) through a path that never reaches
-// `import.complete`. 3x the cron interval absorbs one skipped/slow tick
-// without misfiring, while still self-healing within a few minutes instead
-// of holding a phantom leaf for the life of the process.
+// The publisher re-states every in-flight media about once a minute. A media that has gone this
+// many ticks without a refresh is one whose publisher died or was reconfigured, not one that was
+// slow: 3x the cron interval absorbs a skipped tick while still self-healing in a few minutes.
+//
+// It is a memory bound and a backstop, not the removal mechanism: a download that stops is gone
+// from the very next snapshot, because a snapshot states the whole set.
 const STALE_AFTER_MS = 3 * 60_000;
 
 /**
- * In-memory replay cache for `download.progress`: the publisher can tick as
- * slowly as once a minute, so without this a client that connects between
- * ticks sees nothing until the next one. Mirrors `PluginCountsCacheService`'s
- * shape — not persisted, a restart is a legitimate reset. `import.complete`
- * evicts a leaf immediately (the fast path); the age check in `snapshotFor`
- * is the backstop catch-all for every other way a download stops — it needs
- * no list of end-events and self-heals on the next connect, no sweep timer.
+ * In-memory replay cache for `download.progress`, one entry per media. The publisher can tick as
+ * slowly as once a minute, so without this a client connecting between ticks sees nothing until
+ * the next one. Not persisted; a restart is a legitimate reset.
+ *
+ * Each entry holds a whole snapshot, so recording is a replacement and there is nothing to
+ * reconcile: the shape that made a phantom leaf possible is gone rather than guarded.
  */
 @Injectable()
 export class DownloadProgressCacheService {
-  private readonly leaves = new Map<string, CachedLeaf>();
+  private readonly media = new Map<number, CachedMedia>();
 
   constructor(@Optional() private readonly now: () => number = Date.now) {}
 
-  /** Leaf count — lets a caller (test) confirm the staleness sweep actually
-   *  frees memory instead of merely filtering the same leaf on every read. */
+  /** Media count — lets a caller (test) confirm the staleness sweep actually frees memory
+   *  instead of merely filtering the same entry on every read. */
   get size(): number {
-    return this.leaves.size;
+    return this.media.size;
   }
 
-  private key(e: DownloadProgressEvent): string {
-    return `${e.mediaId}:${e.seasonNumber ?? ''}:${e.episodeNumber ?? ''}:${e.ref ?? ''}`;
+  /** The last snapshot for a media, for a caller adding to it rather than replacing it. */
+  current(mediaId: number): DownloadProgressEvent | undefined {
+    return this.media.get(mediaId)?.event;
   }
 
-  /** Record the latest push for its recipients. A leaf reporting done
-   *  (`progress >= 1`) is dropped rather than replayed as "100% done". */
+  /** Record the latest snapshot. An empty one says the media has nothing in flight, which is
+   *  the same statement as having no entry at all. */
   record(recipients: readonly number[], event: DownloadProgressEvent): void {
-    const key = this.key(event);
-    if (event.progress >= 1) {
-      this.leaves.delete(key);
+    if (!event.downloads.length) {
+      this.media.delete(event.mediaId);
       return;
     }
-    this.leaves.set(key, { event, recipients, recordedAt: this.now() });
+    this.media.set(event.mediaId, { event, recipients, recordedAt: this.now() });
   }
 
-  /** Retire every cached leaf for a media (or just one season/episode within
-   *  it) — mirrors the client's own `clearMedia`, called on `import.complete`. */
+  /** Retire a media's cached downloads (or just one season/episode within it) — the fast path
+   *  on `import.complete`, ahead of the publisher's next snapshot. */
   clear(mediaId: number, seasonNumber?: number, episodeNumber?: number): void {
-    for (const [key, leaf] of this.leaves) {
-      if (leaf.event.mediaId !== mediaId) continue;
-      if (seasonNumber != null && leaf.event.seasonNumber !== seasonNumber) continue;
-      if (episodeNumber != null && leaf.event.episodeNumber !== episodeNumber) continue;
-      this.leaves.delete(key);
+    const entry = this.media.get(mediaId);
+    if (!entry) return;
+    if (seasonNumber == null) {
+      this.media.delete(mediaId);
+      return;
     }
+    const downloads = entry.event.downloads.filter((d) => {
+      if (d.seasonNumber !== seasonNumber) return true;
+      // Narrower than the season filter: a download naming no episode is a pack, which one
+      // episode's import does not finish.
+      return episodeNumber != null && d.episodeNumber !== episodeNumber;
+    });
+    if (!downloads.length) this.media.delete(mediaId);
+    else this.media.set(mediaId, { ...entry, event: { ...entry.event, downloads } });
   }
 
-  /** Every cached leaf this user was a recipient of — replayed on SSE connect.
-   *  Walks every leaf (not just this user's) so a stale one is deleted here
-   *  regardless of which user's connect happened to trigger the check. */
+  /** Every cached snapshot this user was a recipient of — replayed on SSE connect. Walks every
+   *  entry (not just this user's) so a stale one is dropped here regardless of which user's
+   *  connect happened to trigger the check. */
   snapshotFor(userId: number): DownloadProgressEvent[] {
     const cutoff = this.now() - STALE_AFTER_MS;
     const out: DownloadProgressEvent[] = [];
-    for (const [key, leaf] of this.leaves) {
-      if (leaf.recordedAt < cutoff) {
-        this.leaves.delete(key);
+    for (const [mediaId, entry] of this.media) {
+      if (entry.recordedAt < cutoff) {
+        this.media.delete(mediaId);
         continue;
       }
-      if (leaf.recipients.includes(userId)) out.push(leaf.event);
+      if (entry.recipients.includes(userId)) out.push(entry.event);
     }
     return out;
   }

--- a/backend/src/modules/scheduler/events.module.ts
+++ b/backend/src/modules/scheduler/events.module.ts
@@ -12,6 +12,6 @@ import { LibraryUserAccess } from '../libraries/entities/library-user-access.ent
 @Module({
   imports: [TypeOrmModule.forFeature([FliksRequest, User, Media, LibraryUserAccess])],
   providers: [EventsService, SseAudienceService, DownloadProgressCacheService],
-  exports: [EventsService, SseAudienceService],
+  exports: [EventsService, SseAudienceService, DownloadProgressCacheService],
 })
 export class EventsModule {}

--- a/backend/src/modules/scheduler/events.service.progress-replay.spec.ts
+++ b/backend/src/modules/scheduler/events.service.progress-replay.spec.ts
@@ -9,15 +9,21 @@ function connect(events: EventsService, userId: number): unknown[] {
   return received;
 }
 
-const progressEvent = (overrides: Partial<Record<string, unknown>> = {}) => ({
-  type: 'download.progress' as const,
-  mediaId: 42,
-  mediaType: 'movie' as const,
+const dl = (over: Partial<Record<string, unknown>> = {}) => ({
+  ref: 'aaa',
   progress: 0.37,
   dlspeed: 1000,
   eta: 60,
   state: 'active' as const,
-  ...overrides,
+  ...over,
+});
+
+/** A push carries a media's whole set, so a test about one download states a set of one. */
+const progressEvent = (downloads: ReturnType<typeof dl>[] = [dl()], mediaId = 42) => ({
+  type: 'download.progress' as const,
+  mediaId,
+  mediaType: 'movie' as const,
+  downloads,
 });
 
 /**
@@ -39,7 +45,8 @@ describe('EventsService — download.progress replay on connect', () => {
     const received = connect(events, 1);
 
     expect(received[0]).toMatchObject({ type: 'sse.connected' });
-    expect(received[1]).toMatchObject({ type: 'download.progress', mediaId: 42, progress: 0.37 });
+    expect(received[1]).toMatchObject({ type: 'download.progress', mediaId: 42 });
+    expect((received[1] as { downloads: { progress: number }[] }).downloads[0]!.progress).toBe(0.37);
     expect(received).toHaveLength(2);
   });
 
@@ -72,36 +79,36 @@ describe('EventsService — download.progress replay on connect', () => {
     expect(received).toHaveLength(1); // handshake only, no stale progress
   });
 
-  it('retires only the finished season, keeping a sibling season\'s progress live', () => {
+  it("retires only the finished season, keeping a sibling season's downloads live", () => {
     const events = setup();
-    events.emitToUsers([1], progressEvent({ seasonNumber: 1 }));
-    events.emitToUsers([1], progressEvent({ seasonNumber: 2 }));
+    events.emitToUsers([1], progressEvent([dl({ ref: 'a', seasonNumber: 1 }), dl({ ref: 'b', seasonNumber: 2 })]));
     events.emitToUsers([1], { type: 'import.complete', mediaId: 42, seasonNumber: 1, title: 'x' });
 
     const received = connect(events, 1);
 
-    expect(received).toHaveLength(2); // handshake + season 2 only
-    expect(received[1]).toMatchObject({ seasonNumber: 2 });
+    expect(received).toHaveLength(2); // handshake + the trimmed snapshot
+    expect((received[1] as { downloads: { ref: string }[] }).downloads.map((d) => d.ref)).toEqual(['b']);
   });
 
-  it('drops a leaf outright if a push already reports it done (progress >= 1)', () => {
+  it('VERDICT: an empty snapshot drops the media, which is how a removal replays as gone', () => {
     const events = setup();
-    events.emitToUsers([1], progressEvent({ progress: 1 }));
+    events.emitToUsers([1], progressEvent());
+    events.emitToUsers([1], progressEvent([]));
 
     const received = connect(events, 1);
 
     expect(received).toHaveLength(1); // handshake only
   });
 
-  it('a live tick after connecting still arrives normally, on top of the replay', () => {
+  it('a live push after connecting still arrives normally, on top of the replay', () => {
     const events = setup();
     events.emitToUsers([1], progressEvent());
 
     const received = connect(events, 1);
-    events.emitToUsers([1], progressEvent({ progress: 0.5 }));
+    events.emitToUsers([1], progressEvent([dl({ progress: 0.5 })]));
 
     expect(received).toHaveLength(3);
-    expect(received[2]).toMatchObject({ progress: 0.5 });
+    expect((received[2] as { downloads: { progress: number }[] }).downloads[0]!.progress).toBe(0.5);
   });
 });
 

--- a/backend/src/modules/scheduler/events.service.ts
+++ b/backend/src/modules/scheduler/events.service.ts
@@ -75,24 +75,28 @@ export type SseEvent =
     }
   | { type: 'import.failed'; mediaId: number; title: string; error: string }
   | {
-      // Live progress for an in-flight grab, delivered to the media's
-      // request audience. `progress` is 0–1; `state` is core's closed
-      // vocabulary (the client maps it to a label/colour). Season/episode set
-      // for the matched scope of a series.
+      /**
+       * Every download in flight for this media, delivered to its request audience. A
+       * replacement, never a delta: whatever is absent has been retired, and an empty array
+       * retires the media. A per-download event could not say that, so a consumer had to infer
+       * a removal from a compensating event or a timeout.
+       */
       type: 'download.progress';
       mediaId: number;
       mediaType: 'movie' | 'series';
-      seasonNumber?: number;
-      episodeNumber?: number;
-      /** Opaque per-download identity, straight from `progress.set`'s `ref` — whatever the
-       *  plugin that reported it uses to tell its own downloads apart. Disambiguates concurrent
-       *  leaves of the same season when the episode relation couldn't be resolved (loose
-       *  episodes with no episodeNumber would otherwise collide). */
-      ref?: string;
-      progress: number;
-      dlspeed: number;
-      eta: number;
-      state: DownloadProgressState;
+      downloads: {
+        /** Opaque per-download identity, straight from `progress.set`'s `ref`. Disambiguates
+         *  concurrent downloads of the same season when the episode relation could not be
+         *  resolved (loose episodes with no episodeNumber would otherwise collide). */
+        ref: string;
+        seasonNumber?: number;
+        episodeNumber?: number;
+        /** 0–1. */
+        progress: number;
+        dlspeed: number;
+        eta: number;
+        state: DownloadProgressState;
+      }[];
     }
   | { type: 'stalled.removed'; title: string }
   | { type: 'queue.updated' }

--- a/client/src/app/core/services/download-progress.service.spec.ts
+++ b/client/src/app/core/services/download-progress.service.spec.ts
@@ -1,488 +1,224 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { DownloadProgressService } from './download-progress.service';
+import { DownloadProgressItem, DownloadProgressService } from './download-progress.service';
+
+function make(): DownloadProgressService {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
+  return TestBed.inject(DownloadProgressService);
+}
+
+function download(over: Partial<DownloadProgressItem> = {}): DownloadProgressItem {
+  return { ref: 'aaa', progress: 0.5, dlspeed: 0, eta: 0, state: 'active', ...over };
+}
+
+const series = (svc: DownloadProgressService, downloads: DownloadProgressItem[], mediaId = 1) =>
+  svc.applyProgress({ mediaId, mediaType: 'series', downloads });
+
+const movie = (svc: DownloadProgressService, downloads: DownloadProgressItem[], mediaId = 1) =>
+  svc.applyProgress({ mediaId, mediaType: 'movie', downloads });
+
+const leafKeys = (svc: DownloadProgressService, mediaId = 1, seasonNumber = 1) =>
+  [...(svc.progress().get(mediaId)?.seasons?.get(seasonNumber)?.leaves.keys() ?? [])];
 
 describe('DownloadProgressService', () => {
-  // Core is bundled with no acquisition plugin installed, so this store must
-  // expose no way at all to fetch the download-clients queue — not gated,
-  // just gone — otherwise a caller could still reach a plugin route from it.
+  // Core is bundled with no acquisition plugin installed, so this store must expose no way at
+  // all to fetch the download-clients queue — not gated, just gone.
   it('exposes no seed()/queue-fetching method', () => {
-    TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
-    const svc = TestBed.inject(DownloadProgressService) as unknown as Record<string, unknown>;
+    const svc = make() as unknown as Record<string, unknown>;
     expect(svc['seed']).toBeUndefined();
   });
 
-  it('folds an SSE event without any queue fetch', () => {
-    TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
-    const svc = TestBed.inject(DownloadProgressService);
-    svc.applyProgress({
-      mediaId: 1,
-      mediaType: 'movie',
-      progress: 0.5,
-      dlspeed: 100,
-      eta: 10,
-      state: 'active',
-    });
+  it('folds a movie snapshot without any queue fetch', () => {
+    const svc = make();
+    movie(svc, [download({ progress: 0.5, dlspeed: 100, eta: 10 })]);
     expect(svc.progress().get(1)?.percent).toBe(50);
   });
 
-  // Progress is only ever retired by an event. A download that finished while
-  // the stream was down sends none, and the connect replay carries only what is
-  // still live — so absence has to be read as "done" on every reconnect.
-  it('drops leaves the connect snapshot no longer reports', () => {
-    TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
-    const svc = TestBed.inject(DownloadProgressService);
-    svc.applyProgress({
-      mediaId: 1,
-      mediaType: 'movie',
-      progress: 0.52,
-      dlspeed: 100,
-      eta: 10,
-      state: 'active',
-    });
-
+  it('drops everything on reset, for the SSE connect replay to re-state', () => {
+    const svc = make();
+    movie(svc, [download()]);
     svc.reset();
     expect(svc.progress().size).toBe(0);
+  });
+});
 
-    svc.applyProgress({
-      mediaId: 2,
-      mediaType: 'movie',
-      progress: 0.1,
-      dlspeed: 100,
-      eta: 10,
-      state: 'active',
-    });
-    expect([...svc.progress().keys()]).toEqual([2]);
+/**
+ * The point of the snapshot shape. Every consumer used to rebuild the set from per-download
+ * upserts, so a download that stopped being reported — deleted from the client, above all — sat
+ * at its last percent until a timeout swept it. Absence is now the retirement.
+ */
+describe('DownloadProgressService — a snapshot replaces', () => {
+  it('VERDICT: a download absent from the next snapshot is gone, with no retirement event', () => {
+    const svc = make();
+    series(svc, [
+      download({ ref: 'aaa', seasonNumber: 1, episodeNumber: 7 }),
+      download({ ref: 'bbb', seasonNumber: 1, episodeNumber: 8 }),
+    ]);
+    expect(leafKeys(svc)).toEqual(['ref:aaa', 'ref:bbb']);
+
+    series(svc, [download({ ref: 'bbb', seasonNumber: 1, episodeNumber: 8 })]);
+    expect(leafKeys(svc)).toEqual(['ref:bbb']);
   });
 
-  /**
-   * `import.complete` is what retires a finished episode. It arrives with a
-   * season and episode number, never a download ref, so it has to find the leaf
-   * by the episode the leaf names — the key identifies the download.
-   */
-  describe('clearMedia', () => {
-    const make = () => {
-      TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
-      return TestBed.inject(DownloadProgressService);
-    };
-    const tick = (
-      svc: DownloadProgressService,
-      ref: string,
-      episodeNumber: number | undefined,
-    ) =>
-      svc.applyProgress({
-        mediaId: 1,
-        mediaType: 'series',
-        seasonNumber: 1,
-        episodeNumber,
-        ref,
-        progress: 0.5,
-        dlspeed: 0,
-        eta: 0,
-        state: 'active',
-      });
-
-    it('retires the ref-keyed leaf of the imported episode', () => {
-      const svc = make();
-      tick(svc, 'aaa', 8);
-
-      svc.clearMedia(1, 1, 8);
-
-      expect(svc.progress().size).toBe(0);
-    });
-
-    it("leaves a sibling episode's download alone", () => {
-      const svc = make();
-      tick(svc, 'aaa', 8);
-      tick(svc, 'bbb', 9);
-
-      svc.clearMedia(1, 1, 8);
-
-      expect([...svc.progress().get(1)!.seasons!.get(1)!.leaves.keys()]).toEqual(['ref:bbb']);
-    });
-
-    it('retires both releases when two were racing for that episode', () => {
-      const svc = make();
-      tick(svc, 'aaa', 8);
-      tick(svc, 'bbb', 8);
-
-      svc.clearMedia(1, 1, 8);
-
-      expect(svc.progress().size).toBe(0);
-    });
-
-    // One episode landing does not finish the pack that carries the rest.
-    it('keeps a season pack, which names no episode', () => {
-      const svc = make();
-      tick(svc, 'aaa', 8);
-      tick(svc, 'pack', undefined);
-
-      svc.clearMedia(1, 1, 8);
-
-      expect([...svc.progress().get(1)!.seasons!.get(1)!.leaves.keys()]).toEqual(['ref:pack']);
-    });
-
-    it('drops the whole season when given no episode', () => {
-      const svc = make();
-      tick(svc, 'aaa', 8);
-      tick(svc, 'bbb', 9);
-
-      svc.clearMedia(1, 1);
-
-      expect(svc.progress().size).toBe(0);
-    });
+  it('VERDICT: an empty snapshot retires the media outright', () => {
+    const svc = make();
+    series(svc, [download({ ref: 'aaa', seasonNumber: 1 })]);
+    series(svc, []);
+    expect(svc.progress().has(1)).toBe(false);
   });
 
-  /**
-   * The store is fed by events alone, so a download that simply stops being
-   * reported — deleted from the download client, or announced by a plugin too
-   * old to retire it — would sit at its last percent for the life of the app.
-   * The sweep is the backstop, on the same horizon the backend's replay cache
-   * uses: three missed ticks of a once-a-minute publisher.
-   */
-  describe('staleness sweep', () => {
-    const make = () => {
-      TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
-      return TestBed.inject(DownloadProgressService);
-    };
-    const sweep = (svc: DownloadProgressService) =>
-      (svc as unknown as { sweepStale: () => void }).sweepStale();
-    const age = (svc: DownloadProgressService, ms: number) => {
-      for (const entry of svc.progress().values()) {
-        if (entry.updatedAt != null) entry.updatedAt -= ms;
-        for (const sp of entry.seasons?.values() ?? []) {
-          for (const l of sp.leaves.values()) if (l.updatedAt != null) l.updatedAt -= ms;
-        }
-      }
-    };
-    const tick = (svc: DownloadProgressService, ref: string) =>
-      svc.applyProgress({
-        mediaId: 1,
-        mediaType: 'series',
-        seasonNumber: 1,
-        episodeNumber: 8,
-        ref,
-        progress: 0.5,
-        dlspeed: 0,
-        eta: 0,
-        state: 'active',
-      });
-
-    it('keeps a leaf that is still being reported', () => {
-      const svc = make();
-      tick(svc, 'aaa');
-
-      sweep(svc);
-
-      expect(svc.progress().size).toBe(1);
-    });
-
-    it('drops only the leaf that went quiet', () => {
-      const svc = make();
-      tick(svc, 'aaa');
-      age(svc, 4 * 60_000);
-      tick(svc, 'bbb');
-
-      sweep(svc);
-
-      expect([...svc.progress().get(1)!.seasons!.get(1)!.leaves.keys()]).toEqual(['ref:bbb']);
-    });
-
-    it('drops the media once its last leaf goes quiet', () => {
-      const svc = make();
-      tick(svc, 'aaa');
-      age(svc, 4 * 60_000);
-
-      sweep(svc);
-
-      expect(svc.progress().size).toBe(0);
-    });
-
-    it("sweeps a movie's entry, which is its own leaf", () => {
-      const svc = make();
-      svc.applyProgress({
-        mediaId: 2,
-        mediaType: 'movie',
-        progress: 0.5,
-        dlspeed: 0,
-        eta: 0,
-        state: 'active',
-      });
-      age(svc, 4 * 60_000);
-
-      sweep(svc);
-
-      expect(svc.progress().size).toBe(0);
-    });
+  it('an empty snapshot for an unknown media changes nothing', () => {
+    const svc = make();
+    series(svc, [download({ ref: 'aaa', seasonNumber: 1 })], 1);
+    series(svc, [], 2);
+    expect([...svc.progress().keys()]).toEqual([1]);
   });
 
-  /**
-   * Two releases grabbed for the same episode — a second tracker's copy racing
-   * the first. The leaf used to be keyed by episode number, so the second
-   * overwrote the first and the header showed one download where there were two.
-   */
-  describe('two downloads for one episode', () => {
-    const make = () => {
-      TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
-      return TestBed.inject(DownloadProgressService);
-    };
-    const tick = (svc: DownloadProgressService, ref: string, percent: number, state: 'active' | 'stalled' = 'active') =>
-      svc.applyProgress({
-        mediaId: 1,
-        mediaType: 'series',
-        seasonNumber: 1,
-        episodeNumber: 8,
-        ref,
-        progress: percent / 100,
-        dlspeed: 0,
-        eta: 0,
-        state,
-      });
-
-    it('keeps both, each with its own state and percent', () => {
-      const svc = make();
-      tick(svc, 'aaa', 12);
-      tick(svc, 'bbb', 0, 'stalled');
-
-      const leaves = svc.progress().get(1)!.seasons!.get(1)!.leaves;
-      expect(leaves.size).toBe(2);
-      expect([...leaves.values()].map((l) => [l.state, l.percent])).toEqual([
-        ['active', 12],
-        ['stalled', 0],
-      ]);
-    });
-
-    it('records the episode on each, so both stay in that episode\'s scope', () => {
-      const svc = make();
-      tick(svc, 'aaa', 12);
-      tick(svc, 'bbb', 0, 'stalled');
-
-      const leaves = svc.progress().get(1)!.seasons!.get(1)!.leaves;
-      expect([...leaves.values()].every((l) => l.episodeNumber === 8)).toBe(true);
-    });
-
-    it('retires only the one that finished', () => {
-      const svc = make();
-      tick(svc, 'aaa', 12);
-      tick(svc, 'bbb', 0, 'stalled');
-
-      tick(svc, 'aaa', 100);
-
-      const leaves = svc.progress().get(1)!.seasons!.get(1)!.leaves;
-      expect([...leaves.keys()]).toEqual(['ref:bbb']);
-    });
-
-    // The grab puts up a placeholder before any download exists; it has no ref to
-    // be matched on, so the first real tick has to stand in for it explicitly.
-    it('supersedes the placeholder its own grab put up', () => {
-      const svc = make();
-      const release = svc.markGrabbing({ mediaId: 1, mediaType: 'series', seasonNumber: 1, episodeNumber: 8 });
-
-      tick(svc, 'aaa', 12);
-
-      const leaves = svc.progress().get(1)!.seasons!.get(1)!.leaves;
-      expect([...leaves.keys()]).toEqual(['ref:aaa']);
-      release();
-      expect([...svc.progress().get(1)!.seasons!.get(1)!.leaves.keys()]).toEqual(['ref:aaa']);
-    });
+  it('two downloads for the same episode stay two leaves', () => {
+    const svc = make();
+    series(svc, [
+      download({ ref: 'aaa', seasonNumber: 1, episodeNumber: 8, progress: 0.2 }),
+      download({ ref: 'bbb', seasonNumber: 1, episodeNumber: 8, progress: 0.6 }),
+    ]);
+    expect(leafKeys(svc)).toEqual(['ref:aaa', 'ref:bbb']);
   });
 
-  /**
-   * Speed and ETA are per download. They used to be written onto the media
-   * entry by every tick, so with concurrent episodes the figure shown was
-   * whichever leaf happened to report last, not the download's.
-   */
-  describe('speed and ETA across concurrent episodes', () => {
-    const make = () => {
-      TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
-      return TestBed.inject(DownloadProgressService);
-    };
-    const tick = (svc: DownloadProgressService, episodeNumber: number, dlspeed: number, eta: number) =>
-      svc.applyProgress({
-        mediaId: 1,
-        mediaType: 'series',
-        seasonNumber: 1,
-        episodeNumber,
-        progress: 0.5,
-        dlspeed,
-        eta,
-        state: 'active',
-      });
-
-    it('keeps each leaf its own', () => {
-      const svc = make();
-      tick(svc, 6, 1000, 120);
-      tick(svc, 8, 2000, 60);
-
-      const leaves = svc.progress().get(1)!.seasons!.get(1)!.leaves;
-      expect(leaves.get(6)?.dlspeed).toBe(1000);
-      expect(leaves.get(8)?.dlspeed).toBe(2000);
-    });
-
-    it('sums the speed and takes the longest ETA for the media', () => {
-      const svc = make();
-      tick(svc, 6, 1000, 120);
-      tick(svc, 8, 2000, 60);
-
-      const entry = svc.progress().get(1)!;
-      expect(entry.dlspeed).toBe(3000);
-      expect(entry.eta).toBe(120);
-    });
-
-    it('drops a finished leaf from the totals', () => {
-      const svc = make();
-      tick(svc, 6, 1000, 120);
-      tick(svc, 8, 2000, 60);
-
-      svc.applyProgress({
-        mediaId: 1,
-        mediaType: 'series',
-        seasonNumber: 1,
-        episodeNumber: 6,
-        progress: 1,
-        dlspeed: 0,
-        eta: 0,
-        state: 'active',
-      });
-
-      const entry = svc.progress().get(1)!;
-      expect(entry.dlspeed).toBe(2000);
-      expect(entry.eta).toBe(60);
-    });
+  it('sums speed across concurrent downloads and takes the longest ETA', () => {
+    const svc = make();
+    series(svc, [
+      download({ ref: 'aaa', seasonNumber: 1, episodeNumber: 7, dlspeed: 1024, eta: 120 }),
+      download({ ref: 'bbb', seasonNumber: 1, episodeNumber: 8, dlspeed: 2048, eta: 60 }),
+    ]);
+    const entry = svc.progress().get(1)!;
+    expect(entry.dlspeed).toBe(3072);
+    expect(entry.eta).toBe(120);
   });
 
-  /**
-   * A series tick with no season number cannot be placed. The plugin sends one
-   * for a history row that never got a season/episode id, so it is a steady
-   * state — merging it onto whichever leaf happened to be alone attributed
-   * another download's percent to that episode, and taking the movie branch
-   * flattened the entry and lost the season map with it.
-   */
-  describe('a series tick with no season', () => {
-    const make = () => {
-      TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
-      return TestBed.inject(DownloadProgressService);
-    };
-    const seed = (svc: DownloadProgressService) =>
-      svc.applyProgress({
-        mediaId: 1,
-        mediaType: 'series',
-        seasonNumber: 1,
-        episodeNumber: 8,
-        ref: 'aaa',
-        progress: 0.1,
-        dlspeed: 0,
-        eta: 0,
-        state: 'active',
-      });
-    const unattributed = (svc: DownloadProgressService, progress: number) =>
-      svc.applyProgress({
-        mediaId: 1,
-        mediaType: 'series',
-        progress,
-        dlspeed: 9,
-        eta: 5,
-        state: 'active',
-      });
+  it('drops a series download the reporter could not place under a season', () => {
+    const svc = make();
+    series(svc, [download({ ref: 'aaa' })]);
+    expect(svc.progress().has(1)).toBe(false);
+  });
+});
 
-    it("leaves a known leaf's own percent alone", () => {
-      const svc = make();
-      seed(svc);
+/**
+ * A grab the user just clicked has no download to report it yet. It is held apart from the
+ * reported set precisely so a snapshot, which replaces that set wholesale, cannot erase it.
+ */
+describe('DownloadProgressService — markGrabbing', () => {
+  const scope = { mediaId: 1, mediaType: 'series' as const, seasonNumber: 1, episodeNumber: 8 };
 
-      unattributed(svc, 0.6);
-
-      expect(svc.progress().get(1)?.seasons?.get(1)?.leaves.get('ref:aaa')?.percent).toBe(10);
-    });
-
-    it('never flattens the entry into the movie shape', () => {
-      const svc = make();
-      seed(svc);
-
-      unattributed(svc, 0.6);
-
-      expect(svc.progress().get(1)?.seasons?.size).toBe(1);
-    });
-
-    it('creates nothing when there is no entry to place it against', () => {
-      const svc = make();
-
-      unattributed(svc, 0.6);
-
-      expect(svc.progress().size).toBe(0);
-    });
+  it('shows the scope as searching from the click', () => {
+    const svc = make();
+    svc.markGrabbing(scope);
+    expect(svc.progress().get(1)?.state).toBe('searching');
   });
 
-  /**
-   * The window between pressing grab and a download existing. Modelled as an
-   * ordinary leaf so the header's season/episode scoping needs no special case
-   * — and so a failed search clears with the request instead of sticking.
-   */
-  describe('markGrabbing', () => {
-    const make = () => {
-      TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
-      return TestBed.inject(DownloadProgressService);
-    };
-    const episode = { mediaId: 1, mediaType: 'series' as const, seasonNumber: 1, episodeNumber: 8 };
+  it('the release drops it, so a failed search leaves no badge up', () => {
+    const svc = make();
+    svc.markGrabbing(scope)();
+    expect(svc.progress().has(1)).toBe(false);
+  });
 
-    it('keys the phase to the episode, so a sibling page stays clear', () => {
-      const svc = make();
-      svc.markGrabbing(episode);
-      const leaves = svc.progress().get(1)?.seasons?.get(1)?.leaves;
-      expect([...(leaves?.keys() ?? [])]).toEqual([8]);
-      expect(leaves?.get(8)?.state).toBe('searching');
-    });
+  it('VERDICT: a snapshot for another episode does not erase it', () => {
+    const svc = make();
+    svc.markGrabbing(scope);
+    series(svc, [download({ ref: 'aaa', seasonNumber: 1, episodeNumber: 3 })]);
 
-    it('releases the phase when the search fails', () => {
-      const svc = make();
-      svc.markGrabbing(episode)();
-      expect(svc.progress().size).toBe(0);
-    });
+    expect(leafKeys(svc)).toEqual(['ref:aaa', 'pending:1:8']);
+  });
 
-    // Every real tick carries a ref, so these use one: a ref-less payload is a
-    // shape production never emits, and it is exactly the shape where a guard
-    // that reconstructs a key from the episode number passes by accident.
-    it('leaves a real download alone once it takes over', () => {
-      const svc = make();
-      const release = svc.markGrabbing(episode);
-      svc.applyProgress({ ...episode, ref: 'aaa', progress: 0.4, dlspeed: 1, eta: 2, state: 'active' });
+  it('a snapshot reporting that very scope supersedes it', () => {
+    const svc = make();
+    svc.markGrabbing(scope);
+    series(svc, [download({ ref: 'aaa', seasonNumber: 1, episodeNumber: 8 })]);
 
-      release();
+    expect(leafKeys(svc)).toEqual(['ref:aaa']);
+  });
 
-      expect(svc.progress().get(1)?.seasons?.get(1)?.leaves.get('ref:aaa')).toEqual(
-        expect.objectContaining({ state: 'active', percent: 40 }),
-      );
-    });
+  it('says nothing when a download is already reporting for the scope', () => {
+    const svc = make();
+    series(svc, [download({ ref: 'aaa', seasonNumber: 1, episodeNumber: 8 })]);
+    svc.markGrabbing(scope);
+    expect(leafKeys(svc)).toEqual(['ref:aaa']);
+  });
+});
 
-    it('never downgrades a download already reporting to a search', () => {
-      const svc = make();
-      svc.applyProgress({ ...episode, ref: 'aaa', progress: 0.4, dlspeed: 1, eta: 2, state: 'active' });
+/** `import.complete` retires a finished download ahead of the publisher's next snapshot. */
+describe('DownloadProgressService — clearMedia', () => {
+  const twoEpisodes = (svc: DownloadProgressService) =>
+    series(svc, [
+      download({ ref: 'aaa', seasonNumber: 1, episodeNumber: 7 }),
+      download({ ref: 'bbb', seasonNumber: 1, episodeNumber: 8 }),
+    ]);
 
-      svc.markGrabbing(episode)();
+  it('drops only the imported episode, leaving its siblings advancing', () => {
+    const svc = make();
+    twoEpisodes(svc);
+    svc.clearMedia(1, 1, 8);
+    expect(leafKeys(svc)).toEqual(['ref:aaa']);
+  });
 
-      const leaves = svc.progress().get(1)!.seasons!.get(1)!.leaves;
-      expect([...leaves.keys()]).toEqual(['ref:aaa']);
-      expect(leaves.get('ref:aaa')?.state).toBe('active');
-    });
+  it('a season import drops the whole season, pack included', () => {
+    const svc = make();
+    twoEpisodes(svc);
+    svc.clearMedia(1, 1);
+    expect(svc.progress().has(1)).toBe(false);
+  });
 
-    it("drops only its own leaf, not a sibling's download", () => {
-      const svc = make();
-      svc.applyProgress({
-        mediaId: 1,
-        mediaType: 'series',
-        seasonNumber: 1,
-        episodeNumber: 3,
-        ref: 'bbb',
-        progress: 0.5,
-        dlspeed: 1,
-        eta: 2,
-        state: 'active',
-      });
+  it('keeps a pack an episode import does not finish', () => {
+    const svc = make();
+    series(svc, [
+      download({ ref: 'pack', seasonNumber: 1 }),
+      download({ ref: 'bbb', seasonNumber: 1, episodeNumber: 8 }),
+    ]);
+    svc.clearMedia(1, 1, 8);
+    expect(leafKeys(svc)).toEqual(['ref:pack']);
+  });
 
-      svc.markGrabbing(episode)();
+  it('with no season it drops the media', () => {
+    const svc = make();
+    movie(svc, [download()]);
+    svc.clearMedia(1);
+    expect(svc.progress().has(1)).toBe(false);
+  });
+});
 
-      expect([...(svc.progress().get(1)?.seasons?.get(1)?.leaves.keys() ?? [])]).toEqual([
-        'ref:bbb',
-      ]);
-    });
+/**
+ * The backstop, not the removal mechanism: it catches a publisher that died or was
+ * reconfigured, where no further snapshot will ever arrive to state the truth.
+ */
+describe('DownloadProgressService — staleness sweep', () => {
+  const sweep = (svc: DownloadProgressService) =>
+    (svc as unknown as { sweepStale: () => void }).sweepStale();
+  const age = (svc: DownloadProgressService, ms: number) => {
+    for (const entry of svc.progress().values()) {
+      if (entry.updatedAt != null) entry.updatedAt -= ms;
+    }
+  };
+
+  it('keeps a media still being reported', () => {
+    const svc = make();
+    series(svc, [download({ ref: 'aaa', seasonNumber: 1 })]);
+    sweep(svc);
+    expect(svc.progress().has(1)).toBe(true);
+  });
+
+  it('drops a media whose snapshots stopped arriving', () => {
+    const svc = make();
+    series(svc, [download({ ref: 'aaa', seasonNumber: 1 })]);
+    age(svc, 4 * 60_000);
+    sweep(svc);
+    expect(svc.progress().has(1)).toBe(false);
+  });
+
+  it('a fresh snapshot renews the whole media, not one leaf at a time', () => {
+    const svc = make();
+    series(svc, [download({ ref: 'aaa', seasonNumber: 1 })]);
+    age(svc, 4 * 60_000);
+    series(svc, [download({ ref: 'aaa', seasonNumber: 1 })]);
+    sweep(svc);
+    expect(svc.progress().has(1)).toBe(true);
   });
 });

--- a/client/src/app/core/services/download-progress.service.ts
+++ b/client/src/app/core/services/download-progress.service.ts
@@ -1,23 +1,20 @@
-import { Injectable, signal } from '@angular/core';
+import { Injectable, computed, signal } from '@angular/core';
 import { MediaType } from '../enums/media-type.enum';
 import { DownloadProgressState, ProgressPhase } from '../enums/download-progress-state.enum';
 import { foldLeaves } from '../../shared/utils/download-format';
 
-/** Identifies one download within a season. `ref:<r>` whenever the report carries one —
- *  its own identity, so two releases grabbed for the *same* episode stay two leaves instead
- *  of overwriting each other. The episode number (or `'PACK'`) keys the placeholder a grab
- *  puts up before any download exists; the first real tick for that scope supersedes it. */
-export type LeafKey = number | 'PACK' | `ref:${string}`;
+/** Identifies one download within a season. `ref:<r>` is the reporter's own identity for it, so
+ *  two releases grabbed for the *same* episode stay two leaves instead of overwriting each other.
+ *  `pending:<scope>` keys the placeholder a grab puts up before any download exists. */
+export type LeafKey = `ref:${string}` | `pending:${string}`;
 
 /** One in-flight download contributing to a media's download progress. */
 export interface DownloadLeaf {
   percent: number; // 0–100
   state: ProgressPhase;
   /** The episode this download is for, when it names one. Held on the leaf
-   *  rather than in its key, which now identifies the download itself. */
+   *  rather than in its key, which identifies the download itself. */
   episodeNumber?: number;
-  /** When this leaf was last reported, for the staleness sweep. */
-  updatedAt?: number;
   /** This download's own speed and ETA. Held per leaf because concurrent
    *  episodes each have their own, and a media-level pair could only ever
    *  report whichever of them ticked last. */
@@ -32,8 +29,8 @@ export interface SeasonProgress {
 /** Live download progress for one media, keyed by `mediaId`. For a series the
  *  `seasons` sub-map holds per-(season, leaf) progress (a leaf is a season pack
  *  or an individual episode download); `state`/`percent` are the folded
- *  media-level rollup. A movie has no `seasons` — its single download's folded
- *  state and percent sit directly on the entry. */
+ *  media-level rollup. A movie has no `seasons` — its downloads fold straight
+ *  onto the entry. */
 export interface MediaDownloadProgress {
   mediaId: number;
   mediaType: MediaType;
@@ -42,33 +39,57 @@ export interface MediaDownloadProgress {
   dlspeed: number;
   eta: number;
   seasons?: Map<number, SeasonProgress>;
-  /** When this entry was last reported, for the staleness sweep. Only a movie
-   *  needs it here — a series is swept leaf by leaf. */
+  /** When the snapshot behind this entry arrived, for the staleness sweep. */
   updatedAt?: number;
 }
 
-/** Payload of a `download.progress` SSE event. */
-export interface DownloadProgressEvent {
-  mediaId: number;
-  mediaType: MediaType;
+/** One download inside a `download.progress` snapshot. */
+export interface DownloadProgressItem {
+  ref: string;
   seasonNumber?: number;
   episodeNumber?: number;
-  ref?: string;
   progress: number; // 0–1
   dlspeed: number;
   eta: number;
   state: DownloadProgressState;
 }
 
-/** How long a leaf may go unreported before the sweep drops it. The publisher
- *  ticks about once a minute; three missed ticks is gone, not slow. Same
- *  horizon the backend's replay cache uses, for the same reason. */
+/**
+ * Payload of a `download.progress` SSE event: every download in flight for one media.
+ *
+ * A replacement, never a delta. Whatever is absent has been retired, and an empty `downloads`
+ * retires the media. That is what makes a phantom leaf impossible rather than merely unlikely:
+ * there is no removal to miss, because absence is the removal.
+ */
+export interface DownloadProgressEvent {
+  mediaId: number;
+  mediaType: MediaType;
+  downloads: DownloadProgressItem[];
+}
+
+/** A grab the user just started, before any download exists to report it. */
+interface GrabbingScope {
+  mediaType: MediaType;
+  seasonNumber?: number;
+  episodeNumber?: number;
+}
+
+/**
+ * How long a media may go unreported before the sweep drops it. The publisher ticks about once a
+ * minute; three missed ticks is gone, not slow. Same horizon the backend's replay cache uses.
+ *
+ * This is a backstop for a publisher that died or was reconfigured, not the removal mechanism:
+ * a download that stops is absent from the very next snapshot.
+ */
 const STALE_AFTER_MS = 3 * 60_000;
 const SWEEP_INTERVAL_MS = 30_000;
 
-function leafKey(episodeNumber?: number, ref?: string): LeafKey {
-  if (ref) return `ref:${ref}`;
-  return episodeNumber ?? 'PACK';
+function pendingKey(scope: GrabbingScope): LeafKey {
+  return `pending:${scope.seasonNumber ?? ''}:${scope.episodeNumber ?? ''}`;
+}
+
+function sameScope(a: GrabbingScope, b: { seasonNumber?: number; episodeNumber?: number }): boolean {
+  return a.seasonNumber === b.seasonNumber && a.episodeNumber === b.episodeNumber;
 }
 
 /** Fold every season leaf into the media-level state, percent, speed and ETA.
@@ -94,60 +115,136 @@ function rollupSeasons(seasons: Map<number, SeasonProgress>): {
   };
 }
 
+function toLeaf(d: DownloadProgressItem): DownloadLeaf {
+  return {
+    percent: Math.round(d.progress * 100),
+    state: d.state,
+    episodeNumber: d.episodeNumber,
+    dlspeed: d.dlspeed,
+    eta: d.eta,
+  };
+}
+
+/** Build a media entry from one snapshot. A series groups by season; a movie folds flat. */
+function toEntry(e: DownloadProgressEvent, at: number): MediaDownloadProgress | null {
+  if (!e.downloads.length) return null;
+
+  if (e.mediaType !== 'series') {
+    const f = foldLeaves(e.downloads.map(toLeaf));
+    return {
+      mediaId: e.mediaId,
+      mediaType: e.mediaType,
+      percent: f.percent,
+      state: f.state || 'active',
+      dlspeed: e.downloads.reduce((a, d) => a + d.dlspeed, 0),
+      eta: e.downloads.reduce((a, d) => Math.max(a, d.eta), 0),
+      updatedAt: at,
+    };
+  }
+
+  const seasons = new Map<number, SeasonProgress>();
+  for (const d of e.downloads) {
+    // A series download the reporter could not attribute to a season cannot be placed under
+    // one. Dropping it is right: merging it onto whichever leaf happens to be alone would
+    // attribute another download's percent to it.
+    if (d.seasonNumber == null) continue;
+    const leaves = seasons.get(d.seasonNumber)?.leaves ?? new Map<LeafKey, DownloadLeaf>();
+    leaves.set(`ref:${d.ref}`, toLeaf(d));
+    seasons.set(d.seasonNumber, { leaves });
+  }
+  if (!seasons.size) return null;
+  return {
+    mediaId: e.mediaId,
+    mediaType: e.mediaType,
+    seasons,
+    updatedAt: at,
+    ...rollupSeasons(seasons),
+  };
+}
+
 /**
- * App-wide store of in-flight download progress, fed by `download.progress`
- * SSE events (via {@link SseService}). One shared signal — the requests
- * views and media-detail read it by `mediaId`. The status itself
- * (label/colour/aggregation) is derived on read via the pure helpers in
- * `download-format`, so this store stays a plain data holder.
+ * App-wide store of in-flight download progress, fed by `download.progress` SSE events (via
+ * {@link SseService}). One shared signal — the requests views and media-detail read it by
+ * `mediaId`. The status itself (label/colour/aggregation) is derived on read via the pure
+ * helpers in `download-format`, so this store stays a plain data holder.
+ *
+ * Two sources, deliberately kept apart: `reported` is what the server said, replaced wholesale
+ * per media by each snapshot, and `grabbing` is local optimism for a grab the user just clicked.
+ * Merging them at read time is what lets a snapshot replace without erasing a placeholder it
+ * knows nothing about.
  */
 @Injectable({ providedIn: 'root' })
 export class DownloadProgressService {
-  readonly progress = signal<Map<number, MediaDownloadProgress>>(new Map());
+  /** Server truth. Never merged into, only replaced per media. */
+  private readonly reported = signal<Map<number, MediaDownloadProgress>>(new Map());
+
+  /** Grabs started here that no snapshot has reported yet. */
+  private readonly grabbing = signal<Map<number, GrabbingScope[]>>(new Map());
+
+  readonly progress = computed(() => this.merged());
 
   private sweepHandle: ReturnType<typeof setInterval> | null = null;
 
-  /**
-   * Drop leaves nothing has reported in a while. The store is fed by events
-   * alone, so a download that stops being reported — deleted from the download
-   * client, or an acquisition plugin too old to announce its retirement — would
-   * otherwise sit here at its last percent for the life of the app.
-   *
-   * Mirrors the backend's own replay cache, down to the horizon: the publisher
-   * ticks about once a minute, so three missed ticks is a leaf that is gone
-   * rather than one that was slow.
-   */
-  private sweepStale(): void {
-    const cutoff = Date.now() - STALE_AFTER_MS;
-    const prev = this.progress();
-    let changed = false;
-    const next = new Map(prev);
+  private merged(): Map<number, MediaDownloadProgress> {
+    const reported = this.reported();
+    const grabbing = this.grabbing();
+    if (!grabbing.size) return reported;
 
-    for (const [mediaId, entry] of prev) {
-      if (!entry.seasons) {
-        // A movie's single download: the entry itself is the leaf.
-        if ((entry.updatedAt ?? 0) < cutoff) {
-          next.delete(mediaId);
-          changed = true;
+    const out = new Map(reported);
+    for (const [mediaId, scopes] of grabbing) {
+      if (!scopes.length) continue;
+      const cur = out.get(mediaId);
+      const mediaType = cur?.mediaType ?? scopes[0]!.mediaType;
+
+      if (mediaType !== 'series') {
+        // Nothing to place a movie placeholder under, and a reported movie already says more.
+        if (!cur) {
+          out.set(mediaId, {
+            mediaId,
+            mediaType,
+            percent: null,
+            state: 'searching',
+            dlspeed: 0,
+            eta: 0,
+          });
         }
         continue;
       }
-      const seasons = new Map(entry.seasons);
-      let touched = false;
-      for (const [seasonNumber, sp] of entry.seasons) {
-        const leaves = new Map([...sp.leaves].filter(([, l]) => (l.updatedAt ?? 0) >= cutoff));
-        if (leaves.size === sp.leaves.size) continue;
-        touched = true;
-        if (leaves.size === 0) seasons.delete(seasonNumber);
-        else seasons.set(seasonNumber, { leaves });
-      }
-      if (!touched) continue;
-      changed = true;
-      if (seasons.size === 0) next.delete(mediaId);
-      else next.set(mediaId, { ...entry, seasons, ...rollupSeasons(seasons) });
-    }
 
-    if (changed) this.progress.set(next);
+      const seasons = new Map(cur?.seasons ?? []);
+      for (const scope of scopes) {
+        const seasonNumber = scope.seasonNumber ?? 0;
+        const leaves = new Map(seasons.get(seasonNumber)?.leaves ?? []);
+        leaves.set(pendingKey(scope), {
+          percent: 0,
+          state: 'searching',
+          episodeNumber: scope.episodeNumber,
+          dlspeed: 0,
+          eta: 0,
+        });
+        seasons.set(seasonNumber, { leaves });
+      }
+      out.set(mediaId, {
+        mediaId,
+        mediaType,
+        seasons,
+        updatedAt: cur?.updatedAt,
+        ...rollupSeasons(seasons),
+      });
+    }
+    return out;
+  }
+
+  /**
+   * Drop a media whose snapshot has stopped arriving. The store is fed by events alone, so a
+   * publisher that died would otherwise leave its last snapshot on screen for the life of the
+   * app. Removal within a media needs no sweep: the next snapshot states the whole set.
+   */
+  private sweepStale(): void {
+    const cutoff = Date.now() - STALE_AFTER_MS;
+    const prev = this.reported();
+    const next = new Map([...prev].filter(([, entry]) => (entry.updatedAt ?? 0) >= cutoff));
+    if (next.size !== prev.size) this.reported.set(next);
     if (!next.size) this.stopSweep();
   }
 
@@ -163,102 +260,51 @@ export class DownloadProgressService {
     this.sweepHandle = null;
   }
 
-  /** Drop everything, for the SSE connect snapshot. Progress is only ever
-   *  retired by an event, so a download that ended while the stream was down
-   *  would otherwise sit here at its last percent for the life of the app. */
+  /** Drop everything, for the SSE connect snapshot: the replay that follows re-states whatever
+   *  is still in flight, and anything that ended while the stream was down never will. */
   reset(): void {
-    if (this.progress().size) this.progress.set(new Map());
+    if (this.reported().size) this.reported.set(new Map());
+    if (this.grabbing().size) this.grabbing.set(new Map());
     this.stopSweep();
   }
 
-  /** Apply a `download.progress` SSE event. Updates a single leaf; deletes it
-   *  (and any now-empty season/media) once it reaches 100%. */
+  /** Apply one media's snapshot, replacing whatever was held for it. */
   applyProgress(e: DownloadProgressEvent): void {
-    this.applyPhase(e);
-  }
+    const entry = toEntry(e, Date.now());
+    if (entry) this.startSweep();
 
-  /** Same, for a phase the wire can't carry. {@link DownloadProgressEvent}
-   *  stays the SSE shape so nothing suggests the backend sends `searching`. */
-  private applyPhase(e: Omit<DownloadProgressEvent, 'state'> & { state: ProgressPhase }): void {
-    const percent = Math.round(e.progress * 100);
-    this.startSweep();
-    this.progress.update((prev) => {
-      const next = new Map(prev);
-
-      if (e.mediaType === 'series' && e.seasonNumber != null) {
-        const cur = next.get(e.mediaId);
-        const seasons = new Map(cur?.seasons ?? []);
-        const leaves = new Map(seasons.get(e.seasonNumber)?.leaves ?? []);
-        const key = leafKey(e.episodeNumber, e.ref);
-
-        // A download with a ref stands in for the placeholder its grab put up
-        // for the same scope, which has no identity to be matched on — on a
-        // retirement as much as on a live tick.
-        if (e.ref) leaves.delete(e.episodeNumber ?? 'PACK');
-        if (e.progress >= 1) leaves.delete(key);
-        else {
-          leaves.set(key, {
-            percent,
-            state: e.state,
-            episodeNumber: e.episodeNumber,
-            dlspeed: e.dlspeed,
-            eta: e.eta,
-            updatedAt: Date.now(),
-          });
-        }
-
-        if (leaves.size === 0) seasons.delete(e.seasonNumber);
-        else seasons.set(e.seasonNumber, { leaves });
-
-        if (seasons.size === 0) {
-          next.delete(e.mediaId);
-          return next;
-        }
-        next.set(e.mediaId, {
-          mediaId: e.mediaId,
-          mediaType: 'series',
-          seasons,
-          ...rollupSeasons(seasons),
-        });
-        return next;
-      }
-
-      // A series tick with no season number cannot be placed. The plugin sends
-      // these for a history row that never got a season/episode id, so it is a
-      // steady state, not a blip. Merging one onto whichever leaf happens to be
-      // alone would attribute another download's percent to it, and taking the
-      // movie branch below would flatten the entry and lose the season map with
-      // it. Drop it: the next attributed tick carries the same truth.
-      if (e.mediaType === 'series') return next;
-
-      // Movie (single download — no season dimension).
-      if (e.progress >= 1) {
+    this.reported.update((prev) => {
+      if (!entry) {
+        if (!prev.has(e.mediaId)) return prev;
+        const next = new Map(prev);
         next.delete(e.mediaId);
         return next;
       }
-      const f = foldLeaves([{ percent, state: e.state }]);
-      next.set(e.mediaId, {
-        mediaId: e.mediaId,
-        mediaType: e.mediaType,
-        percent: f.percent,
-        state: f.state || 'active',
-        dlspeed: e.dlspeed,
-        eta: e.eta,
-        updatedAt: Date.now(),
-      });
+      return new Map(prev).set(e.mediaId, entry);
+    });
+
+    // A scope the snapshot now reports has a real download: the placeholder has been superseded.
+    this.dropGrabbing(e.mediaId, (scope) => e.downloads.some((d) => sameScope(scope, d)));
+  }
+
+  private dropGrabbing(mediaId: number, matches: (scope: GrabbingScope) => boolean): void {
+    this.grabbing.update((prev) => {
+      const scopes = prev.get(mediaId);
+      if (!scopes?.length) return prev;
+      const kept = scopes.filter((s) => !matches(s));
+      if (kept.length === scopes.length) return prev;
+      const next = new Map(prev);
+      if (kept.length) next.set(mediaId, kept);
+      else next.delete(mediaId);
       return next;
     });
   }
 
   /**
-   * Mark a grab as under way for a scope, before any download exists: the header
-   * says "searching" from the click instead of from the download client's first
-   * tick, seconds later. Returns the release to call when the request settles —
-   * either way, since a failed search must not leave the badge up.
-   *
-   * Modelled as an ordinary leaf so scoping, folding and rendering need no
-   * special case: an episode grab is keyed to that episode and stays off its
-   * siblings' pages, exactly like the download that replaces it.
+   * Mark a grab as under way for a scope, before any download exists: the header says
+   * "searching" from the click instead of from the download client's first tick, seconds later.
+   * Returns the release to call when the request settles — either way, since a failed search
+   * must not leave the badge up.
    */
   markGrabbing(e: {
     mediaId: number;
@@ -266,100 +312,72 @@ export class DownloadProgressService {
     seasonNumber?: number;
     episodeNumber?: number;
   }): () => void {
-    const key = leafKey(e.episodeNumber);
-    // A download already reporting for this scope says strictly more than
-    // "searching" — leave it, and make the release a no-op.
-    if (this.leafState(e) !== undefined) return () => undefined;
+    const scope: GrabbingScope = {
+      mediaType: e.mediaType,
+      seasonNumber: e.seasonNumber,
+      episodeNumber: e.episodeNumber,
+    };
+    // A download already reporting for this scope says strictly more than "searching".
+    if (this.reportsScope(e.mediaId, scope)) return () => undefined;
 
-    this.applyPhase({ ...e, progress: 0, dlspeed: 0, eta: 0, state: 'searching' });
+    this.grabbing.update((prev) => {
+      const scopes = prev.get(e.mediaId) ?? [];
+      if (scopes.some((s) => sameScope(s, scope))) return prev;
+      return new Map(prev).set(e.mediaId, [...scopes, scope]);
+    });
 
     let released = false;
     return () => {
       if (released) return;
       released = true;
-      // Real progress landed while the request was in flight: it owns the leaf.
-      if (this.leafState(e) !== 'searching') return;
-      this.progress.update((prev) => {
-        const cur = prev.get(e.mediaId);
-        if (!cur) return prev;
-        const next = new Map(prev);
-        if (!cur.seasons || e.seasonNumber == null) {
-          next.delete(e.mediaId);
-          return next;
-        }
-        const seasons = new Map(cur.seasons);
-        const leaves = new Map(seasons.get(e.seasonNumber)?.leaves ?? []);
-        leaves.delete(key);
-        if (leaves.size === 0) seasons.delete(e.seasonNumber);
-        else seasons.set(e.seasonNumber, { leaves });
-        if (seasons.size === 0) {
-          next.delete(e.mediaId);
-          return next;
-        }
-        const rolled = rollupSeasons(seasons);
-        next.set(e.mediaId, { ...cur, seasons, ...rolled });
-        return next;
-      });
+      this.dropGrabbing(e.mediaId, (s) => sameScope(s, scope));
     };
   }
 
-  /** Phase of the leaf a grab scope maps to, or undefined when there is none. */
-  private leafState(e: {
-    mediaId: number;
-    seasonNumber?: number;
-    episodeNumber?: number;
-  }): ProgressPhase | undefined {
-    const cur = this.progress().get(e.mediaId);
-    if (!cur) return undefined;
-    if (!cur.seasons || e.seasonNumber == null) return cur.state;
-    // Matched on the leaf's own episode: the key identifies the download, so a
-    // live download is keyed by its ref and reconstructing a key from the
-    // episode number could only ever find the placeholder.
-    for (const leaf of cur.seasons.get(e.seasonNumber)?.leaves.values() ?? []) {
-      if (leaf.episodeNumber === e.episodeNumber) return leaf.state;
+  /** Whether the server already reports a download covering this scope. */
+  private reportsScope(mediaId: number, scope: GrabbingScope): boolean {
+    const cur = this.reported().get(mediaId);
+    if (!cur) return false;
+    if (!cur.seasons || scope.seasonNumber == null) return true;
+    for (const leaf of cur.seasons.get(scope.seasonNumber)?.leaves.values() ?? []) {
+      if (leaf.episodeNumber === scope.episodeNumber) return true;
     }
-    return undefined;
+    return false;
   }
 
-  /** Retire progress for a finished import. With an `episodeNumber` on a series
-   *  drop only that episode's leaf (sibling episodes keep advancing); with only
-   *  a `seasonNumber` drop the whole season (pack / multi-episode import);
-   *  otherwise drop the whole media entry. */
-  clearMedia(
-    mediaId: number,
-    seasonNumber?: number,
-    episodeNumber?: number,
-  ): void {
-    this.progress.update((prev) => {
+  /** Retire progress for a finished import, ahead of the publisher's next snapshot. With an
+   *  `episodeNumber` on a series drop only that episode's leaf (sibling episodes keep
+   *  advancing); with only a `seasonNumber` drop the whole season (pack / multi-episode
+   *  import); otherwise drop the whole media entry. */
+  clearMedia(mediaId: number, seasonNumber?: number, episodeNumber?: number): void {
+    this.dropGrabbing(
+      mediaId,
+      (s) => seasonNumber == null || (s.seasonNumber === seasonNumber && (episodeNumber == null || s.episodeNumber === episodeNumber)),
+    );
+    this.reported.update((prev) => {
       const cur = prev.get(mediaId);
       if (!cur) return prev;
       const next = new Map(prev);
 
-      if (seasonNumber != null && cur.seasons) {
-        const seasons = new Map(cur.seasons);
-        const sp = seasons.get(seasonNumber);
-        if (sp) {
-          if (episodeNumber != null) {
-            // By the leaf's own episode, for the same reason as `leafState`.
-            // Narrower than the scope filter used for rendering: a leaf naming
-            // no episode is a pack, which one episode's import doesn't finish.
-            const leaves = new Map(
-              [...sp.leaves].filter(([, l]) => l.episodeNumber !== episodeNumber),
-            );
-            if (leaves.size === 0) seasons.delete(seasonNumber);
-            else seasons.set(seasonNumber, { leaves });
-          } else {
-            seasons.delete(seasonNumber);
-          }
-        }
-        if (seasons.size === 0) {
-          next.delete(mediaId);
-        } else {
-          next.set(mediaId, { ...cur, seasons, ...rollupSeasons(seasons) });
-        }
-      } else {
+      if (seasonNumber == null || !cur.seasons) {
         next.delete(mediaId);
+        return next;
       }
+      const seasons = new Map(cur.seasons);
+      const sp = seasons.get(seasonNumber);
+      if (sp) {
+        if (episodeNumber != null) {
+          // Narrower than the scope filter used for rendering: a leaf naming no episode is a
+          // pack, which one episode's import does not finish.
+          const leaves = new Map([...sp.leaves].filter(([, l]) => l.episodeNumber !== episodeNumber));
+          if (leaves.size === 0) seasons.delete(seasonNumber);
+          else seasons.set(seasonNumber, { leaves });
+        } else {
+          seasons.delete(seasonNumber);
+        }
+      }
+      if (seasons.size === 0) next.delete(mediaId);
+      else next.set(mediaId, { ...cur, seasons, ...rollupSeasons(seasons) });
       return next;
     });
   }

--- a/client/src/app/core/services/sse.service.ts
+++ b/client/src/app/core/services/sse.service.ts
@@ -180,13 +180,18 @@ export class SseService implements OnDestroy {
         this.downloadProgress.applyProgress({
           mediaId: Number(event['mediaId']),
           mediaType: event['mediaType'] as MediaType,
-          seasonNumber: event['seasonNumber'] as number | undefined,
-          episodeNumber: event['episodeNumber'] as number | undefined,
-          ref: event['ref'] as string | undefined,
-          progress: Number(event['progress']),
-          dlspeed: Number(event['dlspeed'] ?? 0),
-          eta: Number(event['eta'] ?? 0),
-          state: (event['state'] as DownloadProgressState | undefined) ?? 'active',
+          // The whole set for this media, so an absent download is a retired one.
+          downloads: (Array.isArray(event['downloads']) ? event['downloads'] : []).map(
+            (d: Record<string, unknown>) => ({
+              ref: String(d['ref'] ?? ''),
+              seasonNumber: d['seasonNumber'] as number | undefined,
+              episodeNumber: d['episodeNumber'] as number | undefined,
+              progress: Number(d['progress']),
+              dlspeed: Number(d['dlspeed'] ?? 0),
+              eta: Number(d['eta'] ?? 0),
+              state: (d['state'] as DownloadProgressState | undefined) ?? 'active',
+            }),
+          ),
         });
         break;
       case 'import.complete':

--- a/client/src/app/shared/components/download-detail-modal/download-detail-modal.spec.ts
+++ b/client/src/app/shared/components/download-detail-modal/download-detail-modal.spec.ts
@@ -35,7 +35,8 @@ async function render(
         n,
         {
           leaves: new Map(
-            l.map(([k, leaf]) => [k, typeof k === 'number' ? { ...leaf, episodeNumber: k } : leaf]),
+            // The key is the reporter's own ref; the episode a leaf belongs to lives on the leaf.
+            l,
           ),
         },
       ]),
@@ -56,8 +57,8 @@ describe('DownloadDetailModalComponent — one row per download', () => {
   it('gives every episode its own bar, speed and ETA', async () => {
     const f = await render([
       [1, [
-        [6, { state: 'active', percent: 3, dlspeed: 1024, eta: 120 }],
-        [8, { state: 'active', percent: 19, dlspeed: 2048, eta: 60 }],
+        ['ref:e6', { state: 'active', percent: 3, dlspeed: 1024, eta: 120, episodeNumber: 6 }],
+        ['ref:e8', { state: 'active', percent: 19, dlspeed: 2048, eta: 60, episodeNumber: 8 }],
       ]],
     ]);
     const [six, eight] = f.componentInstance.seasonRows()[0].leaves;
@@ -72,7 +73,7 @@ describe('DownloadDetailModalComponent — one row per download', () => {
   });
 
   it('states a stall — the row has no other way to explain itself', async () => {
-    const f = await render([[1, [[7, { state: 'stalled', percent: 0 }]]]]);
+    const f = await render([[1, [['ref:e7', { state: 'stalled', percent: 0, episodeNumber: 7 }]]]]);
     const [seven] = f.componentInstance.seasonRows()[0].leaves;
 
     expect(seven.stateLabelKey).toBe('activity.tstatus_stalled');
@@ -82,7 +83,7 @@ describe('DownloadDetailModalComponent — one row per download', () => {
   });
 
   it('names the search, with no percentage, before a download exists', async () => {
-    const f = await render([[1, [[8, { state: 'searching', percent: 0 }]]]]);
+    const f = await render([[1, [['ref:e8', { state: 'searching', percent: 0, episodeNumber: 8 }]]]]);
     const [row] = f.componentInstance.seasonRows()[0].leaves;
 
     expect(row.percent).toBeNull();
@@ -91,8 +92,8 @@ describe('DownloadDetailModalComponent — one row per download', () => {
 
   it('groups rows under every season in flight', async () => {
     const f = await render([
-      [2, [['PACK', { state: 'active', percent: 20 }]]],
-      [1, [[8, { state: 'active', percent: 50 }]]],
+      [2, [['ref:pack', { state: 'active', percent: 20 }]]],
+      [1, [['ref:e8', { state: 'active', percent: 50, episodeNumber: 8 }]]],
     ]);
 
     expect(f.componentInstance.seasonRows().map((s) => s.seasonNumber)).toEqual([1, 2]);

--- a/client/src/app/shared/utils/download-badges.spec.ts
+++ b/client/src/app/shared/utils/download-badges.spec.ts
@@ -1,7 +1,9 @@
 import { collectScopedLeaves } from './download-format';
-import { MediaDownloadProgress } from '../../core/services/download-progress.service';
+import { LeafKey, MediaDownloadProgress } from '../../core/services/download-progress.service';
 
-const series = (leaves: [number, [number | 'PACK', { state: 'active'; percent: number }][]][]): MediaDownloadProgress => ({
+const series = (
+  leaves: [number, [LeafKey, { state: 'active'; percent: number; episodeNumber?: number }][]][],
+): MediaDownloadProgress => ({
   mediaId: 1,
   mediaType: 'series',
   percent: 50,
@@ -29,34 +31,34 @@ const series = (leaves: [number, [number | 'PACK', { state: 'active'; percent: n
 describe('collectScopedLeaves — several downloads on one media', () => {
   it('keeps every download, with the season it was found under', () => {
     const found = collectScopedLeaves(
-      series([[1, [[6, { state: 'active', percent: 3 }], [8, { state: 'active', percent: 19 }]]]]),
+      series([[1, [['ref:e6', { state: 'active', percent: 3, episodeNumber: 6 }], ['ref:e8', { state: 'active', percent: 19, episodeNumber: 8 }]]]]),
     );
 
     expect(found.map((f) => [f.seasonNumber, f.key, f.leaf.percent])).toEqual([
-      [1, 6, 3],
-      [1, 8, 19],
+      [1, 'ref:e6', 3],
+      [1, 'ref:e8', 19],
     ]);
   });
 
   it('spans seasons, so a pack and a loose episode both surface', () => {
     const found = collectScopedLeaves(
       series([
-        [1, [[8, { state: 'active', percent: 19 }]]],
-        [2, [['PACK', { state: 'active', percent: 40 }]]],
+        [1, [['ref:e8', { state: 'active', percent: 19, episodeNumber: 8 }]]],
+        [2, [['ref:pack', { state: 'active', percent: 40 }]]],
       ]),
     );
 
-    expect(found.map((f) => f.key)).toEqual([8, 'PACK']);
+    expect(found.map((f) => f.key)).toEqual(['ref:e8', 'ref:pack']);
   });
 
   it('narrows to one episode plus anything that could carry it', () => {
     const found = collectScopedLeaves(
-      series([[1, [[6, { state: 'active', percent: 3 }], [8, { state: 'active', percent: 19 }], ['PACK', { state: 'active', percent: 40 }]]]]),
+      series([[1, [['ref:e6', { state: 'active', percent: 3, episodeNumber: 6 }], ['ref:e8', { state: 'active', percent: 19, episodeNumber: 8 }], ['ref:pack', { state: 'active', percent: 40 }]]]]),
       [1],
       8,
     );
 
-    expect(found.map((f) => f.key)).toEqual([8, 'PACK']);
+    expect(found.map((f) => f.key)).toEqual(['ref:e8', 'ref:pack']);
   });
 
   it('is empty for a movie, which has no season dimension to scope by', () => {

--- a/client/src/app/shared/utils/download-format.spec.ts
+++ b/client/src/app/shared/utils/download-format.spec.ts
@@ -8,7 +8,7 @@ import {
   describeBadge,
   describeDownload,
 } from './download-format';
-import { DownloadLeaf, MediaDownloadProgress } from '../../core/services/download-progress.service';
+import { DownloadLeaf, LeafKey, MediaDownloadProgress } from '../../core/services/download-progress.service';
 import { DownloadProgressState } from '../../core/enums/download-progress-state.enum';
 
 const leaf = (state: DownloadProgressState, percent = 50): DownloadLeaf => ({ state, percent });
@@ -109,8 +109,8 @@ describe('download-format', () => {
         dlspeed: 0,
         eta: 0,
         seasons: new Map([
-          [1, { leaves: new Map([[1, leaf('stalled', 10)]]) }],
-          [2, { leaves: new Map([[1, leaf('active', 80)]]) }],
+          [1, { leaves: new Map([['ref:a', leaf('stalled', 10)]]) }],
+          [2, { leaves: new Map([['ref:b', leaf('active', 80)]]) }],
         ]),
       };
       const d = describeBadge(progress, {
@@ -129,7 +129,7 @@ describe('download-format', () => {
   describe('describeDownload — episode scope', () => {
     // The store keys a leaf by its download and records the episode on the leaf,
     // so a fixture has to carry the attribute the scope filter reads.
-    const season1 = (leaves: [number | 'PACK', DownloadLeaf][]): MediaDownloadProgress => ({
+    const season1 = (leaves: [LeafKey, DownloadLeaf][]): MediaDownloadProgress => ({
       mediaId: 2,
       mediaType: 'series',
       percent: 50,
@@ -140,16 +140,15 @@ describe('download-format', () => {
         [
           1,
           {
-            leaves: new Map(
-              leaves.map(([k, l]) => [k, typeof k === 'number' ? { ...l, episodeNumber: k } : l]),
-            ),
+            // The key is the reporter's own ref; the episode a leaf belongs to lives on the leaf.
+            leaves: new Map(leaves),
           },
         ],
       ]),
     });
 
     it('says nothing on episode 7 while only episode 8 downloads', () => {
-      const d = describeDownload(season1([[8, leaf('active', 52)]]), {
+      const d = describeDownload(season1([['ref:e8', { ...leaf('active', 52), episodeNumber: 8 }]]), {
         seasonFilter: [1],
         episodeFilter: 7,
       });
@@ -157,7 +156,7 @@ describe('download-format', () => {
     });
 
     it("reports the episode's own download", () => {
-      const d = describeDownload(season1([[7, leaf('active', 52)]]), {
+      const d = describeDownload(season1([['ref:e7', { ...leaf('active', 52), episodeNumber: 7 }]]), {
         seasonFilter: [1],
         episodeFilter: 7,
       });
@@ -165,7 +164,7 @@ describe('download-format', () => {
     });
 
     it('reports a season pack on every episode of the season', () => {
-      const progress = season1([['PACK', leaf('active', 30)]]);
+      const progress = season1([['ref:pack', leaf('active', 30)]]);
       expect(describeDownload(progress, { seasonFilter: [1], episodeFilter: 7 })?.percent).toBe(30);
       expect(describeDownload(progress, { seasonFilter: [1], episodeFilter: 8 })?.percent).toBe(30);
     });


### PR DESCRIPTION
Deleting a download from the queue left a phantom in the media's progress modal until a timeout swept it. Every previous fix for that shape was another compensating event, so this one changes the shape instead.

## The cause was structural
`progress.set` could only say *"this download is at X%"*, never *"these are all of them"*. Absence was not expressible, so three caches of the same set were each rebuilt from deltas, and each needed its own correction:

| Tier | Held | A download left only by |
|---|---|---|
| plugin poller | one push per torrent | nothing: absence was never sent |
| core replay cache | `Map` keyed `mediaId:season:episode:ref` | an explicit `clear()`, or a 3 min TTL |
| client store | a `Map` of leaves | `progress >= 1`, `import.complete`, or a 3 min sweep |

Correction existed only as **hand-written compensating events**. `retireVanished` was the admission: it diffed history rows against present torrents and fabricated a `progress: 1` for the missing ones — a manually maintained list of end-events, which is exactly what the cache's own comment said it wanted to avoid. `DELETE /queue/:id` emitted none of it, hence the ghost.

The producer already computed the whole set every tick and threw it away, then three tiers downstream tried to reconstruct it by deduction and timeout.

## The change
`progress.set` takes a media's **complete set**. Absence is the retirement at every hop. Gone with it: the `progress >= 1` retirement convention, the per-leaf delete rules, the `'PACK'` placeholder juggling, `retireVanished`, and `acquisition.progress` (which had no producer, and whose shape is the per-download push this replaces).

## Two costs, deliberate and named
**A snapshot asserts "this is all of it."** Built while a download client was unreachable it would claim that client's torrents are gone and wipe them from every viewer — a failure mode the delta protocol did not have, since it simply did not tick. The poller now **skips the tick** unless every client answered. A missed tick shows a stale percentage; a wrong snapshot erases live downloads. The discipline did not disappear, it moved: one invariant in one place, with a test, instead of one per removal path.

**A media dropping to zero must still be told so**, or viewers keep the last set they saw. The in-flight rows stand in for that memory on the first tick of a process, so a restart still corrects; after that it is the previous tick's media ids. The staleness sweep stays as the backstop for a publisher that dies, but it is no longer how a removal is noticed.

## Client
`reported` (server truth, replaced wholesale) and `grabbing` (local optimism for a grab just clicked) are now separate signals merged on read. That is what lets a snapshot replace a media's entry without erasing a placeholder it knows nothing about. Core's own optimistic grab badge is likewise **added to** the media's last known set rather than replacing it.

## Not in here
An immediate publish from `DELETE /queue/:id`. It would need a second implementation of the snapshot builder in the seam layer, and drift between two builders is how this class of bug starts. The next poller tick converges within a minute, which the snapshot model now guarantees.

## Verification
Backend **1832**, client **622**, plugin **391**. New tests on each invariant: a download absent from the next snapshot is gone; an empty snapshot retires the media; a snapshot for another scope leaves a grab placeholder alone; a partial client answer publishes nothing at all.

Contract-breaking for `progress.set`, so it ships in lockstep with the download plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)