### PR TITLE
fix(player): step Back through menu panels and stop the home fade-in replay

### DIFF
--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -46,7 +46,7 @@
   }
 
 <div appTvSection appDefaultFocus="a[data-home-focus^='library:']" focusKey="home" focusIdAttr="data-home-focus"
-     class="flex flex-col gap-8 stagger-children">
+     class="flex flex-col gap-8" [class.stagger-children]="coldStart()">
 
   @if (!loadingFirstPass()) {
 

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -195,10 +195,18 @@ export class HomeComponent implements OnInit, OnDestroy {
       { requests: this.requestsAllowed },
     ),
   );
+  /** Cold-start affordance only: coming back to Home serves cached data, so a
+   *  placeholder would flash for nothing. */
+  private static skeletonShown = false;
+  /** Gates the skeleton and the staggered fade-in. Cleared once the cold-start
+   *  reveal has played: the route is `reuse: true`, so a back-navigation
+   *  re-attaches this same instance and re-inserting the subtree would replay
+   *  every CSS animation still declared on it. */
+  readonly coldStart = signal(!HomeComponent.skeletonShown);
   /** True until the first pass over every section resolves. Each section only
    *  renders once its own data lands, so a cold start would otherwise show an
    *  empty page; the skeleton stands in for the whole page during that pass. */
