### PR TITLE
fix(remote): name the grant indexes as typeorm generates them

### DIFF
--- a/backend/src/migrations/1784500000000-add-remote-control-grants.ts
+++ b/backend/src/migrations/1784500000000-add-remote-control-grants.ts
@@ -17,9 +17,22 @@ export class AddRemoteControlGrants1784500000000 implements MigrationInterface {
         "codeExpiresAt" timestamptz NOT NULL
       )
     `);
-    for (const column of ['code', 'deviceId', 'ownerUserId', 'granteeUserId']) {
+    // TypeORM's own hashed names, not readable ones: the drift check regenerates
+    // from the entities and reports any index this migration named differently.
+    const indexes: [string, string][] = [
+      ['IDX_735e31a7f8cf53db91cc04339d', 'code'],
+      ['IDX_34d4b3c63c41ebc088ba3cfcdb', 'deviceId'],
+      ['IDX_a5a52f3d116c44c2944f0b1088', 'ownerUserId'],
+      ['IDX_28efb3a0402a49dca862fb62e6', 'granteeUserId'],
+    ];
+    for (const [name, column] of indexes) {
+      // Drop the readable name this migration used before, for a database that
+      // already ran it.
       await queryRunner.query(
-        `CREATE INDEX IF NOT EXISTS "IDX_remote_control_grants_${column}" ON "remote_control_grants" ("${column}")`,
+        `DROP INDEX IF EXISTS "IDX_remote_control_grants_${column}"`,
+      );
+      await queryRunner.query(
+        `CREATE INDEX IF NOT EXISTS "${name}" ON "remote_control_grants" ("${column}")`,
       );
     }
     // A per-device grant replaces the mutual-follow gating, so the two account


### PR DESCRIPTION
## What

The `apply-migrations` check failed on main after #1161.

## Why

That job applies every migration to an empty database, runs `migration:generate` against the entities and fails if it emits anything. The grants migration created its four indexes with readable names (`IDX_remote_control_grants_code`), while TypeORM derives hashed ones from the table and column (`IDX_735e31a7f8cf53db91cc04339d`). The regenerated migration therefore dropped and recreated all four, which the check reads as entity changes missing from any committed migration.

Only the index names drifted. Columns, types and the two dropped `users` columns all matched.

## Fix

The migration now creates the indexes under the names TypeORM generates, taken from the failing run's own output. It drops the readable names first, so a database that already applied the migration as it was converges rather than ending up with both.

## Verification

Backend `tsc` exit 0, remote module suite green. The authoritative check is the `apply-migrations` job on this PR.