### PR TITLE
fix(tv): stop a focus move ghosting the neighbouring control

### DIFF
--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.spec.ts
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.spec.ts
@@ -173,10 +173,19 @@ describe('PluginCatalogueComponent — the version picker', () => {
   });
 
   it('leaves the installed version unpickable', async () => {
-    const { fixture } = await createComponent([['fliks.acme', '1.1.0']], true);
+    const { fixture, http } = await createComponent([['fliks.acme', '1.1.0']], true);
     const installed = Array.from(
       (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLButtonElement>('.dropdown-content button'),
     ).find((b) => b.textContent?.includes('1.1.0'));
-    expect(installed!.disabled).toBe(true);
+
+    // `aria-disabled`, not `disabled`: the option stays in the focus order so a
+    // D-pad can land on the version that is actually running.
+    expect(installed!.getAttribute('aria-disabled')).toBe('true');
+    expect(installed!.disabled).toBe(false);
+
+    // Unpickable is enforced by swallowing the click, not by the attribute.
+    installed!.click();
+    await settle(fixture);
+    http.expectNone({ url: '/api/plugins/sources/1/inspect', method: 'POST' });
   });
 });

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -511,6 +511,15 @@ body:not(.keyboard-modality):not(.tv) app-mosaic-card button:focus-visible .mosa
   /* Never set `position` here: it would re-anchor an absolutely placed
      focusable (a modal ✕, a floating cue) and make it jump on focus. */
 }
+/* `z-index` applies to a flex item even at `position: static`, so on a button row
+   the rule above creates and destroys a stacking context on every focus move.
+   This WebView repaints that badly: a neighbour ghosts, re-drawn at its previous
+   offset (half a button's label duplicated on the media-detail action row). The
+   ring is 4px and these rows carry a gap, so nothing overlaps without it. */
+body.tv :is(a, button, select, input, [role="button"], [tabindex]):focus-visible {
+  z-index: auto;
+}
+
 /* Over the video, the ring's inner `--color-base-100` layer has nothing to
    blend into — it reads as a black circle around every control. On the player
    only, drop it and keep the primary ring alone. */


### PR DESCRIPTION
Two independent fixes, one commit each. The TV fix is confirmed on the test TV (QE85Q80BATXXC, Tizen).

## 1. `fix(tv)` — focus ghosting

Moving focus along the media-detail action row left a neighbouring control ghosted for a frame: half of "Depuis le début" re-drawn at its previous offset, with a duplicated ✓ circle.

`z-index` applies to a **flex item even at `position: static`**, so the focus-ring rule's `z-index: 1` created and destroyed a stacking context on every focus move along a button row. This WebView repaints that badly — the same layer-invalidation weakness behind the mosaic corner artefacts, and it's why the ghost landed on a *sibling* rather than on the control being focused.

The lift is dropped on TV only. The ring is 4px and these rows carry a gap, so nothing overlaps without it; desktop keeps it for tighter layouts.

Ruled out first, from the markup: DOM duplication between the buttons (they're adjacent siblings), both layout branches rendering (`tv:hidden` gates the mobile one), scroller promotion (the row is `flex flex-wrap` with no overflow, and `will-change: scroll-position` only applies to `[data-scroller]`, which lives solely on `horizontal-scroller`), and the focus scale (`transform: scale(1.06)` needs `data-tv-focusable`; these are plain `<button>`s).

## 2. `test(plugins)` — the version picker spec was stale

`plugin-catalogue.spec.ts` still expected `disabled` on the running version's option — the last remaining red test in the suite.

That mechanism was replaced when the active option became focusable. `disabled` drops an element out of the focus order, so a D-pad could never land on the version actually installed; [`SelectedOptionDirective`](client/src/app/shared/directives/selected-option.directive.ts) marks it with `aria-disabled` and swallows the click in the capture phase instead, which is what actually makes it unpickable. The component was correct and the assertion had simply been left behind.

The spec now checks the real contract: `aria-disabled="true"`, the element stays enabled, and clicking it fires no install request.

## Verification

`tsc --noEmit` clean, web and tizen builds green, downlevel guard passes, **649/649 specs** — the suite is fully green for the first time in a while.

🤖 Generated with [Claude Code](https://claude.com/claude-code)