### PR TITLE
fix(media-actions): hide download when no file is on disk

### DIFF
--- a/client/src/app/shared/components/media-info-header/core-media-actions.ts
+++ b/client/src/app/shared/components/media-info-header/core-media-actions.ts
@@ -39,7 +39,7 @@ export const CORE_MEDIA_ACTIONS: readonly UiContribution[] = [
     weight: 140,
     labelKey: 'downloads.download',
     icon: 'download',
-    when: ['!isTv', 'mediaType:movie'],
+    when: ['!isTv', 'hasFiles', 'mediaType:movie'],
     action: { kind: 'action', actionId: 'media.download' },
   },
   {
@@ -50,7 +50,7 @@ export const CORE_MEDIA_ACTIONS: readonly UiContribution[] = [
     weight: 140,
     labelKey: 'downloads.download',
     icon: 'download',
-    when: ['!isTv', 'isEpisode', 'surface:card'],
+    when: ['!isTv', 'hasFiles', 'isEpisode', 'surface:card'],
     action: { kind: 'action', actionId: 'media.download' },
   },
   // ── Rows a card owns ────────────────────────────────────────────────────

--- a/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
@@ -269,7 +269,6 @@ describe('MediaInfoHeaderComponent — media.actions permission matrix', () => {
     expect(labels(fixture)).toEqual([
       'recommend.menu_item',
       'media_detail.like',
-      'downloads.download',
       'media_detail.add_to_list',
       'media_card.mark_watched',
       'media_detail.edit_subtitles',
@@ -307,7 +306,6 @@ describe('MediaInfoHeaderComponent — media.actions permission matrix', () => {
     expect(labels(fixture)).toEqual([
       'recommend.menu_item',
       'media_detail.like',
-      'downloads.download',
       'media_detail.add_to_list',
       'media_card.mark_watched',
       'media_detail.edit_subtitles',
@@ -331,7 +329,6 @@ describe('MediaInfoHeaderComponent — media.actions permission matrix', () => {
     expect(labels(fixture)).toEqual([
       'recommend.menu_item',
       'media_detail.like',
-      'downloads.download',
       'media_detail.add_to_list',
       'media_card.mark_watched',
       'media_detail.request_media',
@@ -359,7 +356,6 @@ describe('MediaInfoHeaderComponent — media.actions permission matrix', () => {
     expect(labels(fixture)).toEqual([
       'recommend.menu_item',
       'media_detail.like',
-      'downloads.download',
       'media_detail.add_to_list',
       'media_card.mark_watched',
       'media_detail.edit_subtitles',
@@ -454,12 +450,21 @@ describe('MediaInfoHeaderComponent — destructive-item styling and ephemeral gu
     const fixture = await createFixture(OWNER, {
       mediaType: 'movie',
       ...MOVIE,
+      selectedFileId: 7,
       episodeId: 999,
       episodeInstance: true,
     });
     const shown = labels(fixture);
     expect(shown.filter((l) => l === 'downloads.download').length).toBe(1);
     expect(shown.filter((l) => l === 'media_detail.edit_subtitles').length).toBe(1);
+  });
+
+  it('Download shows only once a file is on disk', async () => {
+    const without = await createFixture(OWNER, { mediaType: 'movie', ...MOVIE });
+    expect(labels(without)).not.toContain('downloads.download');
+
+    const withFile = await createFixture(OWNER, { mediaType: 'movie', ...MOVIE, selectedFileId: 7 });
+    expect(labels(withFile)).toContain('downloads.download');
   });
 
   it('the series-watched toggle swaps its label with the live watched state', async () => {


### PR DESCRIPTION
## Problem

The media context menu offered **Download** for titles with no file on disk.

## Cause

The inline download button in `media-info-header.html` still gates on `selectedFileId() && (mediaType() === 'movie' || episodeId()) && !tv.isTv()`. When the same actions moved into the `media.actions` contribution registry, the `core.download` row kept only `['!isTv', 'mediaType:movie']` — the file check was dropped. So any movie (or episode) without a file still showed the row, and activating it opened a download UI for nothing.

`hasFiles` is already part of the closed `when` vocabulary and is populated by both surfaces (`!!selectedFileId()` on the detail header, `_playable()` on the card), so the fix is one predicate per row.

## Change

- `core.download` and `core.download_episode` now declare `hasFiles`.
- The permission-matrix spec had copied the pre-refactor baseline *without* the file gate, so it asserted Download on four fileless-movie rows — corrected. The episode dedup test now gets a file, and a new test pins the actual rule: Download appears only once a file is present.

## Verification

`npx ng test --watch=false` → 683/683 pass (73 files).