### PR TITLE
feat(releases): link a release title to the tracker's own page

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -934,6 +934,7 @@
     "col_peers": "Seeds/Leech",
     "col_source": "Quelle",
     "season_pack": "Staffel-Pack",
+    "open_on_indexer": "Beim Indexer öffnen",
     "blocklisted": "Blockiert",
     "releases_empty": "Keine Release gefunden. Überprüfen Sie Ihre konfigurierten Quellen.",
     "releases_tab_all": "Alle",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -939,6 +939,7 @@
     "col_peers": "Seeds/Leech",
     "col_source": "Source",
     "season_pack": "Season pack",
+    "open_on_indexer": "Open on the indexer",
     "blocklisted": "Blocked",
     "releases_empty": "No releases found. Check your configured sources.",
     "releases_tab_all": "All",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -934,6 +934,7 @@
     "col_peers": "Seeds/Leech",
     "col_source": "Fuente",
     "season_pack": "Pack de temporada",
+    "open_on_indexer": "Abrir en el indexador",
     "blocklisted": "Bloqueado",
     "releases_empty": "No se encontró ninguna release. Compruebe sus fuentes configuradas.",
     "releases_tab_all": "Todos",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -939,6 +939,7 @@
     "col_peers": "Seeds/Leech",
     "col_source": "Source",
     "season_pack": "Pack de saison",
+    "open_on_indexer": "Ouvrir sur l'indexeur",
     "blocklisted": "Bloqué",
     "releases_empty": "Aucune release trouvée. Vérifiez vos sources configurées.",
     "releases_tab_all": "Tous",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -934,6 +934,7 @@
     "col_peers": "Seed/Leech",
     "col_source": "Fonte",
     "season_pack": "Pack di stagione",
+    "open_on_indexer": "Apri sull'indicizzatore",
     "blocklisted": "Bloccato",
     "releases_empty": "Nessuna release trovata. Verifica le tue fonti configurate.",
     "releases_tab_all": "Tutti",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -934,6 +934,7 @@
     "col_peers": "Seeds/Leech",
     "col_source": "Fonte",
     "season_pack": "Pack de temporada",
+    "open_on_indexer": "Abrir no indexador",
     "blocklisted": "Bloqueado",
     "releases_empty": "Nenhuma release encontrada. Verifique as suas fontes configuradas.",
     "releases_tab_all": "Todos",

--- a/client/src/app/features/media-detail/components/releases-table/releases-table.component.html
+++ b/client/src/app/features/media-detail/components/releases-table/releases-table.component.html
@@ -25,7 +25,19 @@
                 @if (r.isFullSeason) {
                   <svg lucidePackage class="h-4 w-4 shrink-0 text-info" [attr.title]="'media_detail.season_pack' | translate"></svg>
                 }
-                <span>{{ r.title }}</span>
+                @if (indexerPage(r); as page) {
+                  <a
+                    class="link link-hover"
+                    [href]="page"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    [attr.title]="'media_detail.open_on_indexer' | translate"
+                    (click)="$event.stopPropagation()"
+                    >{{ r.title }}</a
+                  >
+                } @else {
+                  <span>{{ r.title }}</span>
+                }
               </p>
             </div>
             <!-- Mobile-only info rows -->

--- a/client/src/app/features/media-detail/components/releases-table/releases-table.component.spec.ts
+++ b/client/src/app/features/media-detail/components/releases-table/releases-table.component.spec.ts
@@ -118,3 +118,25 @@ describe('ReleasesTableComponent — grab control gating', () => {
     expect(emitted).toBe(false);
   });
 });
