### PR TITLE
fix(tv): keep the setup checklist off the 10-foot UI

### DIFF
--- a/client/src/app/shared/components/setup-checklist/setup-checklist.html
+++ b/client/src/app/shared/components/setup-checklist/setup-checklist.html
@@ -1,4 +1,4 @@
-@if (visibleItems().length > 0 || (showAll() && items().length > 0)) {
+@if (!isTv() && (visibleItems().length > 0 || (showAll() && items().length > 0))) {
   <div [class.pb-4]="padding()">
   <section class="card bg-base-200/60 backdrop-blur-sm shadow-sm" >
     <div class="card-body p-4 sm:p-5 gap-3">

--- a/client/src/app/shared/components/setup-checklist/setup-checklist.ts
+++ b/client/src/app/shared/components/setup-checklist/setup-checklist.ts
@@ -7,6 +7,7 @@ import {
   OnInit,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { TvService } from '../../../core/services/tv.service';
 import { TranslateModule } from '@ngx-translate/core';
 import {
   LucideCheck,
@@ -37,6 +38,9 @@ import {
 })
 export class SetupChecklistComponent implements OnInit {
   private readonly api = inject(SetupChecklistApiService);
+  /** Off on TV entirely: a server-setup surface whose every step links into the
+   *  admin pages, which the 10-foot UI was never designed for. */
+  protected readonly isTv = inject(TvService).isTv;
 
   /** When `true`, also surface completed and dismissed items (with a
    *  reactivate button on the latter). Off by default — the home


### PR DESCRIPTION
The "Configuration" card (`setup_checklist.title`) sat at the top of the home page under `@if (auth.canAccessSettings())` with no TV gate, so any admin account saw it on the TV home. It's a server-setup surface — required/recommended steps, each routing into the admin pages — which the 10-foot UI was never designed for.

Gated inside the component rather than at the call site, since it has two: [home.html:2](client/src/app/features/home/home.html#L2) and [general.html:7](client/src/app/features/settings/general/general.html#L7). One `!isTv()` on the root `@if` covers both and anything added later.

Verified on the test TV. `tsc --noEmit` clean, web and tizen builds green, 649/649 specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)