### PR TITLE
style(releases): drop the tooltip on the release title link

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -934,7 +934,6 @@
     "col_peers": "Seeds/Leech",
     "col_source": "Quelle",
     "season_pack": "Staffel-Pack",
-    "open_on_indexer": "Beim Indexer öffnen",
     "blocklisted": "Blockiert",
     "releases_empty": "Keine Release gefunden. Überprüfen Sie Ihre konfigurierten Quellen.",
     "releases_tab_all": "Alle",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -939,7 +939,6 @@
     "col_peers": "Seeds/Leech",
     "col_source": "Source",
     "season_pack": "Season pack",
-    "open_on_indexer": "Open on the indexer",
     "blocklisted": "Blocked",
     "releases_empty": "No releases found. Check your configured sources.",
     "releases_tab_all": "All",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -934,7 +934,6 @@
     "col_peers": "Seeds/Leech",
     "col_source": "Fuente",
     "season_pack": "Pack de temporada",
-    "open_on_indexer": "Abrir en el indexador",
     "blocklisted": "Bloqueado",
     "releases_empty": "No se encontró ninguna release. Compruebe sus fuentes configuradas.",
     "releases_tab_all": "Todos",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -939,7 +939,6 @@
     "col_peers": "Seeds/Leech",
     "col_source": "Source",
     "season_pack": "Pack de saison",
-    "open_on_indexer": "Ouvrir sur l'indexeur",
     "blocklisted": "Bloqué",
     "releases_empty": "Aucune release trouvée. Vérifiez vos sources configurées.",
     "releases_tab_all": "Tous",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -934,7 +934,6 @@
     "col_peers": "Seed/Leech",
     "col_source": "Fonte",
     "season_pack": "Pack di stagione",
-    "open_on_indexer": "Apri sull'indicizzatore",
     "blocklisted": "Bloccato",
     "releases_empty": "Nessuna release trovata. Verifica le tue fonti configurate.",
     "releases_tab_all": "Tutti",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -934,7 +934,6 @@
     "col_peers": "Seeds/Leech",
     "col_source": "Fonte",
     "season_pack": "Pack de temporada",
-    "open_on_indexer": "Abrir no indexador",
     "blocklisted": "Bloqueado",
     "releases_empty": "Nenhuma release encontrada. Verifique as suas fontes configuradas.",
     "releases_tab_all": "Todos",

--- a/client/src/app/features/media-detail/components/releases-table/releases-table.component.html
+++ b/client/src/app/features/media-detail/components/releases-table/releases-table.component.html
@@ -31,7 +31,6 @@
                     [href]="page"
                     target="_blank"
                     rel="noopener noreferrer"
-                    [attr.title]="'media_detail.open_on_indexer' | translate"
                     (click)="$event.stopPropagation()"
                     >{{ r.title }}</a
                   >


### PR DESCRIPTION
The release title link carried a `title` tooltip saying it opened the indexer. A link is already a link; the tooltip was noise.

It was the only user of `media_detail.open_on_indexer`, so that key goes too, in all six languages.

Client suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)