### PR TITLE
feat(player): raise a seek-only OSD on an arrow-key scrub

### DIFF
--- a/client/src/app/core/services/playback-engine/tizen-engine.ts
+++ b/client/src/app/core/services/playback-engine/tizen-engine.ts
@@ -295,7 +295,11 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
     this.emit('stateChanged', { state: 'buffering' });
   }
   private handleBufferingComplete(): void {
-    if (!this._paused) this.emit('stateChanged', { state: 'playing' });
+    // AVPlay fires this while PAUSED too (seekTo is valid from PAUSED, and the
+    // buffering callbacks are state-independent). Emitting nothing there left
+    // `buffering` latched with no other path to clear it, so a paused seek sat
+    // on the spinner until the user pressed play.
+    this.emit('stateChanged', { state: this._paused ? 'paused' : 'playing' });
   }
   private handleCurrentPlayTime(ms: number): void {
     this._currentTime = ms / 1000;

--- a/client/src/app/core/services/playback-engine/webos-engine.ts
+++ b/client/src/app/core/services/playback-engine/webos-engine.ts
@@ -123,8 +123,10 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
       if (!v.ended) this.emit('stateChanged', { state: 'paused' });
     });
     add('waiting', () => this.emit('stateChanged', { state: 'buffering' }));
+    // Same as Tizen: a paused seek has no other path to clear `buffering`, and
+    // `play()` clears `v.paused` synchronously, so this can't race the intent.
     add('canplay', () => {
-      if (!v.paused) this.emit('stateChanged', { state: 'playing' });
+      this.emit('stateChanged', { state: v.paused ? 'paused' : 'playing' });
     });
     add('timeupdate', () => {
       // Drop the optimistic seek target once the real clock catches up to it.

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -4,79 +4,81 @@
 @if (openDropdown()) {
   <div class="fixed inset-0 z-30" (click)="closeDropdown($event)"></div>
 }
-<!-- ===== TOP BAR ===== -->
-<div
-  class="absolute top-0 left-0 right-0 z-40 flex items-center justify-between bg-gradient-to-b from-black/70 to-transparent transition-opacity duration-300 py-5
-         [--ctrl-px:1rem] portrait:[--ctrl-px:0.5rem] xl:[--ctrl-inset:1rem]"
-  style="padding-left: calc(max(var(--ctrl-px), env(safe-area-inset-left)) + var(--ctrl-inset, 0px)); padding-right: calc(max(var(--ctrl-px), env(safe-area-inset-right)) + var(--ctrl-inset, 0px)); padding-top: calc(env(safe-area-inset-top, 0px) + var(--ctrl-py) + var(--ctrl-inset, 0px));"
-  [style.--ctrl-py]="isMobileTouch() ? '0.25rem' : '1.25rem'"
-  [class.opacity-0]="!visible()"
-  [class.pointer-events-none]="!visible()"
->
-  <!-- Left: back + title -->
-  <div class="flex items-center gap-1 min-w-0">
-    <button type="button" class="btn btn-ghost btn-circle btn-md text-white" [attr.aria-label]="'player.back' | translate" (click)="back.emit()">
-      <!-- lucide:chevron-left -->
-      <svg lucideChevronLeft [class]="isMobileTouch() ? 'h-5 w-5' : 'h-6 w-6'"></svg>
-    </button>
-    <!-- Clearlogo only — no title fallback. When the media has no logo (or its
-         image 404s) the slot stays empty rather than reverting to title text. -->
-    @if (showLogo()) {
-      <img [cachedSrc]="logoUrl()! | resolveUrl:'medium'" [alt]="mediaTitle()" (error)="onLogoError()"
-           class="h-7 w-auto max-w-[50vw] object-contain object-left [filter:drop-shadow(0_1px_2px_rgb(0_0_0/0.45))]" />
-    }
-  </div>
+@if (!seekOsd()) {
+  <!-- ===== TOP BAR ===== -->
+  <div
+    class="player-controls-reveal [--reveal-from:-0.5rem] absolute top-0 left-0 right-0 z-40 flex items-center justify-between bg-gradient-to-b from-black/70 to-transparent transition-opacity duration-300 py-5
+           [--ctrl-px:1rem] portrait:[--ctrl-px:0.5rem] xl:[--ctrl-inset:1rem]"
+    style="padding-left: calc(max(var(--ctrl-px), env(safe-area-inset-left)) + var(--ctrl-inset, 0px)); padding-right: calc(max(var(--ctrl-px), env(safe-area-inset-right)) + var(--ctrl-inset, 0px)); padding-top: calc(env(safe-area-inset-top, 0px) + var(--ctrl-py) + var(--ctrl-inset, 0px));"
+    [style.--ctrl-py]="isMobileTouch() ? '0.25rem' : '1.25rem'"
+    [class.opacity-0]="!visible()"
+    [class.pointer-events-none]="!visible()"
+  >
+    <!-- Left: back + title -->
+    <div class="flex items-center gap-1 min-w-0">
+      <button type="button" class="btn btn-ghost btn-circle btn-md text-white" [attr.aria-label]="'player.back' | translate" (click)="back.emit()">
+        <!-- lucide:chevron-left -->
+        <svg lucideChevronLeft [class]="isMobileTouch() ? 'h-5 w-5' : 'h-6 w-6'"></svg>
+      </button>
+      <!-- Clearlogo only — no title fallback. When the media has no logo (or its
+           image 404s) the slot stays empty rather than reverting to title text. -->
+      @if (showLogo()) {
+        <img [cachedSrc]="logoUrl()! | resolveUrl:'medium'" [alt]="mediaTitle()" (error)="onLogoError()"
+             class="h-7 w-auto max-w-[50vw] object-contain object-left [filter:drop-shadow(0_1px_2px_rgb(0_0_0/0.45))]" />
+      }
+    </div>
 
-  <!-- Right -->
-  <div class="flex items-center" [class]="isMobileTouch() ? 'gap-1' : 'gap-1.5'">
-    @if (!isMobileTouch() && !isTv()) {
-      <input
-        type="range"
-        class="range range-xs w-28 opacity-70 hover:opacity-100"
-        [attr.aria-label]="'player.volume' | translate"
-        [min]="0"
-        [max]="1"
-        [step]="0.05"
-        [value]="displayVolume()"
-        (input)="onVolumeChange($event)"
-      />
-      <button type="button" class="btn btn-ghost btn-md btn-circle text-white" [attr.aria-label]="'player.volume' | translate" (click)="toggleMute.emit()">
-        @if (muted() || volume() === 0) {
-          <!-- lucide:volume-x -->
-          <svg lucideVolumeX class="h-6 w-6"></svg>
-        } @else {
-          <!-- lucide:volume-2 -->
-          <svg lucideVolume2 class="h-6 w-6"></svg>
-        }
-      </button>
-    }
-    @if (canLockOrientation()) {
-      <button type="button" class="btn btn-ghost btn-circle text-white btn-md" [attr.aria-label]="(orientationLocked() ? 'player.orientation_unlock' : 'player.orientation_lock') | translate" [attr.aria-pressed]="orientationLocked()" (click)="toggleOrientationLock.emit()">
-        @if (orientationLocked()) {
-          <svg lucideLock [class]="isMobileTouch() ? 'h-5 w-5' : 'h-6 w-6'"></svg>
-        } @else {
-          <svg lucideLockOpen [class]="isMobileTouch() ? 'h-5 w-5' : 'h-6 w-6'"></svg>
-        }
-      </button>
-    }
-    <!-- lucide:picture-in-picture-2 — hidden on TV (no PiP on Android TV) and when permission is revoked -->
-    @if (!isTv() && pipAvailable()) {
-      <button type="button" class="btn btn-ghost btn-circle text-white btn-md" [attr.aria-label]="'player.pip' | translate" (click)="togglePip.emit()">
-        <svg lucidePictureInPicture2 [class]="isMobileTouch() ? 'h-5 w-5' : 'h-6 w-6'"></svg>
-      </button>
-    }
-    <!-- Cast -->
-    @if (castAvailable()) {
-      <button type="button" class="btn btn-ghost btn-circle btn-md" [class.text-info]="castConnected()" [class.text-white]="!castConnected() && !castConnecting()" [disabled]="castConnecting()" (click)="toggleCast.emit()">
-        @if (castConnecting()) {
-          <span class="loading loading-spinner loading-md"></span>
-        } @else {
-          <svg lucideCast [class]="isMobileTouch() ? 'h-5 w-5' : 'h-6 w-6'"></svg>
-        }
-      </button>
-    }
+    <!-- Right -->
+    <div class="flex items-center" [class]="isMobileTouch() ? 'gap-1' : 'gap-1.5'">
+      @if (!isMobileTouch() && !isTv()) {
+        <input
+          type="range"
+          class="range range-xs w-28 opacity-70 hover:opacity-100"
+          [attr.aria-label]="'player.volume' | translate"
+          [min]="0"
+          [max]="1"
+          [step]="0.05"
+          [value]="displayVolume()"
+          (input)="onVolumeChange($event)"
+        />
+        <button type="button" class="btn btn-ghost btn-md btn-circle text-white" [attr.aria-label]="'player.volume' | translate" (click)="toggleMute.emit()">
+          @if (muted() || volume() === 0) {
+            <!-- lucide:volume-x -->
+            <svg lucideVolumeX class="h-6 w-6"></svg>
+          } @else {
+            <!-- lucide:volume-2 -->
+            <svg lucideVolume2 class="h-6 w-6"></svg>
+          }
+        </button>
+      }
+      @if (canLockOrientation()) {
+        <button type="button" class="btn btn-ghost btn-circle text-white btn-md" [attr.aria-label]="(orientationLocked() ? 'player.orientation_unlock' : 'player.orientation_lock') | translate" [attr.aria-pressed]="orientationLocked()" (click)="toggleOrientationLock.emit()">
+          @if (orientationLocked()) {
+            <svg lucideLock [class]="isMobileTouch() ? 'h-5 w-5' : 'h-6 w-6'"></svg>
+          } @else {
+            <svg lucideLockOpen [class]="isMobileTouch() ? 'h-5 w-5' : 'h-6 w-6'"></svg>
+          }
+        </button>
+      }
+      <!-- lucide:picture-in-picture-2 — hidden on TV (no PiP on Android TV) and when permission is revoked -->
+      @if (!isTv() && pipAvailable()) {
+        <button type="button" class="btn btn-ghost btn-circle text-white btn-md" [attr.aria-label]="'player.pip' | translate" (click)="togglePip.emit()">
+          <svg lucidePictureInPicture2 [class]="isMobileTouch() ? 'h-5 w-5' : 'h-6 w-6'"></svg>
+        </button>
+      }
+      <!-- Cast -->
+      @if (castAvailable()) {
+        <button type="button" class="btn btn-ghost btn-circle btn-md" [class.text-info]="castConnected()" [class.text-white]="!castConnected() && !castConnecting()" [disabled]="castConnecting()" (click)="toggleCast.emit()">
+          @if (castConnecting()) {
+            <span class="loading loading-spinner loading-md"></span>
+          } @else {
+            <svg lucideCast [class]="isMobileTouch() ? 'h-5 w-5' : 'h-6 w-6'"></svg>
+          }
+        </button>
+      }
+    </div>
   </div>
-</div>
+}
 
 <!-- ===== CENTER OVERLAY (tap zone) =====
      z-30 so the bottom bar (z-40) stays clickable. Tall titles + seekbar
@@ -93,9 +95,9 @@
      The play/pause button is kept in the layout (only `invisible`) while
      loading/buffering so the seek arrows don't slide inward — the centered
      spinner overlay sits in its place. -->
-@if (isMobileTouch() && videoStarted()) {
+@if (isMobileTouch() && videoStarted() && !seekOsd()) {
   <div
-    class="absolute inset-0 z-50 flex items-center justify-center pointer-events-none transition-opacity duration-200"
+    class="player-controls-reveal [--reveal-from:0px] absolute inset-0 z-50 flex items-center justify-center pointer-events-none transition-opacity duration-200"
     [class.opacity-0]="!visible()"
   >
     <div class="flex items-center gap-6">
@@ -136,44 +138,46 @@
   [class.opacity-0]="!visible()"
   [class.pointer-events-none]="!visible()"
 >
-  <!-- Episode + Title + Mobile action buttons row. The row itself emits
-       tapOverlay so the empty gap between the title and the right-aligned
-       action buttons doubles as a "close controls" hit zone; the buttons
-       stop propagation so their own taps don't also dismiss. -->
-  <div class="flex items-end justify-between mb-0.5 gap-2" (click)="tapOverlay.emit()">
-    <div class="min-w-0 shrink">
-      @if (episodeTitle()) {
-        <div class="text-white/60 font-semibold truncate text-base sm:text-lg">{{ episodeTitle() }}</div>
-      }
-      <div class="text-white font-bold truncate text-2xl sm:text-3xl lg:text-4xl">{{ mediaTitle() }}</div>
-    </div>
-
-    <!-- Mobile: action buttons aligned right -->
-    @if (isMobileTouch()) {
-      <div class="flex items-center lg:gap-1 shrink-0" (click)="$event.stopPropagation()">
-        @if (hasNext()) {
-          <button type="button" class="btn btn-ghost btn-circle text-white/80" [attr.aria-label]="nextLabelKey() | translate" (click)="next.emit()">
-            <svg lucideSkipForward class="h-5 w-5"></svg>
-          </button>
+  @if (!seekOsd()) {
+    <!-- Episode + Title + Mobile action buttons row. The row itself emits
+         tapOverlay so the empty gap between the title and the right-aligned
+         action buttons doubles as a "close controls" hit zone; the buttons
+         stop propagation so their own taps don't also dismiss. -->
+    <div class="player-controls-reveal flex items-end justify-between mb-0.5 gap-2" (click)="tapOverlay.emit()">
+      <div class="min-w-0 shrink">
+        @if (episodeTitle()) {
+          <div class="text-white/60 font-semibold truncate text-base sm:text-lg">{{ episodeTitle() }}</div>
         }
-        @if (availableSubtitles().length > 0) {
-          <button type="button" class="btn btn-ghost btn-circle text-white/80" [attr.aria-label]="'player.subtitles' | translate" (click)="openSheet('subtitles')">
-            <svg lucideCaptions class="h-5 w-5"></svg>
-          </button>
-        }
-        @if (availableAudioTracks().length > 1) {
-          <button type="button" class="btn btn-ghost btn-circle text-white/80" [attr.aria-label]="'player.audio' | translate" (click)="openSheet('audio')">
-            <svg lucideHeadphones class="h-5 w-5"></svg>
-          </button>
-        }
-        <button type="button" class="btn btn-ghost btn-circle text-white/80" [attr.aria-label]="'player.speed' | translate" (click)="openSheet('speed')">{{ playbackRate() }}x</button>
-        <button type="button" class="btn btn-ghost btn-circle text-white/80" [attr.aria-label]="'player.settings' | translate" (click)="openSheet('settings')">
-          <svg lucideSettings class="h-5 w-5"></svg>
-        </button>
-        <ng-container *ngTemplateOutlet="fullscreenBtn; context: { $implicit: 'md' }"></ng-container>
+        <div class="text-white font-bold truncate text-2xl sm:text-3xl lg:text-4xl">{{ mediaTitle() }}</div>
       </div>
-    }
-  </div>
+
+      <!-- Mobile: action buttons aligned right -->
+      @if (isMobileTouch()) {
+        <div class="flex items-center lg:gap-1 shrink-0" (click)="$event.stopPropagation()">
+          @if (hasNext()) {
+            <button type="button" class="btn btn-ghost btn-circle text-white/80" [attr.aria-label]="nextLabelKey() | translate" (click)="next.emit()">
+              <svg lucideSkipForward class="h-5 w-5"></svg>
+            </button>
+          }
+          @if (availableSubtitles().length > 0) {
+            <button type="button" class="btn btn-ghost btn-circle text-white/80" [attr.aria-label]="'player.subtitles' | translate" (click)="openSheet('subtitles')">
+              <svg lucideCaptions class="h-5 w-5"></svg>
+            </button>
+          }
+          @if (availableAudioTracks().length > 1) {
+            <button type="button" class="btn btn-ghost btn-circle text-white/80" [attr.aria-label]="'player.audio' | translate" (click)="openSheet('audio')">
+              <svg lucideHeadphones class="h-5 w-5"></svg>
+            </button>
+          }
+          <button type="button" class="btn btn-ghost btn-circle text-white/80" [attr.aria-label]="'player.speed' | translate" (click)="openSheet('speed')">{{ playbackRate() }}x</button>
+          <button type="button" class="btn btn-ghost btn-circle text-white/80" [attr.aria-label]="'player.settings' | translate" (click)="openSheet('settings')">
+            <svg lucideSettings class="h-5 w-5"></svg>
+          </button>
+          <ng-container *ngTemplateOutlet="fullscreenBtn; context: { $implicit: 'md' }"></ng-container>
+        </div>
+      }
+    </div>
+  }
 
   <!-- Progress bar -->
   <app-seekbar
@@ -196,8 +200,8 @@
   </div>
 
   <!-- Desktop: buttons row BELOW duration -->
-  @if (!isMobileTouch()) {
-    <div class="flex items-center justify-between mt-2 mb-1">
+  @if (!isMobileTouch() && !seekOsd()) {
+    <div class="player-controls-reveal flex items-center justify-between mt-2 mb-1">
       <!-- Left: playback controls -->
       <div class="flex items-center gap-1.5">
         <!-- lucide:rotate-ccw -->
@@ -277,6 +281,7 @@
     type="button"
     class="btn btn-primary absolute z-50 shadow-lg overflow-hidden rounded-lg player-floating-cue"
     [class.controls-visible]="visible()"
+    [class.controls-seek]="visible() && seekOsd()"
     (click)="skipIntro.emit()"
     (focus)="cueFocused.set(true)"
     (blur)="cueFocused.set(false)"
@@ -299,6 +304,7 @@
     type="button"
     class="btn btn-primary absolute z-50 shadow-lg overflow-hidden rounded-lg player-floating-cue"
     [class.controls-visible]="visible()"
+    [class.controls-seek]="visible() && seekOsd()"
     (click)="skipPreRoll.emit()"
   >
     <span class="relative flex items-center gap-2">
@@ -315,6 +321,7 @@
     type="button"
     class="btn btn-primary absolute z-50 shadow-lg overflow-hidden rounded-lg player-floating-cue"
     [class.controls-visible]="visible()"
+    [class.controls-seek]="visible() && seekOsd()"
     (click)="next.emit()"
     (focus)="cueFocused.set(true)"
     (blur)="cueFocused.set(false)"

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -164,8 +164,8 @@ export class PlayerControlsComponent {
       this.lastVisible = visible;
       // Focus play/pause when the bar appears under keyboard / D-pad so the
       // next Enter/Space toggles playback. Skipped for pointer (mouse-revealed
-      // controls shouldn't steal focus). An arrow-seek re-focuses the seekbar
-      // afterwards (player.focusSeekbar), which wins the deferred race.
+      // controls shouldn't steal focus). The seek OSD renders no play/pause, so
+      // an arrow-seek keeps the focus scrubFromKey put on the seekbar.
       if (visible && !wasVisible && this.autoFocusModality()) {
         this.closeDropdown();
         this.playPauseBtn()?.nativeElement.focus({ preventScroll: true });
@@ -256,6 +256,9 @@ export class PlayerControlsComponent {
   readonly isMobileTouch = computed(() => this.playerLayout() === 'mobile');
 
   readonly visible = input(true);
+  /** Reduced bar: only the seekbar and the time row. Raised by an arrow-key
+   *  seek, the way TV players surface a scrub OSD instead of the toolbar. */
+  readonly seekOsd = input(false);
   readonly paused = input(true);
   readonly loading = input(false);
   readonly buffering = input(false);
@@ -299,8 +302,6 @@ export class PlayerControlsComponent {
   /** Desktop (Electron) — native engine but mouse-driven; keeps the fullscreen
    *  button which is otherwise hidden for native (mobile/TV) engines. */
   readonly isDesktop = input(false);
-  readonly subtitlePickerOpen = input(false);
-  readonly qualityPickerOpen = input(false);
   readonly availableSubtitles = input<{ id: string; label: string; menuHead?: string; menuSub?: string; burnIn?: boolean; isImage?: boolean }[]>([]);
   readonly availableQualities = input<{ id: string; label: string; lowBandwidth?: boolean }[]>([]);
   readonly activeSubtitleId = input<string | null>(null);
@@ -349,9 +350,7 @@ export class PlayerControlsComponent {
   readonly toggleFullscreen = output<void>();
   readonly togglePip = output<void>();
   readonly toggleOrientationLock = output<void>();
-  readonly toggleSubtitlePicker = output<void>();
   readonly toggleStats = output<void>();
-  readonly toggleQualityPicker = output<void>();
   readonly selectSubtitle = output<string | null>();
   readonly selectQuality = output<string>();
   /** Play the queue item at this index (picked from the queue list). */
@@ -467,9 +466,13 @@ export class PlayerControlsComponent {
 
   readonly seekbar = viewChild(SeekbarComponent);
 
-  /** Focus the seekbar track (used when an arrow press wakes hidden controls). */
-  focusSeekbar(): void {
-    this.seekbar()?.focus();
+  /** Wake-and-scrub: focus the seekbar and let it own the press, so the whole
+   *  arrow run accumulates into one deferred seek instead of one per key. */
+  scrubFromKey(e: KeyboardEvent): void {
+    const bar = this.seekbar();
+    if (!bar) return;
+    bar.focus();
+    bar.onKeydown(e);
   }
   /** Desktop/TV play-pause button — focused on TV every time the controls
    *  bar reappears, so the next D-pad center triggers play/pause. */

--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -50,6 +50,7 @@
     playsinline
     [class.opacity-0]="!videoStarted()"
     [class.controls-visible]="controlsVisible()"
+    [class.controls-seek]="controlsVisible() && seekOsd()"
     [style.object-fit]="fillScreen() ? 'cover' : 'contain'"
   ></video>
 
@@ -117,6 +118,7 @@
   <app-player-controls
     (interacted)="onControlsInteraction()"
     [visible]="controlsVisible()"
+    [seekOsd]="seekOsd()"
     [paused]="paused()"
     [loading]="loading()"
     [buffering]="buffering()"

--- a/client/src/app/features/player/player.spec.ts
+++ b/client/src/app/features/player/player.spec.ts
@@ -521,3 +521,70 @@ describe('PlayerComponent wake / resume', () => {
     expect(h.component.preparing()).toBe(false);
   });
 });
+
+describe('PlayerComponent seek OSD', () => {
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  const press = (key: string) =>
+    ({ key, keyCode: 0, target: document.body, preventDefault: vi.fn(), stopPropagation: vi.fn() }) as unknown as KeyboardEvent;
+
+  function hiddenBar() {
+    const h = createHarness();
+    const scrubFromKey = vi.fn();
+    h.component.controls = () => ({ scrubFromKey });
+    h.component.onSeek = vi.fn();
+    h.component.controlsVisible.set(false);
+    h.component.seekOsd.set(false);
+    return { ...h, scrubFromKey };
+  }
+
+  it('an arrow on a hidden bar raises the seek-only OSD and hands the press to the seekbar', () => {
+    const h = hiddenBar();
+
+    h.component.onKeyDown(press('ArrowRight'));
+
+    expect(h.component.controlsVisible()).toBe(true);
+    expect(h.component.seekOsd()).toBe(true);
+    // The seekbar owns the scrub: no per-key seek fired from the player.
+    expect(h.scrubFromKey).toHaveBeenCalledTimes(1);
+    expect(h.component.onSeek).not.toHaveBeenCalled();
+  });
+
+  it('a further arrow keeps the OSD, any other key escalates to the full bar', () => {
+    const h = hiddenBar();
+
+    h.component.onKeyDown(press('ArrowLeft'));
+    h.component.onKeyDown(press('ArrowLeft'));
+    expect(h.component.seekOsd()).toBe(true);
+
+    h.component.onKeyDown(press('a'));
+    expect(h.component.seekOsd()).toBe(false);
+    expect(h.component.controlsVisible()).toBe(true);
+  });
+
+  it('hiding from the OSD fades out as-is, without flashing the full bar in', () => {
+    const h = hiddenBar();
+
+    h.component.onKeyDown(press('ArrowRight'));
+    h.component.hideControls();
+
+    expect(h.component.controlsVisible()).toBe(false);
+    // The tier survives the hide: clearing it here would remount every full-bar
+    // row for the length of the fade-out.
+    expect(h.component.seekOsd()).toBe(true);
+    expect(h.component.nativeSubtitleBottomBump()).toBe(0);
+  });
+
+  it('cues clear a smaller bar in OSD mode, and sit flush once it hides', () => {
+    const h = hiddenBar();
+    expect(h.component.nativeSubtitleBottomBump()).toBe(0);
+
+    h.component.onKeyDown(press('ArrowRight'));
+    expect(h.component.nativeSubtitleBottomBump()).toBe(5);
+
+    h.component.showControls();
+    expect(h.component.nativeSubtitleBottomBump()).toBe(10);
+  });
+});

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -392,6 +392,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
    *  off the moment playback actually starts, and the auto-hide
    *  timer takes over from there during the rest of the session. */
   readonly controlsVisible = signal(true);
+  /** Controls reduced to the seekbar + times, raised by an arrow-key seek.
+   *  Any other input escalates back to the full bar via `showControls()`. */
+  readonly seekOsd = signal(false);
   readonly inPipMode = signal(false);
   readonly pipAvailable = signal(true);
   readonly canLockOrientation = Capacitor.getPlatform() === 'ios';
@@ -400,8 +403,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   readonly statsVisible = signal(false);
   readonly fillScreen = signal(false);
   private readonly statsRefreshTick = signal(0);
-  readonly subtitlePickerOpen = signal(false);
-  readonly qualityPickerOpen = signal(false);
   /** True when any panel inside <app-player-controls> (desktop dropdown or
    *  mobile bottom sheet) is open — pins the controls open. */
   private readonly controlsPanelOpen = signal(false);
@@ -417,8 +418,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       this.paused() ||
       this.buffering() ||
       this.seekDragging() ||
-      this.subtitlePickerOpen() ||
-      this.qualityPickerOpen() ||
       this.controlsPanelOpen(),
   );
   /** Single owner of the auto-hide countdown. Arms only while the bar is
@@ -606,7 +605,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   /** Re-apply native subtitle style on controls show/hide so the bottom-margin
       bump kicks in. Browser playback uses CSS instead — see styles below. */
   private readonly subtitleControlsMarginEffect = effect(() => {
-    this.controlsVisible();
+    this.nativeSubtitleBottomBump();
     // webOS drives the same DOM subtitle overlay as the native engines but
     // reports isNativeEngine=false (it keeps the Shaka UX), so it needs an
     // explicit branch — otherwise the margin stays pinned at its load-time
@@ -1892,7 +1891,8 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  showControls() {
+  showControls(seekOsd = false) {
+    this.seekOsd.set(seekOsd);
     this.controlsVisible.set(true);
     this.resetHideTimer();
   }
@@ -1906,11 +1906,11 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     if (this.device.isDpad() && !this.controlsVisible()) this.showControls();
   }
 
-  /** Move focus to the seekbar after the controls bar has rendered/become
-   *  visible. Deferred so it lands after the controls' own "focus play/pause on
-   *  reappear" effect, which would otherwise win the focus race on TV. */
-  private focusSeekbar() {
-    setTimeout(() => this.controls()?.focusSeekbar(), 0);
+  /** Extra bottom margin (vh) keeping native-renderer cues clear of the bar —
+   *  halved for the seek OSD, which is a fraction of the full bar's height. */
+  private nativeSubtitleBottomBump(): number {
+    if (!this.controlsVisible()) return 0;
+    return this.seekOsd() ? 5 : 10;
   }
 
   private hideControls() {
@@ -1953,8 +1953,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   }
 
   private isDropdownOpen(): boolean {
-    // Check via signals (reliable on mobile)
-    if (this.subtitlePickerOpen() || this.qualityPickerOpen()) return true;
     // Click-driven dropdowns / bottom sheets owned by <app-player-controls>.
     // Reported via (panelOpenChange) so we don't depend on DOM focus.
     if (this.controlsPanelOpen()) return true;
@@ -3604,12 +3602,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     this.availableSubtitles.set(subs);
   }
 
-  /**
-   * Apply user's subtitle style settings to native engine. When the player
-   * controls are visible, bumps the bottom margin by 10vh so cues don't sit
-   * under the controls bar — the WebKit `::cue` shift used in browser mode
-   * doesn't apply on ExoPlayer/AVPlayer.
-   */
+  /** Apply the user's subtitle style to a native engine, plus the bar-clearance
+   *  bump — the WebKit `::cue` shift used in browser mode doesn't apply on
+   *  ExoPlayer/AVPlayer. */
   private applyNativeSubtitleStyle() {
     // Subtitle styling on engines that own their own renderer:
     // NativeEngine (ExoPlayer/AVPlayer) and TizenEngine (DOM overlay
@@ -3620,7 +3615,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       return;
     }
     const s = this.playerSettings.get();
-    const extraMargin = this.controlsVisible() ? 10 : 0;
+    const extraMargin = this.nativeSubtitleBottomBump();
     (this.engine as NativeEngine).setSubtitleStyle({
       size: s.subtitleSize,
       color: s.subtitleColor,
@@ -3817,7 +3812,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     if (!sub) {
       try { this.engine.setTextVisibility(false); } catch {}
       this.activeSubtitleId.set(null);
-      this.subtitlePickerOpen.set(false);
       this.trackManager.saveSubtitleSelection(this.mediaId, null);
       if (!this.isOfflinePlayback && this.activeBurnInId) {
         this.activeBurnInId = null;
@@ -3833,7 +3827,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     if (sub.burnIn && sub.subtitleDbId) {
       this.activeBurnInId = sub.subtitleDbId;
       this.activeSubtitleId.set(sub.id);
-      this.subtitlePickerOpen.set(false);
       // Persist like the soft/off branches do, so a burn-in pick is restored
       // on reload / next episode instead of silently reverting.
       this.trackManager.saveSubtitleSelection(
@@ -3875,8 +3868,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     }
 
     this.activeSubtitleId.set(sub.id);
-    this.subtitlePickerOpen.set(false);
-
     this.trackManager.saveSubtitleSelection(this.mediaId, sub.language, sub.forced, sub.id.startsWith('emb-'), sub.isImage);
   }
 
@@ -3916,18 +3907,15 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     const activeEl = document.activeElement as HTMLElement | null;
     const cueFocused = !!activeEl?.closest('.player-floating-cue');
 
-    // Controls hidden + Left/Right: wake the bar, seek, and land focus on the
-    // seekbar so the next presses scrub it — on every device (keyboard + TV
-    // remote), matching the seekbar-focused scrub when the bar is already up.
-    if (
-      !this.controlsVisible() &&
-      (e.key === 'ArrowLeft' || e.key === 'ArrowRight')
-    ) {
-      this.showControls();
-      this.onSeek(this.engine.currentTime + (e.key === 'ArrowLeft' ? -10 : 10));
-      this.focusSeekbar();
+    // Controls hidden + Left/Right: raise the seek-only OSD and hand the press
+    // to the seekbar, which owns the scrub from there (accelerating step, one
+    // deferred seek for the whole run) on keyboard and TV remote alike.
+    const isSeekArrow = e.key === 'ArrowLeft' || e.key === 'ArrowRight';
+    if (!this.controlsVisible() && isSeekArrow) {
       e.preventDefault();
       e.stopPropagation();
+      this.showControls(true);
+      this.controls()?.scrubFromKey(e);
       return;
     }
 
@@ -3968,30 +3956,25 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         e.preventDefault();
         this.onTogglePlay();
         break;
-      // Each seek below goes through showControls(): the bar is already up, so
-      // this only restarts the countdown and marks it as deliberately revealed.
-      // Without that, a seek made while the stream is still loading restarts it,
-      // and the first-frame effect snaps the bar shut under the user.
+      // The trailing showControls() restarts the countdown for every seek
+      // below; without it a seek made while the stream is still loading lets
+      // the first-frame effect snap the bar shut under the user.
       case 'ArrowLeft':
         if (!arrowSeekAllowed) break;
         e.preventDefault();
-        this.showControls();
         this.onSeek(this.engine.currentTime - 10);
         break;
       case 'ArrowRight':
         if (!arrowSeekAllowed) break;
         e.preventDefault();
-        this.showControls();
         this.onSeek(this.engine.currentTime + 10);
         break;
       case 'j':
         e.preventDefault();
-        this.showControls();
         this.onSeek(this.engine.currentTime - 30);
         break;
       case 'l':
         e.preventDefault();
-        this.showControls();
         this.onSeek(this.engine.currentTime + 30);
         break;
       case 'f':
@@ -4036,7 +4019,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // `onPlayerBackEvent` then saw controls visible and only hid them
     // — so Return-on-TV looked stuck. A focused cue is likewise left
     // alone: acting on it shouldn't drag the whole bar onto the screen.
-    if (!isBackKey && !cueFocused) this.showControls();
+    if (!isBackKey && !cueFocused) this.showControls(isSeekArrow && this.seekOsd());
   };
 
   // ── Event handlers ──
@@ -4132,11 +4115,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       const sub = this.availableSubtitles().find(s => s.id === id) ?? null;
       this.selectSubtitle(sub);
     }
-  }
-
-  onToggleQualityPicker() {
-    this.qualityPickerOpen.set(!this.qualityPickerOpen());
-    this.subtitlePickerOpen.set(false);
   }
 
   // ── Private helpers ──

--- a/client/src/app/shared/components/seekbar/seekbar.html
+++ b/client/src/app/shared/components/seekbar/seekbar.html
@@ -15,7 +15,7 @@
   (keyup)="onKeyup($event)"
 >
   <!-- Seek tooltip -->
-  @if (showTooltip() && (hovering() || dragging()) && duration()) {
+  @if (showTooltip() && previewVisible() && duration()) {
     <div
       class="absolute bottom-full mb-3 pointer-events-none z-50"
       [style.left]="tooltipLeft()"
@@ -35,14 +35,14 @@
               ></div>
               <div class="absolute bottom-0 inset-x-0 text-center pb-0.5 pt-2 bg-gradient-to-t from-black/70 to-transparent">
                 <span class="text-white text-xs tabular-nums font-medium drop-shadow">
-                  {{ formatTime(dragging() ? dragTime() : hoverTime()) }}
+                  {{ formatTime(previewTime()) }}
                 </span>
               </div>
             </div>
           } @else {
             <div class="px-3 py-1 text-center">
               <span class="text-white text-xs tabular-nums font-medium">
-                {{ formatTime(dragging() ? dragTime() : hoverTime()) }}
+                {{ formatTime(previewTime()) }}
               </span>
             </div>
           }

--- a/client/src/app/shared/components/seekbar/seekbar.spec.ts
+++ b/client/src/app/shared/components/seekbar/seekbar.spec.ts
@@ -1,0 +1,60 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { vi, afterEach, beforeEach, describe, it, expect } from 'vitest';
+import { SeekbarComponent } from './seekbar';
+
+/** Keyboard scrubbing has no cursor to hold the preview open, so the tooltip
+ *  lingers on a timer instead. These drive the component directly. */
+describe('SeekbarComponent keyboard preview', () => {
+  let bar: SeekbarComponent;
+
+  const arrow = (key: 'ArrowLeft' | 'ArrowRight') =>
+    ({ key, preventDefault: vi.fn(), stopPropagation: vi.fn() }) as unknown as KeyboardEvent;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
+    const fixture = TestBed.createComponent(SeekbarComponent);
+    bar = fixture.componentInstance;
+    fixture.componentRef.setInput('duration', 600);
+    fixture.componentRef.setInput('currentTime', 100);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    TestBed.resetTestingModule();
+  });
+
+  it('outlives the key release, then retires on its own', () => {
+    bar.onKeydown(arrow('ArrowRight'));
+    bar.onKeyup(arrow('ArrowRight'));
+
+    // The drag is committed, but the preview is still up on the target.
+    expect(bar.dragging()).toBe(false);
+    expect(bar.previewVisible()).toBe(true);
+    expect(bar.previewTime()).toBe(110);
+
+    vi.advanceTimersByTime(2300);
+    expect(bar.previewVisible()).toBe(false);
+  });
+
+  it('a run of presses coalesces into one seek and keeps one preview alive', () => {
+    const seeks: number[] = [];
+    bar.seek.subscribe((t) => seeks.push(t));
+
+    // Inside the 250ms commit backstop, so the run accumulates.
+    for (let i = 0; i < 3; i++) {
+      bar.onKeydown(arrow('ArrowRight'));
+      vi.advanceTimersByTime(100);
+      expect(bar.previewVisible()).toBe(true);
+    }
+    bar.onKeyup(arrow('ArrowRight'));
+
+    expect(seeks).toEqual([130]);
+    // Still up well past the last press, then retires.
+    vi.advanceTimersByTime(1500);
+    expect(bar.previewVisible()).toBe(true);
+    vi.advanceTimersByTime(1000);
+    expect(bar.previewVisible()).toBe(false);
+  });
+});

--- a/client/src/app/shared/components/seekbar/seekbar.ts
+++ b/client/src/app/shared/components/seekbar/seekbar.ts
@@ -48,6 +48,27 @@ export class SeekbarComponent {
   readonly seekPending = signal(false);
   private seekTarget = 0;
 
+  /** Keyboard / D-pad scrub holds the preview open: there is no cursor parked
+   *  on the bar to keep it alive the way a pointer drag has, so it would blink
+   *  away the instant the key lifts. */
+  readonly keyScrubbing = signal(false);
+  private keyPreviewTimer: ReturnType<typeof setTimeout> | null = null;
+  private static readonly KEY_PREVIEW_LINGER_MS = 2200;
+
+  /** Tooltip (time + sprite frame) is up while the user points at the bar,
+   *  drags it, or has just scrubbed it with the keyboard. */
+  readonly previewVisible = computed(
+    () => this.hovering() || this.dragging() || this.keyScrubbing(),
+  );
+
+  /** The instant the preview describes: the drag target while scrubbing, the
+   *  committed target while the seek settles, the pointer otherwise. */
+  readonly previewTime = computed(() => {
+    if (this.dragging()) return this.dragTime();
+    if (this.keyScrubbing()) return this.displayTime();
+    return this.hoverTime();
+  });
+
   // Hover state
   readonly hovering = signal(false);
   readonly hoverTime = signal(0);
@@ -159,7 +180,7 @@ export class SeekbarComponent {
     const meta = this.spriteMetadata();
     if (!meta) return '0 0';
     const s = this.previewScale();
-    const time = this.dragging() ? this.dragTime() : this.hoverTime();
+    const time = this.previewTime();
     const index = Math.min(Math.floor(time / meta.interval), meta.count - 1);
     const col = index % meta.columns;
     const row = Math.floor(index / meta.columns);
@@ -175,7 +196,7 @@ export class SeekbarComponent {
   });
 
   readonly tooltipLeft = computed(() => {
-    const pct = this.dragging() ? this.displayPercent() : this.hoverPercent();
+    const pct = this.dragging() || this.keyScrubbing() ? this.displayPercent() : this.hoverPercent();
     // Centre the tooltip on the seek point (the element carries
     // `-translate-x-1/2`). Plain `%` only — a CSS min()/calc() cap is ignored
     // by Tizen's older Chromium in `left`, which left the preview stuck
@@ -190,6 +211,7 @@ export class SeekbarComponent {
 
     try { bar.setPointerCapture(event.pointerId); } catch {}
 
+    this.endKeyPreview();
     this.dragging.set(true);
     this.dragChange.emit(true);
     this.updateDragFromPointer(event, bar);
@@ -276,12 +298,14 @@ export class SeekbarComponent {
         e.preventDefault();
         e.stopPropagation();
         this.cancelScrubTimer();
+        this.holdKeyPreview();
         this.commitScrubTo(0);
         return;
       case 'End':
         e.preventDefault();
         e.stopPropagation();
         this.cancelScrubTimer();
+        this.holdKeyPreview();
         this.commitScrubTo(Math.max(0, dur - 1));
         return;
       default:
@@ -290,6 +314,7 @@ export class SeekbarComponent {
 
     e.preventDefault();
     e.stopPropagation();
+    this.holdKeyPreview();
 
     if (!this.dragging()) {
       this.scrubStartedAt = Date.now();
@@ -318,6 +343,22 @@ export class SeekbarComponent {
     if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
     this.cancelScrubTimer();
     this.commitScrub();
+  }
+
+  /** Restart the linger on every press, so a run of arrows keeps one preview up. */
+  private holdKeyPreview() {
+    this.keyScrubbing.set(true);
+    if (this.keyPreviewTimer) clearTimeout(this.keyPreviewTimer);
+    this.keyPreviewTimer = setTimeout(
+      () => this.endKeyPreview(),
+      SeekbarComponent.KEY_PREVIEW_LINGER_MS,
+    );
+  }
+
+  private endKeyPreview() {
+    if (this.keyPreviewTimer) clearTimeout(this.keyPreviewTimer);
+    this.keyPreviewTimer = null;
+    this.keyScrubbing.set(false);
   }
 
   private cancelScrubTimer() {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -287,6 +287,22 @@ body.native.hero-page {
   .player-floating-cue {
     transition: none;
   }
+
+  .player-controls-reveal {
+    animation: none;
+  }
+}
+
+/* Plays whenever a controls row mounts — i.e. when the seek OSD escalates to
+   the full bar. `--reveal-from` points the slide at the nearest screen edge. */
+@keyframes player-controls-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(var(--reveal-from, 0.5rem));
+  }
+}
+.player-controls-reveal {
+  animation: player-controls-reveal 200ms ease-out;
 }
 
 /* The cue sits low while the controls are hidden and lifts clear of the
@@ -299,6 +315,10 @@ body.native.hero-page {
 }
 .player-floating-cue.controls-visible {
   --cue-bottom: 10.5rem;
+}
+/* Middle rung: the seek OSD is a fraction of the full bar's height. */
+.player-floating-cue.controls-seek {
+  --cue-bottom: 7rem;
 }
 
 /* ============================================================================
@@ -940,6 +960,9 @@ body.tablet [data-touch-only] {
 }
 .player-video.controls-visible ~ .shaka-text-container {
   transform: translateY(calc(-1 * var(--cue-bottom-margin, 0vh) - 15vh));
+}
+.player-video.controls-seek ~ .shaka-text-container {
+  transform: translateY(calc(-1 * var(--cue-bottom-margin, 0vh) - 6vh));
 }
 /* Visual styling applies to the leaf text span (Shaka tags it with
    `translate="no"` and bakes a default background-color inline on it).


### PR DESCRIPTION
## What

An arrow press on hidden player controls used to unfold the whole toolbar and fire one independent 10s seek per key. A long scrub was therefore a run of separate seeks behind a bar covering the picture.

The press is now handed straight to the seekbar, which already owns an accelerating step and a single deferred commit, and the bar renders as a reduced OSD — seekbar plus the time row, nothing else. Any other input escalates to the full bar, whose rows fade/slide in on mount.

## Changes

- `player.ts`: `seekOsd` signal; `showControls(seekOsd = false)`; the hidden-bar arrow branch calls `controls().scrubFromKey(e)` instead of seeking itself. The per-key `showControls()` calls in the visible-bar seek cases collapse into one trailing call.
- `player-controls.ts`: `seekOsd` input; `focusSeekbar()` becomes `scrubFromKey()` (focus, then forward the press so the seekbar accumulates the run).
- `player-controls.html`: every full-bar row gated behind `!seekOsd()`; rows carry `player-controls-reveal` so escalation animates.
- `seekbar.ts`: keyboard/D-pad scrub now shows the preview tooltip. A `KEY_PREVIEW_LINGER_MS` timer restarted on each press keeps one preview up for the whole run — there is no cursor parked on the bar to keep it alive the way a pointer drag has. `previewVisible` / `previewTime` replace the three inlined `dragging() ? … : …` ternaries.
- `styles.css`: `controls-seek` clearance rung for floating cues and the Shaka text container; `player-controls-reveal` keyframes (disabled under `prefers-reduced-motion`).
- Dead code: `subtitlePickerOpen` / `qualityPickerOpen` signals, their inputs, their `toggle*` outputs and `onToggleQualityPicker()` were unreachable — nothing bound them.

### Paused-seek spinner (AVPlay + webOS)

Both engines emitted a state on their buffering-complete callback only when not paused. A seek is valid from PAUSED, so a paused seek left `buffering` latched with no other path to clear it and the spinner sat there until the user pressed play. Both now emit the actual state.

## Tests

20 specs pass (`ng test --include='**/player.spec.ts' --include='**/seekbar.spec.ts'`) — 4 new player specs covering the OSD tier (raise, escalate, hide-without-flash, cue clearance) and the new `seekbar.spec.ts` for the keyboard preview linger. `ng build` and `tsc --noEmit` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)