### PR TITLE
test(plugins): pin the invariant the optimistic grab badge depends on

### DIFF
--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -1605,6 +1605,27 @@ describe('FliksHostImpl', () => {
     // The badge has to come up on the grab: the acquisition plugin's own poll
     // can be a minute out, and a direct grab matches no request, so nothing
     // else would speak for it.
+    // The optimistic badge extends the media's last known set instead of replacing it. A push
+    // states the whole set, so stating this grab alone would retire every other download the
+    // media has in flight — the exact failure the snapshot shape exists to prevent.
+    it('VERDICT: a grab keeps the downloads the media already had in flight', async () => {
+      const h = makeHarness();
+      h.mediaRepo.findOne.mockResolvedValue(makeMedia({ type: MediaType.SERIES }));
+      await h.host['progress.set']({
+        mediaId: 1,
+        downloads: [{ ref: 'live', seasonNumber: 4, episodeNumber: 1, progress: 0.3, state: 'active' }],
+      });
+      h.progressCache.record([9], h.events.emitToUsers.mock.calls[0][1]);
+      h.events.emitToUsers.mockClear();
+
+      await h.host['events.publish']([
+        { type: 'acquisition.grabbed', mediaId: 1, seasonNumber: 4, episodeNumber: 8 },
+      ]);
+
+      const refs = h.events.emitToUsers.mock.calls[0][1].downloads.map((d: { ref: string }) => d.ref);
+      expect(refs).toEqual(['live', 'pending:4:8']);
+    });
+
     it('pushes a queued 0% for the grabbed scope so the badge appears at once', async () => {
       const h = makeHarness();
       h.mediaRepo.findOne.mockResolvedValue(makeMedia());

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -915,6 +915,12 @@ export class FliksHostImpl implements PluginHostApi {
         // which can be a minute out. Added to the media's last known set rather than replacing
         // it: a push states the whole set, so announcing this grab alone would retire whatever
         // else the media already had in flight. The first real snapshot supersedes it.
+        //
+        // This reads the replay cache for correctness, not just for replay. It is safe because
+        // the cache and a viewer's own store cannot disagree about what exists: a client resets
+        // its store on `sse.connected`, so a core restart empties both, and both expire on the
+        // same horizon. A cold cache therefore means the viewer holds nothing either, and
+        // stating a set of one erases nothing from their screen.
         await this.pushProgress({
           mediaId: event.mediaId,
           downloads: [


### PR DESCRIPTION
`acquisition.grabbed` puts the download badge up immediately by pushing a progress snapshot. Since #1145 a push states a media's **whole set**, so that snapshot is built as *last known set + this grab*, never as the grab alone — otherwise announcing a grab would retire every other download the media has in flight.

Nothing held that in place. One test now does.

## And why reading the replay cache here is safe
This is the one place that reads `DownloadProgressCacheService` for **correctness** rather than for replay, which deserves saying out loud rather than leaving as an accident.

It holds because the cache and a viewer's own store cannot disagree about what exists:
- a client calls `reset()` on `sse.connected`, so a core restart empties both sides at once;
- both expire on the same 3-minute horizon.

A cold cache therefore means the viewer is holding nothing either, so stating a set of one erases nothing from their screen. The comment now says so.

Backend **1833**, client **622**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)