### PR TITLE
fix(tv): cue layer under the seek preview, and up/down opens the controls

### DIFF
--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1068,10 +1068,20 @@ export class StreamingController {
     if (live?.userId != null) {
       const stoppedTargetId = this.events.targetIdFor(live.sseConnectionId);
       if (stoppedTargetId) {
+        this.log.debug(
+          `stopLiveSession(${sessionId}): announcing the stop of ${stoppedTargetId}`,
+        );
         this.events.emitToUser(live.userId, {
           type: 'remote.stopped',
           targetId: stoppedTargetId,
         });
+      } else {
+        // Silent until now, and the one branch that leaves a controller showing
+        // playback that has ended.
+        this.log.debug(
+          `stopLiveSession(${sessionId}): no live target for connection ` +
+            `${live.sseConnectionId ?? 'null'}, no stop announced`,
+        );
       }
       this.events.emitToUser(live.userId, { type: 'remote.targets_changed' });
     } else {

--- a/client/src/app/core/services/playback-engine/subtitle-overlay.util.ts
+++ b/client/src/app/core/services/playback-engine/subtitle-overlay.util.ts
@@ -138,7 +138,9 @@ export class SubtitleOverlay {
       'text-align: center',
       'text-shadow: 0 2px 4px rgba(0, 0, 0, 0.9)',
       'pointer-events: none',
-      'z-index: 1000',
+      // Below the controls row (z-40, raised to z-55 while the sprite preview is
+      // up) and above the video: at 1000 a cue covered the seek thumbnail.
+      'z-index: 30',
       'white-space: pre-wrap',
       'display: none',
     ].join(';');

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -190,7 +190,6 @@
     [chapters]="chapters()"
     [introMarker]="introMarker()"
     [outroMarker]="outroMarker()"
-    [chapterSkip]="seekOsd()"
     variant="player"
     (seek)="seek.emit($event)"
     (dragChange)="seekDragging.set($event); seekDragChange.emit($event)"

--- a/client/src/app/shared/components/seekbar/seekbar.html
+++ b/client/src/app/shared/components/seekbar/seekbar.html
@@ -5,7 +5,6 @@
   [class]="variant() === 'player' ? 'h-6' : 'h-5'"
   tabindex="0"
   role="slider"
-  [attr.data-tv-own-vertical]="ownsVertical() ? '' : null"
   [attr.aria-valuemin]="0"
   [attr.aria-valuemax]="duration() || 0"
   [attr.aria-valuenow]="currentTime()"

--- a/client/src/app/shared/components/seekbar/seekbar.spec.ts
+++ b/client/src/app/shared/components/seekbar/seekbar.spec.ts
@@ -232,29 +232,22 @@ describe('SeekbarComponent chapters', () => {
     expect(seeks).toEqual([120]);
   });
 
-  it('binds Up/Down to chapter steps only while the OSD asked for it', () => {
+
+
+  it('leaves Up and Down to the page so they can open the full controls', () => {
     const seeks: number[] = [];
     bar.seek.subscribe((t) => seeks.push(t));
 
-    // Not raised: vertical stays free so focus can escape the slider.
-    expect(bar.ownsVertical()).toBe(false);
+    // The bar used to step chapters here and swallow the key; opening the
+    // controls is the more useful answer and needs the event to bubble.
+    const up = press('ArrowUp');
+    bar.onKeydown(up);
     bar.onKeydown(press('ArrowDown'));
+
     expect(seeks).toEqual([]);
-
-    fixture.componentRef.setInput('chapterSkip', true);
-    expect(bar.ownsVertical()).toBe(true);
-
-    // Stepped from the playhead at 100, not from the head of the file.
-    bar.onKeydown(press('ArrowDown'));
-    expect(seeks).toEqual([120]);
-    bar.onKeydown(press('ArrowUp'));
-    expect(seeks).toEqual([120, 0]);
-  });
-
-  it('keeps vertical free on a file with no chapters', () => {
-    fixture.componentRef.setInput('chapterSkip', true);
-    fixture.componentRef.setInput('chapters', []);
-    expect(bar.ownsVertical()).toBe(false);
+    // Not swallowed: the player's own handler is what opens the controls.
+    expect(up.preventDefault).not.toHaveBeenCalled();
+    expect(up.stopPropagation).not.toHaveBeenCalled();
   });
 
   it('measures the intro and outro bands against the duration', () => {

--- a/client/src/app/shared/components/seekbar/seekbar.ts
+++ b/client/src/app/shared/components/seekbar/seekbar.ts
@@ -37,16 +37,6 @@ export class SeekbarComponent {
    *  are scrubbing into, ahead of the skip cue that covers the same range. */
   readonly introMarker = input<{ startSeconds: number; endSeconds: number } | null>(null);
   readonly outroMarker = input<{ startSeconds: number; endSeconds: number } | null>(null);
-  /** Let Up/Down step chapters instead of escaping the bar vertically. Only
-   *  safe where there is nothing else to reach — the seek OSD raises it. */
-  readonly chapterSkip = input(false);
-
-  /** Vertical is only bound when it has chapters to move between; the escape
-   *  hatch out of the slider has to survive on a file without any. */
-  readonly ownsVertical = computed(
-    () => this.chapterSkip() && this.chapters().length > 0,
-  );
-
   /** Chapter start times as % of duration for seekbar tick rendering. */
   readonly chapterTicks = computed(() => {
     const dur = this.duration() || 0;
@@ -374,15 +364,6 @@ export class SeekbarComponent {
     switch (e.key) {
       case 'ArrowLeft':  direction = -1; break;
       case 'ArrowRight': direction = 1; break;
-      case 'ArrowUp':
-      case 'ArrowDown':
-        if (!this.ownsVertical()) return;
-        e.preventDefault();
-        e.stopPropagation();
-        this.cancelScrubTimer();
-        this.holdKeyPreview();
-        this.stepChapter(e.key === 'ArrowDown' ? 1 : -1);
-        return;
       case 'Home':
         e.preventDefault();
         e.stopPropagation();
@@ -468,20 +449,6 @@ export class SeekbarComponent {
   /** Jump to the next / previous chapter start. Measured from `displayTime`,
    *  not the preview: with no scrub in flight the preview reports the pointer
    *  (0 on a remote), which would step from the head of the file. */
-  private stepChapter(direction: 1 | -1) {
-    const from = this.displayTime();
-    const starts = this.chapters()
-      .map((c) => c.startSeconds)
-      .sort((a, b) => a - b);
-    // 1s of slack so stepping back off a boundary doesn't land on it again.
-    const next =
-      direction === 1
-        ? starts.find((t) => t > from + 1)
-        : [...starts].reverse().find((t) => t < from - 1);
-    if (next === undefined) return;
-    this.dragTime.set(next);
-    this.commitScrubTo(next);
-  }
 
   private snapToChapter(target: number): number {
     let best = target;


### PR DESCRIPTION
Three findings from a Tizen session on a real TV.

## Up and Down no longer step chapters

In the seek OSD the bar bound them to chapter jumps, called `preventDefault` and `stopPropagation`, and raised `data-tv-own-vertical` so spatial navigation trapped vertical focus on the slider. Opening the full controls is the more useful answer on a TV, and it needs nothing new: letting the event reach the player's own key handler is enough, since `showControls` only keeps the OSD for Left and Right.

Removed with it: the `chapterSkip` input, `ownsVertical`, `stepChapter` and the vertical-trap attribute. Chapter ticks on the bar are untouched. The two tests that described the old binding are replaced by one asserting the keys are not swallowed.

## Subtitles no longer cover the seek thumbnail

The TV cue overlay is appended to `document.body` with `z-index: 1000`. The controls row sits at 40 and raises itself to 55 precisely so the sprite preview pops above its buttons, so a cue drew over the thumbnail. The overlay moves to 30: above the video, below the controls. webOS shares this overlay and gets the same fix.

## A session stop now says whether it announced itself

Reported as "quitting on the TV does not clear the remote", which turned out to be a stale Android build. Investigating it surfaced a real observability gap instead: the success path logged nothing, and the branch where the target does not resolve from the session's SSE connection logged nothing at all. That branch is the one that would leave a controller showing playback that has ended, so it is now traceable.

## Verification

| Check | Result |
|---|---|
| Backend `tsc` | exit 0 |
| Backend tests | 168 suites, 1866 tests |
| Client `tsc` | exit 0 |
| `ng build` | success, no warnings |
| Client tests | 72 suites, 677 tests |

Both TV changes were deployed to a Samsung QE85Q80BATXXC and installed successfully. The cue layering and the key behaviour still need a look on the TV itself.