### PR TITLE
feat(tv): slide the mosaic caption down on focus

### DIFF
--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -584,10 +584,12 @@ body.tv app-mosaic-card button:focus-visible .mosaic-art {
 }
 /* Slide the caption clear of the art the lift above scales over it. Global, not
    component `styles:` — those bypass the downlevel `:focus-visible` → `:focus`. */
-app-media-card figure + div {
+app-media-card figure + div,
+app-mosaic-card .mosaic-art + div {
   transition: transform 0.15s ease-out;
 }
-app-media-card figure:focus-visible + div {
+app-media-card figure:focus-visible + div,
+app-mosaic-card button:focus-visible .mosaic-art + div {
   transform: translateY(0.6rem);
 }
 


### PR DESCRIPTION
Genre, playlist and collection cards kept their label fixed while the art scaled over it on focus. media-card already solves this by sliding its caption clear, so this extends that rule rather than adding a parallel one — both card types now share one transition and one offset.

```css
app-media-card figure + div,
app-mosaic-card .mosaic-art + div { transition: transform 0.15s ease-out; }

app-media-card figure:focus-visible + div,
app-mosaic-card button:focus-visible .mosaic-art + div { transform: translateY(0.6rem); }
```

The selector hangs off the inner `button`, not `[data-home-focus]`: on the home page that attribute lands on the `app-mosaic-card` host, which isn't focusable, so the button is what actually receives focus. It's the same shape the focus lift beside it already uses, which is why one selector covers the home playlists row and the library genres and collections tabs alike.

Verified downlevelled in the tizen bundle (`app-mosaic-card button:focus .mosaic-art+div{transform:translateY(.6rem)}` — the pass rewrites `:focus-visible` to `:focus` for Chromium 85) and confirmed on the test TV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)