### PR TITLE
fix(sse): an event with no downloads is not an event saying there are none

### DIFF
--- a/client/src/app/core/services/sse.service.spec.ts
+++ b/client/src/app/core/services/sse.service.spec.ts
@@ -1,0 +1,70 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { SseService } from './sse.service';
+import { DownloadProgressService } from './download-progress.service';
+import { ToastService } from './toast.service';
+import { ServerConfigService } from './server-config.service';
+import { AuthService } from './auth.service';
+
+/**
+ * The seam between the wire and the store. `download.progress` carries a media's whole set, so
+ * this mapping decides what the badge shows and, just as much, what it stops showing.
+ */
+function handle(event: Record<string, unknown>): DownloadProgressService {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideTranslateService({
+        lang: 'en',
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+      }),
+      { provide: ToastService, useValue: { info: () => {}, success: () => {}, error: () => {}, warning: () => {} } },
+      { provide: ServerConfigService, useValue: { apiUrl: () => '' } },
+      { provide: AuthService, useValue: { accessToken: () => null, isAuthenticated: () => false } },
+    ],
+  });
+  const store = TestBed.inject(DownloadProgressService);
+  const sse = TestBed.inject(SseService) as unknown as { handleEvent(e: unknown): void };
+  sse.handleEvent(event);
+  return store;
+}
+
+const progressEvent = (over: Record<string, unknown> = {}) => ({
+  type: 'download.progress',
+  mediaId: 1,
+  mediaType: 'series',
+  downloads: [{ ref: 'aaa', seasonNumber: 1, episodeNumber: 8, progress: 0.4, dlspeed: 10, eta: 60, state: 'paused' }],
+  ...over,
+});
+
+describe('SseService — download.progress', () => {
+  it('maps a snapshot onto the store, field for field', () => {
+    const store = handle(progressEvent());
+    const leaf = [...store.progress().get(1)!.seasons!.get(1)!.leaves.values()][0]!;
+    expect(leaf).toMatchObject({ percent: 40, state: 'paused', episodeNumber: 8, dlspeed: 10, eta: 60 });
+  });
+
+  it('an explicit empty set retires the media — that is what a removal looks like', () => {
+    const store = handle(progressEvent());
+    expect(store.progress().has(1)).toBe(true);
+
+    const sse = TestBed.inject(SseService) as unknown as { handleEvent(e: unknown): void };
+    sse.handleEvent(progressEvent({ downloads: [] }));
+    expect(store.progress().has(1)).toBe(false);
+  });
+
+  it('VERDICT: an event carrying no downloads array is ignored, never read as an empty set', () => {
+    const store = handle(progressEvent());
+    const sse = TestBed.inject(SseService) as unknown as { handleEvent(e: unknown): void };
+
+    // "Said nothing" and "said nothing is running" are opposite statements; only the second
+    // may erase what is on screen.
+    sse.handleEvent({ type: 'download.progress', mediaId: 1, mediaType: 'series' });
+    sse.handleEvent({ type: 'download.progress', mediaId: 1, mediaType: 'series', downloads: null });
+
+    expect(store.progress().has(1)).toBe(true);
+  });
+});

--- a/client/src/app/core/services/sse.service.ts
+++ b/client/src/app/core/services/sse.service.ts
@@ -176,12 +176,16 @@ export class SseService implements OnDestroy {
         }
         break;
       }
-      case 'download.progress':
+      case 'download.progress': {
+        // An empty `downloads` retires the media, so an event that carries no array at all must
+        // be ignored rather than read as one: "said nothing" and "said nothing is running" are
+        // opposite statements, and only the second may erase what is on screen.
+        const downloads = event['downloads'];
+        if (!Array.isArray(downloads)) break;
         this.downloadProgress.applyProgress({
           mediaId: Number(event['mediaId']),
           mediaType: event['mediaType'] as MediaType,
-          // The whole set for this media, so an absent download is a retired one.
-          downloads: (Array.isArray(event['downloads']) ? event['downloads'] : []).map(
+          downloads: downloads.map(
             (d: Record<string, unknown>) => ({
               ref: String(d['ref'] ?? ''),
               seasonNumber: d['seasonNumber'] as number | undefined,
@@ -194,6 +198,7 @@ export class SseService implements OnDestroy {
           ),
         });
         break;
+      }
       case 'import.complete':
         // The download finished → retire its live progress (just the imported
         // season for a series; the whole entry otherwise).


### PR DESCRIPTION
Found auditing my own #1145. An empty `downloads` array **retires the media** — that is how a removal reaches the badge. The handler did:

```ts
downloads: (Array.isArray(event['downloads']) ? event['downloads'] : []).map(…)
```

so an event that lost the field would be read as *"this media has nothing in flight"* and silently erase what was on screen.

Note the direction: before the snapshot change, a malformed event upserted garbage. After it, a malformed event **deletes**. The failure mode got worse, and I did not look.

An event with no array is not a statement about the set, so it is now ignored. Only an explicit `[]` empties.

## The reason it slipped
`sse.service.ts` had **no spec at all**, and this mapping is the seam between the wire and the store: it decides what the badge shows and, just as much, what it stops showing. It has three tests now — the field-for-field mapping, an explicit empty set retiring the media, and a missing array leaving it alone.

Client suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)