+
+describe('ReleasesTableComponent — the tracker page behind the title', () => {
+  const withUrl = (infoUrl?: string) => ({ ...makeRelease(), infoUrl });
+
+  it('links the title to the page the feed named', async () => {
+    const { fixture } = await createFixture([withUrl('https://tracker.example/details/42')]);
+    const link = fixture.nativeElement.querySelector('a[target="_blank"]') as HTMLAnchorElement;
+    expect(link?.getAttribute('href')).toBe('https://tracker.example/details/42');
+    expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  it('VERDICT: refuses a non-http url — the feed that supplied it is not trusted', async () => {
+    // eslint-disable-next-line no-script-url
+    const { fixture } = await createFixture([withUrl('javascript:alert(1)')]);
+    expect(fixture.nativeElement.querySelector('a[target="_blank"]')).toBeNull();
+  });
+
+  it('a release whose feed named no page renders plain text, never a dead link', async () => {
+    const { fixture } = await createFixture([withUrl(undefined)]);
+    expect(fixture.nativeElement.querySelector('a[target="_blank"]')).toBeNull();
+  });
+});

--- a/client/src/app/features/media-detail/components/releases-table/releases-table.component.ts
+++ b/client/src/app/features/media-detail/components/releases-table/releases-table.component.ts
@@ -16,6 +16,7 @@ import {
 import { MovieRelease } from '../../media-detail-release-picker.service';
 import { formatMediaDetailBytes } from '../../media-detail.utils';
 import { formatReleaseRejection } from '../../media-detail-release.utils';
+import { safeExternalUrl } from '../../../../shared/utils/safe-url';
 import { ConfirmationService } from '../../../../core/services/confirmation.service';
 
 @Component({
@@ -64,6 +65,12 @@ export class ReleasesTableComponent {
 
   formatRejection(r: { code: string; params?: Record<string, number | string> }): string {
     return formatReleaseRejection(this.translate, r);
+  }
+
+  /** The tracker's own page for this release, when the feed named one and it is safe to link.
+   *  Undefined renders the title as plain text rather than as a link that goes nowhere. */
+  indexerPage(r: MovieRelease): string | undefined {
+    return safeExternalUrl(r.infoUrl);
   }
 
   formatBytes(bytes: number): string {

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -16,6 +16,7 @@ import { firstValueFrom } from 'rxjs';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
 import { formatBytes, formatSpeed } from '../../utils/download-format';
+import { safeExternalUrl } from '../../utils/safe-url';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { SseService } from '../../../core/services/sse.service';
 import { PaginationComponent } from '../pagination/pagination';
@@ -285,18 +286,6 @@ export class DataTableComponent implements OnInit {
     return BADGE_CLASSES[tone] ?? BADGE_CLASSES.ghost;
   }
 
-  /** A URL a row supplies is indexer data, not manifest data: anything but http(s) — a
-   *  `javascript:` payload above all — renders as plain text instead of an anchor. */
-  private safeHref(value: CellValue): string | undefined {
-    if (typeof value !== 'string' || !value) return undefined;
-    try {
-      const url = new URL(value);
-      return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : undefined;
-    } catch {
-      return undefined;
-    }
-  }
-
   /** A cell's link handler, or undefined when the column declares none, the id is unknown, or
    *  this row cannot resolve it — the cell is then plain text, never a dead link. */
   cellLink(col: TableColumn, row: TableRow): (() => void) | undefined {
@@ -309,7 +298,7 @@ export class DataTableComponent implements OnInit {
       const value = row[field.key];
       if (value === null || value === undefined || value === '') continue;
       if (field.kind === 'link') {
-        const href = this.safeHref(value);
+        const href = safeExternalUrl(value);
         if (href) lines.push({ labelKey: field.labelKey, text: this.translate.instant(field.textKey), href });
         continue;
       }

--- a/client/src/app/shared/utils/safe-url.ts
+++ b/client/src/app/shared/utils/safe-url.ts
@@ -1,0 +1,16 @@
+/**
+ * A URL that reached us from outside — an indexer feed, a plugin row — before it goes into an
+ * `href`. Anything but `http:`/`https:` is refused: a `javascript:` URL in an anchor is a script
+ * the viewer runs by clicking a link.
+ *
+ * Returns undefined rather than throwing, so a caller renders plain text instead of a dead link.
+ */
+export function safeExternalUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string' || !value) return undefined;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
The release picker already knows where each hit came from — the search response carries `infoUrl`, the tracker's own page for that release — and rendered the name as inert text. The title is now the way to that page, so a release can be read about before it is grabbed.

Opens in a new tab, with `rel="noopener noreferrer"`.

## The URL is not trusted
It reached us from an indexer feed. It is refused unless it parses as an absolute `http:`/`https:` URL, because a `javascript:` URL in an anchor is a script the viewer runs by clicking a link. A release whose feed named no page, or named an unusable one, keeps its title as plain text rather than becoming a link that goes nowhere.

That guard already existed as a private method inside `DataTableComponent` (added with the plugin detail dialog in #1142). It moves to `safeExternalUrl` and both callers use it: a security check duplicated is a security check that drifts.

3 tests: a valid page links with the right `rel`, a `javascript:` URL renders no anchor at all, and a release without one renders plain text. Client suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)