### PR TITLE
feat(plugins): give a confirmation toggle a hint line

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -396,8 +396,10 @@ export interface TableConfigPage extends ConfigPageBase {
         confirmKey?: string;
         /** Renders a checkbox inside that confirmation and sends its state as the query
          *  parameter `param`. Needs `confirmKey`: a toggle with no dialog to sit in never
-         *  renders, and would silently send its default. */
-        confirmToggle?: { labelKey: string; param: string };
+         *  renders, and would silently send its default. `hintKey` is the line under it, for
+         *  what the choice does *not* do — the part a label long enough to say it stops being
+         *  a label. */
+        confirmToggle?: { labelKey: string; param: string; hintKey?: string };
         /** Danger styling on the button — a destructive row action must not look like the
          *  two beside it. */
         tone?: 'default' | 'danger';

--- a/client/src/app/core/services/confirmation.service.ts
+++ b/client/src/app/core/services/confirmation.service.ts
@@ -16,12 +16,15 @@ export interface ConfirmOptions {
  *  since it changes what the confirmed action does rather than whether it runs. */
 export interface ConfirmToggleOptions extends ConfirmOptions {
   toggleLabel: string;
+  /** One line under the checkbox, for what the choice does not do. */
+  toggleHint?: string;
   toggleDefault?: boolean;
 }
 
 interface InternalConfirmState extends ConfirmOptions {
   alertOnly: boolean;
   toggleLabel?: string;
+  toggleHint?: string;
   resolve: (value: boolean | null) => void;
 }
 

--- a/client/src/app/shared/components/confirmation-modal.html
+++ b/client/src/app/shared/components/confirmation-modal.html
@@ -3,14 +3,19 @@
     <app-modal-header [title]="title()" />
     <p class="py-4 whitespace-pre-line">{{ message() }}</p>
     @if (toggleLabel(); as tl) {
-      <label class="label cursor-pointer justify-start gap-3 pb-4">
+      <label class="label cursor-pointer items-start justify-start gap-3 pb-4">
         <input
           type="checkbox"
-          class="checkbox checkbox-sm"
+          class="checkbox checkbox-sm mt-0.5 shrink-0"
           [checked]="confirmService.toggle()"
           (change)="confirmService.toggle.set($any($event.target).checked)"
         />
-        <span class="label-text">{{ tl }}</span>
+        <span class="flex flex-col gap-0.5">
+          <span class="label-text">{{ tl }}</span>
+          @if (toggleHint(); as th) {
+            <span class="text-sm text-base-content/60">{{ th }}</span>
+          }
+        </span>
       </label>
     }
     <app-modal-footer>

--- a/client/src/app/shared/components/confirmation-modal.ts
+++ b/client/src/app/shared/components/confirmation-modal.ts
@@ -37,6 +37,7 @@ export class ConfirmationModalComponent {
 
   readonly alertOnly = computed(() => this.confirmService.state()?.alertOnly ?? false);
   readonly toggleLabel = computed(() => this.confirmService.state()?.toggleLabel ?? null);
+  readonly toggleHint = computed(() => this.confirmService.state()?.toggleHint ?? null);
   readonly dismissLabel = computed(() => this.confirmService.state()?.dismissLabel ?? null);
 
   readonly confirmBtnClass = computed(() => {

--- a/client/src/app/shared/components/data-table/data-table.spec.ts
+++ b/client/src/app/shared/components/data-table/data-table.spec.ts
@@ -652,6 +652,38 @@ describe('DataTableComponent — a confirmation that carries a decision', () => 
     confirmToggle: { labelKey: 'x.delete_files', param: 'deleteFiles' },
   };
 
+  it('passes the hint through to the confirmation, for what the choice does not do', async () => {
+    let seen: { toggleHint?: string } | undefined;
+    const fixture = await createComponent({
+      http: { get: () => of([ROW]), delete: () => of({}) },
+      rowActions: [{ ...REMOVE, confirmToggle: { labelKey: 'x.delete_files', param: 'deleteFiles', hintKey: 'x.kept' } }],
+      confirmation: {
+        confirmWithToggle: (o: { toggleHint?: string }) => {
+          seen = o;
+          return Promise.resolve({ ok: false, toggle: false });
+        },
+      },
+    });
+    await fixture.componentInstance.visibleActions(ROW)[0].run();
+    expect(seen?.toggleHint).toBe('x.kept');
+  });
+
+  it('sends no hint when the action declares none', async () => {
+    let seen: { toggleHint?: string } | undefined;
+    const fixture = await createComponent({
+      http: { get: () => of([ROW]), delete: () => of({}) },
+      rowActions: [REMOVE],
+      confirmation: {
+        confirmWithToggle: (o: { toggleHint?: string }) => {
+          seen = o;
+          return Promise.resolve({ ok: false, toggle: false });
+        },
+      },
+    });
+    await fixture.componentInstance.visibleActions(ROW)[0].run();
+    expect('toggleHint' in (seen ?? {})).toBe(false);
+  });
+
   it("VERDICT: sends the checkbox's answer, not its default", async () => {
     const del = vi.fn(() => of({}));
     const fixture = await createComponent({

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -489,7 +489,7 @@ export class DataTableComponent implements OnInit {
     method: 'POST' | 'DELETE',
     path: string,
     confirmKey?: string,
-    toggle?: { labelKey: string; param: string },
+    toggle?: { labelKey: string; param: string; hintKey?: string },
   ): Promise<boolean> {
     let url = path;
     if (confirmKey && toggle) {
@@ -498,6 +498,7 @@ export class DataTableComponent implements OnInit {
         message: this.translate.instant(confirmKey),
         variant: 'danger',
         toggleLabel: this.translate.instant(toggle.labelKey),
+        ...(toggle.hintKey ? { toggleHint: this.translate.instant(toggle.hintKey) } : {}),
       });
       if (!ok) return false;
       url = `${path}${path.includes('?') ? '&' : '?'}${toggle.param}=${checked}`;

--- a/client/src/app/shared/components/data-table/data-table.types.ts
+++ b/client/src/app/shared/components/data-table/data-table.types.ts
@@ -100,8 +100,9 @@ export type RowAction =
       method: 'POST' | 'DELETE';
       path: string;
       confirmKey?: string;
-      /** A checkbox inside the confirmation; its state rides along as the query param `param`. */
-      confirmToggle?: { labelKey: string; param: string };
+      /** A checkbox inside the confirmation; its state rides along as the query param `param`.
+       *  `hintKey` is the explanatory line under it. */
+      confirmToggle?: { labelKey: string; param: string; hintKey?: string };
       tone?: 'default' | 'danger';
       visibleWhen?: TableRowCondition;
     };


### PR DESCRIPTION
A checkbox that changes what a destructive action does often needs to say what it does **not** do. The download plugin's "also delete the downloaded files" is the case: the download client's copy goes, the imported library copy stays, and a label long enough to carry that stops being a label.

`confirmToggle` takes an optional `hintKey`, rendered under the checkbox in the confirmation dialog, the same shape `<app-toggle-field>` already uses everywhere else in the app.

2 tests: the hint reaches the confirmation, and no key is sent when the action declares none. Client suite **627**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)