-  readonly loadingFirstPass = signal(true);
+  readonly loadingFirstPass = signal(this.coldStart());
 
   /** Shape of one skeleton row: how the zone's cards are laid out. */
   private static readonly SHAPES: Partial<Record<HomeSectionType, 'tile' | 'landscape' | 'portrait'>> = {
@@ -366,12 +374,19 @@ export class HomeComponent implements OnInit, OnDestroy {
     if (this.requestsAllowed) void this.loadRequestProfiles();
     // Each section guards itself with `@if (().length)` so sections paint
     // independently as their data arrives. No global loading gate.
-    this.skeletonLayout.set(this.readLayout());
+    const cold = this.coldStart();
+    HomeComponent.skeletonShown = true;
+    if (cold) this.skeletonLayout.set(this.readLayout());
     await this.loadAllSections();
-    this.skeletonFadingOut.set(true);
-    this.loadingFirstPass.set(false);
-    // Long enough for the last zone's staggered fade to have started.
-    setTimeout(() => this.skeletonFadingOut.set(false), 900);
+    if (cold) {
+      this.skeletonFadingOut.set(true);
+      this.loadingFirstPass.set(false);
+      // Long enough for the last zone's staggered fade to have finished.
+      setTimeout(() => {
+        this.skeletonFadingOut.set(false);
+        this.coldStart.set(false);
+      }, 1200);
+    }
     this.captureLayout();
     // App-open SWR: the cache served Pass 1 above (instant render even on
     // a cold network). Now force a network round-trip so the user sees

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -130,9 +130,7 @@
      they're not relevant while the user is dragging the seek thumb and
      the preview is far more useful in that moment. -->
 <div
-  class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent transition-opacity duration-300 pt-12
-         [--ctrl-px:1rem] [--ctrl-pb:0.5rem]
-         sm:[--ctrl-pb:1rem] xl:[--ctrl-inset:1rem]"
+  class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent transition-opacity duration-300 pt-12"
   [class]="seekDragging() ? 'z-[55]' : 'z-40'"
   style="padding-left: calc(max(var(--ctrl-px), env(safe-area-inset-left)) + 0.25rem + var(--ctrl-inset, 0px)); padding-right: calc(max(var(--ctrl-px), env(safe-area-inset-right)) + 0.25rem + var(--ctrl-inset, 0px)); padding-bottom: calc(max(var(--ctrl-pb), env(safe-area-inset-bottom)) + var(--ctrl-inset, 0px));"
   [class.opacity-0]="!visible()"
@@ -277,8 +275,8 @@
   <button
     #skipIntroBtn
     type="button"
-    class="btn btn-primary absolute right-6 z-50 shadow-lg overflow-hidden rounded-lg player-floating-cue"
-    style="right: 1.5rem; bottom: 8rem; right: max(1.5rem, env(safe-area-inset-right)); bottom: max(var(--cue-bottom, 8rem), calc(var(--cue-bottom, 8rem) + env(safe-area-inset-bottom)));"
+    class="btn btn-primary absolute z-50 shadow-lg overflow-hidden rounded-lg player-floating-cue"
+    [class.controls-visible]="visible()"
     (click)="skipIntro.emit()"
     (focus)="cueFocused.set(true)"
     (blur)="cueFocused.set(false)"
@@ -299,8 +297,8 @@
 @if (showPreRollSkip()) {
   <button
     type="button"
-    class="btn btn-primary absolute right-6 z-50 shadow-lg overflow-hidden rounded-lg player-floating-cue"
-    style="right: 1.5rem; bottom: 8rem; right: max(1.5rem, env(safe-area-inset-right)); bottom: max(var(--cue-bottom, 8rem), calc(var(--cue-bottom, 8rem) + env(safe-area-inset-bottom)));"
+    class="btn btn-primary absolute z-50 shadow-lg overflow-hidden rounded-lg player-floating-cue"
+    [class.controls-visible]="visible()"
     (click)="skipPreRoll.emit()"
   >
     <span class="relative flex items-center gap-2">
@@ -315,8 +313,8 @@
   <button
     #nextEpisodeBtn
     type="button"
-    class="btn btn-primary absolute right-6 z-50 shadow-lg overflow-hidden rounded-lg player-floating-cue"
-    style="right: 1.5rem; bottom: 8rem; right: max(1.5rem, env(safe-area-inset-right)); bottom: max(var(--cue-bottom, 8rem), calc(var(--cue-bottom, 8rem) + env(safe-area-inset-bottom)));"
+    class="btn btn-primary absolute z-50 shadow-lg overflow-hidden rounded-lg player-floating-cue"
+    [class.controls-visible]="visible()"
     (click)="next.emit()"
     (focus)="cueFocused.set(true)"
     (blur)="cueFocused.set(false)"
@@ -435,7 +433,7 @@
       <div class="py-2 px-1">
         <!-- Quality row → opens sub-panel -->
         @if (availableQualities().length > 1) {
-          <button class="w-full flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm text-white hover:bg-white/10" (click)="openSettingsPanel('quality')">
+          <button data-panel-row="quality" class="w-full flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm text-white hover:bg-white/10" (click)="openSettingsPanel('quality')">
             <span class="flex-1 text-left">{{ 'player.quality' | translate }}</span>
             <span class="flex items-center gap-1 text-white/50 text-xs">
               {{ activeQualityLabel() }}
@@ -446,7 +444,7 @@
         }
         <!-- Queue row → opens sub-panel -->
         @if (queueItems().length > 1) {
-          <button class="w-full flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm text-white hover:bg-white/10" (click)="openSettingsPanel('queue')">
+          <button data-panel-row="queue" class="w-full flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm text-white hover:bg-white/10" (click)="openSettingsPanel('queue')">
             <span class="flex-1 text-left">{{ 'player.queue' | translate }}</span>
             <span class="text-white/50 text-xs">{{ queueIndex() + 1 }} / {{ queueItems().length }}</span>
             <svg lucideChevronRight class="h-4 w-4 text-white/40 shrink-0"></svg>
@@ -547,7 +545,8 @@
       @if (!castConnected()) {
         <button
           type="button"
-          class="absolute -top-1.5 right-1 focus-keep-position btn btn-ghost btn-xs btn-circle text-white/60 hover:text-white"
+          data-panel-row="appearance"
+          class="absolute -top-1.5 right-1 btn btn-ghost btn-xs btn-circle text-white/60 hover:text-white"
           [attr.aria-label]="'player.appearance' | translate"
           (click)="openSubtitlesPanel('appearance')"
         >
@@ -590,7 +589,7 @@
     </button>
     <div class="divider my-0 before:bg-white/10 after:bg-white/10"></div>
     @for (row of appearanceRows; track row.panel) {
-      <button class="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-white hover:bg-white/10 active:bg-white/10" (click)="openSubtitlesPanel(row.panel)">
+      <button [attr.data-panel-row]="row.panel" class="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-white hover:bg-white/10 active:bg-white/10" (click)="openSubtitlesPanel(row.panel)">
         <span class="flex-1 text-left">{{ row.labelKey | translate }}</span>
         @if (currentOption(row); as current) {
           <span class="text-white/50 text-xs">{{ current.labelKey ? (current.labelKey | translate) : current.label }}</span>

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -117,6 +117,9 @@ interface AppearanceRow {
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './player-controls.html',
+  // Bar insets live on the host so the floating cues inherit them and line up
+  // with the controls' right edge.
+  host: { class: '[--ctrl-px:1rem] [--ctrl-pb:0.5rem] sm:[--ctrl-pb:1rem] xl:[--ctrl-inset:1rem]' },
 })
 export class PlayerControlsComponent {
   private readonly device = inject(DeviceService);
@@ -147,10 +150,7 @@ export class PlayerControlsComponent {
     // panel before falling through to "leave the player".
     effect((onCleanup) => {
       if (!this.openDropdown()) return;
-      const close = () => {
-        this.closeDropdown();
-        this.dropdownTrigger?.focus({ preventScroll: true });
-      };
+      const close = () => this.dropdownBack();
       this.dismissStack.push(close);
       onCleanup(() => this.dismissStack.remove(close));
     });
@@ -440,14 +440,16 @@ export class PlayerControlsComponent {
   /** Navigate the subtitles menu. Focus is pulled into the new panel because
    *  the switch destroys the row the user was standing on (D-pad / keyboard). */
   openSubtitlesPanel(panel: SubtitlePanel) {
+    const from = this.subtitlesPanel();
     this.subtitlesPanel.set(panel);
-    if (this.openDropdown()) this.focusDropdownEntry();
+    if (this.openDropdown()) this.focusDropdownEntry(from);
   }
 
   /** Same as {@link openSubtitlesPanel} for the settings menu. */
   openSettingsPanel(panel: 'main' | 'quality' | 'queue') {
+    const from = this.settingsPanel();
     this.settingsPanel.set(panel);
-    if (this.openDropdown()) this.focusDropdownEntry();
+    if (this.openDropdown()) this.focusDropdownEntry(from);
   }
 
   /**
@@ -528,6 +530,20 @@ export class PlayerControlsComponent {
     if (!isBack) return;
     e.preventDefault();
     e.stopPropagation();
+    this.dropdownBack();
+  }
+
+  /** One step back inside the open dropdown: a sub-panel returns to its parent,
+   *  the root panel closes the menu and hands focus back to its trigger. */
+  private dropdownBack() {
+    if (this.openDropdown() === 'settings' && this.settingsPanel() !== 'main') {
+      this.openSettingsPanel('main');
+      return;
+    }
+    if (this.openDropdown() === 'subtitles' && this.subtitlesPanel() !== 'tracks') {
+      this.openSubtitlesPanel(this.activeAppearanceRow() ? 'appearance' : 'tracks');
+      return;
+    }
     this.closeDropdown();
     this.dropdownTrigger?.focus({ preventScroll: true });
   }
@@ -576,11 +592,17 @@ export class PlayerControlsComponent {
     this.subtitlesPanel.set('tracks');
   }
 
-  private focusDropdownEntry() {
+  /** `fromPanel` is the panel being left: when the new panel holds the row that
+   *  opens it (`data-panel-row`), focus returns there instead of the first
+   *  item. */
+  private focusDropdownEntry(fromPanel?: string) {
     afterNextRender(
       () => {
         const panel = this.hostEl.nativeElement.querySelector<HTMLElement>('.dropdown-open .dropdown-content');
-        initialOverlayFocus(panel)?.focus({ preventScroll: true });
+        const back = fromPanel
+          ? panel?.querySelector<HTMLElement>(`[data-panel-row="${fromPanel}"]`)
+          : null;
+        (back ?? initialOverlayFocus(panel))?.focus({ preventScroll: true });
       },
       { injector: this.injector },
     );

--- a/client/src/app/features/player/overlay/player-stats-overlay.html
+++ b/client/src/app/features/player/overlay/player-stats-overlay.html
@@ -1,11 +1,11 @@
 @if (visible()) {
   <div class="absolute z-50 bg-black/85 text-white select-none backdrop-blur-sm shadow-2xl overflow-y-auto
-              bottom-20 left-4 text-sm p-5 rounded-xl min-w-[320px] max-w-md max-h-[60vh]
-              max-sm:bottom-0 max-sm:left-0 max-sm:right-0 max-sm:text-xs max-sm:p-3 max-sm:rounded-none max-sm:min-w-0 max-sm:max-w-none max-sm:max-h-[50vh]">
+              top-28 left-4 text-sm p-5 rounded-xl min-w-[320px] max-w-md max-h-[60vh]
+              max-sm:top-16 max-sm:left-0 max-sm:right-0 max-sm:text-xs max-sm:p-3 max-sm:rounded-none max-sm:min-w-0 max-sm:max-w-none max-sm:max-h-[50vh]">
 
     <button
       type="button"
-      class="absolute top-2 right-2 text-white/60 hover:text-white text-lg leading-none cursor-pointer sm:top-3 sm:right-3"
+      class="btn btn-ghost btn-xs btn-circle absolute top-2 right-2 text-white/60 hover:text-white text-lg leading-none sm:top-3 sm:right-3"
       [attr.aria-label]="'player.close' | translate"
       (click)="close.emit()"
     >&times;</button>

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -201,7 +201,7 @@ class PausableTimeout {
     }
     /* Lift native subtitles by the user's configured bottom margin
        (--cue-bottom-margin, set per-video by applySubtitleStyle), and bump
-       another 5vh when the controls bar is visible so cues clear it. We
+       further when the controls bar is visible so cues clear it. We
        toggle the class directly on the <video> — toggling on an ancestor
        isn't always enough to trigger a style recalc on UA-shadow
        pseudo-elements in Chromium. WebKit pseudo covers Chromium + Safari
@@ -211,7 +211,7 @@ class PausableTimeout {
       transform: translateY(calc(-1 * var(--cue-bottom-margin, 0vh)));
     }
     .player-video.controls-visible::-webkit-media-text-track-display {
-      transform: translateY(calc(-1 * var(--cue-bottom-margin, 0vh) - 15vh));
+      transform: translateY(calc(-1 * var(--cue-bottom-margin, 0vh) - 20vh));
     }
   `],
 })

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -283,16 +283,22 @@ body.native.hero-page {
     animation: none;
     width: 0;
   }
+
+  .player-floating-cue {
+    transition: none;
+  }
 }
 
-/* Mobile landscape: the viewport is short, so the cue's portrait 8rem offset
-   strands it high on screen (most visible once the controls bar auto-hides).
-   Short + wide identifies a phone in landscape; drop the cue nearer the
-   bottom edge there. --cue-bottom feeds the button's inline bottom offset. */
-@media (orientation: landscape) and (max-height: 600px) {
-  .player-floating-cue {
-    --cue-bottom: 4.5rem;
-  }
+/* The cue sits low while the controls are hidden and lifts clear of the
+   controls bar when it comes up, mirroring the subtitle shift. */
+.player-floating-cue {
+  --cue-bottom: 5rem;
+  right: calc(max(var(--ctrl-px, 1rem), env(safe-area-inset-right)) + 0.25rem + var(--ctrl-inset, 0px));
+  bottom: max(var(--cue-bottom), calc(var(--cue-bottom) + env(safe-area-inset-bottom)));
+  transition: bottom 200ms ease;
+}
+.player-floating-cue.controls-visible {
+  --cue-bottom: 10.5rem;
 }
 
 /* ============================================================================
@@ -418,7 +424,8 @@ body:not(.keyboard-modality):not(.tv) app-mosaic-card button:focus-visible .mosa
     0 0 0 2px var(--color-base-100, #1d232a),
     0 0 0 4px var(--color-primary, #7a3ff2);
   z-index: 1;
-  position: relative;
+  /* Never set `position` here: it would re-anchor an absolutely placed
+     focusable (a modal ✕, a floating cue) and make it jump on focus. */
 }
 /* Over the video, the ring's inner `--color-base-100` layer has nothing to
    blend into — it reads as a black circle around every control. On the player
@@ -437,21 +444,10 @@ app-player-controls :is(a, button, select, input, [role="button"], [tabindex]):f
     @apply rounded-lg;
   }
 }
-/* The floating player cues position themselves absolutely via inline right /
-   bottom offsets. The generic ring above forces `position: relative` (and a low
-   z-index), which would re-anchor those offsets to the cue's in-flow origin and
-   fling it off-screen — re-assert its own placement so the ring decorates it in
-   situ. Same specificity as the rule above, so source order settles it. */
+/* The cues sit above the controls bar, so the ring's low z-index would drop
+   them behind it while focused. */
 .player-floating-cue:focus-visible {
-  position: absolute;
   z-index: 50;
-}
-/* Same trap as `.player-floating-cue` above, made reusable: the focus ring
-   forces `position: relative` so its z-index applies, which re-anchors an
-   absolutely-placed control to its in-flow origin and makes it jump on focus.
-   Opt out here and keep the element's own placement. */
-.focus-keep-position:focus-visible {
-  position: absolute;
 }
 
 /* A scroll container clips at its padding box, and as soon as one axis
@@ -459,10 +455,12 @@ app-player-controls :is(a, button, select, input, [role="button"], [tabindex]):f
    off the left and right edges of any full-width focusable inside one.
    Reserve the ring's 4px and pull it straight back out of the layout, so the
    content keeps its original alignment. Put it on the scrolling element.
-   Horizontal only: a negative vertical margin would pull the container's own
-   first child (a menu title) up out of its padding. */
+   Vertical side is padding only: a negative block margin would let scrolled
+   content bleed over the element above (often a menu title). `scroll-py` makes
+   D-pad `scrollIntoView({block:'nearest'})` stop 4px short so it uncovers the
+   ring instead of aligning the item flush with the clipped edge. */
 .scroll-ring-safe {
-  @apply px-1 -mx-1;
+  @apply px-1 -mx-1 py-1 scroll-py-1;
 }
 
 /* Opt-out for focusables that paint their own focus affordance (e.g.
@@ -941,7 +939,7 @@ body.tablet [data-touch-only] {
   transform: translateY(calc(-1 * var(--cue-bottom-margin, 0vh)));
 }
 .player-video.controls-visible ~ .shaka-text-container {
-  transform: translateY(calc(-1 * var(--cue-bottom-margin, 0vh) - 10vh));
+  transform: translateY(calc(-1 * var(--cue-bottom-margin, 0vh) - 15vh));
 }
 /* Visual styling applies to the leaf text span (Shaka tags it with
    `translate="no"` and bakes a default background-color inline on it).


### PR DESCRIPTION
## Home: the section fade-in replayed on every return

The home route is `reuse: true`, so a back-navigation re-attaches the same
component instance. `ngOnInit` never runs again, but re-inserting the detached
subtree restarts every CSS animation still declared on it, so the staggered
fade-in played on each return and delayed content that was already in hand.

A `coldStart` gate now drives both the skeleton and the stagger class, and it is
cleared once the first reveal has finished. The class is out of the DOM before a
re-attach can replay it, and a warm return renders cached data immediately with
no placeholder flash.

## Player: Back closed the whole menu from any depth

Leaving a subtitle appearance leaf threw the user out of the overlay instead of
returning to the list they came from. Back and Escape now unwind one panel per
press and only close at the root.

Focus follows the same path: `data-panel-row` marks the row that opened a panel,
so returning lands on that row rather than on the first item. This matters on a
D-pad, where the pointer cannot recover its position on its own.

## Player: the floating cues drifted out of line with the controls bar

The cues carried their offsets inline and duplicated the controls bar padding
maths, so the two edges disagreed. The insets move to the component host and both
inherit them, and the cue offset becomes a CSS variable that shifts when the bar
is visible, mirroring the subtitle lift.

That also retires the landscape media query, whose fixed offset stranded the cue
high on short viewports once the bar auto-hid.

## Focus ring no longer re-anchors absolute elements

The generic ring forced `position: relative` so its z-index would apply, which
re-anchored any absolutely placed focusable and made it jump on focus. The cues
and the stats overlay close button each opted out by hand. The declaration is
gone and the cues keep an explicit z-index so the ring does not drop them behind
the bar.

`scroll-ring-safe` gains vertical padding and a matching scroll padding, so D-pad
scrolling stops short of the clipped edge and uncovers the ring instead of
aligning the focused item flush with it.

## Verification

`ng build` passes and `tsc --noEmit` is clean. Behaviour on a real TV and on a
phone in landscape still needs a device pass.