### PR TITLE
feat(downloads): spin the badge while a release is being searched for

### DIFF
--- a/client/src/app/features/requests/request-status-badge/request-status-badge.component.html
+++ b/client/src/app/features/requests/request-status-badge/request-status-badge.component.html
@@ -10,6 +10,7 @@
         <app-progress-badge
           [label]="d.labelKey | translate"
           [percent]="d.percent"
+        [busy]="d.busy"
           [badgeClass]="d.badgeClass"
         />
       </button>
@@ -17,6 +18,7 @@
       <app-progress-badge
         [label]="d.labelKey | translate"
         [percent]="d.percent"
+        [busy]="d.busy"
         [badgeClass]="d.badgeClass"
       />
     }

--- a/client/src/app/features/requests/request-status-badge/request-status-badge.component.ts
+++ b/client/src/app/features/requests/request-status-badge/request-status-badge.component.ts
@@ -68,6 +68,7 @@ export class RequestStatusBadgeComponent {
       badgeClass: this.statusBadgeClass(r.status),
       percent: null,
       isClickable: false,
+      busy: false,
     };
   });
 

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -397,6 +397,7 @@
       <app-progress-badge
         [label]="badgeLabel(b)"
         [percent]="b.percent"
+        [busy]="b.busy"
         [badgeClass]="b.badgeClass"
         [size]="size ?? 'sm'"
       />
@@ -406,6 +407,7 @@
       [class.flex-1]="size === 'xl'"
       [label]="badgeLabel(b)"
       [percent]="b.percent"
+        [busy]="b.busy"
       [badgeClass]="b.badgeClass"
       [size]="size ?? 'sm'"
     />

--- a/client/src/app/shared/components/progress-badge/progress-badge.component.html
+++ b/client/src/app/shared/components/progress-badge/progress-badge.component.html
@@ -8,7 +8,10 @@
       [style.width.%]="100 - (percent() ?? 0)"
     ></span>
   }
-  <span class="relative"
-    >{{ label() }}@if (percent() !== null) { · {{ percent() }}%}</span
-  >
+  <span class="relative inline-flex items-center gap-1.5">
+    @if (busy()) {
+      <span class="loading loading-spinner loading-xs"></span>
+    }
+    <span>{{ label() }}@if (percent() !== null) { · {{ percent() }}%}</span>
+  </span>
 </span>

--- a/client/src/app/shared/components/progress-badge/progress-badge.component.ts
+++ b/client/src/app/shared/components/progress-badge/progress-badge.component.ts
@@ -12,6 +12,8 @@ export class ProgressBadgeComponent {
   readonly label = input('');
   /** 0–100, or null for a plain badge with no progress fill. */
   readonly percent = input<number | null>(null);
+  /** Shows a spinner before the label, for a state with no percentage of its own to show. */
+  readonly busy = input(false);
   /** daisyUI colour class, e.g. `badge-info`. */
   readonly badgeClass = input('');
   /** `xl` matches the play button — full width, same height and radius token —

--- a/client/src/app/shared/utils/download-format.spec.ts
+++ b/client/src/app/shared/utils/download-format.spec.ts
@@ -192,3 +192,26 @@ describe('download-format', () => {
     });
   });
 });
+
+describe('describeDownload — a search has no percentage to show', () => {
+  const searching = (): MediaDownloadProgress => ({
+    mediaId: 1,
+    mediaType: 'series' as MediaDownloadProgress['mediaType'],
+    percent: null,
+    state: 'searching',
+    dlspeed: 0,
+    eta: 0,
+    // `searching` is client-local, never a wire state, so it bypasses the `leaf` helper.
+    seasons: new Map([[1, { leaves: new Map([['ref:pending' as const, { state: 'searching' as const, percent: 0 }]]) }]]),
+  });
+
+  it('VERDICT: marks the badge busy, since nothing else says anything is happening', () => {
+    expect(describeDownload(searching(), { seasonFilter: [1] })?.busy).toBe(true);
+  });
+
+  it('a real download is not busy — its percentage already says so', () => {
+    const progress = { ...searching(), state: 'active' as const,
+      seasons: new Map([[1, { leaves: new Map([['ref:a' as const, leaf('active', 40)]]) }]]) };
+    expect(describeDownload(progress, { seasonFilter: [1] })?.busy).toBe(false);
+  });
+});

--- a/client/src/app/shared/utils/download-format.ts
+++ b/client/src/app/shared/utils/download-format.ts
@@ -149,13 +149,16 @@ export interface DownloadBadgeDescriptor {
   percent: number | null;
   /** True iff there is ≥1 in-flight leaf in scope (so the modal has content). */
   isClickable: boolean;
+  /** A search has no percentage to fill the badge with, so it says nothing is happening. The
+   *  spinner is what carries that it is. */
+  busy: boolean;
 }
 
 function fallbackDescriptor(
   monitored: boolean,
   downloaded: boolean,
 ): DownloadBadgeDescriptor {
-  const base = { percent: null, isClickable: false };
+  const base = { percent: null, isClickable: false, busy: false };
   if (downloaded) return { ...base, labelKey: null, badgeClass: '' };
   return monitored
     ? { ...base, labelKey: 'requests.badge_monitored', badgeClass: 'badge-info' }
@@ -268,5 +271,6 @@ export function describeDownload(
     badgeClass: qbStateBadgeClass(fold.state),
     percent: fold.percent,
     isClickable: true,
+    busy: fold.state === 'searching',
   };
 }


### PR DESCRIPTION
`searching` is the one download state with **no percentage** to fill the badge with, so "Recherche du fichier" sat there reading as if nothing were happening — which is exactly the moment something is.

`DownloadBadgeDescriptor` gains `busy`, set for `searching` alone, and `<app-progress-badge>` shows a spinner before its label.

Set in `describeDownload`, where the leaves are folded, rather than at each of the three call sites: the media header, the request rows and a plugin table read the same descriptor and cannot disagree about when it spins.

2 tests: a search marks the badge busy, a real download does not (its percentage already says so). Client suite **630**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)