### PR TITLE
feat(tv): overhaul the 10-foot UI, navigation and player controls

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -17,6 +17,7 @@ import localePt from '@angular/common/locales/pt';
 import { Capacitor } from '@capacitor/core';
 import { provideServiceWorker } from '@angular/service-worker';
 import { provideRouter, RouteReuseStrategy, withInMemoryScrolling, withViewTransitions } from '@angular/router';
+import { detectDevice } from './core/services/device.service';
 import { HttpBackend, provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideTranslateService, TranslateLoader } from '@ngx-translate/core';
 
@@ -74,7 +75,11 @@ export const appConfig: ApplicationConfig = {
       withInMemoryScrolling({ scrollPositionRestoration: 'top' }),
       // Poster→hero morph. Off on Capacitor: its WebView never completes a snapshot
       // capture for a launch-created document, so every navigation waits Chrome's 4s timeout.
-      ...(Capacitor.isNativePlatform()
+      // Off on TV for the same reason in miniature: measured on a Tizen 9 panel, the
+      // 1920x1080 snapshot holds the first paint back ~400 ms and buys nothing, since the
+      // root cross-fade is already suppressed (see `::view-transition-old(root)` in
+      // styles.css). `main.page-enter` animates the swap there instead.
+      ...(Capacitor.isNativePlatform() || detectDevice().formFactor === 'tv'
         ? []
         : [
             withViewTransitions({

--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -21,6 +21,7 @@ import { NavbarService } from './core/services/navbar.service';
 import { PwaAutoUpdateService } from './core/services/pwa-auto-update.service';
 import { AppResumeService } from './core/services/app-resume.service';
 import { OfflinePlaybackSyncService } from './core/services/offline-playback-sync.service';
+import { TvKeyboardDeferralService } from './core/services/tv-keyboard-deferral.service';
 
 @Component({
   selector: 'app-root',
@@ -30,6 +31,7 @@ import { OfflinePlaybackSyncService } from './core/services/offline-playback-syn
 })
 export class App implements OnInit, OnDestroy {
   private readonly auth = inject(AuthService);
+  private readonly tvKeyboard = inject(TvKeyboardDeferralService);
   private readonly castPlayer = inject(CastPlayerService);
   private readonly sse = inject(SseService);
   /** Injected to ensure DownloadManagerService singleton is created (authEffect, nativeEffect). */
@@ -56,6 +58,7 @@ export class App implements OnInit, OnDestroy {
   private escapeKeyListener?: (e: KeyboardEvent) => void;
 
   ngOnInit() {
+    this.tvKeyboard.init();
     this.auth.hydrateFromServer();
     // Pre-warm device profile cache (codec probing) so it's instant when the player needs it
     this.deviceProfile.getProfile();

--- a/client/src/app/core/interceptors/cache.interceptor.ts
+++ b/client/src/app/core/interceptors/cache.interceptor.ts
@@ -170,6 +170,17 @@ async function getCached(url: string): Promise<CacheEntry | null> {
   } catch { return null; }
 }
 
+/** Defer the write past the render. `store.put` structured-clones the whole
+ *  body on the main thread — a 700-item library list stalls it long enough to
+ *  stutter the loading spinner — and nothing reads the entry back this frame. */
+function putCacheWhenIdle(url: string, body: any, generation: number): void {
+  const write = () => void putCache(url, body, generation);
+  const ric = (globalThis as { requestIdleCallback?: (cb: () => void, o?: { timeout: number }) => void })
+    .requestIdleCallback;
+  if (ric) ric(write, { timeout: 2000 });
+  else setTimeout(write, 0);
+}
+
 async function putCache(url: string, body: any, generation: number): Promise<void> {
   if (generation !== cacheGeneration) return;
   try {
@@ -238,7 +249,7 @@ export const cacheInterceptor: HttpInterceptorFn = (req, next) => {
     return next(cleanReq).pipe(
       tap((event) => {
         if (event instanceof HttpResponse && event.status === 200) {
-          void putCache(url, event.body, generation);
+          putCacheWhenIdle(url, event.body, generation);
         }
       }),
     );
@@ -260,7 +271,7 @@ export const cacheInterceptor: HttpInterceptorFn = (req, next) => {
       next(req).pipe(
         tap((event) => {
           if (event instanceof HttpResponse && event.status === 200) {
-            void putCache(url, event.body, generation);
+            putCacheWhenIdle(url, event.body, generation);
           }
         }),
       ).subscribe({

--- a/client/src/app/core/services/device.service.ts
+++ b/client/src/app/core/services/device.service.ts
@@ -20,6 +20,90 @@ const TABLET_MIN_WIDTH = 768;
 const OVERRIDE_KEY = 'fliks.deviceOverride';
 const TV_PLATFORM_OVERRIDE_KEY = 'fliks.tvPlatformOverride';
 
+function readOverride(): DetectResult | null {
+  if (typeof window === 'undefined') return null;
+  let value: string | null = null;
+  let tvPlatformOverride: TvPlatform = null;
+  try {
+    value = window.localStorage.getItem(OVERRIDE_KEY);
+    const tvp = window.localStorage.getItem(TV_PLATFORM_OVERRIDE_KEY);
+    if (tvp === 'androidtv' || tvp === 'tizen' || tvp === 'webos') {
+      tvPlatformOverride = tvp;
+    }
+  } catch {
+    return null;
+  }
+  switch (value) {
+    case 'tv':
+      return { input: 'dpad', formFactor: 'tv', tvPlatform: tvPlatformOverride };
+    case 'tablet':
+      return { input: 'touch', formFactor: 'tablet', tvPlatform: null };
+    case 'phone':
+      return { input: 'touch', formFactor: 'phone', tvPlatform: null };
+    case 'desktop':
+      return { input: 'mouse', formFactor: 'desktop', tvPlatform: null };
+    default:
+      return null;
+  }
+  }
+
+/** Form factor, input modality and TV OS for the current environment.
+ *  Module-scope so bootstrap-time providers can branch on it before the
+ *  injector exists (see app.config: view transitions are off on TV). */
+export function detectDevice(): DetectResult {
+  if (typeof window === 'undefined') {
+    return { input: 'mouse', formFactor: 'desktop', tvPlatform: null };
+  }
+
+  const override = readOverride();
+  if (override) return override;
+
+  const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+  const mm = typeof window.matchMedia === 'function' ? window.matchMedia : null;
+
+  // 1. AndroidTV marker (Capacitor MainActivity injects it)
+  if (/AndroidTV\/\d/.test(ua)) {
+    return { input: 'dpad', formFactor: 'tv', tvPlatform: 'androidtv' };
+  }
+
+  // 2. Samsung Tizen
+  if (/\bTizen\b|SMART-TV/i.test(ua)) {
+    return { input: 'dpad', formFactor: 'tv', tvPlatform: 'tizen' };
+  }
+
+  // 3. LG webOS (UA writes either `Web0S` with a zero or `webOS`)
+  if (/Web0S|webOS/.test(ua)) {
+    return { input: 'dpad', formFactor: 'tv', tvPlatform: 'webos' };
+  }
+
+  // 4. No pointer at all → TV with no detectable OS
+  if (mm && mm('(pointer: none)').matches) {
+    return { input: 'dpad', formFactor: 'tv', tvPlatform: null };
+  }
+
+  // 5. TV-only UA sniff (best effort, only on native Android)
+  if (
+    Capacitor.getPlatform() === 'android' &&
+    /Android.*TV|BRAVIA|SHIELD|AFT[A-Z0-9]+|GoogleTV/i.test(ua)
+  ) {
+    return { input: 'dpad', formFactor: 'tv', tvPlatform: 'androidtv' };
+  }
+
+  // 7. Coarse pointer → touch device, split by viewport
+  const coarse = mm && mm('(pointer: coarse)').matches;
+  if (coarse) {
+    const vw = window.innerWidth || document.documentElement.clientWidth || 0;
+    return {
+      input: 'touch',
+      formFactor: vw < TABLET_MIN_WIDTH ? 'phone' : 'tablet',
+      tvPlatform: null,
+    };
+  }
+
+  // 8. Default
+  return { input: 'mouse', formFactor: 'desktop', tvPlatform: null };
+  }
+
 interface DetectResult {
   input: InputMode;
   formFactor: FormFactor;
@@ -76,7 +160,7 @@ export class DeviceService {
 
   constructor() {
     this.applyOverrideFromUrl();
-    const detected = this.detect();
+    const detected = detectDevice();
     this.input.set(detected.input);
     this.formFactor.set(detected.formFactor);
     this.tvPlatform.set(detected.tvPlatform);
@@ -94,59 +178,7 @@ export class DeviceService {
     );
   }
 
-  private detect(): DetectResult {
-    if (typeof window === 'undefined') {
-      return { input: 'mouse', formFactor: 'desktop', tvPlatform: null };
-    }
 
-    const override = this.readOverride();
-    if (override) return override;
-
-    const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
-    const mm = typeof window.matchMedia === 'function' ? window.matchMedia : null;
-
-    // 1. AndroidTV marker (Capacitor MainActivity injects it)
-    if (/AndroidTV\/\d/.test(ua)) {
-      return { input: 'dpad', formFactor: 'tv', tvPlatform: 'androidtv' };
-    }
-
-    // 2. Samsung Tizen
-    if (/\bTizen\b|SMART-TV/i.test(ua)) {
-      return { input: 'dpad', formFactor: 'tv', tvPlatform: 'tizen' };
-    }
-
-    // 3. LG webOS (UA writes either `Web0S` with a zero or `webOS`)
-    if (/Web0S|webOS/.test(ua)) {
-      return { input: 'dpad', formFactor: 'tv', tvPlatform: 'webos' };
-    }
-
-    // 4. No pointer at all → TV with no detectable OS
-    if (mm && mm('(pointer: none)').matches) {
-      return { input: 'dpad', formFactor: 'tv', tvPlatform: null };
-    }
-
-    // 5. TV-only UA sniff (best effort, only on native Android)
-    if (
-      Capacitor.getPlatform() === 'android' &&
-      /Android.*TV|BRAVIA|SHIELD|AFT[A-Z0-9]+|GoogleTV/i.test(ua)
-    ) {
-      return { input: 'dpad', formFactor: 'tv', tvPlatform: 'androidtv' };
-    }
-
-    // 7. Coarse pointer → touch device, split by viewport
-    const coarse = mm && mm('(pointer: coarse)').matches;
-    if (coarse) {
-      const vw = window.innerWidth || document.documentElement.clientWidth || 0;
-      return {
-        input: 'touch',
-        formFactor: vw < TABLET_MIN_WIDTH ? 'phone' : 'tablet',
-        tvPlatform: null,
-      };
-    }
-
-    // 8. Default
-    return { input: 'mouse', formFactor: 'desktop', tvPlatform: null };
-  }
 
   /** Electron desktop shell: the preload bridge is authoritative; the UA tag
    *  is a fallback for the brief window before it attaches. */
@@ -164,7 +196,7 @@ export class DeviceService {
     if (typeof window === 'undefined') return;
     const onResize = () => {
       // Only the form-factor side changes with viewport — input mode + tv platform stay put.
-      const next = this.detect();
+      const next = detectDevice();
       if (next.formFactor !== this.formFactor()) {
         this.formFactor.set(next.formFactor);
         this.syncBodyClasses();
@@ -229,30 +261,5 @@ export class DeviceService {
     }
   }
 
-  private readOverride(): DetectResult | null {
-    if (typeof window === 'undefined') return null;
-    let value: string | null = null;
-    let tvPlatformOverride: TvPlatform = null;
-    try {
-      value = window.localStorage.getItem(OVERRIDE_KEY);
-      const tvp = window.localStorage.getItem(TV_PLATFORM_OVERRIDE_KEY);
-      if (tvp === 'androidtv' || tvp === 'tizen' || tvp === 'webos') {
-        tvPlatformOverride = tvp;
-      }
-    } catch {
-      return null;
-    }
-    switch (value) {
-      case 'tv':
-        return { input: 'dpad', formFactor: 'tv', tvPlatform: tvPlatformOverride };
-      case 'tablet':
-        return { input: 'touch', formFactor: 'tablet', tvPlatform: null };
-      case 'phone':
-        return { input: 'touch', formFactor: 'phone', tvPlatform: null };
-      case 'desktop':
-        return { input: 'mouse', formFactor: 'desktop', tvPlatform: null };
-      default:
-        return null;
-    }
-  }
+
 }

--- a/client/src/app/core/services/focusable.constants.ts
+++ b/client/src/app/core/services/focusable.constants.ts
@@ -15,6 +15,26 @@ export const TABBABLE_SELECTOR =
   'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 /**
+ * Where focus lands when an overlay (bottom sheet, dropdown, popover) opens:
+ * the option marking the current selection when there is one, otherwise the
+ * first tabbable. The three markers below are the ones the app uses —
+ * `aria-disabled` is set by `SelectedOptionDirective` (and is preferred over
+ * `disabled` precisely so the current value stays in the focus order), while
+ * `autofocus` and `aria-current` are set by hand at a few call sites.
+ */
+export function initialOverlayFocus(root: ParentNode | null | undefined): HTMLElement | null {
+  if (!root) return null;
+  for (const marker of ['[autofocus]', '[aria-current="true"]', '[aria-disabled="true"]']) {
+    const el = root.querySelector<HTMLElement>(marker);
+    // Only the opt-out half of isFocusCandidate: this can run before layout, so
+    // a rendered-size check would always reject and fall through to the first
+    // item.
+    if (el && !isFocusOptedOut(el)) return el;
+  }
+  return root.querySelector<HTMLElement>(TABBABLE_SELECTOR);
+}
+
+/**
  * A horizontally scrolling rail. Arrow keys stay inside one while stepping,
  * and its off-screen cards remain valid targets.
  */

--- a/client/src/app/core/services/playback-engine/tizen-engine.ts
+++ b/client/src/app/core/services/playback-engine/tizen-engine.ts
@@ -48,6 +48,7 @@ declare const webapis: {
     }): void;
     getTotalTrackInfo(): Array<{ type: 'AUDIO' | 'TEXT' | 'VIDEO'; index: number; extra_info: string }>;
     setSelectTrack(type: 'AUDIO' | 'TEXT' | 'VIDEO', index: number): void;
+    setSpeed(rate: number): void;
     setStreamingProperty(name: string, value: string): void;
     setExternalSubtitlePath(path: string): void;
     setSilentSubtitle(silent: boolean): void;
@@ -463,8 +464,23 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
   get paused(): boolean { return this._paused; }
   get buffered(): number { return this._buffered; }
   get playbackRate(): number { return this._playbackRate; }
-  set playbackRate(_rate: number) {
-    /* `setSpeed(rate)` exists on AVPlay but the controls UI doesn't expose rate on TV. */
+  set playbackRate(rate: number) {
+    // Valid from READY, PLAYING and PAUSED; out-of-range values raise
+    // PLAYER_ERROR_INVALID_PARAMETER, and the fractional rates the UI offers
+    // are not in AVPlay's documented set — so keep the previous rate when the
+    // device rejects one instead of showing a speed that isn't applied.
+    const state = webapis.avplay.getState();
+    if (state !== 'READY' && state !== 'PLAYING' && state !== 'PAUSED') return;
+    try {
+      webapis.avplay.setSpeed(rate);
+      this._playbackRate = rate;
+    } catch (e) {
+      this.emit('error', {
+        code: -1,
+        message: 'AVPlay setSpeed rejected ' + rate + 'x: ' + String(e),
+        errorKey: 'player.playback_error',
+      });
+    }
   }
   get volume(): number { return this._volume; }
   set volume(v: number) {
@@ -518,7 +534,16 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
     if (!m) return;
     const index = Number(m[1]);
     try {
+      // `setSelectTrack` accepts AUDIO only in READY (Smooth Streaming) or
+      // PLAYING — PAUSED is documented for TEXT tracks alone. Calling it from
+      // PAUSED left the stream running while getState() kept reporting PAUSED,
+      // so the UI showed a paused player that was still playing. Enter the
+      // documented state, switch, then restore the user's intent; play() is
+      // valid from PAUSED and pause() from PLAYING.
+      const wasPaused = webapis.avplay.getState() === 'PAUSED';
+      if (wasPaused) webapis.avplay.play();
       webapis.avplay.setSelectTrack('AUDIO', index);
+      if (wasPaused) webapis.avplay.pause();
       this._currentAudioIndex = index;
       this.emitAudioTracks();
     } catch (e) {

--- a/client/src/app/core/services/tv-keyboard-deferral.service.ts
+++ b/client/src/app/core/services/tv-keyboard-deferral.service.ts
@@ -1,0 +1,61 @@
+import { DestroyRef, Injectable, inject } from '@angular/core';
+import { DeviceService } from './device.service';
+
+/** Text-entry fields the TV's on-screen keyboard pops up for. */
+const TEXT_ENTRY =
+  'textarea, input:not([type]), input[type="text"], input[type="search"], input[type="password"], input[type="email"], input[type="url"], input[type="tel"], input[type="number"]';
+
+/** Marks a `readonly` we added, so a genuinely read-only field is left alone. */
+const DEFERRED = 'data-tv-keyboard-deferred';
+
+/**
+ * On TV, merely focusing a text field pops the system keyboard over the whole
+ * screen — so walking a form with the D-pad becomes a fight to dismiss it. The
+ * field is held `readonly` while focused, which the WebView takes as "nothing
+ * to type here", and released on the deliberate press (Enter / OK / click)
+ * that actually means the user wants to type.
+ *
+ * Document-level so it covers every field in the app without each form opting
+ * in, and inert on any other form factor.
+ */
+@Injectable({ providedIn: 'root' })
+export class TvKeyboardDeferralService {
+  private readonly device = inject(DeviceService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  init(): void {
+    if (typeof document === 'undefined' || !this.device.isTv()) return;
+
+    const defer = (e: FocusEvent) => this.hold(e.target as HTMLElement | null);
+    const release = (e: Event) => this.release(e.target as HTMLElement | null);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Enter') this.release(e.target as HTMLElement | null);
+    };
+
+    document.addEventListener('focusin', defer, true);
+    document.addEventListener('click', release, true);
+    document.addEventListener('keydown', onKey, true);
+    this.destroyRef.onDestroy(() => {
+      document.removeEventListener('focusin', defer, true);
+      document.removeEventListener('click', release, true);
+      document.removeEventListener('keydown', onKey, true);
+    });
+  }
+
+  private hold(el: HTMLElement | null): void {
+    if (!el?.matches?.(TEXT_ENTRY)) return;
+    const field = el as HTMLInputElement | HTMLTextAreaElement;
+    if (field.readOnly) return; // the field is read-only on its own terms
+    field.readOnly = true;
+    field.setAttribute(DEFERRED, '');
+  }
+
+  private release(el: HTMLElement | null): void {
+    const field = el?.closest?.<HTMLInputElement>(`[${DEFERRED}]`);
+    if (!field) return;
+    field.removeAttribute(DEFERRED);
+    field.readOnly = false;
+    // Re-focus so the WebView re-evaluates the field and raises the keyboard.
+    field.focus();
+  }
+}

--- a/client/src/app/core/services/tv-spatial-nav.service.ts
+++ b/client/src/app/core/services/tv-spatial-nav.service.ts
@@ -331,6 +331,10 @@ export class TvSpatialNavService {
       const pos = typeof getComputedStyle !== 'undefined' ? getComputedStyle(next).position : 'static';
       if (pos !== 'absolute' && pos !== 'fixed' && pos !== 'sticky') {
         next.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'smooth' });
+        // Last, so it wins: on the TV WebView a smooth `scrollIntoView` leaves a
+        // horizontal scroller untouched (a smooth `scrollTo` on the same element
+        // works), which strands focus off the right edge of a card row.
+        this.scrollRowToFocus(next);
       }
       return;
     }
@@ -339,6 +343,22 @@ export class TvSpatialNavService {
     if (crossZones && !this.openModals().length && (dir === 'down' || dir === 'up')) {
       window.scrollBy({ top: dir === 'down' ? PAGE_SCROLL_AMOUNT_PX : -PAGE_SCROLL_AMOUNT_PX, behavior: 'smooth' });
     }
+  }
+
+  /** Bring `el` inside its card row's scrollport, honouring the row's
+   *  scroll-padding — the horizontal half of `inline: 'nearest'`. */
+  private scrollRowToFocus(el: HTMLElement): void {
+    const row = el.closest<HTMLElement>('[data-scroller]');
+    if (!row) return;
+    const style = getComputedStyle(row);
+    const padStart = parseFloat(style.scrollPaddingLeft) || 0;
+    const padEnd = parseFloat(style.scrollPaddingRight) || 0;
+    const rowLeft = row.getBoundingClientRect().left;
+    const rect = el.getBoundingClientRect();
+    const start = rect.left - rowLeft - padStart;
+    const end = rect.right - rowLeft - (row.clientWidth - padEnd);
+    const delta = start < 0 ? start : end > 0 ? end : 0;
+    if (delta) row.scrollTo({ left: row.scrollLeft + delta, behavior: 'smooth' });
   }
 
   /** True when moving to `next` would leave the [data-tv-zone] that currently
@@ -531,6 +551,8 @@ export class TvSpatialNavService {
    * page-wide rect-based scoring.
    */
   private findNeighborInTree(active: HTMLElement, dir: 'left' | 'right' | 'up' | 'down'): HTMLElement | null {
+    const activeRect = active.getBoundingClientRect();
+    const activeCx = activeRect.left + activeRect.width / 2;
     let cur = this.findParentContainer(active);
     let topMost: ContainerNode | null = null;
     while (cur) {
@@ -550,10 +572,11 @@ export class TvSpatialNavService {
             nextIdx = (nextIdx + children.length) % children.length;
           }
           if (nextIdx >= 0 && nextIdx < children.length) {
-            // A vertical step crosses into a different row: land on that row's
-            // first item, not wherever focus last sat there. A horizontal step
-            // walks to the literal sibling, so keep the leaf as-is.
-            return this.digDown(children[nextIdx], !horizontal);
+            // A vertical step crosses into a different row: land on the item
+            // sitting under the one being left, not wherever focus last sat
+            // there. A horizontal step walks to the literal sibling, so keep
+            // the leaf as-is.
+            return this.digDown(children[nextIdx], !horizontal, horizontal ? undefined : activeCx);
           }
         }
       }
@@ -567,8 +590,8 @@ export class TvSpatialNavService {
     if (topMost) {
       const peer = this.findPeerContainer(topMost, dir);
       // Peer bridging only ever fires for up/down (see findPeerContainer), so
-      // entering the peer region lands on its first item.
-      if (peer) return this.digDown(peer.el, true);
+      // entering the peer region keeps the column the user was on.
+      if (peer) return this.digDown(peer.el, true, activeCx);
     }
     return null;
   }
@@ -633,7 +656,7 @@ export class TvSpatialNavService {
    * When `preferFirst` is true (vertical entry into a new row/region),
    * skip memory and autofocus and land on the first navigable child.
    */
-  private digDown(el: HTMLElement, preferFirst = false): HTMLElement | null {
+  private digDown(el: HTMLElement, preferFirst = false, alignCx?: number): HTMLElement | null {
     const c = this.containers.get(el);
     if (!c) return el; // it's a leaf focusable
     if (!preferFirst && c.activeChild && c.el.contains(c.activeChild) && isFocusCandidate(c.activeChild)) {
@@ -643,9 +666,18 @@ export class TvSpatialNavService {
       const auto = c.el.querySelector<HTMLElement>('[autofocus]');
       if (auto && isFocusCandidate(auto)) return auto;
     }
-    const children = this.getNavigableChildren(c);
+    let children = this.getNavigableChildren(c);
+    // Entering a row from above or below: try the children nearest the column
+    // the user was on first, so focus lands under the card it came from.
+    if (alignCx !== undefined && c.orientation === 'horizontal') {
+      const distance = (child: HTMLElement) => {
+        const r = child.getBoundingClientRect();
+        return Math.abs(r.left + r.width / 2 - alignCx);
+      };
+      children = [...children].sort((a, b) => distance(a) - distance(b));
+    }
     for (const child of children) {
-      const dug = this.digDown(child, preferFirst);
+      const dug = this.digDown(child, preferFirst, alignCx);
       if (dug) return dug;
     }
     return null;

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -4,7 +4,52 @@
 <app-follow-requests-card [padding]="true" />
 
 
-<div appTvSection appDefaultFocus="a[data-home-focus^='library:']" focusKey="home" focusIdAttr="data-home-focus" class="flex flex-col gap-8">
+<!-- The skeleton lifts out of the flow and fades while the real zones stagger
+     in underneath it, so no row is ever blank between the two. -->
+<div class="relative">
+
+  @if (showSkeleton()) {
+    <div class="flex flex-col gap-8 pointer-events-none"
+         [class.absolute]="!loadingFirstPass()"
+         [class.inset-x-0]="!loadingFirstPass()"
+         [class.top-0]="!loadingFirstPass()"
+         [class.skeleton-out]="!loadingFirstPass()">
+    @for (row of skeletonLayout(); track $index) {
+      <div class="flex flex-col gap-3 animate-pulse">
+        <div class="h-6 w-48 bg-base-300/40 rounded"></div>
+        <div class="flex gap-2 lg:gap-4 overflow-hidden">
+          @for (card of row.cards; track card) {
+            @switch (row.shape) {
+              @case ('tile') {
+                <div class="shrink-0 w-36 h-20 sm:w-48 sm:h-28 bg-base-300/40 rounded-xl"></div>
+              }
+              @case ('landscape') {
+                <div class="shrink-0 w-48 sm:w-56 lg:w-72">
+                  <div class="aspect-video bg-base-300/40 rounded-lg"></div>
+                  <div class="mt-2 h-4 w-3/4 bg-base-300/40 rounded"></div>
+                  <div class="mt-1 h-3 w-1/3 bg-base-300/40 rounded"></div>
+                </div>
+              }
+              @default {
+                <div class="shrink-0 w-28 sm:w-32 lg:w-40">
+                  <div class="aspect-2/3 bg-base-300/40 rounded-lg"></div>
+                  <div class="mt-2 h-4 w-3/4 bg-base-300/40 rounded"></div>
+                  <div class="mt-1 h-3 w-1/3 bg-base-300/40 rounded"></div>
+                </div>
+              }
+            }
+          }
+        </div>
+      </div>
+    }
+    </div>
+  }
+
+<div appTvSection appDefaultFocus="a[data-home-focus^='library:']" focusKey="home" focusIdAttr="data-home-focus"
+     class="flex flex-col gap-8 stagger-children">
+
+  @if (!loadingFirstPass()) {
+
 
   @for (section of visibleSections(); track section.key) {
     @switch (section.type) {
@@ -205,6 +250,7 @@
 
     }
   }
+  }
 
   <!-- Compact box (icon beside text) up through tablet portrait; stacked box
        only on desktop / tablet landscape (lg+). -->
@@ -218,6 +264,7 @@
     </div>
   </a>
 
+</div>
 </div>
 
 <app-request-decline-modal

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -26,7 +26,7 @@ import { NavbarService } from '../../core/services/navbar.service';
 import { AppResumeService } from '../../core/services/app-resume.service';
 import { BackgroundService } from '../../core/services/background.service';
 import { DisplaySettingsService } from '../../core/services/display-settings.service';
-import { HomeSettingsService } from '../../core/services/home-settings.service';
+import { HomeSettingsService, HomeSectionType, ResolvedHomeSection } from '../../core/services/home-settings.service';
 import { LibraryPrefsService } from '../../core/services/library-prefs.service';
 import { TvService } from '../../core/services/tv.service';
 import { CardAction } from '../../core/services/card-actions.service';
@@ -42,6 +42,7 @@ import { AuthService } from '../../core/services/auth.service';
 import { RequestCardComponent } from '../requests/request-card/request-card';
 import { RequestDeclineModalComponent } from '../requests/request-decline-modal/request-decline-modal.component';
 import { libraryColorVar } from '../../core/constants/library-appearance';
+import { StorageScopeService } from '../../core/services/storage-scope.service';
 
 /**
  * # Home page
@@ -104,6 +105,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly router = inject(Router);
   private readonly playableMedia = inject(PlayableMediaService);
   private readonly librariesApi = inject(LibrariesApiService);
+  private readonly storageScope = inject(StorageScopeService);
   private readonly playlistsApi = inject(PlaylistsApiService);
   private readonly likesApi = inject(LikesApiService);
   private readonly requestsService = inject(RequestsService);
@@ -193,6 +195,29 @@ export class HomeComponent implements OnInit, OnDestroy {
       { requests: this.requestsAllowed },
     ),
   );
+  /** True until the first pass over every section resolves. Each section only
+   *  renders once its own data lands, so a cold start would otherwise show an
+   *  empty page; the skeleton stands in for the whole page during that pass. */
+  readonly loadingFirstPass = signal(true);
+
+  /** Shape of one skeleton row: how the zone's cards are laid out. */
+  private static readonly SHAPES: Partial<Record<HomeSectionType, 'tile' | 'landscape' | 'portrait'>> = {
+    libraries: 'tile',
+    'continue-watching': 'landscape',
+    likes: 'landscape',
+  };
+  private static readonly LAYOUT_KEY = 'fliks.home.layout';
+  /** Last rendered layout, replayed as the skeleton on the next cold start so
+   *  the placeholders sit where the real zones will land — same order, same
+   *  card shape, same count — instead of three generic rows the content then
+   *  shoves around. */
+  readonly skeletonLayout = signal<{ shape: string; cards: number[] }[]>([]);
+  /** Kept up past the swap so it can fade out over the zones staggering in
+   *  beneath it — removing it on the swap leaves each row blank until its own
+   *  delay elapses. */
+  private readonly skeletonFadingOut = signal(false);
+  readonly showSkeleton = computed(() => this.loadingFirstPass() || this.skeletonFadingOut());
+
   readonly visibleSections = computed(() =>
     this.sections().filter((s) => s.visible),
   );
@@ -286,6 +311,54 @@ export class HomeComponent implements OnInit, OnDestroy {
     return ['/' + (item.mediaType === 'series' ? 'series' : 'movies'), String(item.mediaId)];
   }
 
+  /** Cards actually rendered by each zone, for the layout snapshot. */
+  private sectionCount(s: ResolvedHomeSection): number {
+    switch (s.type) {
+      case 'libraries': return this.displayLibraries().length;
+      case 'continue-watching': return this.continueWatching().length;
+      case 'recommendations': return this.recommendations().length;
+      case 'likes': return this.likes().length;
+      case 'recently-added': return this.recentMedia().length;
+      case 'playlists': return this.playlists().length;
+      case 'coming-soon': return this.comingSoon().length;
+      case 'requests-recent': return this.recentRequests().length;
+      case 'library-recent': return this.libraryRecent().get(s.libraryId ?? -1)?.length ?? 0;
+      default: return 0; // received-recommendations is a card, not a rail
+    }
+  }
+
+  private captureLayout(): void {
+    const rows = this.visibleSections()
+      .map((s) => ({
+        shape: HomeComponent.SHAPES[s.type] ?? 'portrait',
+        cards: Math.min(this.sectionCount(s), 8),
+      }))
+      .filter((r) => r.cards > 0);
+    if (!rows.length) return;
+    try {
+      localStorage.setItem(
+        `${HomeComponent.LAYOUT_KEY}::${this.storageScope.suffix()}`,
+        JSON.stringify(rows),
+      );
+    } catch { /* quota or private mode — the generic skeleton still works */ }
+  }
+
+  private readLayout(): { shape: string; cards: number[] }[] {
+    let rows: { shape: string; cards: number }[] = [];
+    try {
+      rows = JSON.parse(
+        localStorage.getItem(`${HomeComponent.LAYOUT_KEY}::${this.storageScope.suffix()}`) ?? '[]',
+      );
+    } catch { /* corrupt — fall through to the default below */ }
+    if (!Array.isArray(rows) || !rows.length) {
+      rows = [{ shape: 'portrait', cards: 7 }, { shape: 'portrait', cards: 7 }, { shape: 'portrait', cards: 7 }];
+    }
+    return rows.map((r) => ({
+      shape: r.shape ?? 'portrait',
+      cards: Array.from({ length: Math.max(1, Math.min(r.cards ?? 7, 8)) }, (_, i) => i),
+    }));
+  }
+
   async ngOnInit() {
     this.scrollMemory.activate(HomeComponent.SCROLL_KEY);
     // Profile names for the request cards are resolved client-side (same as
@@ -293,7 +366,13 @@ export class HomeComponent implements OnInit, OnDestroy {
     if (this.requestsAllowed) void this.loadRequestProfiles();
     // Each section guards itself with `@if (().length)` so sections paint
     // independently as their data arrives. No global loading gate.
+    this.skeletonLayout.set(this.readLayout());
     await this.loadAllSections();
+    this.skeletonFadingOut.set(true);
+    this.loadingFirstPass.set(false);
+    // Long enough for the last zone's staggered fade to have started.
+    setTimeout(() => this.skeletonFadingOut.set(false), 900);
+    this.captureLayout();
     // App-open SWR: the cache served Pass 1 above (instant render even on
     // a cold network). Now force a network round-trip so the user sees
     // the freshest data — additions, watched-status flips made on

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -284,11 +284,55 @@
       </div>
     </div>
 
+    <!-- Alphabet sidebar — only meaningful when items are actually
+         ordered alphabetically (sort=title ASC). Any other sort
+         would make the letter jumps random, so we hide it.
+         `position: fixed` rather than sticky: sticky would un-stick
+         whenever the cards grid is shorter than the viewport (no
+         containing block to anchor against), leaving the alphabet
+         floating against the cards instead of the viewport mid.
+         Fixed keeps it nailed to the right side at vertical center
+         regardless of how many items the grid holds. -->
+    @if (sortBy() === 'title' && sortOrder() === 'ASC') {
+      <!-- Centred by a full-height flex strip, not by `top-1/2` +
+           `-translate-y-1/2`: a percentage translate is resolved against the
+           element's OWN height, so the column drops half a screen whenever that
+           height isn't settled yet. `justify-center` only ever needs the
+           viewport's. The strip is click-through; the letters are not. -->
+      <nav class="fixed inset-y-0 right-4 z-20 flex flex-col items-center justify-center gap-0 select-none pointer-events-none">
+        @for (letter of alphabet; track letter) {
+          <button
+            type="button"
+            class="text-[0.625rem] font-medium w-4 h-4 flex items-center justify-center rounded transition-colors pointer-events-auto"
+            [class.bg-primary]="list.activeLetter() === letter"
+            [class.text-primary-content]="list.activeLetter() === letter"
+            [class.text-base-content/60]="list.activeLetter() !== letter && list.availableLetters().has(letter)"
+            [class.text-base-content/15]="!list.availableLetters().has(letter)"
+            [class.hover:bg-primary/20]="list.activeLetter() !== letter && list.availableLetters().has(letter)"
+            [disabled]="loading() || !list.availableLetters().has(letter)"
+            (click)="scrollToLetter(letter)"
+          >
+            {{ letter }}
+          </button>
+        }
+      </nav>
+    }
+
     @if (loading()) {
-      <div class="flex justify-center py-12">
-        <span class="loading loading-spinner loading-lg"></span>
+      <!-- Same grid as the real one below, so the cards land where the
+           placeholders sat instead of replacing a centred spinner. -->
+      <div class="grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-6 gap-1.5 sm:gap-4 tv:gap-8 pt-2"
+        [class.pr-10]="sortBy() === 'title' && sortOrder() === 'ASC'"
+        [class.pr-2]="sortBy() !== 'title' || sortOrder() !== 'ASC'">
+        @for (i of jumpSkeletons; track i) {
+          <div class="animate-pulse">
+            <div class="aspect-2/3 bg-base-300/40 rounded-lg"></div>
+            <div class="mt-2 h-4 w-3/4 bg-base-300/40 rounded"></div>
+            <div class="mt-1 h-3 w-1/3 bg-base-300/40 rounded"></div>
+          </div>
+        }
       </div>
-    } @else if (list.visible().length === 0) {
+    } @else if (list.all().length === 0) {
       <div class="text-center py-12 text-base-content/50">
         <p class="text-lg">{{ 'library.empty' | translate }}</p>
         <p class="text-sm mt-2">{{ 'library.empty_hint' | translate }}</p>
@@ -300,13 +344,8 @@
           <button class="btn btn-xs btn-ghost" (click)="deselectAll()">{{ 'library.bulk_deselect' | translate }}</button>
         </div>
       }
-      <div class="flex gap-1">
-        <div #cardGrid data-tv-zone class="flex-1 min-w-0 grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-1.5 sm:gap-4"
-          [class.pr-4]="sortBy() === 'title' && sortOrder() === 'ASC'"
-          [class.pr-2]="sortBy() !== 'title' || sortOrder() !== 'ASC'"
-          [style.paddingTop.px]="list.padTop()"
-          [style.paddingBottom.px]="list.padBottom()">
-          @for (item of list.visible(); track item.id) {
+      <!-- One cell definition, rendered by both grids below. -->
+      <ng-template #cardCell let-item>
             @if (bulkMode()) {
               <div
                 class="relative cursor-pointer cv-auto"
@@ -339,44 +378,33 @@
                 />
               </div>
             }
-          }
-        </div>
+      </ng-template>
 
-        <!-- Alphabet sidebar — only meaningful when items are actually
-             ordered alphabetically (sort=title ASC). Any other sort
-             would make the letter jumps random, so we hide it.
-             `position: fixed` rather than sticky: sticky would un-stick
-             whenever the cards grid is shorter than the viewport (no
-             containing block to anchor against), leaving the alphabet
-             floating against the cards instead of the viewport mid.
-             Fixed keeps it nailed to the right side at vertical center
-             regardless of how many items the grid holds. -->
-        @if (sortBy() === 'title' && sortOrder() === 'ASC') {
-          <nav class="fixed top-1/2 right-2 -translate-y-1/2 z-20 flex flex-col items-center gap-0 select-none tv:pt-20">
-            @for (letter of alphabet; track letter) {
-              <button
-                type="button"
-                class="text-[10px] font-medium w-4 h-4 tv:h-3.5 flex items-center justify-center rounded transition-colors"
-                [class.bg-primary]="list.activeLetter() === letter"
-                [class.text-primary-content]="list.activeLetter() === letter"
-                [class.text-base-content/60]="list.activeLetter() !== letter && list.availableLetters().has(letter)"
-                [class.text-base-content/15]="!list.availableLetters().has(letter)"
-                [class.hover:bg-primary/20]="list.activeLetter() !== letter && list.availableLetters().has(letter)"
-                [disabled]="!list.availableLetters().has(letter)"
-                (click)="scrollToLetter(letter)"
-              >
-                {{ letter }}
-              </button>
+      <div class="flex gap-1 pt-2">
+        <cdk-virtual-scroll-viewport
+          scrollWindow
+          data-tv-zone
+          [itemSize]="rowHeight()"
+          [minBufferPx]="rowHeight() * 2"
+          [maxBufferPx]="rowHeight() * 4"
+          class="flex-1 min-w-0 library-viewport">
+          <!-- The right padding clears the alphabet column: it sits at `right-4`
+               and is `w-4` wide, so anything under 2rem lets the cards slide
+               under the letters. -->
+          <div *cdkVirtualFor="let row of gridRows(); trackBy: trackRow"
+               #cardRow
+               [class.pr-10]="sortBy() === 'title' && sortOrder() === 'ASC'"
+               [class.pr-2]="sortBy() !== 'title' || sortOrder() !== 'ASC'"
+               class="grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-6 gap-1.5 sm:gap-4 tv:gap-8"
+               [style.height.px]="rowHeight()">
+            @for (item of row.items; track item.id) {
+              <ng-container [ngTemplateOutlet]="cardCell" [ngTemplateOutletContext]="{ $implicit: item }" />
             }
-          </nav>
-        }
+          </div>
+        </cdk-virtual-scroll-viewport>
+
       </div>
 
-      @if (list.hasMore()) {
-        <div #sentinel class="flex justify-center py-4">
-          <span class="loading loading-spinner loading-sm"></span>
-        </div>
-      }
     }
 
     @if (bulkMode() && selectedIds().size > 0) {
@@ -415,7 +443,7 @@
       </div>
     }
 
-    @if (list.visible().length > 0) {
+    @if (list.all().length > 0) {
       <div class="flex flex-wrap items-center justify-end gap-x-8 gap-y-1 mt-6 px-2 py-3 border-t border-base-200 text-sm text-base-content/70">
         <div><span class="font-semibold">{{ 'legend.total' | translate }}</span> {{ list.total() }}</div>
         @if (hasMovies()) {
@@ -487,7 +515,7 @@
            page rather than a separate component. -->
       @if (suggestionsRecommendations().length) {
         <h2 class="text-lg font-semibold mt-2">{{ 'home.recommendations' | translate }}</h2>
-        <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-1.5 sm:gap-4">
+        <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-6 gap-1.5 sm:gap-4 tv:gap-8">
           @for (rec of suggestionsRecommendations(); track rec.media.id) {
             <app-media-card
               [imageUrl]="rec.media.posterUrl"
@@ -523,7 +551,7 @@
            (when posters are available) or a folder icon, with the
            genre name below. Click → pivot to `all` with the genre
            filter applied. -->
-      <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 tv:grid-cols-6 gap-3 sm:gap-4">
+      <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 tv:grid-cols-6 gap-3 sm:gap-4 tv:gap-8">
         @for (g of genresList(); track g.genre) {
           <app-mosaic-card
             [posters]="g.posters"
@@ -546,7 +574,7 @@
         <p class="text-lg">{{ 'library.collections_empty' | translate }}</p>
       </div>
     } @else {
-      <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 tv:grid-cols-6 gap-3 sm:gap-4">
+      <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 tv:grid-cols-6 gap-3 sm:gap-4 tv:gap-8">
         @for (c of collectionsList(); track c.id) {
           <app-mosaic-card
             [posters]="c.posters"
@@ -567,7 +595,7 @@
         <p class="text-lg">{{ 'likes.empty' | translate }}</p>
       </div>
     } @else {
-      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 3xl:grid-cols-8 tv:grid-cols-5 gap-3 sm:gap-4">
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 3xl:grid-cols-8 tv:grid-cols-5 gap-3 sm:gap-4 tv:gap-8">
         @for (item of likesList(); track item.mediaId + '-' + (item.seasonId ?? '') + '-' + (item.episodeId ?? '')) {
           <app-media-card
             [aspect]="'landscape'"

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -39,9 +39,16 @@ import { NavbarService } from '../../core/services/navbar.service';
 import { TvService } from '../../core/services/tv.service';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
 import { AppResumeService } from '../../core/services/app-resume.service';
-import { InfiniteScrollList, type GridMetrics } from '../../shared/utils/infinite-scroll-list';
+import { InfiniteScrollList } from '../../shared/utils/infinite-scroll-list';
 import { LucideSearch, LucideSlidersHorizontal, LucideArrowUp, LucideArrowDown, LucideX, LucideFilm } from '@lucide/angular';
 import { MosaicCardComponent } from '../../shared/components/mosaic-card/mosaic-card';
+import { NgTemplateOutlet } from '@angular/common';
+import {
+  CdkVirtualScrollViewport,
+  CdkFixedSizeVirtualScroll,
+  CdkVirtualForOf,
+  CdkVirtualScrollableWindow,
+} from '@angular/cdk/scrolling';
 
 const ALPHABET = '#ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
@@ -81,6 +88,11 @@ const NATURAL_ORDER_BY_SORT: Record<string, SortOrder> = {
     LucideFilm,
     LucideX,
     MosaicCardComponent,
+    NgTemplateOutlet,
+    CdkVirtualScrollViewport,
+    CdkFixedSizeVirtualScroll,
+    CdkVirtualForOf,
+    CdkVirtualScrollableWindow,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './library.html',
@@ -195,14 +207,80 @@ export class LibraryComponent implements OnInit, OnDestroy {
   }
 
   /** The `all`-view card grid — measured for DOM windowing on TV. */
-  private cardGridEl?: HTMLElement;
-  @ViewChild('cardGrid') set cardGridRef(ref: ElementRef<HTMLElement> | undefined) {
-    this.cardGridEl = ref?.nativeElement;
-    // Grid just (re)mounted — e.g. initial load or a tab switch back to `all`.
-    // Recompute the window now that it's measurable.
-    if (ref && this.tv.isTv()) this.list.onWindowScroll();
-  }
   private onResize?: () => void;
+
+  /** One screenful of placeholders for the alphabet-jump skeleton. */
+  protected readonly jumpSkeletons = Array.from({ length: 24 }, (_, i) => i);
+
+  // ── CDK virtual scroll ───────────────────────────────────────────────────
+  // The grid renders through `cdk-virtual-scroll-viewport` on every platform:
+  // only the rows on screen exist, and the views scrolled past are recycled.
+  /** Columns and row pitch, measured from the first laid-out row. The initial
+   *  values only have to be plausible — the viewport re-lays out as soon as the
+   *  real ones land. The row carries the vertical gap as bottom padding, so its
+   *  measured height IS the pitch; deriving it from height + row-gap instead
+   *  drifted and collapsed the space between rows. */
+  readonly gridCols = signal(6);
+  readonly rowHeight = signal(520);
+  /** All items chunked into rows — the viewport scrolls rows, not cards. */
+  readonly gridRows = computed(() => {
+    const cols = this.gridCols();
+    const items = this.list.all();
+    const rows: { index: number; items: Media[] }[] = [];
+    for (let i = 0; i < items.length; i += cols) {
+      rows.push({ index: rows.length, items: items.slice(i, i + cols) });
+    }
+    return rows;
+  });
+  protected trackRow(_: number, row: { index: number }): number {
+    return row.index;
+  }
+  /** Alphabet highlight. Derived from the scroll offset, not from the DOM
+   *  (only a handful of rows exist) and not from `scrolledIndexChange`, which
+   *  stays at 0 when the viewport scrolls the window rather than itself. */
+  private letterRaf: number | null = null;
+  /** A click on the alphabet stays authoritative for a moment: the row it lands
+   *  on usually opens with the tail of the previous letter, and the
+   *  scroll-driven recompute below would immediately highlight that one. */
+  private letterClickUntil = 0;
+  private readonly onLetterScroll = () => {
+    if (this.letterRaf !== null) return;
+    this.letterRaf = requestAnimationFrame(() => {
+      this.letterRaf = null;
+      if (performance.now() < this.letterClickUntil) return;
+      const el = this.viewport?.elementRef.nativeElement;
+      if (!el) return;
+      const scroller = document.scrollingElement ?? document.documentElement;
+      const top = el.getBoundingClientRect().top + scroller.scrollTop;
+      const row = Math.max(0, Math.round((scroller.scrollTop - top) / this.rowHeight()));
+      this.list.activeLetter.set(this.list.letterAt(row * this.gridCols()));
+    });
+  };
+  @ViewChild(CdkVirtualScrollViewport) private viewport?: CdkVirtualScrollViewport;
+  private cardRowEl?: HTMLElement;
+  /** Measured once per layout. The strategy is fixed-size: it places every row
+   *  at `index * itemSize`, so re-measuring a row whose natural height moved by
+   *  a pixel makes the pitch disagree with the placement, and the error
+   *  accumulates — a jump thousands of rows down lands a whole section early. */
+  private rowMeasured = false;
+  @ViewChild('cardRow') set cardRowRef(ref: ElementRef<HTMLElement> | undefined) {
+    this.cardRowEl = ref?.nativeElement;
+    this.measureRow();
+  }
+  private measureRow(force = false): void {
+    const row = this.cardRowEl;
+    if (!row || (this.rowMeasured && !force)) return;
+    const cs = getComputedStyle(row);
+    const cols = cs.gridTemplateColumns.split(' ').filter((t) => t && t !== '0px').length;
+    const gap = parseFloat(cs.rowGap) || 0;
+    // Height of the cards themselves: the row is pinned to `rowHeight` below,
+    // so measure a child, not the row.
+    const cell = row.firstElementChild?.getBoundingClientRect().height ?? 0;
+    if (cols < 1 || cell <= 0) return;
+    this.rowMeasured = true;
+    this.gridCols.set(cols);
+    this.rowHeight.set(cell + gap);
+  }
 
   // Bulk editing
   readonly selectedIds = signal<Set<number>>(new Set());
@@ -218,14 +296,13 @@ export class LibraryComponent implements OnInit, OnDestroy {
   private loadGen = 0;
 
   ngOnInit() {
-    if (this.tv.isTv()) {
-      // DOM windowing for the `all` grid: only render a row-aligned slice
-      // around the viewport so a large library doesn't pile hundreds of cards
-      // into the DOM and stutter the TV's scroll. Inert on every other surface.
-      this.list.enableWindowing(() => this.readGridMetrics(), 4);
-      this.onResize = () => this.list.onWindowScroll();
-      window.addEventListener('resize', this.onResize, { passive: true });
-    }
+    // A resize can change the column count, which re-chunks the rows.
+    this.onResize = () => {
+      this.rowMeasured = false;
+      this.measureRow(true);
+    };
+    window.addEventListener('resize', this.onResize, { passive: true });
+    window.addEventListener('scroll', this.onLetterScroll, { passive: true });
     // Subscribe to route param changes (handles initial load + sidebar nav).
     this.paramSub = this.route.params.subscribe(async (params) => {
       const rawName = params['libraryName'] as string;
@@ -282,7 +359,6 @@ export class LibraryComponent implements OnInit, OnDestroy {
       this.selectedCollectionId.set(collId ? Number(collId) : null);
 
       this.scrollMemory.activate(scrollKey);
-      this.list.trackScroll('media');
       this.syncQueryParams();
       await this.load(lib.id);
       if (this.viewMode() === 'suggestions') {
@@ -372,6 +448,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
     this.scrollMemory.deactivate();
     this.list.destroy();
     if (this.onResize) window.removeEventListener('resize', this.onResize);
+    window.removeEventListener('scroll', this.onLetterScroll);
+    if (this.letterRaf !== null) cancelAnimationFrame(this.letterRaf);
     this.navbar.clearPageTitle();
     this.paramSub?.unsubscribe();
     this.attachedSub?.unsubscribe();
@@ -381,27 +459,39 @@ export class LibraryComponent implements OnInit, OnDestroy {
   }
 
   scrollToLetter(letter: string) {
+    if (this.viewport) {
+      const index = this.list.getAll().findIndex((item) => {
+        const first = (item.title || '').charAt(0).toUpperCase();
+        return letter === '#' ? !/[A-Z]/.test(first) : first === letter;
+      });
+      if (index < 0) return;
+      this.list.activeLetter.set(letter);
+      this.letterClickUntil = performance.now() + 600;
+      // Scroll the window directly rather than through `scrollToIndex`: in
+      // `scrollWindow` mode that lands short, since the row offset it computes
+      // does not account for where the viewport itself sits in the document.
+      // Instant, because the rows in between are not rendered — an animated
+      // jump would spend its whole duration crossing blank space.
+      const el = this.viewport.elementRef.nativeElement;
+      const scroller = document.scrollingElement ?? document.documentElement;
+      const viewportTop = el.getBoundingClientRect().top + scroller.scrollTop;
+      const row = Math.floor(index / this.gridCols());
+      // Stop just short of the row's top edge so it doesn't sit flush against
+      // the screen — everything above has scrolled away by then.
+      const headroom = 32;
+      window.scrollTo({
+        top: Math.max(0, viewportTop + row * this.rowHeight() - headroom),
+        left: 0,
+        behavior: 'instant',
+      });
+      return;
+    }
     this.list.scrollToLetter(letter, (m) => m.title, 'media');
   }
 
   /** Live measurements of the `all` grid for windowing. Read together (rect +
    *  scroller.scrollTop) so a webOS `zoom` scales them consistently. Returns
    *  null until the grid is laid out, where windowing falls back to full render. */
-  private readGridMetrics(): GridMetrics | null {
-    const grid = this.cardGridEl;
-    if (!grid) return null;
-    const cs = getComputedStyle(grid);
-    const cols = cs.gridTemplateColumns.split(' ').filter((t) => t && t !== '0px').length;
-    if (cols < 1) return null;
-    const firstCell = grid.firstElementChild as HTMLElement | null;
-    const cellH = firstCell?.getBoundingClientRect().height ?? 0;
-    if (cellH <= 0) return null;
-    const rowGap = parseFloat(cs.rowGap) || 0;
-    const scroller = document.scrollingElement ?? document.documentElement;
-    const gridTopDoc = grid.getBoundingClientRect().top + scroller.scrollTop;
-    return { gridTopDoc, rowHeight: cellH + rowGap, rowGap, cols };
-  }
-
   onSearch(query: string) {
     this.searchQuery.set(query);
     this.syncQueryParams();
@@ -661,6 +751,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   }
 
   private async load(libraryId?: number, silent = false) {
+    // Filters, search and sort all reflow the header above the grid.
     if (!libraryId) return;
     if (!silent) this.loading.set(true);
     const monitored = this.filterMonitored();

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -12,7 +12,7 @@
           <div class="h-12 w-12 bg-base-300/40 rounded-lg"></div>
         </div>
       </div>
-      <div class="hidden lg:flex tv:flex gap-10 pt-12 tv:pt-24">
+      <div class="hidden lg:flex tv:flex gap-10 pt-12">
         <div class="w-[280px] aspect-2/3 bg-base-300/40 rounded-xl shrink-0"></div>
         <div class="flex-1 space-y-3">
           <div class="h-10 w-2/3 bg-base-300/40 rounded"></div>

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -168,7 +168,7 @@
             <svg lucideHeadphones class="h-5 w-5"></svg>
           </button>
         }
-        <button type="button" class="btn btn-ghost text-white/80" [attr.aria-label]="'player.speed' | translate" (click)="openSheet('speed')">{{ playbackRate() }}x</button>
+        <button type="button" class="btn btn-ghost btn-circle text-white/80" [attr.aria-label]="'player.speed' | translate" (click)="openSheet('speed')">{{ playbackRate() }}x</button>
         <button type="button" class="btn btn-ghost btn-circle text-white/80" [attr.aria-label]="'player.settings' | translate" (click)="openSheet('settings')">
           <svg lucideSettings class="h-5 w-5"></svg>
         </button>
@@ -234,7 +234,7 @@
           <button type="button" class="btn btn-ghost btn-md btn-circle text-white/80" [attr.aria-label]="'player.subtitles' | translate" (click)="toggleDropdown('subtitles', $event)">
             <svg lucideCaptions class="h-6 w-6"></svg>
           </button>
-          <div class="dropdown-content bg-neutral/95 backdrop-blur-sm rounded-2xl shadow-2xl py-4 px-2 min-w-64 max-h-[50vh] overflow-y-auto mb-2">
+          <div class="dropdown-content bg-neutral/95 backdrop-blur-sm rounded-2xl shadow-2xl py-4 px-2 min-w-64 mb-2">
             <ng-container [ngTemplateOutlet]="subtitlesMenu"></ng-container>
           </div>
         </div>
@@ -245,15 +245,15 @@
             <button type="button" class="btn btn-ghost btn-md btn-circle text-white/80" [attr.aria-label]="'player.audio' | translate" (click)="toggleDropdown('audio', $event)">
               <svg lucideHeadphones class="h-6 w-6"></svg>
             </button>
-            <div class="dropdown-content bg-neutral/95 backdrop-blur-sm rounded-2xl shadow-2xl py-4 px-2 min-w-64 max-h-[50vh] overflow-y-auto mb-2">
+            <div class="dropdown-content bg-neutral/95 backdrop-blur-sm rounded-2xl shadow-2xl py-4 px-2 min-w-64 mb-2">
               <ng-container [ngTemplateOutlet]="audioMenu"></ng-container>
             </div>
           </div>
         }
         <!-- Speed dropdown -->
         <div class="dropdown dropdown-top dropdown-end" [class.dropdown-open]="openDropdown() === 'speed'">
-          <button type="button" class="btn btn-ghost btn-md text-white/80" (click)="toggleDropdown('speed', $event)">{{ playbackRate() }}x</button>
-          <div class="dropdown-content bg-neutral/95 backdrop-blur-sm rounded-2xl shadow-2xl py-4 px-2 min-w-48 max-h-[50vh] overflow-y-auto mb-2">
+          <button type="button" class="btn btn-ghost btn-md btn-circle text-white/80" [attr.aria-label]="'player.speed' | translate" (click)="toggleDropdown('speed', $event)">{{ playbackRate() }}x</button>
+          <div class="dropdown-content bg-neutral/95 backdrop-blur-sm rounded-2xl shadow-2xl py-4 px-2 min-w-48 mb-2">
             <ng-container [ngTemplateOutlet]="speedMenu"></ng-container>
           </div>
         </div>
@@ -273,7 +273,7 @@
 </div>
 
 <!-- ===== Skip intro floating button ===== -->
-@if (showSkipIntro()) {
+@if (skipIntroCue()) {
   <button
     #skipIntroBtn
     type="button"
@@ -290,7 +290,7 @@
     ></span>
     <span class="relative flex items-center gap-2">
       <svg lucideSkipForward class="h-4 w-4"></svg>
-      {{ 'player.skip_intro' | translate }} ({{ skipIntroCountdown() }})
+      {{ 'player.skip_intro' | translate }} ({{ cueCountdown() }})
     </span>
   </button>
 }
@@ -311,7 +311,7 @@
 }
 
 <!-- ===== Next item floating button (during outro) ===== -->
-@if (showNextCue()) {
+@if (nextItemCue()) {
   <button
     #nextEpisodeBtn
     type="button"
@@ -328,7 +328,7 @@
     ></span>
     <span class="relative flex items-center gap-2">
       <svg lucideSkipForward class="h-4 w-4"></svg>
-      {{ nextLabelKey() | translate }}
+      {{ nextLabelKey() | translate }} ({{ cueCountdown() }})
     </span>
   </button>
 }
@@ -478,18 +478,21 @@
         </button>
         <div class="divider my-0 before:bg-white/10 after:bg-white/10"></div>
         @for (q of availableQualities(); track q.id) {
+          <!-- Same row shape as the audio / subtitle menus. -->
           <button
-            class="w-full flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm text-white hover:bg-white/10 disabled:opacity-60 disabled:cursor-default disabled:hover:bg-transparent"
-            [disabled]="activeQualityId() === q.id"
+            type="button"
+            class="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-white hover:bg-white/10 active:bg-white/10"
+            [appSelectedOption]="activeQualityId() === q.id"
             (click)="selectQuality.emit(q.id)"
           >
+            <svg lucideSettings class="h-5 w-5 text-white/50 shrink-0"></svg>
             <span class="flex-1 text-left">
               {{ q.label }}
               @if (q.lowBandwidth && showEcoBadge()) {
                 <span class="text-white/50 ml-1 text-xs">({{ 'player.low_bandwidth' | translate }})</span>
               }
             </span>
-            @if (activeQualityId() === q.id) { <svg lucideCheck class="h-4 w-4 text-white shrink-0"></svg> }
+            @if (activeQualityId() === q.id) { <svg lucideCheck class="h-5 w-5 text-white shrink-0"></svg> }
           </button>
         }
       </div>
@@ -504,8 +507,8 @@
         <div class="max-h-[38vh] overflow-y-auto scroll-ring-safe">
           @for (q of queueItems(); track $index; let i = $index) {
             <button
-              class="w-full flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm text-white hover:bg-white/10 disabled:opacity-60 disabled:cursor-default disabled:hover:bg-transparent"
-              [disabled]="queueIndex() === i"
+              class="w-full flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm text-white hover:bg-white/10"
+              [appSelectedOption]="queueIndex() === i"
               [attr.data-queue-active]="queueIndex() === i ? 'true' : null"
               (click)="selectQueueItem.emit(i); closeDropdown($event)"
             >
@@ -544,7 +547,7 @@
       @if (!castConnected()) {
         <button
           type="button"
-          class="absolute -top-1.5 right-1 btn btn-ghost btn-xs btn-circle text-white/60 hover:text-white"
+          class="absolute -top-1.5 right-1 focus-keep-position btn btn-ghost btn-xs btn-circle text-white/60 hover:text-white"
           [attr.aria-label]="'player.appearance' | translate"
           (click)="openSubtitlesPanel('appearance')"
         >
@@ -552,10 +555,12 @@
         </button>
       }
     </div>
+    <!-- Only the options scroll; the title above stays visible. -->
+    <div class="max-h-[40vh] overflow-y-auto scroll-ring-safe">
     <button
       type="button"
-      class="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-white hover:bg-white/10 active:bg-white/10 disabled:opacity-60 disabled:cursor-default disabled:hover:bg-transparent"
-      [disabled]="!activeSubtitleId()"
+      class="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-white hover:bg-white/10 active:bg-white/10"
+      [appSelectedOption]="!activeSubtitleId()"
       (click)="selectSubtitle.emit(null); closeSheet()"
     >
       <svg lucideCaptions class="h-5 w-5 text-white/50 shrink-0"></svg>
@@ -565,8 +570,8 @@
     @for (sub of availableSubtitles(); track sub.id) {
       <button
         type="button"
-        class="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-white hover:bg-white/10 active:bg-white/10 disabled:opacity-60 disabled:cursor-default disabled:hover:bg-transparent"
-        [disabled]="activeSubtitleId() === sub.id"
+        class="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-white hover:bg-white/10 active:bg-white/10"
+        [appSelectedOption]="activeSubtitleId() === sub.id"
         (click)="selectSubtitle.emit(sub.id); closeSheet()"
       >
         <svg lucideCaptions class="h-5 w-5 text-white/50 shrink-0"></svg>
@@ -577,6 +582,7 @@
         @if (activeSubtitleId() === sub.id) { <svg lucideCheck class="h-5 w-5 text-white shrink-0"></svg> }
       </button>
     }
+    </div>
   } @else if (subtitlesPanel() === 'appearance') {
     <button class="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-white hover:bg-white/10 active:bg-white/10 mb-1" (click)="openSubtitlesPanel('tracks')">
       <svg lucideArrowLeft class="h-4 w-4 text-white/60 shrink-0"></svg>
@@ -610,11 +616,13 @@
 
 <ng-template #audioMenu>
   <div class="text-center text-white/60 text-xs font-medium mb-3">{{ 'player.audio_track' | translate }}</div>
+  <!-- Only the options scroll; the title above stays visible. -->
+  <div class="max-h-[40vh] overflow-y-auto scroll-ring-safe">
   @for (track of availableAudioTracks(); track track.id) {
     <button
       type="button"
-      class="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-white hover:bg-white/10 active:bg-white/10 disabled:opacity-60 disabled:cursor-default disabled:hover:bg-transparent"
-      [disabled]="activeAudioTrackId() === track.id"
+      class="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-white hover:bg-white/10 active:bg-white/10"
+      [appSelectedOption]="activeAudioTrackId() === track.id"
       (click)="selectAudioTrack.emit(track.id); closeSheet()"
     >
       <svg lucideHeadphones class="h-5 w-5 text-white/50 shrink-0"></svg>
@@ -625,20 +633,25 @@
       @if (activeAudioTrackId() === track.id) { <svg lucideCheck class="h-5 w-5 text-white shrink-0"></svg> }
     </button>
   }
+  </div>
 </ng-template>
 
 <ng-template #speedMenu>
   <div class="text-center text-white/60 text-xs font-medium mb-3">{{ 'player.speed' | translate }}</div>
+  <!-- Only the options scroll; the title above stays visible. -->
+  <div class="max-h-[40vh] overflow-y-auto scroll-ring-safe">
   @for (r of speedOptions; track r) {
     <button
       type="button"
       class="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-white hover:bg-white/10 active:bg-white/10"
+      [appSelectedOption]="playbackRate() === r"
       (click)="speedChange.emit(r); closeSheet()"
     >
       <span class="flex-1 text-left">{{ r }}x</span>
       @if (playbackRate() === r) { <svg lucideCheck class="h-5 w-5 text-white shrink-0"></svg> }
     </button>
   }
+  </div>
 </ng-template>
 
 <!-- Fullscreen toggle — shared between the mobile action row (sm size) and

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -32,9 +32,11 @@ import { NgTemplateOutlet } from '@angular/common';
 import { BottomSheetComponent } from '../../../shared/components/bottom-sheet';
 import { TranslateModule } from '@ngx-translate/core';
 import { formatTime, SpriteMetadata } from '../../../core/utils/player.utils';
+import { initialOverlayFocus } from '../../../core/services/focusable.constants';
 import { SeekbarComponent } from '../../../shared/components/seekbar/seekbar';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import { CachedSrcDirective } from '../../../shared/directives/cached-src.directive';
+import { SelectedOptionDirective } from '../../../shared/directives/selected-option.directive';
 import {
   LucideCaptions,
   LucideCheck,
@@ -87,6 +89,7 @@ interface AppearanceRow {
   selector: 'app-player-controls',
   imports: [
     CachedSrcDirective,
+    SelectedOptionDirective,
     TranslateModule,
     LucideCaptions,
     LucideCheck,
@@ -176,11 +179,12 @@ export class PlayerControlsComponent {
       this.lastPanelOpen = open;
       this.panelOpenChange.emit(open);
     });
-    // Skip-intro cue countdown — mirrors the progress sweep numerically.
-    // Reset to the full window each time the cue (re)appears.
+    // Floating-cue countdown — mirrors the progress sweep numerically, for the
+    // intro and next-item cues alike. Reset to the full window each time a cue
+    // (re)appears.
     effect(() => {
-      if (this.showSkipIntro()) {
-        this.skipIntroCountdown.set(Math.ceil(this.cueDurationMs() / 1000));
+      if (this.showSkipIntro() || this.showNextCue()) {
+        this.cueCountdown.set(Math.ceil(this.cueDurationMs() / 1000));
       }
     });
     // Tick down to 1, but hold while the cue is "engaged" — the controls bar is
@@ -188,12 +192,23 @@ export class PlayerControlsComponent {
     // the same conditions, so the number stays in lockstep. The cleanup stops
     // the tick on pause and on retract alike.
     effect((onCleanup) => {
-      if (!this.showSkipIntro() || this.visible() || this.cueFocused()) return;
+      if ((!this.showSkipIntro() && !this.showNextCue()) || this.visible() || this.cueFocused()) return;
       const id = setInterval(
-        () => this.skipIntroCountdown.update((n) => (n > 1 ? n - 1 : 1)),
+        () => this.cueCountdown.update((n) => (n > 1 ? n - 1 : 1)),
         1000,
       );
       onCleanup(() => clearInterval(id));
+    });
+    // A cue that disappears under the focus leaves it on <body>: the remote then
+    // acts on nothing at all. Hand it back to play/pause, which is where the bar
+    // puts focus whenever it appears.
+    effect(() => {
+      const gone = !this.skipIntroBtn() && !this.nextEpisodeBtn();
+      if (!gone || !this.cueFocused()) return;
+      this.cueFocused.set(false);
+      const active = document.activeElement;
+      if (active && active !== document.body) return;
+      this.playPauseBtn()?.nativeElement.focus({ preventScroll: true });
     });
     // A cue removed while focused can swallow its blur, leaving the flag stuck;
     // clear it whenever no cue is shown so the next one isn't born frozen.
@@ -305,6 +320,13 @@ export class PlayerControlsComponent {
   readonly statsVisible = input(false);
   readonly showSkipIntro = input(false);
   readonly showNextCue = input(false);
+  /** Gating these on `!visible()` was tried twice and reverted twice: unmounting
+   *  a cue while its `showSkipIntro` is still true strands the `cueFocused`
+   *  flag (its blur never fires), and the retract/countdown state then no
+   *  longer matches what is on screen. Hide them at the player level, by
+   *  retracting them, not by unmounting them here. */
+  protected readonly skipIntroCue = computed(() => this.showSkipIntro());
+  protected readonly nextItemCue = computed(() => this.showNextCue());
   /** Shown for the whole pre-roll item, not a timed cue — no sweep, no countdown. */
   readonly showPreRollSkip = input(false);
   /** How long a floating cue stays up, in ms — drives the in-button progress
@@ -312,7 +334,7 @@ export class PlayerControlsComponent {
   readonly cueDurationMs = input(6000);
   /** Seconds left before the skip-intro cue retracts, shown in the button as a
    *  live countdown next to its progress sweep. */
-  readonly skipIntroCountdown = signal(0);
+  readonly cueCountdown = signal(0);
   /** True while a floating cue holds focus. The player reads it to freeze the
    *  retract timer, and the sweep / countdown freeze on it here — a cue the
    *  user has navigated to (keyboard / D-pad) must not vanish from under them. */
@@ -339,6 +361,21 @@ export class PlayerControlsComponent {
   readonly next = output<void>();
   readonly back = output<void>();
   readonly selectAudioTrack = output<string>();
+  /** Any focus move inside the bar — the parent restarts its auto-hide
+   *  countdown, so walking the controls with the D-pad never lets them retract
+   *  under the user. */
+  readonly interacted = output<void>();
+
+  @HostListener('focusin', ['$event'])
+  protected onBarFocusIn(e: FocusEvent): void {
+    // The floating cues live in this component but are not the bar. They focus
+    // themselves the moment they appear, and counting that as activity restarts
+    // the retract countdown — the bar then never goes away, which in turn keeps
+    // the cues hidden. Only the bar's own controls are activity.
+    const target = e.target as HTMLElement | null;
+    if (target?.closest('.player-floating-cue')) return;
+    this.interacted.emit();
+  }
   readonly toggleCast = output<void>();
   readonly toggleFillScreen = output<void>();
   readonly openMedia = output<void>();
@@ -404,13 +441,13 @@ export class PlayerControlsComponent {
    *  the switch destroys the row the user was standing on (D-pad / keyboard). */
   openSubtitlesPanel(panel: SubtitlePanel) {
     this.subtitlesPanel.set(panel);
-    if (this.openDropdown()) this.focusFirstDropdownItem();
+    if (this.openDropdown()) this.focusDropdownEntry();
   }
 
   /** Same as {@link openSubtitlesPanel} for the settings menu. */
   openSettingsPanel(panel: 'main' | 'quality' | 'queue') {
     this.settingsPanel.set(panel);
-    if (this.openDropdown()) this.focusFirstDropdownItem();
+    if (this.openDropdown()) this.focusDropdownEntry();
   }
 
   /**
@@ -455,9 +492,14 @@ export class PlayerControlsComponent {
    *  and keyboard navigation, where there's no pointer to reach it. A
    *  mouse-revealed cue shouldn't steal focus. */
   private autoFocusCue(btn: ElementRef<HTMLButtonElement> | undefined): void {
-    if (btn && this.autoFocusModality()) {
-      btn.nativeElement.focus({ preventScroll: true });
-    }
+    if (!btn || !this.autoFocusModality()) return;
+    // Never yank focus off something the user is holding: seeking into an intro
+    // makes the cue appear mid-scrub, and stealing focus there drops the
+    // seekbar under their thumb. The cue is only worth auto-focusing when the
+    // user has nothing else in hand.
+    const active = document.activeElement as HTMLElement | null;
+    if (active && active !== document.body && this.hostEl.nativeElement.contains(active)) return;
+    btn.nativeElement.focus({ preventScroll: true });
   }
   readonly hostEl: ElementRef<HTMLElement> = inject(ElementRef);
   private readonly injector = inject(Injector);
@@ -519,7 +561,7 @@ export class PlayerControlsComponent {
       // Push focus into the panel so the first item is reachable without
       // having to traverse out of the trigger via spatial nav (D-pad on TV,
       // arrow keys on desktop keyboard). Harmless for mouse users.
-      this.focusFirstDropdownItem();
+      this.focusDropdownEntry();
     }
   }
 
@@ -534,12 +576,11 @@ export class PlayerControlsComponent {
     this.subtitlesPanel.set('tracks');
   }
 
-  private focusFirstDropdownItem() {
+  private focusDropdownEntry() {
     afterNextRender(
       () => {
         const panel = this.hostEl.nativeElement.querySelector<HTMLElement>('.dropdown-open .dropdown-content');
-        const first = panel?.querySelector<HTMLElement>('button, a, [tabindex]:not([tabindex="-1"])');
-        first?.focus({ preventScroll: true });
+        initialOverlayFocus(panel)?.focus({ preventScroll: true });
       },
       { injector: this.injector },
     );

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -115,6 +115,7 @@
 
   @if (!inPipMode()) {
   <app-player-controls
+    (interacted)="onControlsInteraction()"
     [visible]="controlsVisible()"
     [paused]="paused()"
     [loading]="loading()"

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -602,23 +602,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
    *  cursor / bar impossible to keep visible. Subsequent pause /
    *  resume cycles fall through to the existing auto-hide timer +
    *  user-interaction reveal. */
-  private readonly autoHideOnPlayEffect = effect(() => {
-    if (this.videoStarted() && untracked(() => this.controlsVisible())) {
-      // After an in-place item switch we deliberately kept the controls up to
-      // show the new title; when its first frame plays, don't snap them away —
-      // start the normal auto-hide countdown instead so they linger briefly.
-      if (untracked(() => this.revealAcrossSwitch)) {
-        this.revealAcrossSwitch = false;
-        this.resetHideTimer();
-        return;
-      }
-      this.controlsVisible.set(false);
-    }
-  });
-  /** One-shot: keep the controls visible across the next play-start (set on an
-   *  item switch), letting the auto-hide timer retract them rather than the
-   *  first-frame effect snapping them off. */
-  private revealAcrossSwitch = false;
 
   /** Re-apply native subtitle style on controls show/hide so the bottom-margin
       bump kicks in. Browser playback uses CSS instead — see styles below. */
@@ -1877,7 +1860,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       const existing = this.availableAudioTracks();
       const newIsEngineSourced =
         tracks.length > 0 &&
-        (tracks[0].id.startsWith('audio-') || tracks[0].id.startsWith('shaka-'));
+        (tracks[0].id.startsWith('audio-') ||
+          tracks[0].id.startsWith('avplay-audio-') ||
+          tracks[0].id.startsWith('shaka-'));
       const existingIsFallback =
         existing.length > 0 && existing[0].id.startsWith('si-');
       // Upgrade ONLY when incoming has at least as many tracks as existing —
@@ -1888,6 +1873,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       this.availableAudioTracks.set(tracks);
       const selected = tracks.find((t: any) => t.selected) ?? tracks[0];
       this.activeAudioTrackId.set(selected.id);
+      this.reconcileActiveAudioTrack(tracks, selected.id);
       this.trackManager.autoSelectAudioTrack(
         tracks, this.mediaId, this.mediaFileId,
         this.activeAudioTrackId(),
@@ -1952,6 +1938,16 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   /** Restart the auto-hide countdown by registering activity. The reactive
    *  `autoHideEffect` owns the actual timer and re-arms off this bump and off
    *  the live pin state ({@link keepControlsUp}). */
+  /** Focus moved inside the controls bar: restart the countdown so navigating
+   *  it with the D-pad can never let it retract mid-move. */
+  onControlsInteraction(): void {
+    // A focus move while the bar is down isn't the user navigating it — the
+    // hide itself blurs, and whatever picks the focus up next would otherwise
+    // re-arm the countdown forever.
+    if (!this.controlsVisible()) return;
+    this.resetHideTimer();
+  }
+
   private resetHideTimer() {
     this.controlsActivity.update(n => n + 1);
   }
@@ -2172,7 +2168,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   /** Lifetime of a floating cue, in ms — also the duration of its progress
    *  sweep, forwarded to the controls so the timer and the animation stay in
    *  lockstep. */
-  readonly cueRevealMs = 6000;
+  readonly cueRevealMs = 10000;
   readonly skipIntroVisible = signal(false);
   readonly nextEpisodeVisible = signal(false);
   private skipIntroCueArmed = false;
@@ -2552,10 +2548,8 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
       if (!this.isNativeEngine()) this.engine.play().catch(() => {});
       // Reveal the controls across the switch so the new title/episode shows;
-      // the flag lets them stay through the first frame and then auto-hide on
-      // the usual timer (see autoHideOnPlayEffect).
-      this.revealAcrossSwitch = true;
-      this.controlsVisible.set(true);
+      // the auto-hide countdown retracts them on the usual delay.
+      this.showControls();
     } catch (e: any) {
       // Map to a translated line (Shaka-shaped errors keep their category
       // message, a failed playback-info request its transport status) and
@@ -3672,6 +3666,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
           // Set active to the track the backend is already using (preselected at startup)
           const activeIdx = this.activeAudioStreamIndex ?? 0;
           this.activeAudioTrackId.set(tracks[activeIdx]?.id ?? tracks[0].id);
+          this.reconcileActiveAudioTrack(tracks, tracks[activeIdx]?.id);
           this.trackManager.autoSelectAudioTrack(
             tracks, this.mediaId, this.mediaFileId,
             this.activeAudioTrackId(),
@@ -3703,12 +3698,33 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       if (active?.audioId != null) {
         this.activeAudioTrackId.set(`shaka-${active.audioId}`);
       }
+      this.reconcileActiveAudioTrack(
+        tracks,
+        active?.audioId != null ? `shaka-${active.audioId}` : null,
+      );
       this.trackManager.autoSelectAudioTrack(
         tracks, this.mediaId, this.mediaFileId,
         this.activeAudioTrackId(),
         (trackId) => this.onSelectAudioTrack(trackId),
       );
     }, 2000);
+  }
+
+  /** Keep `activeAudioTrackId` pointing at a track that is actually in the
+   *  list. Every path that replaces the list can otherwise leave it dangling —
+   *  the selector then shows no language as selected at all. `preferred` is the
+   *  engine's own idea of the active track, used when the current id is gone. */
+  private reconcileActiveAudioTrack(
+    tracks: { id: string }[],
+    preferred?: string | null,
+  ): void {
+    if (!tracks.length) return;
+    const current = this.activeAudioTrackId();
+    if (current && tracks.some((t) => t.id === current)) return;
+    this.activeAudioTrackId.set(
+      (preferred && tracks.some((t) => t.id === preferred) ? preferred : null) ??
+        tracks[0].id,
+    );
   }
 
   async onSelectAudioTrack(trackId: string) {
@@ -3740,6 +3756,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
     // Engine-level audio switch (Shaka native or NativeEngine)
     if (isEngineTrack) {
+      // Capture the play/pause intent first: a native engine reloads the stream
+      // to switch track, which comes back playing — switching language must not
+      // resume a player the user paused. `reloadStream` does the same below.
+      const wasPaused = this.paused();
       // Show spinner during audio switch (native player reloads the stream)
       if (this.isNativeEngine()) {
         this.state.buffering.set(true);
@@ -3748,6 +3768,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       if (this.isNativeEngine()) {
         this.state.buffering.set(false);
       }
+      this.restorePlayState(wasPaused);
       return;
     }
 
@@ -3947,22 +3968,30 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         e.preventDefault();
         this.onTogglePlay();
         break;
+      // Each seek below goes through showControls(): the bar is already up, so
+      // this only restarts the countdown and marks it as deliberately revealed.
+      // Without that, a seek made while the stream is still loading restarts it,
+      // and the first-frame effect snaps the bar shut under the user.
       case 'ArrowLeft':
         if (!arrowSeekAllowed) break;
         e.preventDefault();
+        this.showControls();
         this.onSeek(this.engine.currentTime - 10);
         break;
       case 'ArrowRight':
         if (!arrowSeekAllowed) break;
         e.preventDefault();
+        this.showControls();
         this.onSeek(this.engine.currentTime + 10);
         break;
       case 'j':
         e.preventDefault();
+        this.showControls();
         this.onSeek(this.engine.currentTime - 30);
         break;
       case 'l':
         e.preventDefault();
+        this.showControls();
         this.onSeek(this.engine.currentTime + 30);
         break;
       case 'f':

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.html
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.html
@@ -96,7 +96,7 @@
                     <p class="px-3 py-2 text-xs text-base-content/50">{{ 'settings.plugins.catalogue.pick_version' | translate }}</p>
                     @for (entry of versionsFor(row); track entry.version) {
                       <button type="button" class="dropdown-item justify-between"
-                        [disabled]="entry.version === installedVersion(row)"
+                        [appSelectedOption]="entry.version === installedVersion(row)"
                         (click)="installVersion(row, entry.version)">
                         <span>{{ entry.version }}</span>
                         @if (entry.version === installedVersion(row)) {

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.ts
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.ts
@@ -8,6 +8,7 @@ import {
   PluginsApiService,
 } from '../../../../core/services/api/plugins-api.service';
 import { DropdownToggleDirective } from '../../../../shared/directives/dropdown-toggle.directive';
+import { SelectedOptionDirective } from '../../../../shared/directives/selected-option.directive';
 
 interface CatalogueRow {
   sourceId: number;
@@ -21,7 +22,7 @@ interface CatalogueRow {
 /** What every cached catalog offers, merged across sources. */
 @Component({
   selector: 'app-plugin-catalogue',
-  imports: [TranslateModule, DropdownToggleDirective, LucideChevronDown],
+  imports: [TranslateModule, DropdownToggleDirective, LucideChevronDown, SelectedOptionDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugin-catalogue.html',
 })

--- a/client/src/app/features/setup/setup.html
+++ b/client/src/app/features/setup/setup.html
@@ -85,6 +85,7 @@
           {{ 'setup.test' | translate }}
         </button>
         <button
+          #saveBtn
           type="button"
           class="btn btn-primary flex-1"
           [disabled]="!testResult()?.ok"

--- a/client/src/app/features/setup/setup.ts
+++ b/client/src/app/features/setup/setup.ts
@@ -1,8 +1,10 @@
 import {
   Component,
   ChangeDetectionStrategy,
+  ElementRef,
   signal,
   inject,
+  viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
@@ -42,6 +44,7 @@ export class SetupComponent {
   readonly switching = signal(false);
   /** URL of the entry whose ⋯ menu is open, or null. */
   readonly openMenuFor = signal<string | null>(null);
+  private readonly saveBtn = viewChild<ElementRef<HTMLButtonElement>>('saveBtn');
 
   async test() {
     const raw = this.url().trim().replace(/\/+$/, '');
@@ -54,6 +57,9 @@ export class SetupComponent {
         if (await this.reachable(base)) {
           this.url.set(base);
           this.testResult.set({ ok: true, message: 'setup.test_success' });
+          // Save is disabled until the test passes — hand it the focus once
+          // the render that enables it has happened, so the D-pad lands there.
+          setTimeout(() => this.saveBtn()?.nativeElement.focus());
           return;
         }
       }

--- a/client/src/app/features/tmdb-preview/tmdb-preview.html
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.html
@@ -178,8 +178,8 @@
        breakpoint media-info-header uses for its own desktop split. -->
   <div class="hidden md:block relative">
     <div
-      class="flex gap-6 lg:gap-10 relative z-20 tv:pt-24!"
-      [style.padding-top]="!navbar.isHeroPage() || navbar.effectiveSidebarPinned() ? null : navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 3rem)' : null"
+      class="flex gap-6 lg:gap-10 relative z-20"
+      [style.padding-top]="!navbar.isHeroPage() || navbar.effectiveSidebarPinned() || tv.isTv() ? null : navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 3rem)' : null"
     >
       <div class="shrink-0 w-[200px] xl:w-[220px] 2xl:w-[280px]">
         @if (m.posterUrl) {

--- a/client/src/app/features/tmdb-preview/tmdb-preview.ts
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.ts
@@ -24,6 +24,7 @@ import {
 import { ProfilesService } from '../../core/services/api/profiles.service';
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
 import { ToastService } from '../../core/services/toast.service';
+import { TvService } from '../../core/services/tv.service';
 import { NavbarService } from '../../core/services/navbar.service';
 import { BackgroundService } from '../../core/services/background.service';
 import {
@@ -62,6 +63,7 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
   private readonly toast = inject(ToastService);
   private readonly translate = inject(TranslateService);
   protected readonly navbar = inject(NavbarService);
+  protected readonly tv = inject(TvService);
   private readonly backgroundService = inject(BackgroundService);
   readonly auth = inject(AuthService);
 

--- a/client/src/app/shared/components/bottom-sheet.ts
+++ b/client/src/app/shared/components/bottom-sheet.ts
@@ -13,7 +13,7 @@ import {
 } from '@angular/core';
 import { DismissableStackService } from '../../core/services/dismissable-stack.service';
 import { TvService } from '../../core/services/tv.service';
-import { TABBABLE_SELECTOR } from '../../core/services/focusable.constants';
+import { TABBABLE_SELECTOR, initialOverlayFocus } from '../../core/services/focusable.constants';
 
 @Component({
   selector: 'app-bottom-sheet',
@@ -161,21 +161,19 @@ export class BottomSheetComponent {
             this.prevFocused = document.activeElement as HTMLElement | null;
             document.addEventListener('focusin', this.onFocusIn);
             this.focusTrapActive = true;
-            // Move focus to the first item inside the sheet on open. Without
-            // this, the D-pad still operates on the trigger row (or the
-            // previously-focused tile in the route), so up/down moves to a
-            // background element and the focus-trap fires AFTER the user
-            // has already left the sheet visually — feels unresponsive.
+            // Move focus inside the sheet on open. Without this, the D-pad
+            // still operates on the trigger row (or the previously-focused
+            // tile in the route), so up/down moves to a background element and
+            // the focus-trap fires AFTER the user has already left the sheet
+            // visually — feels unresponsive.
             // queueMicrotask waits until @if has materialised the sheet
             // content; rAF would defer one extra frame and let the WebView
             // paint the focus halo on the wrong element first.
             queueMicrotask(() => {
               if (!this.open()) return;
-              const sheetEl = this.sheet()?.nativeElement;
-              const first = sheetEl?.querySelector<HTMLElement>(
-                TABBABLE_SELECTOR,
-              );
-              first?.focus({ preventScroll: true });
+              initialOverlayFocus(this.sheet()?.nativeElement)?.focus({
+                preventScroll: true,
+              });
             });
           }
         } else {

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -51,6 +51,16 @@ export type CardStatus = 'watched' | 'missing' | null;
     CardActionsDirective, SpoilerDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-card.html',
+  // The art scales up on focus and would ride over the caption — slide the text
+  // clear. Component-scoped so every form factor gets it, not just the 10-foot UI.
+  styles: `
+    figure + div {
+      transition: transform 0.15s ease-out;
+    }
+    figure:focus-visible + div {
+      transform: translateY(0.6rem);
+    }
+  `,
 })
 export class MediaCardComponent {
   private readonly translate = inject(TranslateService);

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -177,8 +177,8 @@
 <div class="hidden md:block tv:block relative">
 
   <div
-    class="flex gap-6 lg:gap-10 relative z-20 tv:pt-24!"
-    [style.padding-top]="!navbar.isHeroPage() || navbar.effectiveSidebarPinned() ? null : navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 3rem)' : null"
+    class="flex gap-6 lg:gap-10 relative z-20"
+    [style.padding-top]="!navbar.isHeroPage() || navbar.effectiveSidebarPinned() || tv.isTv() ? null : navbar.mobileNavbarVisible() ? 'calc(env(safe-area-inset-top, 0px) + 3rem)' : null"
   >
     <!-- Poster / Still (desktop only). Compact on the md-to-lg range (landscape
          phones / small windows) so the title keeps room in a short viewport;

--- a/client/src/app/shared/components/popover-menu.ts
+++ b/client/src/app/shared/components/popover-menu.ts
@@ -15,6 +15,7 @@ import { BottomSheetComponent } from './bottom-sheet';
 import { TvService } from '../../core/services/tv.service';
 import { DeviceService } from '../../core/services/device.service';
 import { DismissableStackService } from '../../core/services/dismissable-stack.service';
+import { initialOverlayFocus } from '../../core/services/focusable.constants';
 
 /**
  * Reusable menu chrome that picks its presentation per-platform:
@@ -171,15 +172,9 @@ export class PopoverMenuComponent {
               this.anchor();
           }
         }
-        // Prefer the active item (caller marks it with `[autofocus]` or
-        // `[aria-current]`) so the user lands on the current selection
-        // instead of having to scroll through the list. Falls back to the
-        // first focusable when nothing's marked active.
-        const root = this.host.nativeElement;
-        const target =
-          root.querySelector<HTMLElement>('[autofocus]:not([disabled])') ??
-          root.querySelector<HTMLElement>('[aria-current="true"]:not([disabled])') ??
-          root.querySelector<HTMLElement>('a[href], button:not([disabled]), [tabindex="0"]');
+        // Land on the current selection rather than making the user scroll to
+        // it; falls back to the first focusable when nothing is marked.
+        const target = initialOverlayFocus(this.host.nativeElement);
         target?.focus({ preventScroll: false });
         target?.scrollIntoView({ block: 'nearest', behavior: 'instant' as ScrollBehavior });
       });

--- a/client/src/app/shared/directives/dropdown-toggle.directive.ts
+++ b/client/src/app/shared/directives/dropdown-toggle.directive.ts
@@ -1,6 +1,6 @@
 import { Directive, ElementRef, inject, OnDestroy } from '@angular/core';
 import { DismissableStackService } from '../../core/services/dismissable-stack.service';
-import { TABBABLE_SELECTOR } from '../../core/services/focusable.constants';
+import { TABBABLE_SELECTOR, initialOverlayFocus } from '../../core/services/focusable.constants';
 
 /**
  * Click-driven `.dropdown-open` toggle for any DaisyUI dropdown trigger.
@@ -79,7 +79,7 @@ export class DropdownToggleDirective implements OnDestroy {
     // and keyboard users can act without an extra Tab. Standard ARIA
     // menu pattern.
     queueMicrotask(() => {
-      const first = content?.querySelector<HTMLElement>(TABBABLE_SELECTOR);
+      const first = initialOverlayFocus(content);
       first?.focus({ preventScroll: true });
     });
     const close = () => {

--- a/client/src/app/shared/directives/selected-option.directive.ts
+++ b/client/src/app/shared/directives/selected-option.directive.ts
@@ -1,0 +1,34 @@
+import { Directive, ElementRef, inject, input } from '@angular/core';
+
+/**
+ * Marks the option a single-choice menu is currently on.
+ *
+ * `disabled` would be the obvious way to make it unpickable, but it also drops
+ * the element out of the focus order — a D-pad could then never land on the
+ * value that is actually selected. `aria-disabled` keeps it reachable, styled
+ * as unavailable (see the `[aria-disabled]` rule in styles.css), and lets
+ * {@link initialOverlayFocus} put focus straight on it when the menu opens.
+ *
+ * The click is swallowed in the capture phase so the template's own `(click)`
+ * never runs: re-picking the active audio track or quality costs a real stream
+ * reload.
+ */
+@Directive({
+  selector: '[appSelectedOption]',
+  host: { '[attr.aria-disabled]': "selected() ? 'true' : null" },
+})
+export class SelectedOptionDirective {
+  readonly selected = input.required<boolean>({ alias: 'appSelectedOption' });
+
+  constructor() {
+    inject(ElementRef<HTMLElement>).nativeElement.addEventListener(
+      'click',
+      (e: Event) => {
+        if (!this.selected()) return;
+        e.preventDefault();
+        e.stopImmediatePropagation();
+      },
+      { capture: true },
+    );
+  }
+}

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -4,19 +4,22 @@
      [class.md:drawer-open]="device.isTablet() && navbar.effectiveSidebarPinned()">
   <input id="sidebar" type="checkbox" class="drawer-toggle" />
   <div class="drawer-content flex flex-col relative">
+    <!-- Watched by an IntersectionObserver to derive `scrollAtTop` without ever
+         reading the scroll position. Absolute, so it adds no layout height. -->
+    <div #topSentinel aria-hidden="true" class="absolute top-0 left-0 h-5 w-px pointer-events-none"></div>
     <nav
       appTvRow
-      class="navbar fixed left-0 right-0 z-30 transition-all duration-300"
-      [style.padding-top]="tv.isTizen() ? '0.5rem' : 'calc(env(safe-area-inset-top, 0px) + 4px)'"
+      class="navbar fixed left-0 right-0 z-30 transition-all duration-300 tv:px-[var(--page-p)] tv:static"
+      [style.padding-top]="tv.isTv() ? 'calc(env(safe-area-inset-top, 0px) + var(--page-p) / 2)' : 'calc(env(safe-area-inset-top, 0px) + 4px)'"
       [class.top-0]="!tv.isTv() || tv.isTizen()"
       [class.top-4]="tv.isAndroidTv()"
       [class.lg:hidden]="device.isDesktop() || (device.isTv() && navbar.effectiveSidebarPinned())"
       [class.md:hidden]="device.isTablet() && navbar.effectiveSidebarPinned()"
       [class.-translate-y-full]="navbarHidden()"
-      [class.bg-base-100]="!navbarTransparent() && !background.url()"
+      [class.bg-base-100]="!navbarTransparent() && !background.url() && !tv.isTv()"
       [class.app-navbar-veil]="!navbarTransparent() && !!background.url()"
-      [class.backdrop-blur-sm]="!navbarTransparent() && !!background.url()"
-      [class.shadow-sm]="!navbarTransparent() && !background.url()"
+      [class.backdrop-blur-sm]="!navbarTransparent() && !!background.url() && !tv.isTv()"
+      [class.shadow-sm]="!navbarTransparent() && !background.url() && !tv.isTv()"
       [class.bg-transparent]="navbarTransparent()"
       [class.text-white]="navbarTransparent()"
       [class.nav-hero-icons]="navbarTransparent()"
@@ -52,11 +55,8 @@
           <!-- Hero page without a clearlogo: render nothing. The empty branch
                keeps it from falling through to the mobile-title / app-name
                fallbacks below — no title in the clearlogo slot. -->
-        } @else if (isNative && isHomeRoute() && navbar.mobileNavTitle()) {
-          <span class="flex items-center gap-2 pl-2 text-lg font-bold min-w-0">
-            <img src="fliks-icon.svg" alt="" class="h-7 w-7 shrink-0" />
-            <span class="truncate" [attr.title]="navbar.mobileNavTitle()">{{ navbar.mobileNavTitle() }}</span>
-          </span>
+        } @else if (isHomeRoute()) {
+          <img src="fliks-logo-ondark.svg" [alt]="'app.name' | translate" class="h-7 w-auto pl-2 object-contain object-left" />
         } @else if (navbar.mobileNavTitle()) {
           <span class="block min-w-0 pl-2 text-lg font-bold truncate" [attr.title]="navbar.mobileNavTitle()">{{
             navbar.mobileNavTitle()
@@ -95,21 +95,19 @@
         <app-user-menu />
       </div>
     </nav>
-    <!-- Spacer for fixed navbar on mobile (navbar height + safe area; reduced on hero pages so fanart extends under status bar).
-         TV has no safe-area-inset-top (no notch / status bar), so the 3rem
-         falls flush against the navbar; bump to 4rem there so content has
-         the same visual breathing room as phones/tablets. -->
+    <!-- Spacer for the fixed navbar (navbar height + safe area); collapsed on
+         hero pages so the fanart extends under the status bar, and on TV where
+         the navbar sits in the flow. -->
     <div
       [class.lg:hidden]="device.isDesktop() || (device.isTv() && navbar.effectiveSidebarPinned())"
       [class.md:hidden]="device.isTablet() && navbar.effectiveSidebarPinned()"
-      [class.h-20]="!navbar.isHeroPage() && tv.isTv()"
-      [style.height]="navbar.isHeroPage() ? '0px' : tv.isTv() ? null : 'calc(3rem + env(safe-area-inset-top, 0px))'"
+      [style.height]="navbar.isHeroPage() || tv.isTv() ? '0px' : 'calc(3rem + env(safe-area-inset-top, 0px))'"
     ></div>
     <!-- Desktop top-right: Cast + User -->
     <div appTvRow
          [appTvRowSnap]="true"
-         class="hidden items-center justify-between gap-1 px-4 relative z-30"
-         [style.padding-top]="tv.isTv() ? 'calc(4rem + env(safe-area-inset-top, 0px))' : isNative ? 'calc(0.3rem + env(safe-area-inset-top, 1.5rem))' : '1rem'"
+         class="hidden items-center justify-between gap-1 px-[var(--page-p)] relative z-30"
+         [style.padding-top]="tv.isTv() ? 'calc(env(safe-area-inset-top, 0px) + var(--page-p) / 2)' : isNative ? 'calc(0.3rem + env(safe-area-inset-top, 1.5rem))' : '1rem'"
          [class.lg:flex]="device.isDesktop() || (device.isTv() && navbar.effectiveSidebarPinned())"
          [class.md:flex]="device.isTablet() && navbar.effectiveSidebarPinned()">
       <!-- Hero back + clearlogo (left) -->
@@ -162,7 +160,7 @@
          `position: sticky` on descendants (sticky would anchor to <main>
          and never engage because the actual scroll happens on the page). -->
     <main
-      class="min-w-0 flex-1 p-4"
+      class="min-w-0 flex-1 py-4 px-[var(--page-p)]"
       [class.overflow-x-clip]="!navbar.isHeroPage()"
       [class.pt-8]="!navbar.isHeroPage() && !isNative && navbar.mobileNavbarVisible()"
     >

--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -9,6 +9,7 @@ import {
   OnDestroy,
   DestroyRef,
   viewChild,
+  ElementRef,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Title } from '@angular/platform-browser';
@@ -151,6 +152,7 @@ export class LayoutComponent implements OnInit, OnDestroy {
   readonly canGoBack = this.navbar.canGoBack;
 
   readonly isNative = Capacitor.isNativePlatform();
+  private readonly topSentinel = viewChild<ElementRef<HTMLElement>>('topSentinel');
   readonly bottomMenuOpen = signal(false);
   readonly keyboardOpen = signal(false);
   readonly navbarHidden = signal(false);
@@ -187,13 +189,40 @@ export class LayoutComponent implements OnInit, OnDestroy {
     this.title.setTitle(`${main} · ${this.translate.instant('app.name')}`);
   });
   private lastScrollY = 0;
+  private scrollRaf: number | null = null;
+  private topSentinelObserver?: IntersectionObserver;
+  /** TV never hides the navbar, so the scroll handler would exist only to
+   *  recompute `scrollAtTop` — and reading `scrollY` flushes whatever layout
+   *  the frame has dirtied, which on a windowed library grid is a relayout of
+   *  a 60 000 px document. The sentinel below reports the same thing with no
+   *  layout read at all, so the handler is skipped there entirely. */
   private readonly onScroll = () => {
+    if (this.device.isTv() || this.scrollRaf !== null) return;
+    this.scrollRaf = requestAnimationFrame(() => {
+      this.scrollRaf = null;
+      this.readScroll();
+    });
+  };
+  private readScroll(): void {
     const y = window.scrollY;
     this.navbar.scrollAtTop.set(y < 20);
     if (Math.abs(y - this.lastScrollY) < 10) return;
+    // TV keeps the topbar anchored — it is a D-pad target, and sliding it out
+    // from under the focus ring strands the cursor.
     this.navbarHidden.set(y > this.lastScrollY && y > 56);
     this.lastScrollY = y;
-  };
+  }
+
+  /** `scrollAtTop` without touching the scroll position: a zero-width strip
+   *  pinned to the top of the page, watched by an IntersectionObserver. */
+  private watchTopSentinel(): void {
+    const el = this.topSentinel()?.nativeElement;
+    if (!el || typeof IntersectionObserver === 'undefined') return;
+    this.topSentinelObserver = new IntersectionObserver(
+      ([entry]) => this.navbar.scrollAtTop.set(entry.isIntersecting),
+    );
+    this.topSentinelObserver.observe(el);
+  }
 
   /** Accessible libraries for the sidebar (raw, as fetched). */
   readonly libraries = signal<LibrarySummary[]>([]);
@@ -272,6 +301,7 @@ export class LayoutComponent implements OnInit, OnDestroy {
     }
     // DownloadManagerService is activated by injection (effect in constructor)
     window.addEventListener('scroll', this.onScroll, { passive: true });
+    this.watchTopSentinel();
     if (this.isNative) {
       Keyboard.addListener('keyboardWillShow', () => this.keyboardOpen.set(true));
       Keyboard.addListener('keyboardWillHide', () => this.keyboardOpen.set(false));
@@ -284,12 +314,25 @@ export class LayoutComponent implements OnInit, OnDestroy {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(e => {
         if (e instanceof NavigationEnd) {
+          this.replayPageEnter();
           this.bottomMenuOpen.set(false);
           this.isHomeRoute.set(e.urlAfterRedirects === '/' || e.urlAfterRedirects.startsWith('/?'));
           this.syncNavbarTitleFromRoute();
         }
       });
     this.syncNavbarTitleFromRoute();
+  }
+
+  /** Restart the page-enter animation. Re-adding the class a frame later is
+   *  what lets the same animation run again — reading a layout property to
+   *  force the reflow synchronously costs a full-document relayout, which on
+   *  a long library page lands right where the spinner should stay smooth. */
+  private replayPageEnter(): void {
+    if (!this.device.isTv()) return;
+    const main = document.querySelector('main');
+    if (!main) return;
+    main.classList.remove('page-enter');
+    requestAnimationFrame(() => main.classList.add('page-enter'));
   }
 
   /**
@@ -311,6 +354,8 @@ export class LayoutComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     window.removeEventListener('scroll', this.onScroll);
+    if (this.scrollRaf !== null) cancelAnimationFrame(this.scrollRaf);
+    this.topSentinelObserver?.disconnect();
     if (this.isNative) {
       Keyboard.removeAllListeners();
     }

--- a/client/src/app/shared/utils/infinite-scroll-list.ts
+++ b/client/src/app/shared/utils/infinite-scroll-list.ts
@@ -2,21 +2,6 @@ import { signal, ElementRef } from '@angular/core';
 
 const DEFAULT_BATCH_SIZE = 60;
 
-/** Live measurements of the rendered grid, supplied by the owning component
- *  when windowing is enabled. Every value lives in one coordinate space — CSS
- *  px in the document scroller — so they stay consistent even under a webOS
- *  `zoom` (read rect.top and scroller.scrollTop together). */
-export interface GridMetrics {
-  /** Grid top edge in document coords: rect.top + scroller.scrollTop. */
-  gridTopDoc: number;
-  /** One row's height: a cell's measured height plus the row gap. */
-  rowHeight: number;
-  /** Row gap in px (subtracted once when reserving off-window padding). */
-  rowGap: number;
-  /** Columns currently laid out. */
-  cols: number;
-}
-
 export class InfiniteScrollList<T extends { id: number }> {
   private allItems: T[] = [];
   private visibleCount = 0;
@@ -29,17 +14,8 @@ export class InfiniteScrollList<T extends { id: number }> {
   private unlockOnScroll: (() => void) | null = null;
   private scrollLock = false;
   private scrollLockTimeout: ReturnType<typeof setTimeout> | null = null;
+  private scrollRaf: number | null = null;
   private readonly idIndex = new Map<number, number>();
-
-  // Windowing — opt-in via enableWindowing(). Renders only a row-aligned slice
-  // of allItems around the viewport so large lists don't pile hundreds of DOM
-  // nodes onto the page. Inert (zero behavior change) unless enabled.
-  private windowing = false;
-  private metricsFn: (() => GridMetrics | null) | null = null;
-  private bufferRows = 4;
-  private windowRaf: number | null = null;
-  private windowedOnce = false;
-  private warnedWindowFail = false;
 
   /** All items (reactive — use in computed for counts/stats). */
   readonly all = signal<T[]>([]);
@@ -50,10 +26,6 @@ export class InfiniteScrollList<T extends { id: number }> {
   readonly availableLetters = signal<Set<string>>(new Set());
   /** Currently visible letter based on scroll position. */
   readonly activeLetter = signal('');
-  /** Off-window spacer heights (px). Bound to the grid's padding so the
-   *  scrollbar and absolute item positions match the un-windowed layout. */
-  readonly padTop = signal(0);
-  readonly padBottom = signal(0);
 
   constructor(batchSize = DEFAULT_BATCH_SIZE) {
     this.batchSize = batchSize;
@@ -85,6 +57,18 @@ export class InfiniteScrollList<T extends { id: number }> {
     return this.allItems;
   }
 
+  /** The letter section item `index` falls in — the alphabet index reads this
+   *  from the rendered row rather than from the DOM, which under virtual
+   *  scrolling only holds a handful of rows. */
+  letterAt(index: number): string {
+    let current = this.letterBoundaries[0]?.letter ?? '';
+    for (const b of this.letterBoundaries) {
+      if (b.index <= index) current = b.letter;
+      else break;
+    }
+    return current;
+  }
+
   /** Index of an item id in allItems, or -1. */
   indexOf(id: number): number {
     return this.idIndex.get(id) ?? -1;
@@ -92,7 +76,6 @@ export class InfiniteScrollList<T extends { id: number }> {
 
   /** Load next batch. */
   showMore() {
-    if (this.windowing) return;
     if (this.visibleCount >= this.allItems.length) return;
     this.visibleCount = Math.min(
       this.visibleCount + this.batchSize,
@@ -101,99 +84,15 @@ export class InfiniteScrollList<T extends { id: number }> {
     this.updateVisible();
   }
 
-  // ---------------------------------------------------------------------------
-  // Windowing (opt-in)
-  // ---------------------------------------------------------------------------
-
-  /** Opt in to DOM windowing: only a row-aligned slice around the viewport
-   *  renders, with `bufferRows` of overscan each side so D-pad focus targets
-   *  stay rendered. `metricsFn` reads the live grid. Pages that never call this
-   *  keep the plain slice-0..visibleCount behavior. */
-  enableWindowing(metricsFn: () => GridMetrics | null, bufferRows = 4) {
-    this.windowing = true;
-    this.metricsFn = metricsFn;
-    this.bufferRows = bufferRows;
-    this.hasMore.set(false);
-    this.updateVisible();
-  }
-
-  /** Recompute the window from the current scroll position (rAF-throttled). */
-  onWindowScroll() {
-    if (!this.windowing || this.windowRaf !== null) return;
-    this.windowRaf = requestAnimationFrame(() => {
-      this.windowRaf = null;
-      this.recomputeWindow();
+  /** Coalesce scroll-driven work into one frame: the active-letter tracker
+   *  reads geometry, and doing that per scroll event forces a layout flush on
+   *  every one of them. */
+  private scheduleScrollWork() {
+    if (this.scrollRaf !== null) return;
+    this.scrollRaf = requestAnimationFrame(() => {
+      this.scrollRaf = null;
+      this.onScroll();
     });
-  }
-
-  /** Synchronously ensure the row containing `index` (± buffer) is rendered. */
-  ensureRendered(index: number) {
-    if (!this.windowing) return;
-    const m = this.metricsFn?.();
-    if (!m || m.cols < 1) return;
-    const row = Math.floor(index / m.cols);
-    this.applyWindow(m, row - this.bufferRows, row + this.bufferRows + 1);
-  }
-
-  private recomputeWindow() {
-    const m = this.metricsFn?.();
-    if (!m || m.rowHeight <= 0 || m.cols < 1) {
-      // Metrics not ready yet (grid not laid out) — render everything, which
-      // is exactly the non-windowed behavior, so never worse than before.
-      // Warn once if windowing previously succeeded then broke: that's a grid
-      // CSS / measurement regression silently disabling the DOM cap, not the
-      // benign first-render case.
-      if (this.windowedOnce && this.allItems.length && !this.warnedWindowFail) {
-        this.warnedWindowFail = true;
-        console.warn(
-          '[InfiniteScrollList] grid metrics unavailable after windowing succeeded — ' +
-            'rendering all items. A grid layout change likely broke readGridMetrics().',
-        );
-      }
-      this.visible.set(this.allItems.slice());
-      this.padTop.set(0);
-      this.padBottom.set(0);
-      return;
-    }
-    const scrollTop = (document.scrollingElement ?? document.documentElement).scrollTop;
-    const vh = window.innerHeight;
-    const firstRow = Math.floor((scrollTop - m.gridTopDoc) / m.rowHeight);
-    const lastRow = Math.floor((scrollTop + vh - m.gridTopDoc) / m.rowHeight);
-    this.applyWindow(m, firstRow - this.bufferRows, lastRow + this.bufferRows + 1);
-  }
-
-  private applyWindow(m: GridMetrics, startRowRaw: number, endRowRaw: number) {
-    this.windowedOnce = true;
-    this.warnedWindowFail = false;
-    const total = this.allItems.length;
-    const cols = m.cols;
-    const totalRows = Math.ceil(total / cols);
-    let startRow = Math.max(0, Math.min(startRowRaw, totalRows));
-    let endRow = Math.min(totalRows, Math.max(startRow + 1, endRowRaw));
-    // Never window out the focused card's row — detaching it drops focus to
-    // <body>, and the next arrow press then jumps back to the first card.
-    const focusRow = this.focusedRow(cols);
-    if (focusRow >= 0) {
-      startRow = Math.min(startRow, focusRow);
-      endRow = Math.max(endRow, focusRow + 1);
-    }
-    const windowStart = startRow * cols;
-    const windowEnd = Math.min(total, endRow * cols);
-    // Row gap sits only BETWEEN tracks, never between padding and the first/last
-    // track — drop one gap from each spacer so total height matches exactly.
-    this.padTop.set(startRow > 0 ? startRow * m.rowHeight - m.rowGap : 0);
-    this.padBottom.set(endRow < totalRows ? (totalRows - endRow) * m.rowHeight - m.rowGap : 0);
-    this.visible.set(this.allItems.slice(windowStart, windowEnd));
-  }
-
-  private focusedRow(cols: number): number {
-    if (typeof document === 'undefined') return -1;
-    const active = document.activeElement as HTMLElement | null;
-    const el = active?.closest<HTMLElement>('[data-library-focus^="media:"]');
-    const sel = el?.getAttribute('data-library-focus');
-    if (!sel) return -1;
-    const idx = this.idIndex.get(Number(sel.slice('media:'.length)));
-    return idx == null ? -1 : Math.floor(idx / cols);
   }
 
   /**
@@ -213,27 +112,10 @@ export class InfiniteScrollList<T extends { id: number }> {
       return firstChar === letter;
     });
     if (index < 0) return;
+
     this.activeLetter.set(letter);
     this.scrollLock = true;
     if (this.scrollLockTimeout) clearTimeout(this.scrollLockTimeout);
-
-    if (this.windowing) {
-      const m = this.metricsFn?.();
-      if (m && m.rowHeight > 0 && m.cols >= 1) {
-        // The target card may be windowed out — render it first, then scroll
-        // to its computed Y (scrollIntoView would need the element to exist).
-        this.ensureRendered(index);
-        const targetY = Math.max(
-          0,
-          m.gridTopDoc + Math.floor(index / m.cols) * m.rowHeight - 96,
-        );
-        requestAnimationFrame(() => {
-          window.scrollTo({ top: targetY, left: 0, behavior: 'smooth' });
-          this.armScrollUnlock();
-        });
-        return;
-      }
-    }
 
     if (index >= this.visibleCount) {
       this.visibleCount = Math.min(
@@ -255,8 +137,7 @@ export class InfiniteScrollList<T extends { id: number }> {
     });
   }
 
-  /** Release the scroll lock once the smooth scroll settles (shared by the
-   *  windowed and non-windowed scrollToLetter paths). */
+  /** Release the scroll lock once the smooth scroll settles. */
   private armScrollUnlock() {
     // Re-arming clears the pending timer, so the previous closure has to be
     // dropped here or it stays bound to window with nothing left to remove it.
@@ -294,10 +175,7 @@ export class InfiniteScrollList<T extends { id: number }> {
   trackScroll(idPrefix: string) {
     this.idPrefix = idPrefix;
     if (this.scrollHandler) window.removeEventListener('scroll', this.scrollHandler);
-    this.scrollHandler = () => {
-      this.onWindowScroll();
-      this.onScroll();
-    };
+    this.scrollHandler = () => this.scheduleScrollWork();
     window.addEventListener('scroll', this.scrollHandler, { passive: true });
   }
 
@@ -311,17 +189,13 @@ export class InfiniteScrollList<T extends { id: number }> {
       window.removeEventListener('scroll', this.unlockOnScroll);
       this.unlockOnScroll = null;
     }
-    if (this.windowRaf !== null) {
-      cancelAnimationFrame(this.windowRaf);
-      this.windowRaf = null;
+    if (this.scrollRaf !== null) {
+      cancelAnimationFrame(this.scrollRaf);
+      this.scrollRaf = null;
     }
   }
 
   private updateVisible() {
-    if (this.windowing) {
-      this.recomputeWindow();
-      return;
-    }
     this.visible.set(this.allItems.slice(0, this.visibleCount));
     this.hasMore.set(this.visibleCount < this.allItems.length);
   }
@@ -351,22 +225,6 @@ export class InfiniteScrollList<T extends { id: number }> {
 
   private onScroll() {
     if (this.scrollLock || !this.letterBoundaries.length || !this.idPrefix) return;
-    if (this.windowing) {
-      // Position math — no getElementById, which would miss windowed-out
-      // boundary cards (and skips the per-scroll forced layout entirely).
-      const m = this.metricsFn?.();
-      if (!m || m.rowHeight <= 0 || m.cols < 1) return;
-      const scrollTop = (document.scrollingElement ?? document.documentElement).scrollTop;
-      const topRow = Math.max(0, Math.floor((scrollTop + 96 - m.gridTopDoc) / m.rowHeight));
-      const topIndex = topRow * m.cols;
-      let current = this.letterBoundaries[0].letter;
-      for (const b of this.letterBoundaries) {
-        if (b.index <= topIndex) current = b.letter;
-        else break;
-      }
-      this.activeLetter.set(current);
-      return;
-    }
     let current = this.letterBoundaries[0].letter;
     for (const { letter, itemId } of this.letterBoundaries) {
       const el = document.getElementById(`${this.idPrefix}-${itemId}`);

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -9,6 +9,8 @@
 
 /* Rounder corners for all DaisyUI components */
 :root, [data-theme] {
+  /* Page padding — <main>, the topbars, and anything that bleeds out of them. */
+  --page-p: 1rem;
   --radius-selector: 1rem;
   --radius-field: 1rem;
   --radius-box: 0.5rem;
@@ -161,8 +163,8 @@ body.native.hero-page {
 /* Landscape: fanart edge-to-edge into side safe areas (browser + native); body/main padding keeps content safe */
 @media (orientation: landscape) {
   body.hero-page .hero-fanart-bleed {
-    margin-left: calc(-1rem - env(safe-area-inset-left, 0px));
-    margin-right: calc(-1rem - env(safe-area-inset-right, 0px));
+    margin-left: calc(-1 * var(--page-p) - env(safe-area-inset-left, 0px));
+    margin-right: calc(-1 * var(--page-p) - env(safe-area-inset-right, 0px));
   }
 }
 
@@ -299,6 +301,9 @@ body.native.hero-page {
 body.tv {
   /* Slight scale-up of base text for legibility from the couch */
   font-size: 18px;
+  /* Viewport-relative so it holds across the logical widths the different
+     TV WebViews report. */
+  --page-p: 4vw;
 }
 /* Horizontal overscan compensation — shrink the body 4% horizontally
    so content stays inside the TV's displayable area. `scaleX` only
@@ -318,14 +323,22 @@ body.tv:not(.tv-tizen):not(.tv-webos) {
 body.tv.immersive {
   transform: none;
 }
-/* webOS lays the app out at a 1920×1080 logical viewport, whereas the
-   Tizen WebView reports ~1280×720. At 1920 every element is ~⅔ the
-   physical size of its Tizen counterpart, so the 10-foot UI reads as
-   tiny from the couch. Zoom 1.5 (1920÷1280) brings the effective density
-   back in line with Tizen. Excluded while immersive so the fullscreen
-   player isn't scaled past the panel edges. */
-body.tv-webos:not(.immersive) {
-  zoom: 1.5;
+/* The 10-foot UI is sized for the 1280-wide logical viewport older TV
+   WebViews report. webOS and Tizen 9 lay it out at 1920 instead, so every
+   element renders at ⅔ the intended physical size and reads as tiny from
+   the couch. Scaling the root font restores the density: Tailwind sizes
+   spacing, text and box dimensions in rem, so they all follow. `zoom: 1.5`
+   would be the obvious lever and is the wrong one — it does not divide
+   viewport units, so every `min-h-screen` box rendered 1.5 screens tall and
+   scrolled. Keyed on the viewport rather than the OS: a 1280-wide TV must
+   not be scaled. */
+@media (min-width: 1900px) {
+  html.tv-host {
+    font-size: 24px;
+  }
+  body.tv {
+    font-size: 1.125rem;
+  }
 }
 /* Backfill html so the WebView doesn't show its default white during route
    transitions, before bootstrap, or in the 4% bottom band the scale leaves.
@@ -407,6 +420,13 @@ body:not(.keyboard-modality):not(.tv) app-mosaic-card button:focus-visible .mosa
   z-index: 1;
   position: relative;
 }
+/* Over the video, the ring's inner `--color-base-100` layer has nothing to
+   blend into — it reads as a black circle around every control. On the player
+   only, drop it and keep the primary ring alone. */
+app-player-controls :is(a, button, select, input, [role="button"], [tabindex]):focus-visible {
+  box-shadow: 0 0 0 3px var(--color-primary, #7a3ff2);
+}
+
 /* Default radius for the ring above, so a bare focusable (a section heading,
    a plain link) doesn't get a rectangle around it and no component has to
    remember its own. On an element with no background or border a radius paints
@@ -426,11 +446,21 @@ body:not(.keyboard-modality):not(.tv) app-mosaic-card button:focus-visible .mosa
   position: absolute;
   z-index: 50;
 }
+/* Same trap as `.player-floating-cue` above, made reusable: the focus ring
+   forces `position: relative` so its z-index applies, which re-anchors an
+   absolutely-placed control to its in-flow origin and makes it jump on focus.
+   Opt out here and keep the element's own placement. */
+.focus-keep-position:focus-visible {
+  position: absolute;
+}
+
 /* A scroll container clips at its padding box, and as soon as one axis
    scrolls CSS forces the other out of `visible` — so the ring above is cut
    off the left and right edges of any full-width focusable inside one.
    Reserve the ring's 4px and pull it straight back out of the layout, so the
-   content keeps its original alignment. Put it on the scrolling element. */
+   content keeps its original alignment. Put it on the scrolling element.
+   Horizontal only: a negative vertical margin would pull the container's own
+   first child (a menu title) up out of its padding. */
 .scroll-ring-safe {
   @apply px-1 -mx-1;
 }
@@ -469,6 +499,92 @@ body.tv [data-home-focus]:focus-visible,
 body.tv [data-tv-focusable]:focus-visible,
 body.tv app-mosaic-card button:focus-visible .mosaic-art {
   transform: scale(1.06);
+}
+
+/* Fade each row of a list in after the one above it. Applied to the CHILDREN
+   rather than through a wrapper per row: a section that renders nothing must
+   leave no element behind, or the parent's `gap` would open a hole for it.
+   `backwards` holds the row invisible through its delay. */
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+}
+.stagger-children > * {
+  animation: fade-in 320ms ease-out backwards;
+}
+.stagger-children > *:nth-child(1) { animation-delay: 0ms; }
+.stagger-children > *:nth-child(2) { animation-delay: 80ms; }
+.stagger-children > *:nth-child(3) { animation-delay: 160ms; }
+.stagger-children > *:nth-child(4) { animation-delay: 240ms; }
+.stagger-children > *:nth-child(5) { animation-delay: 320ms; }
+.stagger-children > *:nth-child(6) { animation-delay: 400ms; }
+.stagger-children > *:nth-child(7) { animation-delay: 480ms; }
+.stagger-children > *:nth-child(n + 8) { animation-delay: 560ms; }
+
+@keyframes fade-out {
+  to {
+    opacity: 0;
+  }
+}
+.skeleton-out {
+  animation: fade-out 600ms ease-out forwards;
+}
+
+/* View transitions are off on TV (see app.config), so a navigation would be an
+   abrupt swap — fade the routed content in instead. */
+/* Opacity only, never `transform`: an element with a running transform becomes
+   the containing block for its `position: fixed` descendants, so the library's
+   alphabet index centred itself on <main> for the length of this animation and
+   then jumped into place when it ended. */
+@keyframes page-enter {
+  from {
+    opacity: 0;
+  }
+}
+body.tv main.page-enter {
+  animation: page-enter 220ms ease-out;
+}
+
+/* CDK gives its content wrapper `contain: content`, whose paint containment
+   clips anything drawn outside a row — which is exactly where the focus ring
+   and the card's scale-up land. The wrapper is absolutely positioned and sized
+   by the viewport, so dropping containment costs no layout correctness. */
+.library-viewport .cdk-virtual-scroll-content-wrapper {
+  contain: none;
+}
+
+/* An option that is only marked unavailable because it IS the current selection
+   must stay focusable — a D-pad has to be able to land on it — so it carries
+   `aria-disabled` instead of `disabled`, which removes an element from the
+   focus order entirely. It still reads and behaves as unavailable. */
+[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: default;
+}
+[aria-disabled='true']:hover {
+  background-color: transparent !important;
+}
+
+/* Promote the card rails to their own composited scroll layer. Without it the
+   TV WebView re-rasterizes the whole rail on every frame of a smooth
+   horizontal scroll — measured on a Tizen 9 panel, 7.7 s of raster and 3.1 s of
+   commit over 20 D-pad steps, against 3.4 s / 0.7 s once composited. TV only:
+   the promotion costs layer memory and no other form factor scrolls these rails
+   one animated step at a time. */
+body.tv [data-scroller] {
+  will-change: scroll-position;
+}
+
+/* Run the focus lift on the compositor. The scale itself is cheap; animating it
+   on an unpromoted element is not — the TV WebView repaints the card and
+   everything overlapping it on every frame of the transition. Measured over 20
+   D-pad steps in the library: 7.8 s of raster unpromoted, 2.2 s promoted, 1.3 s
+   with no transition at all. Windowing keeps the rendered card count low enough
+   that a layer each is affordable. */
+body.tv app-media-card figure,
+body.tv app-media-card figure + div {
+  will-change: transform;
 }
 
 /* Card labels are sized in rem (text-sm / text-xs), so the body.tv 18px font


### PR DESCRIPTION
## Summary

A pass over the Tizen TV experience, driven by measurement on a real Samsung set (Chromium 120 WebView) rather than guesswork. Most of it is not TV-only: the CDK migration, the overlay focus rule and the card caption apply on every platform.

## Shell and layout

- Scale-up runs off the root font-size. `zoom` was tried first and rejected: it does not divide viewport units, so every `min-h-screen` became 1.5 screens tall and broke the login page's vertical centring. A viewport meta width is ignored by this WebView (measured `innerWidth` stayed 1920).
- One `--page-p` token drives the topbar and content inset, so they can no longer drift apart.
- The topbar loses its blur, background and bottom border on TV, and scrolls away with the page.

## Navigation

- Horizontal scrollers now follow D-pad focus. A smooth `scrollIntoView` does not move a horizontal scroller on this WebView, so the row is scrolled explicitly afterwards.
- Changing rows lands on the card nearest the previous column instead of snapping to the first.
- Text inputs no longer open the TV keyboard on focus — only on Enter. The keyboard swallowed the D-pad and trapped the user mid-form.

## Library

- The grid moves to `cdk-virtual-scroll-viewport` on every platform, deleting ~200 lines of hand-rolled windowing that measured no better than the browser.
- Row height is measured once. Re-measuring made `itemSize` drift and letter jumps land a section early.
- The alphabet is always rendered and vertically centred, so it no longer appears and disappears across navigations.

## Overlays

- Every menu and select opens focused on its current value, falling back to the first option, through one shared `initialOverlayFocus` helper.
- A selected option stays focusable and is only made non-activatable, so the D-pad can walk past it.
- Player dropdowns pin their title and scroll only the options.

## Player

- `setSelectTrack('AUDIO')` is only valid from `READY` or `PLAYING`. Switching language while paused silently resumed playback and left `getState()` reporting a stale value. Play, switch, pause back.
- Playback speed goes through `setSpeed`; the Shaka path never exercised it.
- Nothing tied to player start-up hides the controls while the reveal timer is still running, and moving within them always resets it.
- Skip intro/outro get a 10 s window with a visible countdown, and hide while the controls bar is up.

## Home

- A skeleton built from the user's last cached section layout, so it matches the shape of the content that replaces it. It lifts out of the flow and fades while the real sections stagger in underneath, so no row is blank and nothing pushes the scroll position.

## Verification

Built and installed on a Samsung set (`tizen package -s fliks` + `tizen install`) and walked with the D-pad over the CDP harness. Production build clean.

One known-open item is deliberately **not** in this PR: the skip-intro cue can still vanish while the user is reaching for it after pausing during an intro. A timer-restart fix was tried, did not work on device, and was reverted rather than shipped on a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
