### PR TITLE
fix(tv): repair the Samsung rendering the Chromium 85 gaps broke

### DIFF
--- a/client/postcss/tv-color-mix-alpha.cjs
+++ b/client/postcss/tv-color-mix-alpha.cjs
@@ -1,0 +1,72 @@
+/**
+ * Restore the alpha on Tailwind's `/NN` colour variants for Chromium 85.
+ *
+ * `bg-base-300/40` compiles to `color-mix(in oklab, var(--color-base-300) 40%,
+ * transparent)`. preset-env cannot resolve through the `var()`, so the fallback
+ * it emits is the bare colour: the alpha is dropped and the TV paints at 100 %
+ * — solid skeleton blocks, opaque `.divider` bars, black instead of dimmed
+ * scrims, every `text-base-content/50` at full contrast.
+ *
+ * Emit a `--color-X-rgb: r, g, b` companion beside each literal `--color-X` and
+ * rewrite the mix to `rgba(var(--color-X-rgb), .4)`, which Chromium 85 parses.
+ * Must run after preset-env, which is what turns the themes' `oklch()` values
+ * into the `rgb()` ones this reads. Mixing an opaque colour with `transparent`
+ * is just that colour at N% alpha, so the rewrite is exact, not an approximation.
+ *
+ * Literal mixes (`color-mix(in srgb, #fff 20%, transparent)`) already get a
+ * computed fallback from preset-env and are left alone, as is any mix this
+ * can't express: `currentColor`, or a second colour that isn't transparent.
+ */
+const CHANNELS =
+  /^rgba?\(\s*([\d.]+)[\s,]+([\d.]+)[\s,]+([\d.]+)\s*(?:[,/]\s*(?:1|1?\.0+|100%)\s*)?\)$/;
+const HEX = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+/** `r, g, b` for a colour Chromium 85 can already parse, else null. */
+function toChannels(value) {
+  const v = value.trim();
+  const m = CHANNELS.exec(v);
+  if (m) return `${m[1]}, ${m[2]}, ${m[3]}`;
+  const h = HEX.exec(v);
+  if (!h) return null;
+  const hex =
+    h[1].length === 3
+      ? h[1]
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : h[1];
+  const n = parseInt(hex, 16);
+  return `${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}`;
+}
+
+const MIX =
+  /color-mix\(\s*(?:in\s+[\w-]+\s*,\s*)?var\(\s*(--color-[\w-]+)\s*\)\s+([\d.]+)%\s*,\s*(?:transparent|#0000|rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\))\s*\)/gi;
+
+module.exports = () => ({
+  postcssPlugin: 'tv-color-mix-alpha',
+  // OnceExit, not Once: PostCSS interleaves plugin visitors, so the `rgb()`
+  // theme fallbacks this reads only exist once preset-env has finished.
+  OnceExit: (root) => {
+    // A companion per declaration, not one global set, so the `-rgb` var
+    // follows whichever theme block wins the cascade.
+    const known = new Set();
+    root.walkDecls(/^--color-/, (decl) => {
+      if (decl.prop.endsWith('-rgb')) return;
+      const channels = toChannels(decl.value);
+      if (!channels) return;
+      known.add(decl.prop);
+      decl.cloneAfter({ prop: `${decl.prop}-rgb`, value: channels });
+    });
+    if (known.size === 0) return;
+
+    root.walkDecls((decl) => {
+      if (!decl.value.includes('color-mix(')) return;
+      decl.value = decl.value.replace(MIX, (whole, name, pct) =>
+        known.has(name)
+          ? `rgba(var(${name}-rgb), ${+(Number(pct) / 100).toFixed(4)})`
+          : whole,
+      );
+    });
+  },
+});
+module.exports.postcss = true;

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -66,9 +66,8 @@
             @for (lib of displayLibraries(); track lib.id) {
               <a [routerLink]="libraryUrl(lib)"
                  [attr.data-home-focus]="'library:' + lib.id"
-                 class="shrink-0 w-36 h-20 sm:w-48 sm:h-28 rounded-xl border flex items-center gap-3 px-4 sm:px-5 hover:shadow-lg transition-shadow"
-                 [style.background]="'linear-gradient(135deg, color-mix(in oklch, ' + libraryColor(lib) + ' 20%, transparent), color-mix(in oklch, ' + libraryColor(lib) + ' 5%, transparent))'"
-                 [style.border-color]="'color-mix(in oklch, ' + libraryColor(lib) + ' 15%, transparent)'"
+                 class="library-card shrink-0 w-36 h-20 sm:w-48 sm:h-28 rounded-xl flex items-center gap-3 px-4 sm:px-5 hover:shadow-lg transition-shadow"
+                 [style.--lib-color]="libraryColor(lib)"
               >
                 <app-lucide-icon [name]="lib.icon || 'library'" class="h-6 w-6 sm:h-8 sm:w-8 shrink-0" [style.color]="libraryColor(lib)" />
                 <span class="text-sm sm:text-base font-semibold">{{ lib.name }}</span>

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -226,8 +226,12 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly skeletonFadingOut = signal(false);
   readonly showSkeleton = computed(() => this.loadingFirstPass() || this.skeletonFadingOut());
 
+  /** Recent requests are hidden on TV: the card is an admin surface (approve /
+   *  decline, profile names) that the 10-foot UI isn't designed for. */
   readonly visibleSections = computed(() =>
-    this.sections().filter((s) => s.visible),
+    this.sections().filter(
+      (s) => s.visible && !(this.tv.isTv() && s.type === 'requests-recent'),
+    ),
   );
 
   qualityProfileDisplay(id: number | null): string {

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -324,12 +324,8 @@
       <div class="grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-6 gap-1.5 sm:gap-4 tv:gap-8 pt-2"
         [class.pr-10]="sortBy() === 'title' && sortOrder() === 'ASC'"
         [class.pr-2]="sortBy() !== 'title' || sortOrder() !== 'ASC'">
-        @for (i of jumpSkeletons; track i) {
-          <div class="animate-pulse">
-            <div class="aspect-2/3 bg-base-300/40 rounded-lg"></div>
-            <div class="mt-2 h-4 w-3/4 bg-base-300/40 rounded"></div>
-            <div class="mt-1 h-3 w-1/3 bg-base-300/40 rounded"></div>
-          </div>
+        @for (i of skeletonCards; track i) {
+          <app-card-skeleton class="animate-pulse" [aspect]="'portrait'" />
         }
       </div>
     } @else if (list.all().length === 0) {
@@ -458,8 +454,25 @@
     }
   } @else if (viewMode() === 'suggestions') {
     @if (suggestionsLoading()) {
-      <div class="flex justify-center py-12">
-        <span class="loading loading-spinner loading-lg"></span>
+      <!-- The tab opens on a scroller row above the recommendations grid;
+           stand in for both rather than guess which sections have data. -->
+      <div class="flex flex-col gap-8 animate-pulse">
+        <div class="flex flex-col gap-3">
+          <div class="h-6 w-48 bg-base-300/40 rounded"></div>
+          <div class="flex gap-2 lg:gap-4 overflow-hidden">
+            @for (i of skeletonRow; track i) {
+              <app-card-skeleton class="shrink-0 w-48 sm:w-56 lg:w-72" [aspect]="'landscape'" />
+            }
+          </div>
+        </div>
+        <div class="flex flex-col gap-3">
+          <div class="h-6 w-48 bg-base-300/40 rounded"></div>
+          <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-6 gap-1.5 sm:gap-4 tv:gap-8">
+            @for (i of skeletonCards; track i) {
+              <app-card-skeleton [aspect]="'portrait'" />
+            }
+          </div>
+        </div>
       </div>
     } @else {
       <!-- Recommended by other members (personal inbox, not library-scoped). -->
@@ -539,8 +552,10 @@
       </span>
     </div>
     @if (genresLoading() && !genresList().length) {
-      <div class="flex justify-center py-12">
-        <span class="loading loading-spinner loading-lg"></span>
+      <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 tv:grid-cols-6 gap-3 sm:gap-4 tv:gap-8 animate-pulse">
+        @for (i of skeletonCards; track i) {
+          <app-card-skeleton [aspect]="'square'" />
+        }
       </div>
     } @else if (!genresList().length) {
       <div class="text-center py-24 text-base-content/50">
@@ -567,7 +582,11 @@
       {{ 'library.collections_count' | translate:{ count: collectionsList().length } }}
     </p>
     @if (collectionsLoading() && !collectionsList().length) {
-      <div class="flex justify-center py-16"><span class="loading loading-spinner loading-lg"></span></div>
+      <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 tv:grid-cols-6 gap-3 sm:gap-4 tv:gap-8 animate-pulse">
+        @for (i of skeletonCards; track i) {
+          <app-card-skeleton [aspect]="'square'" />
+        }
+      </div>
     } @else if (!collectionsList().length) {
       <div class="flex flex-col items-center justify-center py-16 gap-3 text-base-content/40">
         <svg lucideFilm class="w-12 h-12" [strokeWidth]="1.5"></svg>
@@ -587,8 +606,10 @@
     }
   } @else if (viewMode() === 'likes') {
     @if (likesLoading() && !likesList().length) {
-      <div class="flex justify-center py-12">
-        <span class="loading loading-spinner loading-lg"></span>
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 3xl:grid-cols-8 tv:grid-cols-5 gap-3 sm:gap-4 tv:gap-8 animate-pulse">
+        @for (i of skeletonCards; track i) {
+          <app-card-skeleton [aspect]="'landscape'" />
+        }
       </div>
     } @else if (!likesList().length) {
       <div class="text-center py-24 text-base-content/50">

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -42,6 +42,7 @@ import { AppResumeService } from '../../core/services/app-resume.service';
 import { InfiniteScrollList } from '../../shared/utils/infinite-scroll-list';
 import { LucideSearch, LucideSlidersHorizontal, LucideArrowUp, LucideArrowDown, LucideX, LucideFilm } from '@lucide/angular';
 import { MosaicCardComponent } from '../../shared/components/mosaic-card/mosaic-card';
+import { CardSkeletonComponent } from '../../shared/components/card-skeleton';
 import { NgTemplateOutlet } from '@angular/common';
 import {
   CdkVirtualScrollViewport,
@@ -93,6 +94,7 @@ const NATURAL_ORDER_BY_SORT: Record<string, SortOrder> = {
     CdkFixedSizeVirtualScroll,
     CdkVirtualForOf,
     CdkVirtualScrollableWindow,
+    CardSkeletonComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './library.html',
@@ -133,7 +135,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
 
   readonly list = new InfiniteScrollList<Media>();
   readonly watchedIds = signal<Set<number>>(new Set());
-  readonly loading = signal(false);
+  readonly loading = signal(true);
   readonly searchQuery = signal('');
   readonly sortBy = signal('title');
   readonly sortOrder = signal<SortOrder>('ASC');
@@ -156,25 +158,25 @@ export class LibraryComponent implements OnInit, OnDestroy {
   readonly suggestionsFromFollowing = signal<RecommendationItem[]>([]);
   /** Content other members have recommended to the viewer. */
   readonly recommendedForYou = signal<ReceivedRecommendation[]>([]);
-  readonly suggestionsLoading = signal(false);
+  readonly suggestionsLoading = signal(true);
 
   // ── Genres view ─────────────────────────────────────────────────────
   /** Distinct genres in the library + sample posters for the mosaic. */
   readonly genresList = signal<GenreSummary[]>([]);
-  readonly genresLoading = signal(false);
+  readonly genresLoading = signal(true);
   /** When set, the `all` grid is filtered to this genre via the API's
    *  `genre=` param. Cleared with the chip's × button. */
   readonly selectedGenre = signal<string>('');
 
   // ── Collections view ────────────────────────────────────────────────
   readonly collectionsList = signal<CollectionSummary[]>([]);
-  readonly collectionsLoading = signal(false);
+  readonly collectionsLoading = signal(true);
   readonly selectedCollectionId = signal<number | null>(null);
 
   // ── Likes view ──────────────────────────────────────────────────────
   /** The viewer's liked content scoped to the active library. */
   readonly likesList = signal<LikedItem[]>([]);
-  readonly likesLoading = signal(false);
+  readonly likesLoading = signal(true);
 
   readonly monitoredCount = computed(() => this.list.all().filter((m) => m.monitored).length);
   readonly movieFileCount = computed(() =>
@@ -209,8 +211,10 @@ export class LibraryComponent implements OnInit, OnDestroy {
   /** The `all`-view card grid — measured for DOM windowing on TV. */
   private onResize?: () => void;
 
-  /** One screenful of placeholders for the alphabet-jump skeleton. */
-  protected readonly jumpSkeletons = Array.from({ length: 24 }, (_, i) => i);
+  /** Placeholder counts for the tab skeletons: a screenful for a grid, a row
+   *  for a horizontal scroller. */
+  protected readonly skeletonCards = Array.from({ length: 24 }, (_, i) => i);
+  protected readonly skeletonRow = Array.from({ length: 6 }, (_, i) => i);
 
   // ── CDK virtual scroll ───────────────────────────────────────────────────
   // The grid renders through `cdk-virtual-scroll-viewport` on every platform:
@@ -330,7 +334,10 @@ export class LibraryComponent implements OnInit, OnDestroy {
 
       const lib = this.allLibraries.find((l) => l.name === name);
       this.library.set(lib ?? null);
-      if (!lib) return;
+      if (!lib) {
+        this.stopLoading();
+        return;
+      }
 
       this.navbar.setPageTitle(lib.name);
 
@@ -750,9 +757,22 @@ export class LibraryComponent implements OnInit, OnDestroy {
     }
   }
 
+  /** Drop every tab out of its initial loading state — for the dead ends where
+   *  no fetch will follow, which would otherwise leave a skeleton up for good. */
+  private stopLoading() {
+    this.loading.set(false);
+    this.suggestionsLoading.set(false);
+    this.genresLoading.set(false);
+    this.collectionsLoading.set(false);
+    this.likesLoading.set(false);
+  }
+
   private async load(libraryId?: number, silent = false) {
     // Filters, search and sort all reflow the header above the grid.
-    if (!libraryId) return;
+    if (!libraryId) {
+      if (!silent) this.loading.set(false);
+      return;
+    }
     if (!silent) this.loading.set(true);
     const monitored = this.filterMonitored();
     const fs = this.filterStatus();

--- a/client/src/app/shared/components/card-skeleton.html
+++ b/client/src/app/shared/components/card-skeleton.html
@@ -1,0 +1,8 @@
+<div
+  class="bg-base-300/40 rounded-lg"
+  [class.aspect-2/3]="aspect() === 'portrait'"
+  [class.aspect-video]="aspect() === 'landscape'"
+  [class.aspect-square]="aspect() === 'square'"
+></div>
+<div class="mt-2 h-4 w-3/4 bg-base-300/40 rounded"></div>
+<div class="mt-1 h-3 w-1/3 bg-base-300/40 rounded"></div>

--- a/client/src/app/shared/components/card-skeleton.ts
+++ b/client/src/app/shared/components/card-skeleton.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+/**
+ * One card-shaped placeholder: art box plus a title and subtitle bar. Sized by
+ * its container, so the caller keeps its own grid or scroller classes and the
+ * placeholders land where the real cards will. Put `animate-pulse` on that
+ * container — it drives the shimmer and is what the TV WebView's
+ * `aspect-ratio` fallback keys off.
+ */
+@Component({
+  selector: 'app-card-skeleton',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './card-skeleton.html',
+  host: { class: 'block' },
+})
+export class CardSkeletonComponent {
+  /** Art ratio of the card being stood in for. */
+  readonly aspect = input<'portrait' | 'landscape' | 'square'>('portrait');
+}

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -51,16 +51,6 @@ export type CardStatus = 'watched' | 'missing' | null;
     CardActionsDirective, SpoilerDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-card.html',
-  // The art scales up on focus and would ride over the caption — slide the text
-  // clear. Component-scoped so every form factor gets it, not just the 10-foot UI.
-  styles: `
-    figure + div {
-      transition: transform 0.15s ease-out;
-    }
-    figure:focus-visible + div {
-      transform: translateY(0.6rem);
-    }
-  `,
 })
 export class MediaCardComponent {
   private readonly translate = inject(TranslateService);

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -73,6 +73,26 @@
   background-color: rgba(29, 35, 42, 0.95);
 }
 
+/* Home library pill. The tint and border are an overlay dimmed by `opacity`
+   rather than a `color-mix()` alpha, which the TV WebView can't parse. */
+.library-card {
+  position: relative;
+}
+.library-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border: 1px solid var(--lib-color);
+  border-radius: inherit;
+  background: linear-gradient(135deg, var(--lib-color), transparent);
+  opacity: 0.2;
+}
+/* Lift the icon and label over that overlay — it is a positioned child, so
+   static content would otherwise paint under it. */
+.library-card > * {
+  position: relative;
+}
+
 /* Router scroll-to-top on navigation goes through window.scrollTo, so smooth
    here animates the jump instead of teleporting. Scroll restores that must land
    instantly pass behavior:'instant'. */
@@ -191,17 +211,61 @@ body.native.hero-page {
 /* Browsers without `aspect-ratio` (the TV WebView's Chromium 85) ignore the
    poster figure's aspect-2/3, so it reserves no height and the lazy <img>
    only claims space once it decodes — every decode mid-scroll reflows the
-   whole non-virtualized library grid. Reserve the 2:3 box with the padding
-   ratio there and float the image into it, so a decode never resizes a cell.
-   Modern browsers keep the native aspect-ratio path (this block is skipped). */
+   whole non-virtualized library grid. A ratio `::before` reserves the box
+   instead, and the content is lifted out of the flow over it.
+   Modern browsers keep the native aspect-ratio path (this block is skipped).
+
+   The ratio goes on the pseudo-element rather than the box itself
+   (`height: 0` + `padding-bottom`): a zero-height content box breaks the
+   `overflow: hidden` + `border-radius` clip on this WebView, which square off
+   the corners of every card that rounds its art. */
 @supports not (aspect-ratio: 1 / 1) {
-  app-media-card figure.aspect-2\/3 {
-    height: 0;
+  app-media-card figure.aspect-2\/3::before,
+  .animate-pulse .aspect-2\/3::before {
+    content: '';
+    display: block;
     padding-bottom: 150%;
   }
-  app-media-card figure.aspect-2\/3 > img {
+  app-media-card figure.aspect-video::before,
+  .animate-pulse .aspect-video::before {
+    content: '';
+    display: block;
+    padding-bottom: 56.25%;
+  }
+  /* Mosaic art: playlists, genres, collections. */
+  .animate-pulse .aspect-square::before,
+  .mosaic-art::before {
+    content: '';
+    display: block;
+    padding-bottom: 100%;
+  }
+  /* `h-full` resolves to zero against the auto height the ::before produces, so
+     every layer that filled the box has to be positioned instead. */
+  app-media-card figure.aspect-2\/3 > img,
+  app-media-card figure.aspect-video > img,
+  .mosaic-art > * {
     position: absolute;
     inset: 0;
+  }
+  /* daisyUI's `.loading` takes its height from `aspect-ratio` alone, so without
+     it the spinner is zero-height. Mirror the width ladder it does set. */
+  .loading {
+    height: calc(var(--size-selector, 0.25rem) * 6);
+  }
+  .loading-xs {
+    height: calc(var(--size-selector, 0.25rem) * 4);
+  }
+  .loading-sm {
+    height: calc(var(--size-selector, 0.25rem) * 5);
+  }
+  .loading-md {
+    height: calc(var(--size-selector, 0.25rem) * 6);
+  }
+  .loading-lg {
+    height: calc(var(--size-selector, 0.25rem) * 7);
+  }
+  .loading-xl {
+    height: calc(var(--size-selector, 0.25rem) * 8);
   }
 }
 
@@ -518,6 +582,14 @@ body.tv [data-tv-focusable]:focus-visible,
 body.tv app-mosaic-card button:focus-visible .mosaic-art {
   transform: scale(1.06);
 }
+/* Slide the caption clear of the art the lift above scales over it. Global, not
+   component `styles:` — those bypass the downlevel `:focus-visible` → `:focus`. */
+app-media-card figure + div {
+  transition: transform 0.15s ease-out;
+}
+app-media-card figure:focus-visible + div {
+  transform: translateY(0.6rem);
+}
 
 /* Fade each row of a list in after the one above it. Applied to the CHILDREN
    rather than through a wrapper per row: a section that renders nothing must
@@ -658,6 +730,37 @@ body.tv app-mosaic-card button:focus-visible .mosaic-art {
     0 0 0 2px var(--color-base-100, #1d232a),
     0 0 0 6px var(--color-primary, #7a3ff2) !important;
 }
+/* Rounded corners without an ancestor clip. This WebView drops a `border-radius`
+   + `overflow: hidden` clip once the box is composited — the mosaic art is, both
+   from its own focus scale and from a child's fade — so the art squared off while
+   loading and while focus moved. Every layer rounds itself instead, which the
+   compositor always honours. The nth-child arms mirror mosaic-card's 2x2 grid:
+   each quadrant only rounds the corner of the card it actually sits in. */
+body.tv .mosaic-art > * {
+  border-radius: inherit;
+}
+body.tv .mosaic-art > * > img {
+  border-radius: 0;
+}
+body.tv .mosaic-art > * > img:nth-child(1) {
+  border-top-left-radius: inherit;
+}
+body.tv .mosaic-art > * > img:nth-child(2) {
+  border-top-right-radius: inherit;
+}
+body.tv .mosaic-art > * > img:nth-child(3) {
+  border-bottom-left-radius: inherit;
+}
+body.tv .mosaic-art > * > img:nth-child(4) {
+  border-bottom-right-radius: inherit;
+}
+/* One promotion source fewer, and the reveal stays (the art is still hidden
+   until it has decoded — only the 200 ms tween goes). */
+body.tv app-media-card figure img,
+body.tv .mosaic-art img {
+  transition: none !important;
+}
+
 /* Resting cards carry shadow-md (a blurred shadow) re-rasterised for every
    visible card on each scroll frame — drop it on TV; the focus ring is the
    only affordance the 10-foot UI needs. */

--- a/client/tizen/build-wgt.mjs
+++ b/client/tizen/build-wgt.mjs
@@ -48,9 +48,13 @@ for (const f of stylesFiles) {
 // Guard: a Chromium-85-unsafe token surviving the downlevel pass means a
 // pipeline gap (e.g. a new Tailwind feature) would ship a silently-broken WGT —
 // fail the build here instead. Each token below is one the pipeline is supposed
-// to have folded/flattened/dropped. (color-mix is intentionally NOT listed: its
-// @supports fallback path is kept on purpose.)
+// to have folded/flattened/dropped. (A bare color-mix is intentionally NOT
+// listed: its @supports fallback path is kept on purpose.)
 const UNSAFE_TOKENS = [
+  [
+    /color-mix\(\s*(?:in\s+[\w-]+\s*,\s*)?var\(\s*--color-[\w-]+\s*\)\s+[\d.]+%\s*,\s*(?:transparent|#0000|rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\))\s*\)/,
+    'alpha variant left on color-mix — `tv-color-mix-alpha` should have made it rgba()',
+  ],
   [/[;{](?:translate|rotate|scale):/, 'individual transform property — should fold into `transform`'],
   // Negative lookbehind excludes Tailwind's escaped container-query CLASSES
   // (`.\@container`, `.\@md\:…`) — only the real at-rules are unsafe.

--- a/client/tizen/downlevel-css.mjs
+++ b/client/tizen/downlevel-css.mjs
@@ -32,6 +32,7 @@ const require = createRequire(import.meta.url);
 const unwrapLayers = require(resolve(clientRoot, 'postcss/unwrap-layers.cjs'));
 const stripUnsupportedSelectors = require(resolve(clientRoot, 'postcss/strip-unsupported-selectors.cjs'));
 const tvFallbacks = require(resolve(clientRoot, 'postcss/tv-fallbacks.cjs'));
+const tvColorMixAlpha = require(resolve(clientRoot, 'postcss/tv-color-mix-alpha.cjs'));
 
 const processor = postcss([
   // preset-env handles the bulk: cascade-layer ordering via specificity
@@ -76,6 +77,9 @@ const processor = postcss([
   // Final pass: unwrap `:where()`, flatten `@container`, drop
   // `@starting-style`, `text-wrap`, and `cq*`-unit declarations.
   tvFallbacks(),
+  // Rebuild the alpha on Tailwind's `/NN` colour variants. Last, and after
+  // preset-env, which is what leaves the `rgb()` theme values it reads.
+  tvColorMixAlpha(),
 ]);
 
 export const downlevelCss = async (css, from) => {


### PR DESCRIPTION
Validated on the test TV (QE85Q80BATXXC, Tizen, Chromium 85) across several deploy rounds.

Every symptom reported on the TV traced back to three engine gaps, so the fixes sit at the cause rather than on each broken card.

## 1. `/NN` alpha variants lost their alpha entirely

`bg-base-content/5` compiles to `color-mix(in oklab, var(--color-base-content) 5%, transparent)`. preset-env cannot resolve through the `var()`, so the fallback it emitted was the *bare colour* — around **120 rules painted at 100%**:

- the "customise the home" card came out solid base-content (reported as "toute blanche")
- every daisyUI `.divider` and popover-menu separator: a bright bar instead of a hairline
- `bg-black/NN` scrims fully opaque
- skeleton blocks dark holes instead of a light tint
- every `text-base-content/NN` at full contrast

New pass [`postcss/tv-color-mix-alpha.cjs`](client/postcss/tv-color-mix-alpha.cjs) emits a `--color-X-rgb: r, g, b` companion beside each literal theme colour and rewrites the mix to `rgba(var(--color-X-rgb), .05)`. Mixing an opaque colour with `transparent` *is* that colour at N% alpha, so the rewrite is exact, not an approximation.

Two things worth knowing about it:

- It must run as **`OnceExit`, not `Once`** — PostCSS 8 interleaves plugin visitors, so the `rgb()` theme fallbacks it reads don't exist yet at `Once`. This failed the first build.
- It deliberately leaves alone what it can't express exactly: `currentColor` mixes, and mixes whose second colour isn't transparent (daisyUI's hover-darkening, which sits behind an `@supports` guard anyway). Literal mixes like `color-mix(in srgb, #fff 20%, transparent)` already get a computed fallback from preset-env.

`UNSAFE_TOKENS` in the wgt build now fails if a var-alpha `color-mix()` ever survives the pipeline again. It caught two real problems while iterating.

## 2. `aspect-ratio` is Chrome 88 — boxes sized by it alone had no height

- `.mosaic-art` → playlist, genre and collection cards (reported broken)
- skeleton placeholders on home, library and media-detail
- daisyUI's `.loading`, whose only sizing is `width` + `aspect-ratio: 1` — invisible spinner. Its masks were fine; autoprefixer emits `-webkit-mask-*`.

Handled in the existing `@supports not (aspect-ratio)` block, with the ratio on a **`::before`** rather than `height: 0` + `padding-bottom`: a zero-height content box is its own source of clipping bugs. Skeleton rules key off `.animate-pulse`, so all three pages are covered by one pair of selectors.

## 3. Rounded corners broke while compositing

The mosaic art drew its corners with an ancestor `border-radius` + `overflow: hidden` clip. This WebView drops that clip for a **composited child** — and focusing a card promotes it (the `scale(1.06)` lift) and squashes everything painted after it into layers too. So the art squared off on every card *past the focused one*, until the promotion was released, and again during each load fade.

Each layer now rounds itself, which the compositor always honours regardless of promotion. The `nth-child` arms mirror mosaic-card's 2x2 grid so each quadrant rounds only the card corner it occupies. The 200 ms art fade also goes on TV: one promotion source fewer and a little less raster on the SoC, while the reveal survives since the art stays hidden until it has decoded.

## Also in scope

- **Recent requests off the TV home** — an approve/decline admin surface with profile names, which the 10-foot UI was never designed for. Filtering it out of `visibleSections()` drops the row *and* its fetch, since both load paths read that signal.
- **Library tabs: spinners to skeletons.** New [`card-skeleton`](client/src/app/shared/components/card-skeleton.ts) is one card-shaped placeholder sized by its container, so each tab keeps its real grid classes and the placeholders land where the cards will. Genres and collections get the square mosaic grid, likes the 16:9 grid, suggestions a scroller row above the portrait grid. The `all` tab's inline skeleton moves to the same component. The one remaining `loading-spinner` in library.html is the in-button busy state on bulk-apply, where a skeleton would be wrong.
- **No more "no media" flash.** The five library loading signals started `false`, indistinguishable from "loaded and empty" — and resolving a library is itself a round-trip (`listMine()`), so the empty message painted for the whole gap. They now start `true`, with a `stopLoading()` for the dead ends (a URL naming no library; `load()` without an id) so a skeleton can't stick. This also fixed a case not yet reported: a `?view=genres` deep link flashed "no genres" for the length of the main grid's load, since `ngOnInit` awaits `load()` before calling `loadGenres()`.
- The media-card caption slide moves out of the component's `styles:` into the global sheet. Component styles are bundled into JS chunks that the downlevel pass never touches, so its `:focus-visible` was never rewritten to `:focus` and the rule was dead on TV.

## Verification

`tsc --noEmit` clean, web and tizen builds green, downlevel guard passes, 637/638 specs (the `plugin-catalogue` version-picker failure is pre-existing — it fails identically on a pristine worktree at `main`). Each fix was confirmed in the actual downlevelled stylesheet before deploying, not just in source.

## Known gap, not addressed here

`webos/build-ipk.mjs` runs **no downlevel pass at all**, so webOS ships the raw stylesheet and neither the alpha rewrite nor the `:focus-visible` rewrite reaches it. The `@supports` and corner-radius fixes work there regardless. Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)