### PR TITLE
feat(tv): pin the settings shells, style the dashboard selects, keep round things round

### DIFF
--- a/client/postcss/tv-fallbacks.cjs
+++ b/client/postcss/tv-fallbacks.cjs
@@ -139,6 +139,9 @@ function scaleToFn(value) {
 
 const CQ_UNIT = /\d(cqi|cqw|cqh|cqb)\b/;
 const DROP_PROPS = new Set(['text-wrap', 'field-sizing']);
+/** Tailwind v4's `rounded-full`: `calc(infinity * 1px)`, unknown to Chromium 85. */
+const INFINITY_CALC = /calc\(\s*infinity\s*\*\s*1px\s*\)/g;
+
 const SCROLL_INLINE_MAP = {
   'scroll-padding-inline': ['scroll-padding-left', 'scroll-padding-right'],
   'scroll-margin-inline': ['scroll-margin-left', 'scroll-margin-right'],
@@ -240,6 +243,13 @@ module.exports = () => ({
     // fine for UI backdrops.
     if (/ in (oklab|oklch|lab|lch|srgb-linear)\b/.test(decl.value)) {
       decl.value = decl.value.replace(/\s+in (oklab|oklch|lab|lch|srgb-linear)\b\s*,?/g, '');
+    }
+    // `calc(infinity * 1px)` is what Tailwind v4 emits for `rounded-full`.
+    // Chromium 85 has no `infinity` keyword, so the declaration is discarded
+    // and every pill, avatar and dot renders square. A large finite length is
+    // indistinguishable at any size we ship.
+    if (INFINITY_CALC.test(decl.value)) {
+      decl.value = decl.value.replace(INFINITY_CALC, '9999px');
     }
     if (CQ_UNIT.test(decl.value)) decl.remove();
   },

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -330,6 +330,7 @@ export const routes: Routes = [
       },
       {
         path: 'cast',
+        canActivate: [noTvGuard],
         loadComponent: () =>
           import('./features/playback-settings/cast-settings/cast-settings').then(
             (m) => m.CastSettingsPageComponent,

--- a/client/src/app/core/services/focusable.constants.ts
+++ b/client/src/app/core/services/focusable.constants.ts
@@ -22,6 +22,34 @@ export const TABBABLE_SELECTOR =
  * `disabled` precisely so the current value stays in the focus order), while
  * `autofocus` and `aria-current` are set by hand at a few call sites.
  */
+/**
+ * Whether focus should be handed back to whatever opened an overlay. Only a
+ * keyboard or a D-pad needs it: on touch it would mark a control the user is no
+ * longer on, and refocusing a `<select>` on iOS reopens the native picker we
+ * just replaced.
+ */
+export function wantsFocusRestore(): boolean {
+  if (typeof document === 'undefined') return false;
+  const b = document.body.classList;
+  return b.contains('keyboard-modality') || b.contains('tv');
+}
+
+/**
+ * Settle focus after an overlay closes. A keyboard or D-pad gets it back on the
+ * opener, so the next Enter reopens it. Touch gets it taken off: the overlay
+ * backdrop deliberately does not blur (that is what kept the ring from
+ * flickering), so without this the opener kept a focus mark for a control the
+ * user had already left. One rule for every overlay that closes.
+ */
+export function restoreOpenerFocus(opener: HTMLElement | null | undefined): void {
+  if (!opener?.isConnected) return;
+  if (wantsFocusRestore()) {
+    opener.focus({ preventScroll: true });
+    return;
+  }
+  if (document.activeElement === opener) opener.blur();
+}
+
 export function initialOverlayFocus(root: ParentNode | null | undefined): HTMLElement | null {
   if (!root) return null;
   for (const marker of ['[autofocus]', '[aria-current="true"]', '[aria-disabled="true"]']) {

--- a/client/src/app/core/services/home-settings.service.spec.ts
+++ b/client/src/app/core/services/home-settings.service.spec.ts
@@ -1,13 +1,32 @@
+import { TestBed } from '@angular/core/testing';
 import { HomeSettingsService, type HomeSectionPref } from './home-settings.service';
+import { TvService } from './tv.service';
 
 const lib = (id: number, name: string) => ({ id, name });
 const keys = (sections: { key: string }[]) => sections.map((s) => s.key);
+
+/** Built through the injector: the zone catalogue reads the form factor, so the
+ *  exclusion is stated once instead of at each call site. */
+const make = (isTv = false): HomeSettingsService => {
+  // Reset first: a second call has to yield a fresh instance, which is what the
+  // persistence tests read localStorage through.
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      {
+        provide: TvService,
+        useValue: { isTv: () => isTv } as unknown as TvService,
+      },
+    ],
+  });
+  return TestBed.inject(HomeSettingsService);
+};
 
 describe('HomeSettingsService.resolve', () => {
   beforeEach(() => localStorage.clear());
 
   it('returns the canonical built-in order, all visible, for a fresh user', () => {
-    const svc = new HomeSettingsService();
+    const svc = make();
     expect(keys(svc.resolve([]))).toEqual([
       'received-recommendations',
       'libraries',
@@ -22,7 +41,7 @@ describe('HomeSettingsService.resolve', () => {
   });
 
   it('honours a saved order for zones still available', () => {
-    const svc = new HomeSettingsService();
+    const svc = make();
     svc.setOrder([
       { key: 'likes', visible: false },
       { key: 'libraries', visible: true },
@@ -47,7 +66,7 @@ describe('HomeSettingsService.resolve', () => {
   });
 
   it('appends a built-in the saved layout predates, at its canonical position', () => {
-    const svc = new HomeSettingsService();
+    const svc = make();
     // A layout saved before "likes" existed — every built-in but that one.
     svc.setOrder([
       { key: 'received-recommendations', visible: true },
@@ -71,7 +90,7 @@ describe('HomeSettingsService.resolve', () => {
   });
 
   it('unshifts received-recommendations to the front when a saved layout predates it, instead of appending it', () => {
-    const svc = new HomeSettingsService();
+    const svc = make();
     svc.setOrder([
       { key: 'libraries', visible: true },
       { key: 'continue-watching', visible: true },
@@ -85,7 +104,7 @@ describe('HomeSettingsService.resolve', () => {
   });
 
   it('drops a saved zone whose library no longer exists', () => {
-    const svc = new HomeSettingsService();
+    const svc = make();
     svc.setOrder([
       { key: 'received-recommendations', visible: true },
       { key: 'library-recent:99', visible: true },
@@ -101,7 +120,7 @@ describe('HomeSettingsService.resolve', () => {
   });
 
   it('appends one hidden-by-default zone per library not yet in the saved order', () => {
-    const svc = new HomeSettingsService();
+    const svc = make();
     const result = svc.resolve([lib(1, 'Movies'), lib(2, 'Series')]);
     const movies = result.find((s) => s.key === 'library-recent:1');
     const series = result.find((s) => s.key === 'library-recent:2');
@@ -112,7 +131,7 @@ describe('HomeSettingsService.resolve', () => {
   });
 
   it('keeps a saved visibility/position for a library-recent zone', () => {
-    const svc = new HomeSettingsService();
+    const svc = make();
     svc.setOrder([
       { key: 'library-recent:1', visible: true },
       { key: 'received-recommendations', visible: true },
@@ -130,12 +149,12 @@ describe('HomeSettingsService.resolve', () => {
   });
 
   it('omits requests-recent when the caller does not opt in', () => {
-    const svc = new HomeSettingsService();
+    const svc = make();
     expect(keys(svc.resolve([]))).not.toContain('requests-recent');
   });
 
   it('inserts requests-recent just above recently-added, visible by default, when opted in with no saved preference', () => {
-    const svc = new HomeSettingsService();
+    const svc = make();
     const result = svc.resolve([], { requests: true });
     const idx = keys(result).indexOf('requests-recent');
     expect(idx).toBe(keys(result).indexOf('recently-added') - 1);
@@ -143,7 +162,7 @@ describe('HomeSettingsService.resolve', () => {
   });
 
   it('honours a saved position/visibility for requests-recent instead of re-slotting it', () => {
-    const svc = new HomeSettingsService();
+    const svc = make();
     svc.setOrder([
       { key: 'requests-recent', visible: false },
       { key: 'received-recommendations', visible: true },
@@ -161,28 +180,35 @@ describe('HomeSettingsService.resolve', () => {
   });
 
   it('drops requests-recent entirely once the caller stops opting in, even if it was saved', () => {
-    const svc = new HomeSettingsService();
+    const svc = make();
     svc.setOrder([{ key: 'requests-recent', visible: true }]);
     expect(keys(svc.resolve([]))).not.toContain('requests-recent');
   });
+});
+
+it('leaves out the zones the 10-foot UI hides, so the settings page cannot offer them', () => {
+  const onTv = make(true);
+  expect(keys(onTv.resolve([], { requests: true }))).not.toContain('requests-recent');
+  // Same permission, other form factor: it is a TV rule, not a permission one.
+  expect(keys(make(false).resolve([], { requests: true }))).toContain('requests-recent');
 });
 
 describe('HomeSettingsService persistence', () => {
   beforeEach(() => localStorage.clear());
 
   it('persists setOrder and setMode across instances', () => {
-    const a = new HomeSettingsService();
+    const a = make();
     const order: HomeSectionPref[] = [{ key: 'likes', visible: false }];
     a.setOrder(order);
     a.setMode('media');
 
-    const b = new HomeSettingsService();
+    const b = make();
     expect(b.settings().order).toEqual(order);
     expect(b.settings().recentlyAddedMode).toBe('media');
   });
 
   it('resetLayout restores canonical order/visibility but keeps the recently-added mode', () => {
-    const svc = new HomeSettingsService();
+    const svc = make();
     svc.setOrder([{ key: 'likes', visible: false }]);
     svc.setMode('both');
     svc.resetLayout();

--- a/client/src/app/core/services/home-settings.service.ts
+++ b/client/src/app/core/services/home-settings.service.ts
@@ -1,5 +1,6 @@
-import { Injectable, signal } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
 import { mergeOrdered } from '../plugin-ui/merge-ordered';
+import { TvService } from './tv.service';
 
 /** Stable identity of a home zone. Built-ins are fixed; per-library
  *  "recently added" zones are keyed by their library id. */
@@ -73,8 +74,15 @@ const DEFAULTS: HomeSettings = {
  * "recently added" ranking mode), persisted to localStorage exactly like
  * `DisplaySettingsService` / `PlayerSettingsService`. No backend involvement.
  */
+/** Zones the 10-foot UI does not show. Recent requests is an admin surface
+ *  (approve, decline, profile names) the TV layout was never designed for. */
+const HIDDEN_ON_TV: ReadonlySet<HomeSectionKey> = new Set<HomeSectionKey>([
+  'requests-recent',
+]);
+
 @Injectable({ providedIn: 'root' })
 export class HomeSettingsService {
+  private readonly tv = inject(TvService);
   readonly settings = signal<HomeSettings>(this.load());
 
   private load(): HomeSettings {
@@ -136,6 +144,10 @@ export class HomeSettingsService {
     const libName = new Map(libraries.map((l) => [l.id, l.name]));
     const available = new Set<HomeSectionKey>(BUILTIN_ORDER);
     if (opts.requests) available.add('requests-recent');
+    // The one answer to "which zones exist here", form factor included: the
+    // home page renders what this returns and the settings page lists it, so a
+    // zone the 10-foot UI hides is not offered for reordering either.
+    if (this.tv.isTv()) for (const key of HIDDEN_ON_TV) available.delete(key);
     for (const lib of libraries) {
       available.add(`${LIBRARY_RECENT_PREFIX}${lib.id}` as HomeSectionKey);
     }
@@ -151,7 +163,7 @@ export class HomeSettingsService {
     // Permission-gated built-in: only offered when the user can use requests.
     // With no saved preference it defaults visible, slotted just above
     // "recently-added"; a saved order (handled above) wins.
-    if (opts.requests && !merged.some((p) => p.key === 'requests-recent')) {
+    if (available.has('requests-recent') && !merged.some((p) => p.key === 'requests-recent')) {
       const pref: HomeSectionPref = { key: 'requests-recent', visible: true };
       const at = merged.findIndex((p) => p.key === 'recently-added');
       merged = at >= 0 ? [...merged.slice(0, at), pref, ...merged.slice(at)] : [...merged, pref];

--- a/client/src/app/core/services/navbar.service.spec.ts
+++ b/client/src/app/core/services/navbar.service.spec.ts
@@ -2,11 +2,36 @@ import { TestBed } from '@angular/core/testing';
 import { Component, inject as ngInject } from '@angular/core';
 import { provideRouter, Router, UrlTree } from '@angular/router';
 import { NavbarService } from './navbar.service';
+import { DeviceService } from './device.service';
 
 @Component({ template: '' })
 class PageStub {}
 
 describe('NavbarService', () => {
+  /** Never a docked sidebar on a TV: the main layout there is a 10-foot browse
+   *  surface, a permanent column steals from it, and focus would have one more
+   *  region to escape on every screen. */
+  it('never docks the sidebar on a TV, whatever the pin preference says', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([{ path: '**', component: PageStub }]),
+        {
+          provide: DeviceService,
+          useValue: {
+            isTv: () => true,
+            isTablet: () => false,
+            isDesktop: () => false,
+          } as unknown as DeviceService,
+        },
+      ],
+    });
+    const navbar = TestBed.inject(NavbarService);
+
+    expect(navbar.sidebarPinned()).toBe(true);
+    expect(navbar.effectiveSidebarPinned()).toBe(false);
+    expect(navbar.sidebarDocked()).toBe(false);
+  });
+
   /** Entry screens are reached through a guard redirect (Tizen boots into
    *  /setup). A back entry recorded there makes the first hardware-back press
    *  a no-op redirect instead of leaving the app — Samsung rejects that. */

--- a/client/src/app/core/services/navbar.service.ts
+++ b/client/src/app/core/services/navbar.service.ts
@@ -37,20 +37,19 @@ export class NavbarService {
   /** Effective pin state for layout decisions — auto-disabled on narrow
    *  screens (e.g. tablet portrait < lg) where a pinned drawer would eat too
    *  much horizontal space and leave the user without the standard mobile
-   *  navbar (= no back button, no title). The user's stored preference is
-   *  preserved; once the screen is wide enough again the pin is honoured. */
+   *  navbar (= no back button, no title). Never on a TV: the main layout there
+   *  is a 10-foot browse surface and a permanent column steals from it, and
+   *  focus would have one more region to escape on every screen. The user's
+   *  stored preference is preserved for the form factors that can use it. */
   readonly effectiveSidebarPinned = computed(
-    () => this.sidebarPinned() && this.isLargeScreen(),
+    () => this.sidebarPinned() && this.isLargeScreen() && !this.device.isTv(),
   );
 
   /** Whether the layout shows the sidebar as a permanent column. Desktop always
-   *  does; a TV or a tablet does when the pin is in effect. Stated here rather
-   *  than in the template so the form-factor list lives in one place. */
+   *  does; a tablet does when the pin is in effect. Stated here rather than in
+   *  the template so the form-factor list lives in one place. */
   readonly sidebarDocked = computed(
-    () =>
-      this.device.isDesktop() ||
-      ((this.device.isTv() || this.device.isTablet()) &&
-        this.effectiveSidebarPinned()),
+    () => this.device.isDesktop() || this.effectiveSidebarPinned(),
   );
 
   private readonly device = inject(DeviceService);
@@ -208,16 +207,12 @@ export class NavbarService {
   readonly mobileNavbarVisible = computed(() => {
     // Mirror the layout's actual navbar visibility, not just the form-factor:
     // - desktop is always pinned → navbar hidden at lg+
-    // - tablet & TV are user-pinnable → navbar hidden only when the user
-    //   pinned the sidebar (effectiveSidebarPinned, gated on lg+)
+    // - a tablet is user-pinnable → navbar hidden only when the user pinned
+    //   the sidebar (effectiveSidebarPinned, which never holds on a TV)
     if (this.isLargeScreen() && this.device.isDesktop()) return false;
-    if (
-      (this.device.isTablet() || this.device.isTv()) &&
-      this.effectiveSidebarPinned()
-    ) {
-      return false;
-    }
-    return true;
+    // One test now that the pin itself rules out a TV: naming the form factors
+    // twice let the two drift apart.
+    return !this.effectiveSidebarPinned();
   });
 
   /** Mobile navbar center: hero title on fanart pages, otherwise static/dynamic page title. */

--- a/client/src/app/core/services/navbar.service.ts
+++ b/client/src/app/core/services/navbar.service.ts
@@ -27,10 +27,13 @@ export class NavbarService {
   /**
    * User preference: whether the sidebar should stay pinned at lg breakpoint
    * even on form-factors that default to a drawer (tablet). Persisted in
-   * localStorage. Desktop and TV are always pinned regardless of this flag;
-   * phones never have a sidebar.
+   * localStorage, and on by default: wherever the pin is offered there is room
+   * for the column, and the drawer made every navigation a two-step. Desktop is
+   * always pinned regardless of this flag; phones never have a sidebar.
    */
-  readonly sidebarPinned = signal(localStorage.getItem('fliks.sidebarPinned') === 'true');
+  readonly sidebarPinned = signal(
+    localStorage.getItem('fliks.sidebarPinned') !== 'false',
+  );
   /** Effective pin state for layout decisions — auto-disabled on narrow
    *  screens (e.g. tablet portrait < lg) where a pinned drawer would eat too
    *  much horizontal space and leave the user without the standard mobile
@@ -40,8 +43,18 @@ export class NavbarService {
     () => this.sidebarPinned() && this.isLargeScreen(),
   );
 
-  private readonly router = inject(Router);
+  /** Whether the layout shows the sidebar as a permanent column. Desktop always
+   *  does; a TV or a tablet does when the pin is in effect. Stated here rather
+   *  than in the template so the form-factor list lives in one place. */
+  readonly sidebarDocked = computed(
+    () =>
+      this.device.isDesktop() ||
+      ((this.device.isTv() || this.device.isTablet()) &&
+        this.effectiveSidebarPinned()),
+  );
+
   private readonly device = inject(DeviceService);
+  private readonly router = inject(Router);
   /** Stack of in-app URLs we've visited (most recent last, current excluded). */
   private readonly history: string[] = [];
   /** Set while goBack() is navigating, so the NavigationEnd it triggers is

--- a/client/src/app/core/services/select-picker.service.ts
+++ b/client/src/app/core/services/select-picker.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, signal } from '@angular/core';
+import { restoreOpenerFocus } from './focusable.constants';
 
 export interface SelectPickerOption {
   label: string;
@@ -49,17 +50,9 @@ export class SelectPickerService {
     const sel = this.currentSelect;
     this.open.set(false);
     this.currentSelect = null;
-    // Restore focus to the trigger so a subsequent Enter / Space re-opens
-    // the picker — without this the browser drops focus to <body> when the
-    // popover unmounts and the user has to Tab back to the select. Only
-    // worth doing in keyboard / D-pad modality though: on iOS touch,
-    // calling `focus()` on a `<select>` pops the native picker right
-    // after we just dismissed our custom one. The `keyboard-modality`
-    // body class (toggled by app.ts) plus `body.tv` cover every modality
-    // where focus restoration is actually wanted.
-    const wantsFocusRestore =
-      document.body.classList.contains('keyboard-modality') ||
-      document.body.classList.contains('tv');
-    if (wantsFocusRestore) sel?.focus({ preventScroll: true });
+    // Restore focus to the trigger so a subsequent Enter / Space re-opens the
+    // picker: the browser drops focus to <body> when the popover unmounts. The
+    // modality test lives in `restoreOpenerFocus`, which every overlay shares.
+    restoreOpenerFocus(sel);
   }
 }

--- a/client/src/app/features/app-settings/app-settings-shell.html
+++ b/client/src/app/features/app-settings/app-settings-shell.html
@@ -10,7 +10,11 @@
     <li><a routerLink="/app-settings/display" routerLinkActive="active"><svg lucideMonitor class="h-4 w-4"></svg>{{ 'app_settings.nav.display' | translate }}</a></li>
     <li><a routerLink="/app-settings/player" routerLinkActive="active"><svg lucidePlay class="h-4 w-4"></svg>{{ 'app_settings.nav.player' | translate }}</a></li>
     <li><a routerLink="/app-settings/subtitles" routerLinkActive="active"><svg lucideCaptions class="h-4 w-4"></svg>{{ 'app_settings.nav.subtitles' | translate }}</a></li>
-    <li><a routerLink="/app-settings/cast" routerLinkActive="active"><svg lucideCast class="h-4 w-4"></svg>{{ 'app_settings.nav.cast' | translate }}</a></li>
+    <!-- No Chromecast sender on a TV: it is a target, and the section would
+         only offer settings for a session it cannot start. -->
+    @if (!tv.isTv()) {
+      <li><a routerLink="/app-settings/cast" routerLinkActive="active"><svg lucideCast class="h-4 w-4"></svg>{{ 'app_settings.nav.cast' | translate }}</a></li>
+    }
     <li><a routerLink="/app-settings/remote" routerLinkActive="active"><svg lucideMonitorSmartphone class="h-4 w-4"></svg>{{ 'app_settings.nav.remote' | translate }}</a></li>
     @if (!tv.isTv()) {
       <li><a routerLink="/app-settings/storage" routerLinkActive="active"><svg lucideHardDrive class="h-4 w-4"></svg>{{ 'app_settings.nav.storage' | translate }}</a></li>

--- a/client/src/app/features/app-settings/display-settings/display-settings.html
+++ b/client/src/app/features/app-settings/display-settings/display-settings.html
@@ -4,6 +4,7 @@
     <div class="flex flex-col gap-1">
       <span class="text-sm font-medium">{{ 'display_settings.language' | translate }}</span>
       <select
+    appTvSelect
         class="select select-bordered w-full max-w-xs"
         [ngModel]="language()"
         (ngModelChange)="onLanguageChange($event)"

--- a/client/src/app/features/app-settings/display-settings/display-settings.ts
+++ b/client/src/app/features/app-settings/display-settings/display-settings.ts
@@ -1,4 +1,5 @@
 import { Component, ChangeDetectionStrategy, inject, signal, OnInit } from '@angular/core';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { DisplaySettingsService } from '../../../core/services/display-settings.service';
@@ -7,7 +8,7 @@ import { ToggleFieldComponent } from '../../../shared/components/forms/toggle-fi
 
 @Component({
   selector: 'app-display-settings',
-  imports: [FormsModule, TranslateModule, ToggleFieldComponent],
+  imports: [TvSelectDirective, FormsModule, TranslateModule, ToggleFieldComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './display-settings.html',
 })

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -28,7 +28,6 @@ import { BackgroundService } from '../../core/services/background.service';
 import { DisplaySettingsService } from '../../core/services/display-settings.service';
 import { HomeSettingsService, HomeSectionType, ResolvedHomeSection } from '../../core/services/home-settings.service';
 import { LibraryPrefsService } from '../../core/services/library-prefs.service';
-import { TvService } from '../../core/services/tv.service';
 import { CardAction } from '../../core/services/card-actions.service';
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
 import { MosaicCardComponent } from '../../shared/components/mosaic-card/mosaic-card';
@@ -121,7 +120,6 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly home = inject(HomeSettingsService);
   private readonly libraryPrefs = inject(LibraryPrefsService);
   readonly auth = inject(AuthService);
-  private readonly tv = inject(TvService);
   private readonly injector = inject(Injector);
   private readonly route = inject(ActivatedRoute);
   private readonly reuseStrategy = inject(CachingReuseStrategy);
@@ -226,12 +224,10 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly skeletonFadingOut = signal(false);
   readonly showSkeleton = computed(() => this.loadingFirstPass() || this.skeletonFadingOut());
 
-  /** Recent requests are hidden on TV: the card is an admin surface (approve /
-   *  decline, profile names) that the 10-foot UI isn't designed for. */
+  /** Form-factor exclusions belong to `HomeSettingsService.resolve`, which is
+   *  what produced `sections()`: a zone hidden on TV is not in it at all. */
   readonly visibleSections = computed(() =>
-    this.sections().filter(
-      (s) => s.visible && !(this.tv.isTv() && s.type === 'requests-recent'),
-    ),
+    this.sections().filter((s) => s.visible),
   );
 
   qualityProfileDisplay(id: number | null): string {

--- a/client/src/app/features/import-disk/import-disk.html
+++ b/client/src/app/features/import-disk/import-disk.html
@@ -146,6 +146,7 @@
                   </td>
                   <td>
                     <select
+    appTvSelect
                       class="select select-bordered select-sm w-full"
                       [ngModel]="row.targetLibraryId"
                       (ngModelChange)="setRowLibrary(i, $event ? +$event : null)"

--- a/client/src/app/features/import-disk/import-disk.ts
+++ b/client/src/app/features/import-disk/import-disk.ts
@@ -7,6 +7,7 @@ import {
   OnInit,
 } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
+import { TvSelectDirective } from '../../shared/directives/tv-select.directive';
 import { FormsModule } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -56,7 +57,7 @@ export type ImportMethod = 'copy' | 'move';
 
 @Component({
   selector: 'app-import-disk',
-  imports: [DecimalPipe, FormsModule, TranslateModule, SearchableSelectComponent],
+  imports: [TvSelectDirective, DecimalPipe, FormsModule, TranslateModule, SearchableSelectComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './import-disk.html',
 })

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.spec.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.spec.ts
@@ -136,6 +136,7 @@ const SEASON_ACTIONS_REGISTRY: Partial<Record<SlotId, UiContribution[]>> = {
 };
 
 describe('MediaDetailSeasonsComponent — media.season.actions is plugin-only', () => {
+
   it('VERDICT: with no plugin installed, no release-picker row renders in the season dropdown', async () => {
     const fixture = await createFixture();
     const labels = seasonDropdownLabels(fixture.nativeElement);
@@ -202,6 +203,20 @@ describe('MediaDetailSeasonsComponent — media.season.actions is plugin-only', 
       seasonGrabBestBusyIds: new Set([SEASON.id + 1]),
     });
     expect(seasonDropdownItems(other.nativeElement)[grabIdx].disabled).toBe(false);
+  });
+});
+
+describe('MediaDetailSeasonsComponent — unreleased greyscale', () => {
+  const future = '2999-01-01';
+  const ep = (id: number, episodeNumber: number, hasFile: boolean) =>
+    ({ id, episodeNumber, hasFile, airDate: future, monitored: true }) as Episode;
+
+  it('keeps colour on an unreleased episode whose file is already there', async () => {
+    // The air date is the source's view, and the video can land before it.
+    const fixture = await createFixture();
+
+    expect(fixture.componentInstance.episodeGrayscale(ep(9, 3, true))).toBe(false);
+    expect(fixture.componentInstance.episodeGrayscale(ep(10, 4, false))).toBe(true);
   });
 });
 

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -319,7 +319,13 @@ export class MediaDetailSeasonsComponent {
   }
 
   episodeGrayscale(ep: Episode): boolean {
-    return this.displaySettings.settings().grayUnreleased && episodeUnreleased(ep);
+    // The file settles it: an air date in the future is the source's view, and
+    // the video can land before it.
+    return (
+      this.displaySettings.settings().grayUnreleased &&
+      episodeUnreleased(ep) &&
+      !ep.hasFile
+    );
   }
 
   episodeRoute(ep: Episode): string[] {

--- a/client/src/app/features/persons/persons.html
+++ b/client/src/app/features/persons/persons.html
@@ -14,7 +14,7 @@
           (ngModelChange)="onSearch($event)"
         />
       </div>
-      <select
+      <select appTvSelect
         class="select select-bordered select-sm min-w-28"
         [ngModel]="filterRole()"
         (ngModelChange)="onFilterRole($event)"

--- a/client/src/app/features/persons/persons.ts
+++ b/client/src/app/features/persons/persons.ts
@@ -10,6 +10,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { TvSelectDirective } from '../../shared/directives/tv-select.directive';
 import { Subscription } from 'rxjs';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
@@ -25,7 +26,7 @@ const ALPHABET = '#ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
 @Component({
   selector: 'app-persons',
-  imports: [
+  imports: [TvSelectDirective, 
     CachedSrcDirective,FormsModule, TranslateModule, RouterLink, ResolveUrlPipe, LucideSearch, LucideUsers],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './persons.html',

--- a/client/src/app/features/playback-settings/cast-settings/cast-settings.html
+++ b/client/src/app/features/playback-settings/cast-settings/cast-settings.html
@@ -11,7 +11,8 @@
 
     <label class="form-control w-full max-w-xs">
       <div class="label"><span class="label-text font-medium">{{ 'playback_settings.cast_max_quality' | translate }}</span></div>
-      <select class="select select-bordered w-full" [ngModel]="maxQuality()" (ngModelChange)="maxQuality.set($event)">
+      <select
+    appTvSelect class="select select-bordered w-full" [ngModel]="maxQuality()" (ngModelChange)="maxQuality.set($event)">
         @for (q of qualityOptions; track q.value) { <option [value]="q.value">{{ q.label }}</option> }
       </select>
       <div class="label"><span class="label-text-alt text-base-content/50">{{ 'playback_settings.cast_max_quality_hint' | translate }}</span></div>
@@ -21,7 +22,8 @@
 
     <label class="form-control w-full max-w-xs">
       <div class="label"><span class="label-text font-medium">{{ 'playback_settings.cast_audio' | translate }}</span></div>
-      <select class="select select-bordered w-full" [ngModel]="audioChannels()" (ngModelChange)="audioChannels.set(+$event)">
+      <select
+    appTvSelect class="select select-bordered w-full" [ngModel]="audioChannels()" (ngModelChange)="audioChannels.set(+$event)">
         @for (a of audioOptions; track a.value) { <option [ngValue]="a.value">{{ a.label }}</option> }
       </select>
       <div class="label"><span class="label-text-alt text-base-content/50">{{ 'playback_settings.cast_audio_hint' | translate }}</span></div>

--- a/client/src/app/features/playback-settings/cast-settings/cast-settings.ts
+++ b/client/src/app/features/playback-settings/cast-settings/cast-settings.ts
@@ -6,6 +6,7 @@ import {
   OnInit,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { CastSettingsService, CastSettings, DEFAULT_CAST_SUBTITLE_STYLE } from '../../../core/services/cast-settings.service';
 import { ToastService } from '../../../core/services/toast.service';
@@ -15,7 +16,7 @@ import { QUALITY_OPTIONS, AUDIO_CHANNEL_OPTIONS } from '../playback-options';
 
 @Component({
   selector: 'app-cast-settings',
-  imports: [FormsModule, TranslateModule, SubtitleAppearanceComponent, ToggleFieldComponent],
+  imports: [TvSelectDirective, FormsModule, TranslateModule, SubtitleAppearanceComponent, ToggleFieldComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './cast-settings.html',
 })

--- a/client/src/app/features/playback-settings/storage-settings/storage-settings.html
+++ b/client/src/app/features/playback-settings/storage-settings/storage-settings.html
@@ -25,6 +25,7 @@
           <p class="text-sm text-base-content/60">{{ 'storage_settings.max_concurrent_hint' | translate }}</p>
         </div>
         <select
+    appTvSelect
           class="select select-sm select-bordered w-20"
           [ngModel]="maxConcurrent()"
           (ngModelChange)="onMaxConcurrentChange($event)"

--- a/client/src/app/features/playback-settings/storage-settings/storage-settings.ts
+++ b/client/src/app/features/playback-settings/storage-settings/storage-settings.ts
@@ -1,4 +1,5 @@
 import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ToastService } from '../../../core/services/toast.service';
@@ -14,7 +15,7 @@ import { DeviceService } from '../../../core/services/device.service';
 
 @Component({
   selector: 'app-storage-settings',
-  imports: [FormsModule, TranslateModule],
+  imports: [TvSelectDirective, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './storage-settings.html',
 })

--- a/client/src/app/features/playback-settings/subtitle-settings/subtitle-settings.html
+++ b/client/src/app/features/playback-settings/subtitle-settings/subtitle-settings.html
@@ -3,7 +3,8 @@
   <div class="card-body gap-5">
     <label class="form-control w-full max-w-xs">
       <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_preferred_lang' | translate }}</span></div>
-      <select class="select select-bordered w-full" [ngModel]="preferredSubtitleLanguage()" (ngModelChange)="preferredSubtitleLanguage.set($event)">
+      <select
+    appTvSelect class="select select-bordered w-full" [ngModel]="preferredSubtitleLanguage()" (ngModelChange)="preferredSubtitleLanguage.set($event)">
         @for (l of languageOptions; track l.value) { <option [value]="l.value">{{ l.labelKey ? (l.labelKey | translate) : l.label }}</option> }
       </select>
     </label>
@@ -12,7 +13,8 @@
 
     <label class="form-control w-full max-w-xs">
       <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_mode' | translate }}</span></div>
-      <select class="select select-bordered w-full" [ngModel]="subtitleMode()" (ngModelChange)="subtitleMode.set($event)">
+      <select
+    appTvSelect class="select select-bordered w-full" [ngModel]="subtitleMode()" (ngModelChange)="subtitleMode.set($event)">
         @for (m of subtitleModeOptions; track m.value) { <option [value]="m.value">{{ m.labelKey | translate }}</option> }
       </select>
       <div class="label"><span class="label-text-alt text-base-content/50">{{ 'playback_settings.sub_mode_hint' | translate }}</span></div>
@@ -63,7 +65,8 @@
 
     <label class="form-control w-full max-w-xs">
       <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_bottom_margin' | translate }}</span></div>
-      <select class="select select-bordered w-full" [ngModel]="subtitleBottomMargin()" (ngModelChange)="subtitleBottomMargin.set(+$event)">
+      <select
+    appTvSelect class="select select-bordered w-full" [ngModel]="subtitleBottomMargin()" (ngModelChange)="subtitleBottomMargin.set(+$event)">
         @for (v of bottomMarginOptions; track v) { <option [ngValue]="v">{{ v }}%</option> }
       </select>
       <div class="label"><span class="label-text-alt text-base-content/50">{{ 'playback_settings.sub_bottom_margin_hint' | translate }}</span></div>
@@ -71,7 +74,8 @@
 
     <label class="form-control w-full max-w-xs">
       <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_top_margin' | translate }}</span></div>
-      <select class="select select-bordered w-full" [ngModel]="subtitleTopMargin()" (ngModelChange)="subtitleTopMargin.set(+$event)">
+      <select
+    appTvSelect class="select select-bordered w-full" [ngModel]="subtitleTopMargin()" (ngModelChange)="subtitleTopMargin.set(+$event)">
         @for (v of topMarginOptions; track v) { <option [ngValue]="v">{{ v }}%</option> }
       </select>
       <div class="label"><span class="label-text-alt text-base-content/50">{{ 'playback_settings.sub_top_margin_hint' | translate }}</span></div>

--- a/client/src/app/features/playback-settings/subtitle-settings/subtitle-settings.ts
+++ b/client/src/app/features/playback-settings/subtitle-settings/subtitle-settings.ts
@@ -1,4 +1,5 @@
 import { Component, ChangeDetectionStrategy, inject, signal, OnInit } from '@angular/core';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { PlayerSettingsService } from '../../../core/services/player-settings.service';
@@ -13,7 +14,7 @@ import {
 
 @Component({
   selector: 'app-subtitle-settings',
-  imports: [FormsModule, TranslateModule, LucideTrash2, SubtitleAppearanceComponent, ToggleFieldComponent],
+  imports: [TvSelectDirective, FormsModule, TranslateModule, LucideTrash2, SubtitleAppearanceComponent, ToggleFieldComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './subtitle-settings.html',
 })

--- a/client/src/app/features/playlists/playlist-detail/playlist-detail.html
+++ b/client/src/app/features/playlists/playlist-detail/playlist-detail.html
@@ -396,6 +396,7 @@
           <span class="label-text">{{ 'social.playlist_visibility' | translate }}</span>
         </label>
         <select
+    appTvSelect
           class="select select-bordered select-sm"
           [ngModel]="draftVisibility()"
           (ngModelChange)="draftVisibility.set($event)"
@@ -466,6 +467,7 @@
             }}</span>
           } @else {
             <select
+    appTvSelect
               class="select select-bordered select-xs w-36 shrink-0"
               [ngModel]="m.role"
               (ngModelChange)="changeMemberRole(m.userId, $event)"

--- a/client/src/app/features/playlists/playlist-detail/playlist-detail.ts
+++ b/client/src/app/features/playlists/playlist-detail/playlist-detail.ts
@@ -10,6 +10,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { NgTemplateOutlet } from '@angular/common';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -77,7 +78,7 @@ type PlaylistGroupedEntry =
 
 @Component({
   selector: 'app-playlist-detail',
-  imports: [
+  imports: [TvSelectDirective, 
     ModalFooterComponent,
     CachedSrcDirective,
     TranslateModule,

--- a/client/src/app/features/requests/request-edit-modal/request-edit-modal.component.html
+++ b/client/src/app/features/requests/request-edit-modal/request-edit-modal.component.html
@@ -15,6 +15,7 @@
           <label class="form-control w-full">
             <span class="label-text">{{ 'settings.libraries.title' | translate }}</span>
             <select
+    appTvSelect
               class="select select-bordered select-sm w-full"
               [ngModel]="libraryId()"
               (ngModelChange)="libraryIdChange.emit($event ? +$event : null)"
@@ -30,6 +31,7 @@
           <label class="form-control w-full">
             <span class="label-text">{{ 'discover.quality_profile' | translate }}</span>
             <select
+    appTvSelect
               class="select select-bordered select-sm w-full"
               [ngModel]="qualityProfileId()"
               (ngModelChange)="qualityProfileIdChange.emit($event)"
@@ -45,6 +47,7 @@
           <label class="form-control w-full">
             <span class="label-text">{{ 'discover.language_profile' | translate }}</span>
             <select
+    appTvSelect
               class="select select-bordered select-sm w-full"
               [ngModel]="languageProfileId()"
               (ngModelChange)="languageProfileIdChange.emit($event)"

--- a/client/src/app/features/requests/request-edit-modal/request-edit-modal.component.ts
+++ b/client/src/app/features/requests/request-edit-modal/request-edit-modal.component.ts
@@ -7,6 +7,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { TranslateModule } from '@ngx-translate/core';
 import { FliksRequestRow } from '../../../core/services/api/requests.service';
 import { LibrarySummary } from '../../../core/services/api/libraries-api.service';
@@ -15,7 +16,7 @@ import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-request-edit-modal',
-  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
+  imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './request-edit-modal.component.html',
 })

--- a/client/src/app/features/requests/requests.html
+++ b/client/src/app/features/requests/requests.html
@@ -3,6 +3,7 @@
     <h1 class="sr-only lg:not-sr-only text-2xl font-bold">{{ 'requests.title' | translate }}</h1>
     <div class="flex flex-col sm:flex-row gap-2 sm:w-auto w-full">
       <select
+    appTvSelect
         class="select select-bordered select-sm w-full sm:w-40"
         [ngModel]="kindFilter()"
         (ngModelChange)="onKindChange($event)"
@@ -12,6 +13,7 @@
         <option value="delete">{{ 'requests.kind_delete' | translate }}</option>
       </select>
       <select
+    appTvSelect
         class="select select-bordered select-sm w-full sm:w-48"
         [ngModel]="statusFilter()"
         (ngModelChange)="onStatusChange($event)"

--- a/client/src/app/features/requests/requests.ts
+++ b/client/src/app/features/requests/requests.ts
@@ -10,6 +10,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { Subscription } from 'rxjs';
+import { TvSelectDirective } from '../../shared/directives/tv-select.directive';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -45,7 +46,7 @@ import { LocaleDatePipe } from '../../core/pipes/locale-date.pipe';
 
 @Component({
   selector: 'app-requests',
-  imports: [
+  imports: [TvSelectDirective, 
     FormsModule,
     LocaleDatePipe,
     TranslateModule,

--- a/client/src/app/features/search/search.html
+++ b/client/src/app/features/search/search.html
@@ -268,7 +268,7 @@
 
     <div class="flex flex-col gap-1">
       <span class="text-sm text-base-content/60">{{ 'search.sort_label' | translate }}</span>
-      <select
+      <select appTvSelect
         class="select select-bordered select-sm w-full"
         [ngModel]="state.discoverSort()"
         (ngModelChange)="state.discoverSort.set($event)"

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -13,6 +13,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../shared/directives/tv-select.directive';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
@@ -44,7 +45,7 @@ import { UserAvatarComponent } from '../../shared/components/user-avatar/user-av
 
 @Component({
   selector: 'app-search',
-  imports: [UserAvatarComponent, FormsModule, TranslateModule, NgTemplateOutlet, MediaCardComponent, HorizontalScrollerComponent, DropdownMenuComponent, LucideSearch, LucideX, LucideSettings, ModalHeaderComponent],
+  imports: [TvSelectDirective, UserAvatarComponent, FormsModule, TranslateModule, NgTemplateOutlet, MediaCardComponent, HorizontalScrollerComponent, DropdownMenuComponent, LucideSearch, LucideX, LucideSettings, ModalHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './search.html',
 })

--- a/client/src/app/features/settings/auto-approval/auto-approval.html
+++ b/client/src/app/features/settings/auto-approval/auto-approval.html
@@ -165,6 +165,7 @@
               'settings.auto_approval.field_media_type' | translate
             }}</span>
             <select
+    appTvSelect
               class="select select-bordered select-sm w-full"
               [ngModel]="formMediaType()"
               (ngModelChange)="setMediaType($event)"

--- a/client/src/app/features/settings/auto-approval/auto-approval.ts
+++ b/client/src/app/features/settings/auto-approval/auto-approval.ts
@@ -9,6 +9,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import {
@@ -31,7 +32,7 @@ type RuleMediaType = '' | 'movie' | 'series';
 
 @Component({
   selector: 'app-auto-approval',
-  imports: [
+  imports: [TvSelectDirective, 
     ModalFooterComponent,
     ModalHeaderComponent,
     MultiSelectComponent,

--- a/client/src/app/features/settings/custom-formats/custom-formats.html
+++ b/client/src/app/features/settings/custom-formats/custom-formats.html
@@ -170,6 +170,7 @@
         @for (spec of formSpecs(); track $index) {
           <div class="flex flex-wrap gap-2 p-3 rounded-lg bg-base-200/40 border border-base-300">
             <select
+    appTvSelect
               class="select select-bordered select-xs"
               [ngModel]="spec.type"
               (ngModelChange)="updateSpec($index, { type: $event })"
@@ -180,6 +181,7 @@
             </select>
             @if (spec.type === 'release_flag') {
               <select
+    appTvSelect
                 class="select select-bordered select-xs flex-1 min-w-32"
                 [ngModel]="spec.value"
                 (ngModelChange)="updateSpec($index, { value: $event })"

--- a/client/src/app/features/settings/custom-formats/custom-formats.ts
+++ b/client/src/app/features/settings/custom-formats/custom-formats.ts
@@ -8,6 +8,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { LucideX } from '@lucide/angular';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
@@ -21,7 +22,7 @@ import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-custom-formats-settings',
-  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
+  imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './custom-formats.html',
 })

--- a/client/src/app/features/settings/data-imports/data-imports.html
+++ b/client/src/app/features/settings/data-imports/data-imports.html
@@ -217,6 +217,7 @@
           <label class="form-control w-full">
             <span class="label-text">{{ 'import.mode_label' | translate }}</span>
             <select
+    appTvSelect
               class="select select-bordered select-sm w-full"
               [ngModel]="radarrMode()"
               (ngModelChange)="radarrMode.set($event)"
@@ -239,6 +240,7 @@
           <label class="form-control w-full">
             <span class="label-text">{{ 'settings.libraries.import_target' | translate }}</span>
             <select
+    appTvSelect
               class="select select-bordered select-sm w-full"
               [ngModel]="radarrLibrary()"
               (ngModelChange)="radarrLibrary.set($event)"
@@ -383,6 +385,7 @@
           <label class="form-control w-full">
             <span class="label-text">{{ 'import.mode_label' | translate }}</span>
             <select
+    appTvSelect
               class="select select-bordered select-sm w-full"
               [ngModel]="sonarrMode()"
               (ngModelChange)="sonarrMode.set($event)"
@@ -405,6 +408,7 @@
           <label class="form-control w-full">
             <span class="label-text">{{ 'settings.libraries.import_target' | translate }}</span>
             <select
+    appTvSelect
               class="select select-bordered select-sm w-full"
               [ngModel]="sonarrLibrary()"
               (ngModelChange)="sonarrLibrary.set($event)"
@@ -555,6 +559,7 @@
                   }}</code>
                   <span class="text-base-content/40 hidden sm:inline">→</span>
                   <select
+    appTvSelect
                     class="select select-bordered select-sm sm:flex-1"
                     [ngModel]="m.ignore ? IGNORE_VALUE : m.localLibraryId"
                     (ngModelChange)="setMapping('radarr', m.remotePath, $event)"
@@ -630,6 +635,7 @@
                   }}</code>
                   <span class="text-base-content/40 hidden sm:inline">→</span>
                   <select
+    appTvSelect
                     class="select select-bordered select-sm sm:flex-1"
                     [ngModel]="m.ignore ? IGNORE_VALUE : m.localLibraryId"
                     (ngModelChange)="setMapping('sonarr', m.remotePath, $event)"

--- a/client/src/app/features/settings/data-imports/data-imports.ts
+++ b/client/src/app/features/settings/data-imports/data-imports.ts
@@ -8,6 +8,7 @@ import {
   signal,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -76,7 +77,7 @@ type LibrarySelection = number | null;
 
 @Component({
   selector: 'app-data-imports-settings',
-  imports: [
+  imports: [TvSelectDirective, 
     ModalHeaderComponent,
     ModalFooterComponent,
     FormsModule,

--- a/client/src/app/features/settings/general/general.html
+++ b/client/src/app/features/settings/general/general.html
@@ -68,6 +68,7 @@
             <span class="label-text">{{ 'settings.general.metadata_language' | translate }}</span>
           </div>
           <select
+    appTvSelect
             class="select select-bordered w-full"
             [ngModel]="metadataLanguage()"
             (ngModelChange)="metadataLanguage.set($event)"
@@ -86,6 +87,7 @@
             <span class="label-text">{{ 'settings.general.metadata_region' | translate }}</span>
           </div>
           <select
+    appTvSelect
             class="select select-bordered w-full"
             [ngModel]="metadataRegion()"
             (ngModelChange)="metadataRegion.set($event)"

--- a/client/src/app/features/settings/general/general.ts
+++ b/client/src/app/features/settings/general/general.ts
@@ -6,6 +6,7 @@ import {
   OnInit,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { SettingsApiService } from '../../../core/services/api/settings-api.service';
 import { ToastService } from '../../../core/services/toast.service';
@@ -17,7 +18,7 @@ import {
 
 @Component({
   selector: 'app-general-settings',
-  imports: [FormsModule, TranslateModule, SetupChecklistComponent],
+  imports: [TvSelectDirective, FormsModule, TranslateModule, SetupChecklistComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './general.html',
 })

--- a/client/src/app/features/settings/language-profiles/language-profiles.html
+++ b/client/src/app/features/settings/language-profiles/language-profiles.html
@@ -146,6 +146,7 @@
                   <label class="flex items-center gap-1 text-xs">
                     <span>{{ 'settings.language_profiles.hi_label' | translate }}</span>
                     <select
+    appTvSelect
                       class="select select-bordered select-xs"
                       [ngModel]="subHiMode(l.isoCode)"
                       (ngModelChange)="setSubHiMode(l.isoCode, $event)"

--- a/client/src/app/features/settings/language-profiles/language-profiles.ts
+++ b/client/src/app/features/settings/language-profiles/language-profiles.ts
@@ -8,6 +8,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { ToastService } from '../../../core/services/toast.service';
@@ -37,7 +38,7 @@ const HI_MODES: HearingImpairedMode[] = ['prefer', 'avoid', 'require', 'forbid']
 
 @Component({
   selector: 'app-language-profiles',
-  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
+  imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './language-profiles.html',
 })

--- a/client/src/app/features/settings/libraries/library-detail/library-form-fields/library-form-fields.html
+++ b/client/src/app/features/settings/libraries/library-detail/library-form-fields/library-form-fields.html
@@ -80,7 +80,8 @@
   <div class="label">
     <span class="label-text text-base">{{ 'settings.libraries.preferred_provider' | translate }}</span>
   </div>
-  <select class="select select-bordered w-full"
+  <select
+    appTvSelect class="select select-bordered w-full"
     [ngModel]="state.formProvider()" (ngModelChange)="state.formProvider.set($event || null)">
     @for (opt of providerOptions; track opt.value) {
       <option [ngValue]="opt.value">{{ opt.labelKey ? (opt.labelKey | translate) : opt.label }}</option>
@@ -92,7 +93,8 @@
   <div class="label">
     <span class="label-text text-base">{{ 'settings.libraries.metadata_language' | translate }}</span>
   </div>
-  <select class="select select-bordered w-full"
+  <select
+    appTvSelect class="select select-bordered w-full"
     [ngModel]="state.formMetadataLanguage() ?? ''" (ngModelChange)="state.formMetadataLanguage.set($event || null)">
     <option value="">{{ 'settings.libraries.metadata_inherit' | translate }}</option>
     @for (opt of metadataLanguageOptions; track opt.code) {
@@ -105,7 +107,8 @@
   <div class="label">
     <span class="label-text text-base">{{ 'settings.libraries.metadata_region' | translate }}</span>
   </div>
-  <select class="select select-bordered w-full"
+  <select
+    appTvSelect class="select select-bordered w-full"
     [ngModel]="state.formMetadataRegion() ?? ''" (ngModelChange)="state.formMetadataRegion.set($event || null)">
     <option value="">{{ 'settings.libraries.metadata_inherit' | translate }}</option>
     @for (opt of metadataRegionOptions; track opt.code) {
@@ -118,7 +121,8 @@
   <div class="label">
     <span class="label-text text-base">{{ 'settings.libraries.default_quality_profile' | translate }}</span>
   </div>
-  <select class="select select-bordered w-full"
+  <select
+    appTvSelect class="select select-bordered w-full"
     [ngModel]="state.formQualityProfileId()" (ngModelChange)="state.formQualityProfileId.set($event)">
     <option [ngValue]="null">—</option>
     @for (qp of state.qualityProfiles(); track qp.id) {
@@ -131,7 +135,8 @@
   <div class="label">
     <span class="label-text text-base">{{ 'settings.libraries.default_language_profile' | translate }}</span>
   </div>
-  <select class="select select-bordered w-full"
+  <select
+    appTvSelect class="select select-bordered w-full"
     [ngModel]="state.formLanguageProfileId()" (ngModelChange)="state.formLanguageProfileId.set($event)">
     <option [ngValue]="null">—</option>
     @for (lp of state.languageProfiles(); track lp.id) {

--- a/client/src/app/features/settings/libraries/library-detail/library-form-fields/library-form-fields.ts
+++ b/client/src/app/features/settings/libraries/library-detail/library-form-fields/library-form-fields.ts
@@ -1,4 +1,5 @@
 import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { TvSelectDirective } from '../../../../../shared/directives/tv-select.directive';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
@@ -16,7 +17,7 @@ import { LibraryDetailState } from '../library-detail.state';
 
 @Component({
   selector: 'app-library-form-fields',
-  imports: [FormsModule, TranslateModule, LucideIconComponent],
+  imports: [TvSelectDirective, FormsModule, TranslateModule, LucideIconComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './library-form-fields.html',
   host: { class: 'flex flex-col gap-5' },

--- a/client/src/app/features/settings/media-servers/media-servers.html
+++ b/client/src/app/features/settings/media-servers/media-servers.html
@@ -97,6 +97,7 @@
       <label class="form-control w-full">
         <span class="label-text">{{ 'settings.media_servers.field_type' | translate }}</span>
         <select
+    appTvSelect
           class="select select-bordered select-sm w-full"
           [ngModel]="formType()"
           (ngModelChange)="onTypeChange($event)"

--- a/client/src/app/features/settings/media-servers/media-servers.ts
+++ b/client/src/app/features/settings/media-servers/media-servers.ts
@@ -9,6 +9,7 @@ import {
   OnInit,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { LucideX } from '@lucide/angular';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
@@ -22,7 +23,7 @@ import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-media-servers-settings',
-  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
+  imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-servers.html',
 })

--- a/client/src/app/features/settings/notifications/notifications.html
+++ b/client/src/app/features/settings/notifications/notifications.html
@@ -95,6 +95,7 @@
       <label class="form-control w-full">
         <span class="label-text">{{ 'settings.notifications.field_type' | translate }}</span>
         <select
+    appTvSelect
           class="select select-bordered select-sm w-full"
           [ngModel]="formType()"
           (ngModelChange)="formType.set($event)"

--- a/client/src/app/features/settings/notifications/notifications.ts
+++ b/client/src/app/features/settings/notifications/notifications.ts
@@ -9,6 +9,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { HttpClient } from '@angular/common/http';
 import { LucideX } from '@lucide/angular';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -44,7 +45,7 @@ interface CreateNotificationBody {
 
 @Component({
   selector: 'app-notifications-settings',
-  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
+  imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './notifications.html',
 })

--- a/client/src/app/features/settings/quality-profiles/quality-profiles.html
+++ b/client/src/app/features/settings/quality-profiles/quality-profiles.html
@@ -97,6 +97,7 @@
       <label class="form-control w-full">
         <span class="label-text">{{ 'settings.quality_profiles.field_cutoff' | translate }}</span>
         <select
+    appTvSelect
           class="select select-bordered w-full"
           [ngModel]="formCutoff()"
           (ngModelChange)="formCutoff.set(+$event)"

--- a/client/src/app/features/settings/quality-profiles/quality-profiles.ts
+++ b/client/src/app/features/settings/quality-profiles/quality-profiles.ts
@@ -8,6 +8,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { ToggleFieldComponent } from '../../../shared/components/forms/toggle-field/toggle-field';
 import { RouterLink } from '@angular/router';
 import { LucideChevronLeft } from '@lucide/angular';
@@ -20,7 +21,7 @@ import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-quality-profiles',
-  imports: [
+  imports: [TvSelectDirective, 
     ModalFooterComponent,
     ModalHeaderComponent,
     FormsModule,

--- a/client/src/app/features/settings/streaming/streaming.html
+++ b/client/src/app/features/settings/streaming/streaming.html
@@ -9,7 +9,8 @@
          The help line below shows the trade-off of the selected mode. -->
     <div class="form-control">
       <label class="label"><span class="label-text font-medium">{{ 'settings.streaming.auto_quality_mode' | translate }}</span></label>
-      <select class="select select-bordered w-full" [ngModel]="autoQualityMode()" (ngModelChange)="autoQualityMode.set($event)">
+      <select
+    appTvSelect class="select select-bordered w-full" [ngModel]="autoQualityMode()" (ngModelChange)="autoQualityMode.set($event)">
         <option value="directplay">{{ 'settings.streaming.auto_quality_mode_directplay' | translate }} ({{ 'settings.streaming.default' | translate }})</option>
         <option value="abr">{{ 'settings.streaming.auto_quality_mode_abr' | translate }}</option>
       </select>
@@ -23,7 +24,8 @@
          container, so this picks where that read happens. -->
     <div class="form-control">
       <label class="label"><span class="label-text font-medium">{{ 'settings.streaming.subtitle_prewarm' | translate }}</span></label>
-      <select class="select select-bordered w-full" [ngModel]="subtitlePrewarm()" (ngModelChange)="subtitlePrewarm.set($event)">
+      <select
+    appTvSelect class="select select-bordered w-full" [ngModel]="subtitlePrewarm()" (ngModelChange)="subtitlePrewarm.set($event)">
         <option value="playback">{{ 'settings.streaming.subtitle_prewarm_playback' | translate }} ({{ 'settings.streaming.default' | translate }})</option>
         <option value="import">{{ 'settings.streaming.subtitle_prewarm_import' | translate }}</option>
         <option value="off">{{ 'settings.streaming.subtitle_prewarm_off' | translate }}</option>
@@ -37,7 +39,8 @@
     <!-- Segment duration -->
     <div class="form-control">
       <label class="label"><span class="label-text font-medium">{{ 'settings.streaming.segment_duration' | translate }}</span></label>
-      <select class="select select-bordered w-full" [ngModel]="segmentDuration()" (ngModelChange)="segmentDuration.set($event)">
+      <select
+    appTvSelect class="select select-bordered w-full" [ngModel]="segmentDuration()" (ngModelChange)="segmentDuration.set($event)">
         <option value="2">2s</option>
         <option value="3">3s</option>
         <option value="4">4s</option>
@@ -57,7 +60,8 @@
     <!-- QSV / libx264 encoder preset -->
     <div class="form-control">
       <label class="label"><span class="label-text font-medium">{{ 'settings.streaming.qsv_preset' | translate }}</span></label>
-      <select class="select select-bordered w-full" [ngModel]="qsvPreset()" (ngModelChange)="qsvPreset.set($event)">
+      <select
+    appTvSelect class="select select-bordered w-full" [ngModel]="qsvPreset()" (ngModelChange)="qsvPreset.set($event)">
         <option value="veryfast">veryfast</option>
         <option value="faster">faster ({{ 'settings.streaming.default' | translate }})</option>
         <option value="fast">fast</option>
@@ -74,7 +78,8 @@
     @if (tonemapAlgosAvailable().length > 1) {
       <div class="form-control">
         <label class="label"><span class="label-text font-medium">{{ 'settings.streaming.tonemap_algo' | translate }}</span></label>
-        <select class="select select-bordered w-full" [ngModel]="tonemapAlgo()" (ngModelChange)="tonemapAlgo.set($event)">
+        <select
+    appTvSelect class="select select-bordered w-full" [ngModel]="tonemapAlgo()" (ngModelChange)="tonemapAlgo.set($event)">
           @for (algo of tonemapAlgosAvailable(); track algo) {
             <option [value]="algo">{{ ('settings.streaming.tonemap_algo_' + algo) | translate }}@if (algo === 'auto') { ({{ 'settings.streaming.default' | translate }}) }</option>
           }
@@ -87,7 +92,8 @@
     @if (gpus().length > 1) {
       <div class="form-control">
         <label class="label"><span class="label-text font-medium">{{ 'settings.streaming.gpu_device' | translate }}</span></label>
-        <select class="select select-bordered w-full" [ngModel]="gpuRenderNode()" (ngModelChange)="gpuRenderNode.set($event)">
+        <select
+    appTvSelect class="select select-bordered w-full" [ngModel]="gpuRenderNode()" (ngModelChange)="gpuRenderNode.set($event)">
           <option value="auto">{{ 'settings.streaming.gpu_device_auto' | translate }}</option>
           @for (g of gpus(); track g.renderNode) {
             <option [value]="g.renderNode">{{ g.label }}</option>

--- a/client/src/app/features/settings/streaming/streaming.ts
+++ b/client/src/app/features/settings/streaming/streaming.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject, signal, OnInit } from '@angular/core';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ToggleFieldComponent } from '../../../shared/components/forms/toggle-field/toggle-field';
@@ -10,7 +11,7 @@ import { ToastService } from '../../../core/services/toast.service';
 
 @Component({
   selector: 'app-streaming-settings',
-  imports: [FormsModule, TranslateModule, ToggleFieldComponent],
+  imports: [TvSelectDirective, FormsModule, TranslateModule, ToggleFieldComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './streaming.html',
 })

--- a/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
+++ b/client/src/app/features/settings/subtitle-providers/subtitle-providers.html
@@ -257,6 +257,7 @@
           'settings.subtitle_providers.translation_engine' | translate
         }}</span>
         <select
+    appTvSelect
           class="select select-bordered select-sm w-full"
           [ngModel]="trFormEngine()"
           (ngModelChange)="onTranslationEngineChange($event)"
@@ -284,6 +285,7 @@
             'settings.subtitle_providers.translation_model' | translate
           }}</span>
           <select
+    appTvSelect
             class="select select-bordered select-sm w-full font-mono"
             [ngModel]="trFormModel()"
             (ngModelChange)="trFormModel.set($event)"

--- a/client/src/app/features/settings/subtitle-providers/subtitle-providers.ts
+++ b/client/src/app/features/settings/subtitle-providers/subtitle-providers.ts
@@ -8,6 +8,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { firstValueFrom } from 'rxjs';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -106,7 +107,7 @@ const LABELS: ProviderListLabels = {
 
 @Component({
   selector: 'app-subtitle-providers-settings',
-  imports: [
+  imports: [TvSelectDirective, 
     ModalFooterComponent,
     ModalHeaderComponent,
     FormsModule,

--- a/client/src/app/features/settings/subtitles-activity/subtitles-activity.html
+++ b/client/src/app/features/settings/subtitles-activity/subtitles-activity.html
@@ -1,14 +1,16 @@
 <h1 class="sr-only lg:not-sr-only text-2xl font-bold mb-4">{{ 'activity.tab_subtitles' | translate }}</h1>
 
 <div class="flex gap-2 mb-4">
-  <select class="select select-bordered select-sm" [ngModel]="subFilterStatus()" (ngModelChange)="subFilterStatus.set($event); applySubFilters()">
+  <select
+    appTvSelect class="select select-bordered select-sm" [ngModel]="subFilterStatus()" (ngModelChange)="subFilterStatus.set($event); applySubFilters()">
     <option value="">{{ 'activity.all_statuses' | translate }}</option>
     <option value="downloaded">{{ 'activity.status_downloaded' | translate }}</option>
     <option value="upgraded">{{ 'activity.status_upgraded' | translate }}</option>
     <option value="synced">{{ 'activity.status_synced' | translate }}</option>
     <option value="failed">{{ 'activity.status_failed' | translate }}</option>
   </select>
-  <select class="select select-bordered select-sm" [ngModel]="subFilterLang()" (ngModelChange)="subFilterLang.set($event); applySubFilters()">
+  <select
+    appTvSelect class="select select-bordered select-sm" [ngModel]="subFilterLang()" (ngModelChange)="subFilterLang.set($event); applySubFilters()">
     <option value="">{{ 'activity.all_languages' | translate }}</option>
     @for (code of languageCodes; track code) {
       <option [value]="code">{{ code | localizeLanguage }}</option>

--- a/client/src/app/features/settings/subtitles-activity/subtitles-activity.ts
+++ b/client/src/app/features/settings/subtitles-activity/subtitles-activity.ts
@@ -6,6 +6,7 @@ import {
   OnInit,
 } from '@angular/core';
 import { NgClass } from '@angular/common';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -21,7 +22,7 @@ import { episodeLabel } from '../../../shared/utils/episode-label';
 
 @Component({
   selector: 'app-subtitles-activity',
-  imports: [TranslateModule, LocaleDatePipe, LocalizeLanguagePipe, NgClass, RouterLink, FormsModule, PaginationComponent],
+  imports: [TvSelectDirective, TranslateModule, LocaleDatePipe, LocalizeLanguagePipe, NgClass, RouterLink, FormsModule, PaginationComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './subtitles-activity.html',
 })

--- a/client/src/app/features/settings/users/user-detail/user-general.html
+++ b/client/src/app/features/settings/users/user-detail/user-general.html
@@ -41,6 +41,7 @@
       <label class="form-control w-full">
         <span class="label-text">{{ 'settings.users.field_role' | translate }}</span>
         <select
+    appTvSelect
           class="select select-bordered select-sm w-full"
           [ngModel]="formRoleId()"
           (ngModelChange)="formRoleId.set($event)"

--- a/client/src/app/features/settings/users/user-detail/user-general.ts
+++ b/client/src/app/features/settings/users/user-detail/user-general.ts
@@ -6,6 +6,7 @@ import {
   OnInit,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../../../shared/directives/tv-select.directive';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
   UsersApiService,
@@ -21,7 +22,7 @@ import { LucideIconComponent } from '../../../../shared/components/lucide-icon';
 
 @Component({
   selector: 'app-user-general',
-  imports: [FormsModule, TranslateModule, LucideIconComponent],
+  imports: [TvSelectDirective, FormsModule, TranslateModule, LucideIconComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './user-general.html',
 })

--- a/client/src/app/features/settings/users/users.html
+++ b/client/src/app/features/settings/users/users.html
@@ -108,6 +108,7 @@
       <label class="form-control w-full">
         <span class="label-text">{{ 'settings.users.field_role' | translate }}</span>
         <select
+    appTvSelect
           class="select select-bordered select-sm w-full"
           [ngModel]="formRoleId()"
           (ngModelChange)="formRoleId.set($event)"

--- a/client/src/app/features/settings/users/users.ts
+++ b/client/src/app/features/settings/users/users.ts
@@ -8,6 +8,7 @@ import {
   OnInit,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { RouterLink } from '@angular/router';
 import { LucideX } from '@lucide/angular';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -26,7 +27,7 @@ import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 
 @Component({
   selector: 'app-users-settings',
-  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, RouterLink, TranslateModule],
+  imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, RouterLink, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './users.html',
 })

--- a/client/src/app/features/system/logs/logs.html
+++ b/client/src/app/features/system/logs/logs.html
@@ -1,5 +1,6 @@
 <div class="flex justify-end gap-2 mb-3">
-  <select class="select select-bordered select-xs" [ngModel]="logLevel()" (ngModelChange)="logLevel.set($event); load()">
+  <select
+    appTvSelect class="select select-bordered select-xs" [ngModel]="logLevel()" (ngModelChange)="logLevel.set($event); load()">
     <option value="">{{ 'system.logs_all_levels' | translate }}</option>
     <option value="log">Info</option>
     <option value="warn">Warning</option>

--- a/client/src/app/features/system/logs/logs.ts
+++ b/client/src/app/features/system/logs/logs.ts
@@ -2,6 +2,7 @@ import {
   Component, ChangeDetectionStrategy, signal, inject, OnInit, OnDestroy,
 } from '@angular/core';
 import { DatePipe, NgClass } from '@angular/common';
+import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { FormsModule } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
 import { TranslateModule } from '@ngx-translate/core';
@@ -9,7 +10,7 @@ import { firstValueFrom } from 'rxjs';
 
 @Component({
   selector: 'app-system-logs',
-  imports: [TranslateModule, DatePipe, NgClass, FormsModule],
+  imports: [TvSelectDirective, TranslateModule, DatePipe, NgClass, FormsModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './logs.html',
 })

--- a/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.html
+++ b/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.html
@@ -23,6 +23,7 @@
               'discover.quality_profile' | translate
             }}</span>
             <select
+    appTvSelect
               class="select select-bordered select-sm w-full"
               [ngModel]="selectedQualityProfileId()"
               (ngModelChange)="selectedQualityProfileId.set(+$event)"
@@ -39,6 +40,7 @@
               'discover.language_profile' | translate
             }}</span>
             <select
+    appTvSelect
               class="select select-bordered select-sm w-full"
               [ngModel]="selectedLanguageProfileId()"
               (ngModelChange)="selectedLanguageProfileId.set(+$event)"
@@ -55,6 +57,7 @@
               'settings.libraries.title' | translate
             }}</span>
             <select
+    appTvSelect
               class="select select-bordered select-sm w-full"
               [ngModel]="selectedLibraryId()"
               (ngModelChange)="selectedLibraryId.set($event ? +$event : null)"

--- a/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.ts
+++ b/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.ts
@@ -10,6 +10,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../../../shared/directives/tv-select.directive';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { Router } from '@angular/router';
 import { MetadataService } from '../../../../core/services/api/metadata.service';
@@ -23,7 +24,7 @@ import { ModalFooterComponent } from '../../../../shared/components/modal-footer
 
 @Component({
   selector: 'app-import-modal',
-  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
+  imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './import-modal.component.html',
 })

--- a/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.html
+++ b/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.html
@@ -93,6 +93,7 @@
                 'settings.libraries.title' | translate
               }}</span>
               <select
+    appTvSelect
                 class="select select-bordered select-sm w-full"
                 [ngModel]="libraryId()"
                 (ngModelChange)="libraryId.set($event ? +$event : null)"
@@ -110,6 +111,7 @@
                 'discover.quality_profile' | translate
               }}</span>
               <select
+    appTvSelect
                 class="select select-bordered select-sm w-full"
                 [ngModel]="qualityProfileId()"
                 (ngModelChange)="qualityProfileId.set(+$event)"
@@ -126,6 +128,7 @@
                 'discover.language_profile' | translate
               }}</span>
               <select
+    appTvSelect
                 class="select select-bordered select-sm w-full"
                 [ngModel]="languageProfileId()"
                 (ngModelChange)="languageProfileId.set(+$event)"

--- a/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.ts
+++ b/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.ts
@@ -10,6 +10,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../../../shared/directives/tv-select.directive';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { MetadataService, MetadataSeason } from '../../../../core/services/api/metadata.service';
 import { RequestsService } from '../../../../core/services/api/requests.service';
@@ -21,7 +22,7 @@ import { ModalFooterComponent } from '../../../../shared/components/modal-footer
 
 @Component({
   selector: 'app-request-modal',
-  imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
+  imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './request-modal.component.html',
 })

--- a/client/src/app/shared/components/bottom-sheet.ts
+++ b/client/src/app/shared/components/bottom-sheet.ts
@@ -13,7 +13,11 @@ import {
 } from '@angular/core';
 import { DismissableStackService } from '../../core/services/dismissable-stack.service';
 import { TvService } from '../../core/services/tv.service';
-import { TABBABLE_SELECTOR, initialOverlayFocus } from '../../core/services/focusable.constants';
+import {
+  TABBABLE_SELECTOR,
+  initialOverlayFocus,
+  restoreOpenerFocus,
+} from '../../core/services/focusable.constants';
 
 @Component({
   selector: 'app-bottom-sheet',
@@ -295,9 +299,7 @@ export class BottomSheetComponent {
     if (this.focusTrapActive && typeof document !== 'undefined') {
       document.removeEventListener('focusin', this.onFocusIn);
       this.focusTrapActive = false;
-      if (this.prevFocused && document.contains(this.prevFocused)) {
-        this.prevFocused.focus({ preventScroll: true });
-      }
+      restoreOpenerFocus(this.prevFocused);
       this.prevFocused = null;
     }
   }

--- a/client/src/app/shared/components/bottom-sheet.ts
+++ b/client/src/app/shared/components/bottom-sheet.ts
@@ -28,13 +28,17 @@ import { TABBABLE_SELECTOR, initialOverlayFocus } from '../../core/services/focu
     @if (visible()) {
       <!-- Backdrop — CSS @starting-style handles the fade-in declaratively
            (browser interpolates from opacity 0 on element creation), so the
-           component does not need a JS-side toggling pattern. -->
+           component does not need a JS-side toggling pattern.
+           Preventing the pointerdown default keeps the tap from blurring
+           whatever opened the sheet: focus used to leave and be restored a tick
+           later, which flickered the opener's ring off and back on. -->
       <div
         [class]="
           'bottom-sheet-backdrop fixed inset-0 z-[100] transition-opacity duration-150 ' +
           (showBackdrop() ? 'bg-black/60' : '')
         "
         [class.opacity-0]="dismissing()"
+        (pointerdown)="$event.preventDefault()"
         (click)="dismiss()"
       ></div>
       <!-- Sheet -->

--- a/client/src/app/shared/components/data-table/data-table.html
+++ b/client/src/app/shared/components/data-table/data-table.html
@@ -51,6 +51,7 @@
           }
           @case ('select') {
             <select
+    appTvSelect
               class="select select-bordered select-sm"
               [attr.aria-label]="filter.labelKey | translate"
               (change)="onSelectChange(filter.key, $event)"

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -11,6 +11,7 @@ import {
   untracked,
 } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
+import { TvSelectDirective } from '../../directives/tv-select.directive';
 import { Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -65,7 +66,7 @@ const BADGE_CLASSES: Readonly<Record<BadgeTone, string>> = {
  */
 @Component({
   selector: 'app-data-table',
-  imports: [
+  imports: [TvSelectDirective, 
     ModalFooterComponent,
     ModalHeaderComponent,
     TranslateModule,

--- a/client/src/app/shared/components/dropdown-menu.ts
+++ b/client/src/app/shared/components/dropdown-menu.ts
@@ -11,6 +11,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
+import { restoreOpenerFocus } from '../../core/services/focusable.constants';
 import { BottomSheetComponent } from './bottom-sheet';
 import { DropdownToggleDirective } from '../directives/dropdown-toggle.directive';
 import { DeviceService } from '../../core/services/device.service';
@@ -129,9 +130,9 @@ export class DropdownMenuComponent {
       this.wasOpen = open;
       if (!justClosed || this.useDropdown()) return;
       queueMicrotask(() => {
-        this.host.nativeElement
-          .querySelector<HTMLElement>('[trigger]')
-          ?.focus({ preventScroll: true });
+        restoreOpenerFocus(
+          this.host.nativeElement.querySelector<HTMLElement>('[trigger]'),
+        );
       });
     });
   }

--- a/client/src/app/shared/components/dropdown-option/dropdown-option.html
+++ b/client/src/app/shared/components/dropdown-option/dropdown-option.html
@@ -1,4 +1,12 @@
-<button type="button" class="dropdown-item" [class.text-primary]="selected()">
+<!-- `aria-current` is what the shared initial-focus rule looks for, so a menu
+     opens on the current choice instead of at the top, and a screen reader
+     announces it. The colour and the dot alone said it only visually. -->
+<button
+  type="button"
+  class="dropdown-item"
+  [class.text-primary]="selected()"
+  [attr.aria-current]="selected() ? 'true' : null"
+>
   @if (imageUrl()) {
     <img
       [cachedSrc]="imageUrl()! | resolveUrl:'thumb'"

--- a/client/src/app/shared/components/dropdown-option/dropdown-option.spec.ts
+++ b/client/src/app/shared/components/dropdown-option/dropdown-option.spec.ts
@@ -1,0 +1,28 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { DropdownOptionComponent } from './dropdown-option';
+
+/**
+ * `aria-current` is not decoration here: it is the marker
+ * `initialOverlayFocus` looks for, so it decides whether a menu opens on the
+ * current choice or at the top of the list.
+ */
+describe('DropdownOptionComponent', () => {
+  const render = (selected: boolean) => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
+    const fixture = TestBed.createComponent(DropdownOptionComponent);
+    fixture.componentRef.setInput('head', 'French');
+    fixture.componentRef.setInput('selected', selected);
+    fixture.detectChanges();
+    return fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+  };
+
+  it('marks the selected option as current so a menu opens on it', () => {
+    expect(render(true).getAttribute('aria-current')).toBe('true');
+  });
+
+  it('leaves an unselected option unmarked, so exactly one is the target', () => {
+    expect(render(false).getAttribute('aria-current')).toBeNull();
+  });
+});

--- a/client/src/app/shared/components/forms/searchable-select/searchable-select.html
+++ b/client/src/app/shared/components/forms/searchable-select/searchable-select.html
@@ -38,6 +38,7 @@
             type="button"
             class="w-full text-left px-3 py-1.5 text-sm hover:bg-base-200"
             [class.text-primary]="value() === null"
+            [attr.aria-current]="value() === null ? 'true' : null"
             (click)="pick(null)"
           >
             {{ emptyOptionLabel() }}
@@ -50,6 +51,7 @@
             type="button"
             class="w-full text-left px-3 py-1.5 text-sm hover:bg-base-200 truncate"
             [class.text-primary]="opt.value === value()"
+            [attr.aria-current]="opt.value === value() ? 'true' : null"
             (click)="pick(opt.value)"
             [title]="opt.label"
           >

--- a/client/src/app/shared/components/forms/select-field/select-field.html
+++ b/client/src/app/shared/components/forms/select-field/select-field.html
@@ -1,6 +1,7 @@
 <label class="form-control w-full">
   <div class="label"><span class="label-text font-medium">{{ label() }}</span></div>
   <select
+    appTvSelect
     class="select select-bordered w-full"
     [class.select-sm]="size() === 'sm'"
     [ngModel]="value()"

--- a/client/src/app/shared/components/forms/select-field/select-field.ts
+++ b/client/src/app/shared/components/forms/select-field/select-field.ts
@@ -5,6 +5,7 @@ import {
   model,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../../directives/tv-select.directive';
 
 /**
  * DaisyUI select with label + optional hint. Options are projected via
@@ -18,7 +19,7 @@ import { FormsModule } from '@angular/forms';
  */
 @Component({
   selector: 'app-select-field',
-  imports: [FormsModule],
+  imports: [TvSelectDirective, FormsModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './select-field.html',
 })

--- a/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
@@ -132,6 +132,7 @@ async function createFixture(
           mobileNavbarVisible: () => true,
           effectiveSidebarPinned: () => false,
           sidebarPinned: () => false,
+          sidebarDocked: () => false,
           toggleSidebarPinned: () => {},
           scrollAtTop: { set: () => {} },
           setPageTitle: () => {},

--- a/client/src/app/shared/components/popover-menu.ts
+++ b/client/src/app/shared/components/popover-menu.ts
@@ -52,8 +52,14 @@ import { initialOverlayFocus } from '../../core/services/focusable.constants';
     <ng-template #content><ng-content></ng-content></ng-template>
 
     @if (open() && useDropdown()) {
-      <!-- Click-out backdrop (transparent) -->
-      <div class="fixed inset-0 z-[100]" (click)="close()"></div>
+      <!-- Click-out backdrop (transparent). Preventing the pointerdown default
+           keeps the click from blurring the opener first: focus would leave and
+           be restored a tick later, flickering its ring off and back on. -->
+      <div
+        class="fixed inset-0 z-[100]"
+        (pointerdown)="$event.preventDefault()"
+        (click)="close()"
+      ></div>
       <div
         data-tv-modal
         [attr.data-tv-submenu]="submenu() ? '' : null"

--- a/client/src/app/shared/components/popover-menu.ts
+++ b/client/src/app/shared/components/popover-menu.ts
@@ -15,7 +15,7 @@ import { BottomSheetComponent } from './bottom-sheet';
 import { TvService } from '../../core/services/tv.service';
 import { DeviceService } from '../../core/services/device.service';
 import { DismissableStackService } from '../../core/services/dismissable-stack.service';
-import { initialOverlayFocus } from '../../core/services/focusable.constants';
+import { initialOverlayFocus, restoreOpenerFocus } from '../../core/services/focusable.constants';
 
 /**
  * Reusable menu chrome that picks its presentation per-platform:
@@ -189,8 +189,7 @@ export class PopoverMenuComponent {
       // focus to the opener so keyboard / D-pad users don't lose their place
       // (a submenu returns to its parent entry, a menu to its trigger).
       const close = () => {
-        const opener = this.anchor();
-        if (opener?.isConnected) opener.focus({ preventScroll: true });
+        restoreOpenerFocus(this.anchor());
         this.close();
       };
       this.dismissStack.push(close);

--- a/client/src/app/shared/components/settings-drawer/settings-drawer.html
+++ b/client/src/app/shared/components/settings-drawer/settings-drawer.html
@@ -1,18 +1,14 @@
-<!-- Drawer: `lg:drawer-open` is gated on NON-tv so desktop keeps the
-     pinned-sidebar look while TV behaves like mobile (checkbox-driven,
-     transient). `tv-drawer-closed` is NOT used — the checkbox alone
-     controls visibility, no class toggle, no `display:none` override,
-     no DaisyUI animation quirks to dance around. -->
-<div class="drawer min-h-screen" [class.lg:drawer-open]="!tv.isTv()">
+<!-- The sidebar is pinned from `lg` up, which covers desktop and TV alike: an
+     admin surface wants its sections in view, not behind a hamburger. Below
+     `lg` the checkbox drives a transient drawer. -->
+<div class="drawer min-h-screen lg:drawer-open">
   <input [id]="drawerId()" #drawerToggle type="checkbox" class="drawer-toggle" />
   <div class="drawer-content flex flex-col relative min-w-0">
-    <!-- Top bar — `lg:hidden` on desktop only. On TV the navbar is
-         permanent (drawer is transient there, the hamburger is the
-         entry point back). -->
+    <!-- Top bar and its hamburger belong to the transient drawer only: with the
+         sidebar pinned they would duplicate its own title and back link. -->
     <nav
       appTvRow
-      class="navbar bg-base-100 shadow-sm fixed top-0 left-0 right-0 z-30 transition-all duration-300"
-      [class.lg:hidden]="!tv.isTv()"
+      class="navbar bg-base-100 shadow-sm fixed top-0 left-0 right-0 z-30 transition-all duration-300 lg:hidden"
       style="padding-top: calc(env(safe-area-inset-top, 0px) + 4px)"
       [class.top-4]="tv.isAndroidTv()"
       [class.-translate-y-full]="navbarHidden()"
@@ -32,7 +28,7 @@
     <!-- Spacer pushes content below the fixed navbar (visible on TV too
          where the navbar is permanent). -->
     <div
-      [class.lg:hidden]="!tv.isTv()"
+      class="lg:hidden"
       style="height: calc(env(safe-area-inset-top, 0px) + 4rem)"
     ></div>
     <main
@@ -62,7 +58,7 @@
         </h2>
       </div>
 
-      <ul class="menu p-4 flex-1 gap-0.5 min-w-64 overflow-y-auto" (click)="onMenuClick($event)">
+      <ul class="menu p-4 flex-1 gap-0.5 min-w-64 overflow-y-auto">
         <ng-content select="[drawerMenu]"></ng-content>
       </ul>
     </aside>

--- a/client/src/app/shared/components/settings-drawer/settings-drawer.ts
+++ b/client/src/app/shared/components/settings-drawer/settings-drawer.ts
@@ -59,9 +59,6 @@ export class SettingsDrawerComponent implements OnInit, OnDestroy {
     this.titleService.setTitle(page ? `${page} | ${layout}` : layout);
   });
 
-  private readonly drawerToggleEl =
-    viewChild<ElementRef<HTMLInputElement>>('drawerToggle');
-
   private lastScrollY = 0;
   private readonly onScroll = () => {
     const y = window.scrollY;
@@ -71,16 +68,6 @@ export class SettingsDrawerComponent implements OnInit, OnDestroy {
   };
 
   ngOnInit() {
-    // On TV the drawer behaves like mobile (checkbox-driven, no
-    // `lg:drawer-open`). Start "open" so the user lands on /admin with
-    // the sidebar visible — they navigate to a section, drawer slides
-    // out, hamburger brings it back.
-    if (this.tv.isTv()) {
-      queueMicrotask(() => {
-        const cb = this.drawerToggleEl()?.nativeElement;
-        if (cb) cb.checked = true;
-      });
-    }
     window.addEventListener('scroll', this.onScroll, { passive: true });
 
     this.routerSub = this.router.events
@@ -124,14 +111,4 @@ export class SettingsDrawerComponent implements OnInit, OnDestroy {
     this.location.back();
   }
 
-  /** Click inside the menu region (TV) — close the drawer if the click
-   *  hit a link so the main content takes over. No-op on desktop where
-   *  `lg:drawer-open` keeps the drawer permanent. */
-  onMenuClick(event: Event) {
-    if (!this.tv.isTv()) return;
-    const target = event.target as HTMLElement | null;
-    if (!target?.closest('a')) return;
-    const cb = this.drawerToggleEl()?.nativeElement;
-    if (cb) cb.checked = false;
-  }
 }

--- a/client/src/app/shared/components/subtitle-appearance/subtitle-appearance.ts
+++ b/client/src/app/shared/components/subtitle-appearance/subtitle-appearance.ts
@@ -5,6 +5,7 @@ import {
   output,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../directives/tv-select.directive';
 import { TranslateModule } from '@ngx-translate/core';
 import {
   SIZE_OPTIONS,
@@ -25,7 +26,7 @@ import {
 @Component({
   selector: 'app-subtitle-appearance',
   standalone: true,
-  imports: [FormsModule, TranslateModule],
+  imports: [TvSelectDirective, FormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="flex flex-col gap-5">
@@ -36,28 +37,28 @@ import {
 
       <label class="form-control w-full max-w-xs">
         <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_size' | translate }}</span></div>
-        <select class="select select-bordered w-full" [ngModel]="size()" (ngModelChange)="sizeChange.emit($event)">
+        <select appTvSelect class="select select-bordered w-full" [ngModel]="size()" (ngModelChange)="sizeChange.emit($event)">
           @for (s of sizeOptions; track s.value) { <option [value]="s.value">{{ s.labelKey | translate }}</option> }
         </select>
       </label>
 
       <label class="form-control w-full max-w-xs">
         <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_color' | translate }}</span></div>
-        <select class="select select-bordered w-full" [ngModel]="color()" (ngModelChange)="colorChange.emit($event)">
+        <select appTvSelect class="select select-bordered w-full" [ngModel]="color()" (ngModelChange)="colorChange.emit($event)">
           @for (c of colorOptions; track c.value) { <option [value]="c.value">{{ c.labelKey | translate }}</option> }
         </select>
       </label>
 
       <label class="form-control w-full max-w-xs">
         <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_shadow' | translate }}</span></div>
-        <select class="select select-bordered w-full" [ngModel]="shadow()" (ngModelChange)="shadowChange.emit($event)">
+        <select appTvSelect class="select select-bordered w-full" [ngModel]="shadow()" (ngModelChange)="shadowChange.emit($event)">
           @for (s of shadowOptions; track s.value) { <option [value]="s.value">{{ s.labelKey | translate }}</option> }
         </select>
       </label>
 
       <label class="form-control w-full max-w-xs">
         <div class="label"><span class="label-text font-medium">{{ 'playback_settings.sub_bg' | translate }}</span></div>
-        <select class="select select-bordered w-full" [ngModel]="background()" (ngModelChange)="backgroundChange.emit($event)">
+        <select appTvSelect class="select select-bordered w-full" [ngModel]="background()" (ngModelChange)="backgroundChange.emit($event)">
           @for (b of bgOptions; track b.value) { <option [value]="b.value">{{ b.labelKey | translate }}</option> }
         </select>
       </label>

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -244,6 +244,7 @@
       <label class="form-control w-full">
         <span class="label-text">{{ 'media_detail.sync_reference' | translate }}</span>
         <select
+    appTvSelect
           class="select select-bordered select-sm w-full"
           [ngModel]="syncReference()"
           (ngModelChange)="syncReference.set($event)"
@@ -414,6 +415,7 @@
       <label class="form-control flex-1">
         <span class="label-text">{{ 'media_detail.fps_from' | translate }}</span>
         <select
+    appTvSelect
           class="select select-bordered select-sm w-full"
           [ngModel]="fpsFrom()"
           (ngModelChange)="fpsFrom.set($event)"
@@ -428,6 +430,7 @@
       <label class="form-control flex-1">
         <span class="label-text">{{ 'media_detail.fps_to' | translate }}</span>
         <select
+    appTvSelect
           class="select select-bordered select-sm w-full"
           [ngModel]="fpsTo()"
           (ngModelChange)="fpsTo.set($event)"
@@ -492,6 +495,7 @@
     </app-modal-header>
     <div class="mt-2 space-y-4">
       <select
+    appTvSelect
         class="select select-bordered w-full"
         [ngModel]="ocrLang()"
         (ngModelChange)="ocrLang.set($event)"
@@ -504,6 +508,7 @@
         <label class="form-control w-full">
           <span class="label-text mb-1">{{ 'media_detail.translate_provider' | translate }}</span>
           <select
+    appTvSelect
             class="select select-bordered w-full"
             [ngModel]="selectedTranslationProviderId()"
             (ngModelChange)="selectedTranslationProviderId.set($event)"

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -10,6 +10,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { TvSelectDirective } from '../../directives/tv-select.directive';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
   LucideChevronDown,
@@ -68,7 +69,7 @@ interface SubtitleRow {
  */
 @Component({
   selector: 'app-subtitles-modal',
-  imports: [
+  imports: [TvSelectDirective, 
     ModalFooterComponent,
     ModalHeaderComponent,
     FormsModule,

--- a/client/src/app/shared/components/user-menu.html
+++ b/client/src/app/shared/components/user-menu.html
@@ -36,7 +36,8 @@
     <svg lucideSettings class="h-5 w-5 shrink-0 opacity-80"></svg>
     <span class="flex-1">{{ 'nav.app_settings' | translate }}</span>
   </a>
-  @if (auth.canAccessSettings()) {
+  <!-- Its route already refuses a TV, so the entry only led to a dead end. -->
+  @if (auth.canAccessSettings() && !tv.isTv()) {
     <a routerLink="/admin" class="dropdown-item text-white">
       <svg lucideShield class="h-5 w-5 shrink-0 opacity-80"></svg>
       <span class="flex-1">{{ 'nav.administration' | translate }}</span>

--- a/client/src/app/shared/directives/dropdown-toggle.directive.ts
+++ b/client/src/app/shared/directives/dropdown-toggle.directive.ts
@@ -1,6 +1,6 @@
 import { Directive, ElementRef, inject, OnDestroy } from '@angular/core';
 import { DismissableStackService } from '../../core/services/dismissable-stack.service';
-import { TABBABLE_SELECTOR, initialOverlayFocus } from '../../core/services/focusable.constants';
+import { TABBABLE_SELECTOR, initialOverlayFocus, restoreOpenerFocus } from '../../core/services/focusable.constants';
 
 /**
  * Click-driven `.dropdown-open` toggle for any DaisyUI dropdown trigger.
@@ -84,7 +84,7 @@ export class DropdownToggleDirective implements OnDestroy {
     });
     const close = () => {
       dropdown.classList.remove('dropdown-open');
-      this.triggerEl?.focus({ preventScroll: true });
+      restoreOpenerFocus(this.triggerEl);
       this.cleanup();
     };
     this.currentClose = close;

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -1,6 +1,6 @@
 <app-background />
 <div class="drawer min-h-screen"
-     [class.lg:drawer-open]="device.isDesktop() || (device.isTv() && navbar.effectiveSidebarPinned())"
+     [class.lg:drawer-open]="navbar.sidebarDocked()"
      [class.md:drawer-open]="device.isTablet() && navbar.effectiveSidebarPinned()">
   <input id="sidebar" type="checkbox" class="drawer-toggle" />
   <div class="drawer-content flex flex-col relative">

--- a/client/src/app/shared/layout/layout.spec.ts
+++ b/client/src/app/shared/layout/layout.spec.ts
@@ -141,6 +141,7 @@ async function createFixture(f: Fixture): Promise<ComponentFixture<LayoutCompone
           mobileNavbarVisible: () => true,
           effectiveSidebarPinned: () => false,
           sidebarPinned: () => false,
+          sidebarDocked: () => false,
           toggleSidebarPinned: () => {},
           scrollAtTop: { set: () => {} },
           setPageTitle: () => {},

--- a/client/src/app/shared/layout/layout.spec.ts
+++ b/client/src/app/shared/layout/layout.spec.ts
@@ -304,6 +304,7 @@ describe('LayoutComponent nav — characterisation (data, not pixels)', () => {
     nativeState.value = false;
   });
 
+
   it('sidebar: admin with libraries', async () => {
     const fixture = await createFixture(ADMIN_WITH_LIBRARIES);
     expect(sidebarItems(fixture.nativeElement)).toEqual([

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -483,6 +483,15 @@ body:not(.keyboard-modality):not(.tv)
   box-shadow: none !important;
 }
 
+/* daisyUI paints its own outline on a focused select. The suppression above is
+   written against :focus-visible, which some engines do not match on a tapped
+   select (WebKit notably), so there the outline stayed and read as a second ring
+   next to the untouched border. Reached on plain :focus so the modality, not the
+   engine's focus-visible verdict, decides. */
+body:not(.keyboard-modality):not(.tv) .select:focus {
+  outline: none;
+}
+
 /* iOS Safari auto-zooms the viewport when a focused input has
    `font-size` below 16 px — Apple's anti-eyestrain default, but it
    reads as "the page suddenly grows" when tapping the search bar.

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -18,8 +18,13 @@
 
 /* Thinner focus outline on form fields. Suppress daisyUI's border on focus —
    the focus ring (outline) is the only visual cue we want, the extra white
-   border doubled up with the ring looks noisy. */
-.select:focus, .input:focus, .textarea:focus {
+   border doubled up with the ring looks noisy.
+
+   A select uses `:focus-visible` rather than `:focus`: it has no caret, so a
+   tap has nothing left to show once the ring is suppressed, and dropping the
+   border too made a tapped field look borderless. Text fields keep `:focus` —
+   their caret is the indication and the ring is not the only cue. */
+.select:focus-visible, .input:focus, .textarea:focus {
   outline-width: 1px;
   outline-offset: 0px;
   border-color: transparent;
@@ -467,9 +472,13 @@ body.tv *:hover {
    class is set by app.ts on the first navigation keydown and cleared
    on the next pointer / touch interaction; TV always uses the ring
    so it short-circuits the suppression. `transform: none` covers the
-   scale-up rule on media cards a few selectors down. */
+   scale-up rule on media cards a few selectors down.
+
+   A select is not exempt: tapping one opens its picker, which is the
+   indication, and no platform leaves a ring on a field after a tap. Text
+   fields stay exempt because a caret alone reads as nothing on a wide row. */
 body:not(.keyboard-modality):not(.tv)
-  :focus-visible:not(input, textarea, select, [contenteditable]) {
+  :focus-visible:not(input, textarea, [contenteditable]) {
   outline: none !important;
   box-shadow: none !important;
 }

--- a/client/tizen/build-wgt.mjs
+++ b/client/tizen/build-wgt.mjs
@@ -62,6 +62,7 @@ const UNSAFE_TOKENS = [
   [/(?<!\\)@starting-style[\s{]/, '@starting-style'],
   [/\d(?:cqi|cqw|cqh|cqb)\b/, 'container-query length unit'],
   [/:where\(/, ':where()'],
+  [/\binfinity\b/, "`infinity` in calc — `rounded-full` should have folded to a finite length"],
 ];
 for (const f of stylesFiles) {
   const css = readFileSync(resolve(stage, f), 'utf8');


### PR DESCRIPTION
TV polish, plus three fixes that turned out to be app-wide rather than TV-only.

## Selects

Every dashboard select now routes through the styled picker. The mechanism already existed as the
`appTvSelect` directive, rendered by `app-select-picker`, and media detail used it while the
dashboards did not: 62 selects across settings, playback and app settings, requests, libraries,
playlists, the TMDB preview, search and persons, including the shared select field and data table so
their consumers follow.

An unknown attribute on a native element is not a template error, so a missing directive import
would have failed silently: every touched pair was checked. The scan also had to cover inline
templates, which is where the subtitle appearance selects were hiding.

## An option menu opens on the current choice

The shared initial-focus rule looks for `aria-current`, and the shared option row marked its
selection only with a colour and a dot, so every menu built on it opened at the top of the list: the
language and subtitle pickers on a media page, and the cast overlay's. Marking it there fixes all of
them and lets a screen reader announce the choice. Both open paths already asked the shared rule.

## Focus is settled by modality when an overlay closes

Five close paths handed focus back to the opener; only the select picker asked whether the modality
wanted it. On touch that left a focus mark on a control the user had already left. The question now
lives in one function beside the one that decides where focus lands on open.

Two related pieces: the backdrops stop the pointerdown default, so a dismissing tap no longer blurs
the opener first and the ring cannot flicker off and back on under the keyboard; and a tapped select
no longer keeps a ring at all, which is the platform convention. Keyboard and D-pad are untouched,
the ring is what tells them where they are.

## Round things stay round on Tizen

Tailwind v4 emits `calc(infinity * 1px)` for `rounded-full`, and Chromium 85 has no `infinity`
keyword, so it discarded the declaration: every pill, avatar, badge and dot rendered square. The
downlevel pass folds it to a finite length, and the build guard now blocks on the token, which is
what it exists for. It already catches individual transform properties and container queries and
missed this one.

## TV shells

The admin and settings shells treated TV like mobile: a transient drawer behind a hamburger. An
admin surface wants its sections in view, and "pinned, no hamburger" is exactly the desktop
treatment, so the TV branch is gone rather than replaced by a third variant. With it go the top bar
that duplicated the sidebar's own title and back link, the forced open at mount, and the
close-on-link handler.

The main layout is the opposite case and never docks its sidebar on a TV: it is a 10-foot browse
surface, a permanent column steals from it, and focus would have one more region to escape on every
screen. Defaulting the pin on had docked it there.

The Chromecast section leaves app settings on a TV (a TV is a cast target, never a sender) and the
administration entry leaves the user menu, whose route already refused a TV, so the entry only led to
a dead end.

## Two smaller ones

The home zone catalogue and the TV exclusion lived in different files, so the settings page offered
to reorder a zone the home page never rendered. `resolve` now answers "which zones exist here", form
factor included.

An unreleased episode is no longer greyed when its file is already there: the air date is the
source's view and the video can land before it.

## Verification

| Check | Result |
|---|---|
| Client `tsc` | exit 0 |
| `ng build` | success, no warnings |
| Client tests | 73 suites, 682 tests |
| Tizen bundle | downlevel guard passes, no `infinity` left |

Deployed to a Samsung QE85Q80BATXXC throughout. What a machine cannot check here is the rendering
and the D-pad path: that focus reaches the now-pinned admin sidebar and gets back out, and that the
Android press behaviour reads right.
