### PR TITLE
fix(custom-formats): repair the editor and match parsed attributes

### DIFF
--- a/backend/src/common/plugin-contract/host-methods.ts
+++ b/backend/src/common/plugin-contract/host-methods.ts
@@ -29,8 +29,6 @@ export interface AcquisitionTarget {
     decision: 'missing' | 'upgrade' | 'skip';
     allowedQualityIds: number[];
     allowedLanguageIds: number[];
-    minRankExclusive: number;
-    maxRankInclusive: number;
     minResolution: number;
     resolutionUpgradeOnly: boolean;
   } | null;

--- a/backend/src/common/plugin-contract/host-methods.ts
+++ b/backend/src/common/plugin-contract/host-methods.ts
@@ -162,6 +162,11 @@ export interface PluginHostApi {
       seeders: number;
       leechers: number;
       publishDate: string;
+      /** Source-declared markers, matched by name by a `release_flag` custom-format
+       *  condition and by the ordering rule. Open set: a new marker needs no change here.
+       *  `freeleech`/`downloadVolumeFactor` are the torrent spelling of the same thing and
+       *  are folded into it, so a plugin can send either. */
+      flags?: string[];
       freeleech?: boolean;
       downloadVolumeFactor?: number;
       sourceRef: string;

--- a/backend/src/common/plugin-contract/protocol.ts
+++ b/backend/src/common/plugin-contract/protocol.ts
@@ -38,8 +38,12 @@ export const PLUGIN_API_VERSION = 1;
  * Every value core still accepts from a manifest, newest last. Retiring one is what orphans the
  * plugins that declare it, so a bump adds an entry and a later release drops the oldest — the
  * window in between is when authors republish.
+ *
+ * `0` was retired when the upgrade window left `AcquisitionTarget.want`: within one value the
+ * shape is additive only, so a removal has to orphan the old value rather than quietly hand a
+ * plugin an absent field it filters releases on.
  */
-export const SUPPORTED_PLUGIN_API_VERSIONS: readonly number[] = [0, 1];
+export const SUPPORTED_PLUGIN_API_VERSIONS: readonly number[] = [1];
 
 /**
  * Environment core sets on every spawn (see `supervisor/spawn-plan.ts`) — the only way in

--- a/backend/src/common/release-scoring/release-rejection.helper.spec.ts
+++ b/backend/src/common/release-scoring/release-rejection.helper.spec.ts
@@ -37,6 +37,20 @@ describe('sortReleasesByRelevance', () => {
     expect(order([deadHd, liveSd])).toEqual(['live-720p', 'dead-1080p']);
   });
 
+  it('puts the custom-format score above the freeleech bonus', () => {
+    // Freeleech is expressible as a `release_flag` condition, so a configured score
+    // has to outrank the hardcoded preference rather than be overridden by it.
+    const free = row({ id: 'freeleech', freeleech: true });
+    const scored = row({ id: 'scored', customFormatScore: 100 });
+    expect(order([free, scored])).toEqual(['scored', 'freeleech']);
+  });
+
+  it('still prefers freeleech at an equal custom-format score', () => {
+    const free = row({ id: 'freeleech', freeleech: true, customFormatScore: 100 });
+    const paid = row({ id: 'paid', customFormatScore: 100 });
+    expect(order([free, paid])).toEqual(['freeleech', 'paid']);
+  });
+
   it('keeps quality first between two live releases', () => {
     const liveHdFewSeeds = row({ id: 'hd', rank: 200, seeders: 5 });
     const liveSdManySeeds = row({ id: 'sd', rank: 100, seeders: 500 });

--- a/backend/src/common/release-scoring/release-rejection.helper.spec.ts
+++ b/backend/src/common/release-scoring/release-rejection.helper.spec.ts
@@ -19,7 +19,7 @@ function row(over: Partial<Row> & { id: string }): Row & { id: string } {
     customFormatScore: 0,
     seeders: 10,
     leechers: 0,
-    freeleech: false,
+    flags: [],
     sizeDeviation: 0,
     ...over,
   };
@@ -40,13 +40,13 @@ describe('sortReleasesByRelevance', () => {
   it('puts the custom-format score above the freeleech bonus', () => {
     // Freeleech is expressible as a `release_flag` condition, so a configured score
     // has to outrank the hardcoded preference rather than be overridden by it.
-    const free = row({ id: 'freeleech', freeleech: true });
+    const free = row({ id: 'freeleech', flags: ['freeleech'] });
     const scored = row({ id: 'scored', customFormatScore: 100 });
     expect(order([free, scored])).toEqual(['scored', 'freeleech']);
   });
 
   it('still prefers freeleech at an equal custom-format score', () => {
-    const free = row({ id: 'freeleech', freeleech: true, customFormatScore: 100 });
+    const free = row({ id: 'freeleech', flags: ['freeleech'], customFormatScore: 100 });
     const paid = row({ id: 'paid', customFormatScore: 100 });
     expect(order([free, paid])).toEqual(['freeleech', 'paid']);
   });
@@ -561,5 +561,39 @@ describe('computeRejections — custom format floor', () => {
 
   it('applies no floor when the profile declares none', () => {
     expect(codes(-9999)).not.toContain('CUSTOM_FORMAT_SCORE_TOO_LOW');
+  });
+});
+
+describe('computeRejections — upgrade window', () => {
+  const base = {
+    qualityId: 1,
+    allowed: new Set([1]),
+    languageId: 1,
+    allowedLangs: new Set<number>(),
+    isBlocklisted: false,
+    sizeBytes: 0,
+    runtimeMinutes: 112,
+    sizeByQuality: new Map(),
+    seeders: 10,
+    sourceId: 0,
+    sourceMinSeeders: new Map(),
+  };
+  const codes = (rank: number, minRankExclusive?: number, maxRankInclusive?: number) =>
+    computeRejections({ ...base, rank, minRankExclusive, maxRankInclusive }).map((r) => r.code);
+
+  it('refuses a rank at or below what is on disk', () => {
+    expect(codes(62, 62, 100)).toContain('RANK_NOT_AN_UPGRADE');
+    expect(codes(61, 62, 100)).toContain('RANK_NOT_AN_UPGRADE');
+    expect(codes(63, 62, 100)).not.toContain('RANK_NOT_AN_UPGRADE');
+  });
+
+  it('refuses a rank above the cutoff', () => {
+    expect(codes(101, 0, 100)).toContain('RANK_ABOVE_CUTOFF');
+    expect(codes(100, 0, 100)).not.toContain('RANK_ABOVE_CUTOFF');
+    expect(codes(101, 0, Number.POSITIVE_INFINITY)).not.toContain('RANK_ABOVE_CUTOFF');
+  });
+
+  it('applies no window when the caller declares no bounds', () => {
+    expect(codes(1)).toEqual([]);
   });
 });

--- a/backend/src/common/release-scoring/release-rejection.helper.spec.ts
+++ b/backend/src/common/release-scoring/release-rejection.helper.spec.ts
@@ -521,3 +521,31 @@ describe('computeRejections — the quality profile', () => {
     expect(codeFor(16, [])).toEqual(['QUALITY_NOT_ALLOWED']);
   });
 });
+
+describe('computeRejections — custom format floor', () => {
+  const base = {
+    qualityId: 1,
+    allowed: new Set([1]),
+    languageId: 1,
+    allowedLangs: new Set<number>(),
+    isBlocklisted: false,
+    sizeBytes: 0,
+    runtimeMinutes: 112,
+    sizeByQuality: new Map(),
+    seeders: 10,
+    sourceId: 0,
+    sourceMinSeeders: new Map(),
+  };
+  const codes = (customFormatScore: number, minCustomFormatScore?: number) =>
+    computeRejections({ ...base, customFormatScore, minCustomFormatScore }).map((r) => r.code);
+
+  it('rejects a release scoring below the profile floor', () => {
+    expect(codes(-50, 0)).toContain('CUSTOM_FORMAT_SCORE_TOO_LOW');
+    expect(codes(0, 0)).not.toContain('CUSTOM_FORMAT_SCORE_TOO_LOW');
+    expect(codes(10, 50)).toContain('CUSTOM_FORMAT_SCORE_TOO_LOW');
+  });
+
+  it('applies no floor when the profile declares none', () => {
+    expect(codes(-9999)).not.toContain('CUSTOM_FORMAT_SCORE_TOO_LOW');
+  });
+});

--- a/backend/src/common/release-scoring/release-rejection.helper.ts
+++ b/backend/src/common/release-scoring/release-rejection.helper.ts
@@ -20,8 +20,26 @@ export interface ReleaseCandidate {
   seeders: number;
   leechers: number;
   publishDate: string | null; // ISO date string from <pubDate>, null if unavailable
-  freeleech: boolean;
-  downloadVolumeFactor: number; // 0=free, 0.5=half, 1=normal
+  /** Source-declared markers a name cannot carry — `freeleech`, `halfleech`, whatever a
+   *  tracker announces next. An open set on purpose: a custom-format condition and the
+   *  ordering rule both read it by name, so a new marker needs no change here. */
+  flags: readonly string[];
+}
+
+/**
+ * Fold a source's release markers into the open flag set the scorer reads. A torrent's
+ * `freeleech` / `downloadVolumeFactor` are one spelling of it, so a caller may send either
+ * form; anything unrecognised rides through under its own name.
+ */
+export function releaseFlags(source: {
+  flags?: readonly string[];
+  freeleech?: boolean;
+  downloadVolumeFactor?: number;
+}): string[] {
+  const out = new Set(source.flags ?? []);
+  if (source.freeleech || source.downloadVolumeFactor === 0) out.add('freeleech');
+  if (source.downloadVolumeFactor === 0.5) out.add('halfleech');
+  return [...out];
 }
 
 /**
@@ -522,6 +540,12 @@ export function computeRejections(opts: {
    *  score is a tiebreak and the release is still taken when nothing better exists. */
   customFormatScore?: number;
   minCustomFormatScore?: number;
+  /** Quality rank of this release, and the window the profile leaves open: strictly
+   *  above what is on disk, up to the cutoff. Absent bounds mean no window applies
+   *  (a missing grab, or a title with no quality profile). */
+  rank?: number;
+  minRankExclusive?: number;
+  maxRankInclusive?: number;
 }): ReleaseRejection[] {
   const out: ReleaseRejection[] = [];
 
@@ -609,6 +633,24 @@ export function computeRejections(opts: {
         min: opts.minCustomFormatScore,
       },
     });
+  }
+
+  // The window an upgrade may move within. Computed by core and, until now, applied only by the
+  // acquisition plugin's own picker — so `releases.score` answered "no rejections" for releases
+  // the scheduler then refused, and the manual search modal had nothing to show for it.
+  if (opts.rank != null) {
+    if (opts.minRankExclusive != null && opts.rank <= opts.minRankExclusive) {
+      out.push({
+        code: 'RANK_NOT_AN_UPGRADE',
+        params: { actual: opts.rank, min: opts.minRankExclusive },
+      });
+    }
+    if (opts.maxRankInclusive != null && opts.rank > opts.maxRankInclusive) {
+      out.push({
+        code: 'RANK_ABOVE_CUTOFF',
+        params: { actual: opts.rank, max: opts.maxRankInclusive },
+      });
+    }
   }
 
   // "Upgrade resolution only": the profile refuses a same-resolution tier hop, so a 1080p Bluray
@@ -722,7 +764,7 @@ export function sortReleasesByRelevance<
     customFormatScore: number;
     seeders: number;
     leechers: number;
-    freeleech: boolean;
+    flags: readonly string[];
     sizeDeviation?: number | null;
     isFullSeason?: boolean;
   },
@@ -767,7 +809,9 @@ export function sortReleasesByRelevance<
       return b.customFormatScore - a.customFormatScore;
 
     // 8. Freeleech bonus
-    if (a.freeleech !== b.freeleech) return a.freeleech ? -1 : 1;
+    const aFree = a.flags.includes('freeleech');
+    const bFree = b.flags.includes('freeleech');
+    if (aFree !== bFree) return aFree ? -1 : 1;
 
     // 9. Seeders desc (log scale)
     const aSeed = swarmScore(a.seeders);
@@ -814,10 +858,7 @@ export interface ScoredRelease extends ReleaseCandidate {
 
 /** Async callbacks injected by the caller (avoids coupling to NestJS services). */
 export interface ReleaseScorerDeps {
-  scoreCustomFormats(
-    title: string,
-    meta: { freeleech?: boolean; downloadVolumeFactor?: number },
-  ): Promise<number>;
+  scoreCustomFormats(title: string, flags: readonly string[]): Promise<number>;
   /** `sourceId` rides along so a caller keyed by per-release index (rather
    *  than by title, which two releases may share) can disambiguate. */
   isBlocked(title: string, sourceId: number): Promise<boolean>;
@@ -855,6 +896,9 @@ export async function scoreAndSortReleases(
     expectedYear?: number | null;
     /** From the quality profile: releases scoring below this are rejected outright. */
     minCustomFormatScore?: number;
+    /** The upgrade window: strictly above what is on disk, up to the cutoff. */
+    minRankExclusive?: number;
+    maxRankInclusive?: number;
   },
   deps: ReleaseScorerDeps,
 ): Promise<ScoredRelease[]> {
@@ -866,10 +910,7 @@ export async function scoreAndSortReleases(
         opts.sourceUnknownLang.get(r.sourceId),
       );
       const [cfScore, isBlocklisted] = await Promise.all([
-        deps.scoreCustomFormats(r.title, {
-          freeleech: r.freeleech,
-          downloadVolumeFactor: r.downloadVolumeFactor,
-        }),
+        deps.scoreCustomFormats(r.title, r.flags),
         deps.isBlocked(r.title, r.sourceId),
       ]);
       const rejections = computeRejections({
@@ -892,6 +933,9 @@ export async function scoreAndSortReleases(
         expectedYear: opts.expectedYear,
         customFormatScore: cfScore,
         minCustomFormatScore: opts.minCustomFormatScore,
+        rank: parsed.quality.rank,
+        minRankExclusive: opts.minRankExclusive,
+        maxRankInclusive: opts.maxRankInclusive,
       });
       return {
         ...r,

--- a/backend/src/common/release-scoring/release-rejection.helper.ts
+++ b/backend/src/common/release-scoring/release-rejection.helper.ts
@@ -517,6 +517,11 @@ export function computeRejections(opts: {
   /** Release year of the media. A release stating another year names another work — the
    *  token-inclusion title check cannot tell `Nova Skyline 2 2015` from `Nova Skyline`. */
   expectedYear?: number | null;
+  /** Total custom-format score of this release, and the profile's floor for it. A
+   *  negative-score format only blocks a grab through this floor; without it the
+   *  score is a tiebreak and the release is still taken when nothing better exists. */
+  customFormatScore?: number;
+  minCustomFormatScore?: number;
 }): ReleaseRejection[] {
   const out: ReleaseRejection[] = [];
 
@@ -591,6 +596,19 @@ export function computeRejections(opts: {
 
   if (!opts.allowed.has(opts.qualityId)) {
     out.push({ code: 'QUALITY_NOT_ALLOWED' });
+  }
+
+  if (
+    opts.minCustomFormatScore != null &&
+    (opts.customFormatScore ?? 0) < opts.minCustomFormatScore
+  ) {
+    out.push({
+      code: 'CUSTOM_FORMAT_SCORE_TOO_LOW',
+      params: {
+        actual: opts.customFormatScore ?? 0,
+        min: opts.minCustomFormatScore,
+      },
+    });
   }
 
   // "Upgrade resolution only": the profile refuses a same-resolution tier hop, so a 1080p Bluray
@@ -682,8 +700,8 @@ export function computeRejections(opts: {
  *    episodes at the same resolution whatever the source, but never
  *    outranks a higher resolution.
  * 6. Quality rank (higher = better)
- * 7. Freeleech bonus
- * 8. Custom format score (higher = better)
+ * 7. Custom format score (higher = better)
+ * 8. Freeleech bonus
  * 9. Seeders (more = better, log scale to avoid over-weighting)
  * 10. Leechers (more = better, same scale) — breaks seeder ties toward the
  *    busier swarm.
@@ -743,12 +761,13 @@ export function sortReleasesByRelevance<
     // 6. Quality rank desc
     if (a.rank !== b.rank) return b.rank - a.rank;
 
-    // 7. Freeleech bonus
-    if (a.freeleech !== b.freeleech) return a.freeleech ? -1 : 1;
-
-    // 8. Custom format score desc
+    // 7. Custom format score desc — above freeleech, which a `release_flag`
+    //    condition can express and score itself.
     if (a.customFormatScore !== b.customFormatScore)
       return b.customFormatScore - a.customFormatScore;
+
+    // 8. Freeleech bonus
+    if (a.freeleech !== b.freeleech) return a.freeleech ? -1 : 1;
 
     // 9. Seeders desc (log scale)
     const aSeed = swarmScore(a.seeders);
@@ -834,6 +853,8 @@ export async function scoreAndSortReleases(
     minResolution?: number;
     /** Release year of the media — a release naming another year names another work. */
     expectedYear?: number | null;
+    /** From the quality profile: releases scoring below this are rejected outright. */
+    minCustomFormatScore?: number;
   },
   deps: ReleaseScorerDeps,
 ): Promise<ScoredRelease[]> {
@@ -869,6 +890,8 @@ export async function scoreAndSortReleases(
         expectedEpisode: opts.expectedEpisode,
         minResolution: opts.minResolution,
         expectedYear: opts.expectedYear,
+        customFormatScore: cfScore,
+        minCustomFormatScore: opts.minCustomFormatScore,
       });
       return {
         ...r,

--- a/backend/src/migrations/1784600000000-custom-format-specs-and-min-score.ts
+++ b/backend/src/migrations/1784600000000-custom-format-specs-and-min-score.ts
@@ -1,0 +1,70 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * The stored condition shape (`{name, implementation, …}`) never matched what the
+ * settings page sends, so every save was refused and the column only ever held
+ * rows written straight through the API. Rewrites those to the shape both sides
+ * now speak, dropping conditions whose kind isn't one we evaluate and formats
+ * left with none — a conditionless format matched every release.
+ */
+export class CustomFormatSpecsAndMinScore1784600000000
+  implements MigrationInterface
+{
+  name = 'CustomFormatSpecsAndMinScore1784600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE "custom_formats" SET "specifications" = COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+          'type', s->>'implementation',
+          'value', s->>'value',
+          'negate', COALESCE((s->>'negate')::boolean, false),
+          'required', COALESCE((s->>'required')::boolean, false)
+        ))
+        FROM jsonb_array_elements("specifications") s
+        WHERE s->>'implementation' IN (
+          'title_regex', 'source', 'resolution', 'language', 'release_flag',
+          'release_group', 'edition', 'video_codec', 'audio_codec'
+        )
+      ), '[]'::jsonb)
+      WHERE EXISTS (
+        SELECT 1 FROM jsonb_array_elements("specifications") s
+        WHERE s ? 'implementation'
+      )
+    `);
+    await queryRunner.query(
+      `DELETE FROM "custom_formats" WHERE jsonb_array_length("specifications") = 0`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "custom_formats" RENAME COLUMN "specifications" TO "specs"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "quality_profiles" ADD COLUMN IF NOT EXISTS "minCustomFormatScore" integer NOT NULL DEFAULT 0`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "quality_profiles" DROP COLUMN IF EXISTS "minCustomFormatScore"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "custom_formats" RENAME COLUMN "specs" TO "specifications"`,
+    );
+    await queryRunner.query(`
+      UPDATE "custom_formats" SET "specifications" = COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+          'name', s->>'type',
+          'implementation', s->>'type',
+          'value', s->>'value',
+          'negate', COALESCE((s->>'negate')::boolean, false),
+          'required', COALESCE((s->>'required')::boolean, false)
+        ))
+        FROM jsonb_array_elements("specifications") s
+      ), '[]'::jsonb)
+      WHERE EXISTS (
+        SELECT 1 FROM jsonb_array_elements("specifications") s
+        WHERE s ? 'type'
+      )
+    `);
+  }
+}

--- a/backend/src/modules/plugins/api-compatibility.spec.ts
+++ b/backend/src/modules/plugins/api-compatibility.spec.ts
@@ -26,6 +26,14 @@ describe('plugin API compatibility', () => {
     }
   });
 
+  it('VERDICT: hides a retired pluginApi, so a removal inside one revision is impossible', () => {
+    // 0 was retired when the upgrade window left `AcquisitionTarget.want`. A plugin built against
+    // it must be refused outright rather than handed a `want` missing a field it filters on.
+    expect(SUPPORTED_PLUGIN_API_VERSIONS).not.toContain(0);
+    const result = filterCatalog(catalogWith(0, '>=3.0.0 <4.0.0'), SUPPORTED_PLUGIN_API_VERSIONS, '3.8.0');
+    expect(result.plugins[0]!.installable).toHaveLength(0);
+  });
+
   it('hides a version whose pluginApi the set does not carry', () => {
     const unsupported = Math.max(...SUPPORTED_PLUGIN_API_VERSIONS) + 1;
     const result = filterCatalog(catalogWith(unsupported, '>=2.0.0 <3.0.0'), SUPPORTED_PLUGIN_API_VERSIONS, '2.0.1');

--- a/backend/src/modules/plugins/archive/test-manifests.ts
+++ b/backend/src/modules/plugins/archive/test-manifests.ts
@@ -1,10 +1,11 @@
+import { PLUGIN_API_VERSION } from '../../../common/plugin-contract';
 import type { DataPluginManifest, ProcessPluginManifest } from '../../../common/plugin-contract';
 
 /** Minimal, structurally-valid `data` manifest — spread `overrides` to break one field at a time. */
 export function minimalDataManifest(overrides: Partial<DataPluginManifest> = {}): DataPluginManifest {
   return {
     id: 'fliks.testplugin',
-    pluginApi: 0,
+    pluginApi: PLUGIN_API_VERSION,
     name: 'Test plugin',
     version: '1.0.0',
     fliks: '>=2.1.0 <3.0.0',
@@ -24,7 +25,7 @@ export function minimalProcessManifest(
 ): ProcessPluginManifest {
   return {
     id: 'fliks.testprocessplugin',
-    pluginApi: 0,
+    pluginApi: PLUGIN_API_VERSION,
     name: 'Test process plugin',
     version: '1.0.0',
     fliks: '>=2.1.0 <3.0.0',

--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -267,7 +267,11 @@ describe('FliksHostImpl', () => {
   // ===========================================================================
 
   describe('media.acquisitionContext', () => {
-    it('returns a serialisable target for a missing movie, with the Infinity ceiling made JSON-safe', async () => {
+    // `want` used to carry the upgrade window, which meant shipping `Infinity` as
+    // MAX_SAFE_INTEGER to stay JSON-safe. The window is a profile rule and now comes back as a
+    // rejection from `releases.score`, so nothing is left for a plugin to reapply — or to
+    // reapply against an absent field, which is what a removal inside one pluginApi would cause.
+    it('returns a serialisable target for a missing movie, carrying no rule to reapply', async () => {
       const h = makeHarness();
       const media = makeMedia();
       h.mediaRepo.findOne.mockResolvedValue(media);
@@ -280,8 +284,13 @@ describe('FliksHostImpl', () => {
 
       const result = await h.host['media.acquisitionContext']({ mediaId: 1 });
       expect(result?.want?.decision).toBe('missing');
-      expect(result?.want?.maxRankInclusive).toBe(Number.MAX_SAFE_INTEGER);
-      expect(Number.isFinite(result?.want?.maxRankInclusive)).toBe(true);
+      expect(Object.keys(result!.want!).sort()).toEqual([
+        'allowedLanguageIds',
+        'allowedQualityIds',
+        'decision',
+        'minResolution',
+        'resolutionUpgradeOnly',
+      ]);
       expectJsonSafe(result);
     });
 
@@ -309,7 +318,7 @@ describe('FliksHostImpl', () => {
       ).toBeNull();
     });
 
-    it('carries the ranked constraints for a "skip" decision, so a manual search can still score releases', async () => {
+    it('still answers with a want for a "skip" decision, so a manual search can score releases', async () => {
       const h = makeHarness();
       h.mediaRepo.findOne.mockResolvedValue(makeMedia());
       h.mediaFileRepo.find.mockResolvedValue([]);
@@ -320,11 +329,7 @@ describe('FliksHostImpl', () => {
         maxRankInclusive: 62,
       });
       const result = await h.host['media.acquisitionContext']({ mediaId: 1 });
-      expect(result?.want).toMatchObject({
-        decision: 'skip',
-        minRankExclusive: 62,
-        maxRankInclusive: 62,
-      });
+      expect(result?.want?.decision).toBe('skip');
       expectJsonSafe(result);
     });
 

--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -15,6 +15,8 @@ import { getAppLanguageById } from '../../../common/constants/app-languages';
 import type { Media } from '../../media/entities/media.entity';
 import type { Season } from '../../media/entities/season.entity';
 import type { Episode } from '../../media/entities/episode.entity';
+import { CustomFormatsService } from '../../profiles/custom-formats.service';
+import type { CustomFormat } from '../../profiles/entities/custom-format.entity';
 
 /** Round-trips `value` through JSON and asserts nothing was lost or mutated —
  *  the property that matters once the transport becomes a socket (Phase 10.4).
@@ -1051,6 +1053,161 @@ describe('FliksHostImpl', () => {
         h.mediaFileRepo.find.mockResolvedValue([{ quality: 'WEBDL-1080p' }]);
 
         expect(await score(h, 'A Movie 2020 1080p WEB-DL')).toEqual([]);
+      });
+    });
+
+    // The plugin trusts this call for the whole verdict: it grabs the first row with an empty
+    // `rejections` array (`pickReleases` in fk-plugin-download) and never re-scores. So the
+    // profile floor and the matcher have to arrive here, not just in the settings page.
+    describe('custom-format floor', () => {
+      const matcher = new CustomFormatsService({} as never);
+
+      const format = (
+        id: number,
+        score: number,
+        specs: CustomFormat['specs'],
+      ): CustomFormat => ({ id, name: `f${id}`, score, specs }) as CustomFormat;
+
+      const setup = (
+        h: ReturnType<typeof makeHarness>,
+        formats: CustomFormat[],
+        minCustomFormatScore: number,
+      ) => {
+        h.mediaRepo.findOne.mockResolvedValue(
+          makeMedia({
+            runtime: 120,
+            qualityProfile: {
+              id: 1,
+              cutoff: 20,
+              upgradeAllowed: true,
+              items: [],
+              resolutionUpgradeOnly: false,
+              minCustomFormatScore,
+            },
+          }),
+        );
+        h.profiles.resolveAllowedForMedia.mockReturnValue({
+          allowed: new Set([16, 17, 18]),
+          allowedLangs: new Set(),
+        });
+        h.qualityDefs.getSizeLimitsMap.mockResolvedValue(new Map());
+        h.customFormats.findAll.mockResolvedValue(formats);
+        // The real matcher, so the format definition is exercised end to end.
+        h.customFormats.scoreReleaseWith.mockImplementation(
+          (f: CustomFormat[], title: string, meta: Parameters<typeof matcher.scoreReleaseWith>[2]) =>
+            matcher.scoreReleaseWith(f, title, meta),
+        );
+      };
+
+      const scoreOne = async (h: ReturnType<typeof makeHarness>, title: string) => {
+        const [row] = await h.host['releases.score']({
+          mediaId: 1,
+          releases: [
+            {
+              id: 'r1',
+              title,
+              size: 4_000_000_000,
+              seeders: 10,
+              leechers: 2,
+              publishDate: new Date().toISOString(),
+              sourceRef: 'source-a',
+              blocked: false,
+            },
+          ],
+        });
+        return row;
+      };
+
+      it('VERDICT: a negative total below the floor becomes a rejection, not just a low rank', async () => {
+        const h = makeHarness();
+        setup(h, [format(1, -100, [{ type: 'source', value: 'webrip' }])], 0);
+
+        const row = await scoreOne(h, 'A Movie 2020 1080p WEBRip x264-GRP');
+        expect(row.customFormatScore).toBe(-100);
+        expect((row.rejections as { code: string }[]).map((r) => r.code)).toEqual([
+          'CUSTOM_FORMAT_SCORE_TOO_LOW',
+        ]);
+      });
+
+      it('lets a release at or above the floor through', async () => {
+        const h = makeHarness();
+        setup(h, [format(1, 100, [{ type: 'source', value: 'webrip' }])], 0);
+
+        const row = await scoreOne(h, 'A Movie 2020 1080p WEBRip x264-GRP');
+        expect(row.customFormatScore).toBe(100);
+        expect(row.rejections).toEqual([]);
+      });
+
+      it('refuses a positive total that still misses a positive floor', async () => {
+        const h = makeHarness();
+        setup(h, [format(1, 10, [{ type: 'source', value: 'webrip' }])], 50);
+
+        const row = await scoreOne(h, 'A Movie 2020 1080p WEBRip x264-GRP');
+        expect((row.rejections as { code: string }[]).map((r) => r.code)).toEqual([
+          'CUSTOM_FORMAT_SCORE_TOO_LOW',
+        ]);
+      });
+
+      it('applies the matcher the settings page saves, conditions and all', async () => {
+        const h = makeHarness();
+        // Two types: the release must be both 1080p and BluRay to score.
+        setup(
+          h,
+          [
+            format(1, 100, [
+              { type: 'resolution', value: '1080p' },
+              { type: 'source', value: 'bluray' },
+            ]),
+          ],
+          0,
+        );
+
+        expect((await scoreOne(h, 'A Movie 2020 1080p BluRay x264-GRP')).customFormatScore).toBe(100);
+        expect((await scoreOne(h, 'A Movie 2020 1080p WEBRip x264-GRP')).customFormatScore).toBe(0);
+      });
+
+      it('applies no floor to a title with no quality profile', async () => {
+        const h = makeHarness();
+        setup(h, [format(1, -100, [{ type: 'source', value: 'webrip' }])], 0);
+        h.mediaRepo.findOne.mockResolvedValue(makeMedia({ runtime: 120, qualityProfile: null }));
+
+        const row = await scoreOne(h, 'A Movie 2020 1080p WEBRip x264-GRP');
+        expect((row.rejections as { code: string }[]).map((r) => r.code)).not.toContain(
+          'CUSTOM_FORMAT_SCORE_TOO_LOW',
+        );
+      });
+
+      it('ranks a scored release above a freeleech one — the plugin takes the first row', async () => {
+        const h = makeHarness();
+        setup(h, [format(1, 100, [{ type: 'source', value: 'bluray' }])], 0);
+
+        const rows = await h.host['releases.score']({
+          mediaId: 1,
+          releases: [
+            {
+              id: 'freeleech',
+              title: 'A Movie 2020 1080p WEBRip x264-GRP',
+              size: 4_000_000_000,
+              seeders: 10,
+              leechers: 2,
+              publishDate: new Date().toISOString(),
+              sourceRef: 'source-a',
+              freeleech: true,
+              blocked: false,
+            },
+            {
+              id: 'scored',
+              title: 'A Movie 2020 1080p BluRay x264-GRP',
+              size: 4_000_000_000,
+              seeders: 10,
+              leechers: 2,
+              publishDate: new Date().toISOString(),
+              sourceRef: 'source-a',
+              blocked: false,
+            },
+          ],
+        });
+        expect(rows.map((r) => r.id)).toEqual(['scored', 'freeleech']);
       });
     });
 

--- a/backend/src/modules/plugins/host/fliks-host.service.spec.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.spec.ts
@@ -15,6 +15,7 @@ import { getAppLanguageById } from '../../../common/constants/app-languages';
 import type { Media } from '../../media/entities/media.entity';
 import type { Season } from '../../media/entities/season.entity';
 import type { Episode } from '../../media/entities/episode.entity';
+import { AutoGrabPipelineService } from '../../media/auto-grab-pipeline.service';
 import { CustomFormatsService } from '../../profiles/custom-formats.service';
 import type { CustomFormat } from '../../profiles/entities/custom-format.entity';
 
@@ -163,7 +164,15 @@ function makeHarness(pluginId: string | null = 'test.plugin'): Harness {
   const episodeRepo = fakeRepo();
   const mediaFileRepo = fakeRepo();
   const pluginRegistrationRepo = fakeRepo();
-  const autoGrab = { classifyForSearch: jest.fn() };
+  // A window that constrains nothing (every real quality ranks above 0), so a test that does not
+  // care about the upgrade window is not silently exempted from it either.
+  const autoGrab = {
+    classifyForSearch: jest.fn().mockReturnValue({
+      mode: 'missing',
+      minRankExclusive: 0,
+      maxRankInclusive: Number.POSITIVE_INFINITY,
+    }),
+  };
   const acquisitionCandidates = {
     listMovieTargets: jest.fn().mockResolvedValue([]),
     listEpisodeTargets: jest.fn().mockResolvedValue([]),
@@ -1053,6 +1062,99 @@ describe('FliksHostImpl', () => {
         h.mediaFileRepo.find.mockResolvedValue([{ quality: 'WEBDL-1080p' }]);
 
         expect(await score(h, 'A Movie 2020 1080p WEB-DL')).toEqual([]);
+      });
+    });
+
+    // The upgrade window was the third profile rule core computed and never applied: it rode in
+    // `want` for the plugin's picker to reapply, so this call answered "no rejections" for
+    // releases the scheduler then refused, and the search modal had no reason to show.
+    describe('upgrade window', () => {
+      const classifier = new AutoGrabPipelineService();
+
+      const setup = (
+        h: ReturnType<typeof makeHarness>,
+        qualityProfile: unknown,
+        files: { quality: string }[],
+      ) => {
+        h.mediaRepo.findOne.mockResolvedValue(makeMedia({ runtime: 120, qualityProfile }));
+        h.mediaFileRepo.find.mockResolvedValue(files);
+        // The real classifier, so the profile cutoff and the on-disk quality are what decide.
+        h.autoGrab.classifyForSearch.mockImplementation(
+          (m: Parameters<typeof classifier.classifyForSearch>[0], f: { quality?: string | null }[]) =>
+            classifier.classifyForSearch(m, f),
+        );
+        h.profiles.resolveAllowedForMedia.mockReturnValue({
+          allowed: new Set([15, 16, 17, 18, 19, 20, 21, 22, 23, 24]),
+          allowedLangs: new Set(),
+        });
+        h.qualityDefs.getSizeLimitsMap.mockResolvedValue(new Map());
+      };
+
+      const codes = async (h: ReturnType<typeof makeHarness>, title: string) => {
+        const [row] = await h.host['releases.score']({
+          mediaId: 1,
+          releases: [
+            {
+              id: 'r1',
+              title,
+              size: 4_000_000_000,
+              seeders: 10,
+              leechers: 2,
+              publishDate: new Date().toISOString(),
+              sourceRef: 'source-a',
+              blocked: false,
+            },
+          ],
+        });
+        return (row.rejections as { code: string }[]).map((r) => r.code);
+      };
+
+      // On disk: WEBDL-1080p (rank 62). Cutoff: Bluray-1080p (rank 68).
+      const upgradeProfile = {
+        id: 1,
+        cutoff: 18,
+        upgradeAllowed: true,
+        items: [],
+        resolutionUpgradeOnly: false,
+        minCustomFormatScore: 0,
+      };
+
+      it('VERDICT: refuses a release that is not above what is on disk', async () => {
+        const h = makeHarness();
+        setup(h, upgradeProfile, [{ quality: 'WEBDL-1080p' }]);
+
+        expect(await codes(h, 'A Movie 2020 1080p WEBRip x264-GRP')).toEqual(['RANK_NOT_AN_UPGRADE']);
+      });
+
+      it('VERDICT: refuses a release above the profile cutoff', async () => {
+        const h = makeHarness();
+        setup(h, upgradeProfile, [{ quality: 'WEBDL-1080p' }]);
+
+        expect(await codes(h, 'A Movie 2020 2160p BluRay REMUX HEVC-GRP')).toEqual([
+          'RANK_ABOVE_CUTOFF',
+        ]);
+      });
+
+      it('takes a release inside the window', async () => {
+        const h = makeHarness();
+        setup(h, upgradeProfile, [{ quality: 'WEBDL-1080p' }]);
+
+        expect(await codes(h, 'A Movie 2020 1080p BluRay x264-GRP')).toEqual([]);
+      });
+
+      it('caps nothing on a missing grab — no file, no floor and no ceiling', async () => {
+        const h = makeHarness();
+        setup(h, upgradeProfile, []);
+
+        expect(await codes(h, 'A Movie 2020 2160p BluRay REMUX HEVC-GRP')).toEqual([]);
+        expect(await codes(h, 'A Movie 2020 1080p WEBRip x264-GRP')).toEqual([]);
+      });
+
+      it('applies no window to a title with no quality profile', async () => {
+        const h = makeHarness();
+        setup(h, null, [{ quality: 'WEBDL-1080p' }]);
+
+        expect(await codes(h, 'A Movie 2020 1080p WEBRip x264-GRP')).toEqual([]);
       });
     });
 

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -594,6 +594,7 @@ export class FliksHostImpl implements PluginHostApi {
         // resolution, and the profile's "upgrade resolution only" toggle had no enforcement
         // anywhere after the acquisition split.
         minResolution: await this.minResolutionFor(media, p.seasonNumber, p.episodeNumber),
+        minCustomFormatScore: media.qualityProfile?.minCustomFormatScore ?? 0,
       },
       {
         scoreCustomFormats: (title, meta) =>

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -47,6 +47,7 @@ import {
   scoreAndSortReleases,
   indexTitleExpectations,
   matchesIndexedExpectation,
+  releaseFlags,
   releaseTitleTokens,
   type TitleExpectationIndex,
   type ReleaseCandidate,
@@ -528,6 +529,7 @@ export class FliksHostImpl implements PluginHostApi {
       seeders: number;
       leechers: number;
       publishDate: string;
+      flags?: string[];
       freeleech?: boolean;
       downloadVolumeFactor?: number;
       sourceRef: string;
@@ -544,9 +546,10 @@ export class FliksHostImpl implements PluginHostApi {
     const { expectedTitles } = resolveSearchTitles(media);
     // Both read once per call: the scorer runs its callback per candidate, and this
     // route is called once per indexer while a streamed search fills in.
-    const [sizeByQuality, customFormats] = await Promise.all([
+    const [sizeByQuality, customFormats, scoringWindow] = await Promise.all([
       this.qualityDefs.getSizeLimitsMap(),
       this.customFormats.findAll(),
+      this.scoringWindowFor(media, p.seasonNumber, p.episodeNumber),
     ]);
 
     type CandidateWithId = ReleaseCandidate & { id: string };
@@ -560,8 +563,7 @@ export class FliksHostImpl implements PluginHostApi {
       seeders: r.seeders,
       leechers: r.leechers,
       publishDate: r.publishDate,
-      freeleech: r.freeleech ?? false,
-      downloadVolumeFactor: r.downloadVolumeFactor ?? 1,
+      flags: releaseFlags(r),
     }));
     const sourceMinSeeders = new Map(
       p.releases.map((r, i) => [i, r.minSeeders ?? 0]),
@@ -593,16 +595,11 @@ export class FliksHostImpl implements PluginHostApi {
         // Recomputed here rather than sent by the caller: only core can map a quality to a
         // resolution, and the profile's "upgrade resolution only" toggle had no enforcement
         // anywhere after the acquisition split.
-        minResolution: await this.minResolutionFor(media, p.seasonNumber, p.episodeNumber),
-        // Undefined, not 0, without a profile: 0 is a real floor that refuses any
-        // negative total, and an unprofiled title has no floor to apply.
-        minCustomFormatScore: media.qualityProfile
-          ? media.qualityProfile.minCustomFormatScore ?? 0
-          : undefined,
+        ...scoringWindow,
       },
       {
-        scoreCustomFormats: (title, meta) =>
-          Promise.resolve(this.customFormats.scoreReleaseWith(customFormats, title, meta)),
+        scoreCustomFormats: (title, flags) =>
+          Promise.resolve(this.customFormats.scoreReleaseWith(customFormats, title, flags)),
         isBlocked: (_title, i) =>
           Promise.resolve(sourceBlocked.get(i) ?? false),
       },
@@ -630,16 +627,20 @@ export class FliksHostImpl implements PluginHostApi {
   }
 
   /**
-   * The on-disk resolution a release must beat, or 0 when the profile does not ask for it. Mirrors
-   * `buildWant`: the rule applies to an upgrade, never to something genuinely missing.
+   * Every bound the quality profile puts on a candidate, from one read of what is on disk.
+   * `scoreReleases` is the only place these rules are applied, so they are resolved together:
+   * each one that stayed in `want` for the plugin to reapply ended up enforced nowhere.
    */
-  private async minResolutionFor(
+  private async scoringWindowFor(
     media: Media,
     seasonNumber?: number,
     episodeNumber?: number,
-  ): Promise<number> {
-    if (!media.qualityProfile?.resolutionUpgradeOnly) return 0;
-
+  ): Promise<{
+    minResolution: number;
+    minCustomFormatScore?: number;
+    minRankExclusive?: number;
+    maxRankInclusive?: number;
+  }> {
     let season: Season | null = null;
     let episode: Episode | null = null;
     if (media.type === MediaType.SERIES && seasonNumber != null) {
@@ -654,8 +655,31 @@ export class FliksHostImpl implements PluginHostApi {
     }
     const files = await this.filesForClassification(media, season, episode);
     // Nothing on disk is a `missing` grab, which the toggle deliberately does not gate.
-    if (!files.length) return 0;
-    return maxResolutionFromQualityStrings(files);
+    const minResolution =
+      media.qualityProfile?.resolutionUpgradeOnly && files.length
+        ? maxResolutionFromQualityStrings(files)
+        : 0;
+    // Undefined, not 0: 0 is a real floor that refuses any negative total, and an
+    // unprofiled title has no floor to apply.
+    const minCustomFormatScore = media.qualityProfile
+      ? media.qualityProfile.minCustomFormatScore ?? 0
+      : undefined;
+
+    // A whole-series lookup has no single on-disk quality to move up from, same guard as
+    // `buildAcquisitionTarget`.
+    const isWholeSeriesLookup = media.type !== MediaType.MOVIE && season == null;
+    if (isWholeSeriesLookup) return { minResolution, minCustomFormatScore };
+
+    const decision = this.autoGrab.classifyForSearch(media, files);
+    if (decision.mode === 'unprofiled') {
+      return { minResolution, minCustomFormatScore };
+    }
+    return {
+      minResolution,
+      minCustomFormatScore,
+      minRankExclusive: decision.minRankExclusive,
+      maxRankInclusive: decision.maxRankInclusive,
+    };
   }
 
   /**

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -594,7 +594,11 @@ export class FliksHostImpl implements PluginHostApi {
         // resolution, and the profile's "upgrade resolution only" toggle had no enforcement
         // anywhere after the acquisition split.
         minResolution: await this.minResolutionFor(media, p.seasonNumber, p.episodeNumber),
-        minCustomFormatScore: media.qualityProfile?.minCustomFormatScore ?? 0,
+        // Undefined, not 0, without a profile: 0 is a real floor that refuses any
+        // negative total, and an unprofiled title has no floor to apply.
+        minCustomFormatScore: media.qualityProfile
+          ? media.qualityProfile.minCustomFormatScore ?? 0
+          : undefined,
       },
       {
         scoreCustomFormats: (title, meta) =>

--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -1236,12 +1236,6 @@ export class FliksHostImpl implements PluginHostApi {
       decision: decision.mode,
       allowedQualityIds: [...allowed],
       allowedLanguageIds: [...allowedLangs],
-      minRankExclusive: decision.minRankExclusive,
-      // `Infinity` (JSON-unsafe) means "no ceiling" — MAX_SAFE_INTEGER says the
-      // same thing to a plugin without breaking JSON across the wire.
-      maxRankInclusive: Number.isFinite(decision.maxRankInclusive)
-        ? decision.maxRankInclusive
-        : Number.MAX_SAFE_INTEGER,
       minResolution: resolutionUpgradeOnly
         ? maxResolutionFromQualityStrings(files)
         : 0,

--- a/backend/src/modules/plugins/plugin-ui.controller.spec.ts
+++ b/backend/src/modules/plugins/plugin-ui.controller.spec.ts
@@ -2,6 +2,7 @@ import { Logger } from '@nestjs/common';
 import { PluginUiController } from './plugin-ui.controller';
 import type { RegisteredPlugin } from './plugin-registry.service';
 import type { TrustOutcome } from './archive';
+import { PLUGIN_API_VERSION } from '../../common/plugin-contract';
 import type { DataPluginManifest, ProcessPluginManifest } from '../../common/plugin-contract';
 
 function dataPlugin(
@@ -14,7 +15,7 @@ function dataPlugin(
     kind: 'data',
     manifest: {
       id: pluginId,
-      pluginApi: 0,
+      pluginApi: PLUGIN_API_VERSION,
       name: pluginId,
       version: '1.0.0',
       fliks: '>=1.0.0',
@@ -67,7 +68,7 @@ function processPlugin(pluginId: string): RegisteredPlugin {
     kind: 'process',
     manifest: {
       id: pluginId,
-      pluginApi: 0,
+      pluginApi: PLUGIN_API_VERSION,
       name: pluginId,
       version: '1.0.0',
       fliks: '>=1.0.0',

--- a/backend/src/modules/plugins/supervisor/spawn-plan.spec.ts
+++ b/backend/src/modules/plugins/supervisor/spawn-plan.spec.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { dirname, join } from 'path';
-import { PLUGIN_API_VERSION, SUPPORTED_PLUGIN_API_VERSIONS } from '../../../common/plugin-contract';
+import { PLUGIN_API_VERSION } from '../../../common/plugin-contract';
 import {
   PLUGIN_UID_MIN,
   allocateChildUid,
@@ -98,9 +98,10 @@ describe('buildSpawnPlan', () => {
   });
 
   it('tells a plugin the revision its own manifest declares, not core\'s newest', () => {
-    const older = SUPPORTED_PLUGIN_API_VERSIONS.find((v) => v !== PLUGIN_API_VERSION);
-    expect(older).toBeDefined();
-    const plan = buildSpawnPlan({ ...baseInput, pluginApi: older as number });
+    // Any other revision, supported or not: the plan echoes what the manifest declared and
+    // leaves accepting it to the registry, so this must not depend on a window being open.
+    const older = PLUGIN_API_VERSION - 1;
+    const plan = buildSpawnPlan({ ...baseInput, pluginApi: older });
     expect(plan.env.FLIKS_API_VERSION).toBe(String(older));
     expect(plan.env.HOME).toBe(baseInput.dataDir);
     expect(plan.env.NODE_ENV).toBe('production');

--- a/backend/src/modules/profiles/custom-formats.controller.ts
+++ b/backend/src/modules/profiles/custom-formats.controller.ts
@@ -11,6 +11,7 @@ import {
 } from '@nestjs/common';
 import { CustomFormatsService } from './custom-formats.service';
 import { CreateCustomFormatDto } from './dto/create-custom-format.dto';
+import { TestCustomFormatDto } from './dto/test-custom-format.dto';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
 import { PoliciesGuard } from '../auth/casl/policies.guard';
 import { CheckPolicies } from '../auth/casl/check-policies.decorator';
@@ -29,8 +30,11 @@ export class CustomFormatsController {
 
   @Post('test')
   @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
-  testRelease(@Body() body: { title: string }) {
-    return this.service.testRelease(body.title);
+  testRelease(@Body() dto: TestCustomFormatDto) {
+    return this.service.testRelease(dto.title, {
+      freeleech: dto.freeleech,
+      downloadVolumeFactor: dto.downloadVolumeFactor,
+    });
   }
 
   @Get()

--- a/backend/src/modules/profiles/custom-formats.controller.ts
+++ b/backend/src/modules/profiles/custom-formats.controller.ts
@@ -12,6 +12,7 @@ import {
 import { CustomFormatsService } from './custom-formats.service';
 import { CreateCustomFormatDto } from './dto/create-custom-format.dto';
 import { TestCustomFormatDto } from './dto/test-custom-format.dto';
+import { releaseFlags } from '../../common/release-scoring';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
 import { PoliciesGuard } from '../auth/casl/policies.guard';
 import { CheckPolicies } from '../auth/casl/check-policies.decorator';
@@ -31,10 +32,7 @@ export class CustomFormatsController {
   @Post('test')
   @CheckPolicies((ability) => ability.can(Action.Read, 'Settings'))
   testRelease(@Body() dto: TestCustomFormatDto) {
-    return this.service.testRelease(dto.title, {
-      freeleech: dto.freeleech,
-      downloadVolumeFactor: dto.downloadVolumeFactor,
-    });
+    return this.service.testRelease(dto.title, releaseFlags(dto));
   }
 
   @Get()

--- a/backend/src/modules/profiles/custom-formats.service.spec.ts
+++ b/backend/src/modules/profiles/custom-formats.service.spec.ts
@@ -10,11 +10,8 @@ function format(
 
 describe('CustomFormatsService matching', () => {
   const service = new CustomFormatsService({} as never);
-  const score = (
-    fmt: CustomFormat,
-    title: string,
-    meta?: { freeleech?: boolean; downloadVolumeFactor?: number },
-  ) => service.scoreReleaseWith([fmt], title, meta);
+  const score = (fmt: CustomFormat, title: string, flags?: string[]) =>
+    service.scoreReleaseWith([fmt], title, flags);
 
   const BLURAY_1080 = 'Some.Show.2024.1080p.BluRay.x264-GRP';
   const WEBRIP_1080 = 'Some.Show.2024.1080p.WEBRip.x264-GRP';
@@ -92,13 +89,15 @@ describe('CustomFormatsService matching', () => {
 
   it('reads release flags from the caller, not the title', () => {
     const fmt = format([{ type: 'release_flag', value: 'freeleech' }]);
-    expect(score(fmt, BLURAY_1080, { freeleech: true })).toBe(10);
-    expect(score(fmt, BLURAY_1080, { freeleech: false })).toBe(0);
-    expect(
-      score(format([{ type: 'release_flag', value: 'halfleech' }]), BLURAY_1080, {
-        downloadVolumeFactor: 0.5,
-      }),
-    ).toBe(10);
+    expect(score(fmt, BLURAY_1080, ['freeleech'])).toBe(10);
+    expect(score(fmt, BLURAY_1080, [])).toBe(0);
+    expect(score(format([{ type: 'release_flag', value: 'halfleech' }]), BLURAY_1080, ['halfleech'])).toBe(10);
+  });
+
+  it('matches a flag core has never heard of', () => {
+    const fmt = format([{ type: 'release_flag', value: 'internal' }]);
+    expect(score(fmt, BLURAY_1080, ['internal'])).toBe(10);
+    expect(score(fmt, BLURAY_1080, ['freeleech'])).toBe(0);
   });
 
   it('tests a regex against the untouched title', () => {

--- a/backend/src/modules/profiles/custom-formats.service.spec.ts
+++ b/backend/src/modules/profiles/custom-formats.service.spec.ts
@@ -1,0 +1,122 @@
+import { CustomFormatsService } from './custom-formats.service';
+import type { CustomFormat, CustomFormatSpec } from './entities/custom-format.entity';
+
+function format(
+  specs: CustomFormatSpec[],
+  over: Partial<CustomFormat> = {},
+): CustomFormat {
+  return { id: 1, name: 'fmt', score: 10, specs, ...over } as CustomFormat;
+}
+
+describe('CustomFormatsService matching', () => {
+  const service = new CustomFormatsService({} as never);
+  const score = (
+    fmt: CustomFormat,
+    title: string,
+    meta?: { freeleech?: boolean; downloadVolumeFactor?: number },
+  ) => service.scoreReleaseWith([fmt], title, meta);
+
+  const BLURAY_1080 = 'Some.Show.2024.1080p.BluRay.x264-GRP';
+  const WEBRIP_1080 = 'Some.Show.2024.1080p.WEBRip.x264-GRP';
+
+  it('scores a format whose only condition matches', () => {
+    expect(score(format([{ type: 'resolution', value: '1080p' }]), BLURAY_1080)).toBe(10);
+  });
+
+  it('requires every condition type, not just one of them', () => {
+    const fmt = format([
+      { type: 'resolution', value: '1080p' },
+      { type: 'source', value: 'bluray' },
+    ]);
+    expect(score(fmt, BLURAY_1080)).toBe(10);
+    // 1080p alone used to be enough: the two conditions were OR-ed together.
+    expect(score(fmt, WEBRIP_1080)).toBe(0);
+  });
+
+  it('treats conditions of the same type as alternatives', () => {
+    const fmt = format([
+      { type: 'source', value: 'bluray' },
+      { type: 'source', value: 'webrip' },
+    ]);
+    expect(score(fmt, BLURAY_1080)).toBe(10);
+    expect(score(fmt, WEBRIP_1080)).toBe(10);
+    expect(score(fmt, 'Some.Show.2024.1080p.HDTV.x264-GRP')).toBe(0);
+  });
+
+  it('a required condition must hold whatever its alternatives do', () => {
+    const fmt = format([
+      { type: 'source', value: 'bluray', required: true },
+      { type: 'source', value: 'webrip' },
+    ]);
+    expect(score(fmt, WEBRIP_1080)).toBe(0);
+    expect(score(fmt, BLURAY_1080)).toBe(10);
+  });
+
+  it('negates a condition', () => {
+    const fmt = format([{ type: 'source', value: 'webrip', negate: true }]);
+    expect(score(fmt, BLURAY_1080)).toBe(10);
+    expect(score(fmt, WEBRIP_1080)).toBe(0);
+  });
+
+  it('matches a source by its parsed value, not by substring', () => {
+    const fmt = format([{ type: 'source', value: 'web-dl' }]);
+    expect(score(fmt, 'Some.Show.2024.1080p.WEBDL.x264-GRP')).toBe(10);
+    expect(score(fmt, 'Some.Show.2024.1080p.WEB-DL.x264-GRP')).toBe(10);
+    expect(score(fmt, WEBRIP_1080)).toBe(0);
+  });
+
+  it('matches a language by its parsed value, not by substring', () => {
+    const fmt = format([{ type: 'language', value: 'it' }]);
+    expect(score(fmt, 'Some.Show.2024.1080p.ITA.BluRay.x264-GRP')).toBe(10);
+    // 'it' appears in the title, which the substring check used to accept.
+    expect(score(fmt, 'Whitewater.2024.1080p.BluRay.x264-GRP')).toBe(0);
+  });
+
+  it('matches a resolution numerically', () => {
+    const fmt = format([{ type: 'resolution', value: '2160p' }]);
+    expect(score(fmt, 'Some.Show.2024.2160p.BluRay.x265-GRP')).toBe(10);
+    expect(score(fmt, 'Some.Show.2024.UHD.BluRay.x265-GRP')).toBe(10);
+    expect(score(fmt, BLURAY_1080)).toBe(0);
+  });
+
+  it('matches release group, edition and codecs', () => {
+    expect(score(format([{ type: 'release_group', value: 'GRP' }]), BLURAY_1080)).toBe(10);
+    expect(
+      score(format([{ type: 'edition', value: 'imax' }]), 'Some.Show.2024.IMAX.1080p.BluRay-GRP'),
+    ).toBe(10);
+    expect(score(format([{ type: 'video_codec', value: 'h264' }]), BLURAY_1080)).toBe(10);
+    expect(
+      score(format([{ type: 'audio_codec', value: 'truehd' }]), 'Some.Show.2024.1080p.TrueHD-GRP'),
+    ).toBe(10);
+  });
+
+  it('reads release flags from the caller, not the title', () => {
+    const fmt = format([{ type: 'release_flag', value: 'freeleech' }]);
+    expect(score(fmt, BLURAY_1080, { freeleech: true })).toBe(10);
+    expect(score(fmt, BLURAY_1080, { freeleech: false })).toBe(0);
+    expect(
+      score(format([{ type: 'release_flag', value: 'halfleech' }]), BLURAY_1080, {
+        downloadVolumeFactor: 0.5,
+      }),
+    ).toBe(10);
+  });
+
+  it('tests a regex against the untouched title', () => {
+    expect(score(format([{ type: 'title_regex', value: 'blu-?ray' }]), BLURAY_1080)).toBe(10);
+    expect(score(format([{ type: 'title_regex', value: '[(' }]), BLURAY_1080)).toBe(0);
+  });
+
+  it('never matches a format with no condition', () => {
+    expect(score(format([]), BLURAY_1080)).toBe(0);
+  });
+
+  it('sums the scores of every matching format', () => {
+    const formats = [
+      format([{ type: 'source', value: 'bluray' }], { id: 1, score: 100 }),
+      format([{ type: 'source', value: 'webrip' }], { id: 2, score: -50 }),
+      format([{ type: 'resolution', value: '1080p' }], { id: 3, score: 5 }),
+    ];
+    expect(service.scoreReleaseWith(formats, BLURAY_1080)).toBe(105);
+    expect(service.scoreReleaseWith(formats, WEBRIP_1080)).toBe(-45);
+  });
+});

--- a/backend/src/modules/profiles/custom-formats.service.ts
+++ b/backend/src/modules/profiles/custom-formats.service.ts
@@ -56,10 +56,10 @@ export class CustomFormatsService {
 
   async update(id: number, dto: CreateCustomFormatDto): Promise<CustomFormat> {
     const cf = await this.findOne(id);
-    if (dto.specs !== undefined) this.assertRegexesCompile(dto.specs);
-    if (dto.name !== undefined) cf.name = dto.name;
-    if (dto.score !== undefined) cf.score = dto.score;
-    if (dto.specs !== undefined) cf.specs = dto.specs as CustomFormatSpec[];
+    this.assertRegexesCompile(dto.specs);
+    cf.name = dto.name;
+    cf.score = dto.score ?? 0;
+    cf.specs = dto.specs as CustomFormatSpec[];
     return this.repo.save(cf);
   }
 
@@ -86,18 +86,11 @@ export class CustomFormatsService {
   }
 
   /**
-   * Total custom-format score for a release title.
-   * Used in the grab flow to rank releases beyond basic quality.
+   * Total custom-format score for a release title — the grab flow's ranking
+   * signal beyond basic quality. Takes the format list the caller already read:
+   * the release scorer runs this once per candidate, so re-reading the table per
+   * release is an N+1.
    */
-  async scoreRelease(
-    releaseTitle: string,
-    meta?: ReleaseFlagMeta,
-  ): Promise<number> {
-    return this.scoreReleaseWith(await this.findAll(), releaseTitle, meta);
-  }
-
-  /** Same scoring against a format list the caller already read. The release scorer
-   *  runs this once per candidate, so re-reading the table per release is an N+1. */
   scoreReleaseWith(
     formats: CustomFormat[],
     releaseTitle: string,

--- a/backend/src/modules/profiles/custom-formats.service.ts
+++ b/backend/src/modules/profiles/custom-formats.service.ts
@@ -1,11 +1,31 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import {
-  CustomFormat,
-  CustomFormatSpecification,
-} from './entities/custom-format.entity';
+import { CustomFormat, CustomFormatSpec } from './entities/custom-format.entity';
 import { CreateCustomFormatDto } from './dto/create-custom-format.dto';
+import {
+  parseReleaseAttributes,
+  parseReleaseLanguage,
+  type ReleaseAttributes,
+} from '../../common/release-parsing';
+
+/** Torrent-level facts a release carries outside its name. */
+export interface ReleaseFlagMeta {
+  freeleech?: boolean;
+  downloadVolumeFactor?: number;
+}
+
+export interface CustomFormatMatch {
+  formatId: number;
+  formatName: string;
+  matched: boolean;
+  score: number;
+}
+
+/** Collapses the spelling variants of one tag ("WEB-DL", "web.dl", "WEBDL"). */
+function norm(value: string | null | undefined): string {
+  return (value ?? '').replace(/[^a-z0-9]/gi, '').toLowerCase();
+}
 
 @Injectable()
 export class CustomFormatsService {
@@ -15,10 +35,11 @@ export class CustomFormatsService {
   ) {}
 
   create(dto: CreateCustomFormatDto): Promise<CustomFormat> {
+    this.assertRegexesCompile(dto.specs);
     const row = this.repo.create({
       name: dto.name,
       score: dto.score ?? 0,
-      specifications: (dto.specifications ?? []) as CustomFormatSpecification[],
+      specs: dto.specs as CustomFormatSpec[],
     });
     return this.repo.save(row);
   }
@@ -35,10 +56,10 @@ export class CustomFormatsService {
 
   async update(id: number, dto: CreateCustomFormatDto): Promise<CustomFormat> {
     const cf = await this.findOne(id);
+    if (dto.specs !== undefined) this.assertRegexesCompile(dto.specs);
     if (dto.name !== undefined) cf.name = dto.name;
     if (dto.score !== undefined) cf.score = dto.score;
-    if (dto.specifications !== undefined)
-      cf.specifications = dto.specifications as CustomFormatSpecification[];
+    if (dto.specs !== undefined) cf.specs = dto.specs as CustomFormatSpec[];
     return this.repo.save(cf);
   }
 
@@ -47,31 +68,30 @@ export class CustomFormatsService {
     await this.repo.remove(cf);
   }
 
-  /**
-   * Test a release title against all custom formats and return a breakdown.
-   */
+  /** Per-format verdict for one release title — the settings page's tester. */
   async testRelease(
     title: string,
-    meta?: { freeleech?: boolean; downloadVolumeFactor?: number },
-  ): Promise<
-    { formatId: number; formatName: string; matched: boolean; score: number }[]
-  > {
-    const formats = await this.repo.find();
-    return formats.map((cf) => ({
-      formatId: cf.id,
-      formatName: cf.name,
-      matched: this.matchesFormat(title, cf, meta),
-      score: this.matchesFormat(title, cf, meta) ? cf.score : 0,
-    }));
+    meta?: ReleaseFlagMeta,
+  ): Promise<CustomFormatMatch[]> {
+    const formats = await this.findAll();
+    return formats.map((cf) => {
+      const matched = this.matchesFormat(title, cf, meta);
+      return {
+        formatId: cf.id,
+        formatName: cf.name,
+        matched,
+        score: matched ? cf.score : 0,
+      };
+    });
   }
 
   /**
-   * Compute the total custom-format score for a release title.
+   * Total custom-format score for a release title.
    * Used in the grab flow to rank releases beyond basic quality.
    */
   async scoreRelease(
     releaseTitle: string,
-    meta?: { freeleech?: boolean; downloadVolumeFactor?: number },
+    meta?: ReleaseFlagMeta,
   ): Promise<number> {
     return this.scoreReleaseWith(await this.findAll(), releaseTitle, meta);
   }
@@ -81,69 +101,109 @@ export class CustomFormatsService {
   scoreReleaseWith(
     formats: CustomFormat[],
     releaseTitle: string,
-    meta?: { freeleech?: boolean; downloadVolumeFactor?: number },
+    meta?: ReleaseFlagMeta,
   ): number {
     let total = 0;
     for (const fmt of formats) {
-      if (this.matchesFormat(releaseTitle, fmt, meta)) {
-        total += fmt.score;
-      }
+      if (this.matchesFormat(releaseTitle, fmt, meta)) total += fmt.score;
     }
     return total;
   }
 
+  /**
+   * Conditions of the same type are alternatives (OR); different types must all
+   * hold (AND). So `resolution:1080p` + `resolution:2160p` accepts either, while
+   * adding `source:bluray` narrows both. A `required` condition must hold on its
+   * own, whatever the rest of its group does.
+   *
+   * A format with no condition matches nothing: it would otherwise score every
+   * release in the library.
+   */
   private matchesFormat(
     title: string,
     fmt: CustomFormat,
-    meta?: { freeleech?: boolean; downloadVolumeFactor?: number },
+    meta?: ReleaseFlagMeta,
   ): boolean {
-    const titleLower = title.toLowerCase();
-    let allRequiredMet = true;
-    let anyNonRequiredMet = false;
-    let hasNonRequired = false;
+    const specs = fmt.specs ?? [];
+    if (!specs.length) return false;
 
-    for (const spec of fmt.specifications) {
-      const match = this.evalSpec(titleLower, spec, meta);
-      const result = spec.negate ? !match : match;
-
-      if (spec.required) {
-        if (!result) allRequiredMet = false;
-      } else {
-        hasNonRequired = true;
-        if (result) anyNonRequiredMet = true;
-      }
+    const attrs = parseReleaseAttributes(title);
+    const groups = new Map<string, CustomFormatSpec[]>();
+    for (const spec of specs) {
+      const group = groups.get(spec.type);
+      if (group) group.push(spec);
+      else groups.set(spec.type, [spec]);
     }
 
-    if (!allRequiredMet) return false;
-    if (hasNonRequired && !anyNonRequiredMet) return false;
+    for (const group of groups.values()) {
+      let anyMatched = false;
+      for (const spec of group) {
+        const raw = this.evalSpec(title, attrs, spec, meta);
+        const result = spec.negate ? !raw : raw;
+        if (spec.required && !result) return false;
+        if (result) anyMatched = true;
+      }
+      if (!anyMatched) return false;
+    }
     return true;
   }
 
   private evalSpec(
-    titleLower: string,
-    spec: CustomFormatSpecification,
-    meta?: { freeleech?: boolean; downloadVolumeFactor?: number },
+    title: string,
+    attrs: ReleaseAttributes,
+    spec: CustomFormatSpec,
+    meta?: ReleaseFlagMeta,
   ): boolean {
-    const val = (spec.value || '').toLowerCase();
-    switch (spec.implementation) {
+    const value = norm(spec.value);
+    switch (spec.type) {
       case 'title_regex':
+        // Tested against the untouched title so a pattern can still assert case.
         try {
-          return new RegExp(spec.value, 'i').test(titleLower);
+          return new RegExp(spec.value, 'i').test(title);
         } catch {
           return false;
         }
       case 'source':
-        return titleLower.includes(val);
+        return norm(attrs.source) === value;
       case 'resolution':
-        return titleLower.includes(val);
-      case 'language':
-        return titleLower.includes(val);
+        return attrs.resolution > 0 && attrs.resolution === parseInt(value, 10);
+      case 'language': {
+        const lang = parseReleaseLanguage(title);
+        return (
+          norm(lang.isoCode) === value ||
+          norm(lang.name) === value ||
+          (lang.iso639_2 ?? []).some((code) => norm(code) === value)
+        );
+      }
       case 'release_flag':
-        if (val === 'freeleech') return meta?.freeleech === true;
-        if (val === 'halfleech') return meta?.downloadVolumeFactor === 0.5;
+        if (value === 'freeleech') return meta?.freeleech === true;
+        if (value === 'halfleech') return meta?.downloadVolumeFactor === 0.5;
         return false;
+      case 'release_group':
+        return norm(attrs.releaseGroup) === value;
+      case 'edition':
+        return norm(attrs.edition) === value;
+      case 'video_codec':
+        return norm(attrs.videoCodec) === value;
+      case 'audio_codec':
+        return norm(attrs.audioCodec) === value;
       default:
         return false;
+    }
+  }
+
+  /** A pattern that doesn't compile would match nothing for ever, silently —
+   *  refuse it at the edit instead of at every search. */
+  private assertRegexesCompile(specs: readonly { type: string; value: string }[]) {
+    for (const spec of specs) {
+      if (spec.type !== 'title_regex') continue;
+      try {
+        new RegExp(spec.value, 'i');
+      } catch {
+        throw new BadRequestException(
+          `Invalid regular expression: ${spec.value}`,
+        );
+      }
     }
   }
 }

--- a/backend/src/modules/profiles/custom-formats.service.ts
+++ b/backend/src/modules/profiles/custom-formats.service.ts
@@ -9,12 +9,6 @@ import {
   type ReleaseAttributes,
 } from '../../common/release-parsing';
 
-/** Torrent-level facts a release carries outside its name. */
-export interface ReleaseFlagMeta {
-  freeleech?: boolean;
-  downloadVolumeFactor?: number;
-}
-
 export interface CustomFormatMatch {
   formatId: number;
   formatName: string;
@@ -71,11 +65,11 @@ export class CustomFormatsService {
   /** Per-format verdict for one release title — the settings page's tester. */
   async testRelease(
     title: string,
-    meta?: ReleaseFlagMeta,
+    flags: readonly string[] = [],
   ): Promise<CustomFormatMatch[]> {
     const formats = await this.findAll();
     return formats.map((cf) => {
-      const matched = this.matchesFormat(title, cf, meta);
+      const matched = this.matchesFormat(title, cf, flags);
       return {
         formatId: cf.id,
         formatName: cf.name,
@@ -94,11 +88,11 @@ export class CustomFormatsService {
   scoreReleaseWith(
     formats: CustomFormat[],
     releaseTitle: string,
-    meta?: ReleaseFlagMeta,
+    flags: readonly string[] = [],
   ): number {
     let total = 0;
     for (const fmt of formats) {
-      if (this.matchesFormat(releaseTitle, fmt, meta)) total += fmt.score;
+      if (this.matchesFormat(releaseTitle, fmt, flags)) total += fmt.score;
     }
     return total;
   }
@@ -115,7 +109,7 @@ export class CustomFormatsService {
   private matchesFormat(
     title: string,
     fmt: CustomFormat,
-    meta?: ReleaseFlagMeta,
+    flags: readonly string[],
   ): boolean {
     const specs = fmt.specs ?? [];
     if (!specs.length) return false;
@@ -131,7 +125,7 @@ export class CustomFormatsService {
     for (const group of groups.values()) {
       let anyMatched = false;
       for (const spec of group) {
-        const raw = this.evalSpec(title, attrs, spec, meta);
+        const raw = this.evalSpec(title, attrs, spec, flags);
         const result = spec.negate ? !raw : raw;
         if (spec.required && !result) return false;
         if (result) anyMatched = true;
@@ -145,7 +139,7 @@ export class CustomFormatsService {
     title: string,
     attrs: ReleaseAttributes,
     spec: CustomFormatSpec,
-    meta?: ReleaseFlagMeta,
+    flags: readonly string[],
   ): boolean {
     const value = norm(spec.value);
     switch (spec.type) {
@@ -169,9 +163,9 @@ export class CustomFormatsService {
         );
       }
       case 'release_flag':
-        if (value === 'freeleech') return meta?.freeleech === true;
-        if (value === 'halfleech') return meta?.downloadVolumeFactor === 0.5;
-        return false;
+        // Whatever the source announced, matched by name — core does not need to know
+        // which markers exist for a condition to test one.
+        return flags.some((flag) => norm(flag) === value);
       case 'release_group':
         return norm(attrs.releaseGroup) === value;
       case 'edition':

--- a/backend/src/modules/profiles/dto/create-custom-format.dto.ts
+++ b/backend/src/modules/profiles/dto/create-custom-format.dto.ts
@@ -6,22 +6,22 @@ import {
   IsOptional,
   ValidateNested,
   IsIn,
+  ArrayNotEmpty,
+  IsNotEmpty,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import {
+  CUSTOM_FORMAT_SPEC_TYPES,
+  type CustomFormatSpecType,
+} from '../entities/custom-format.entity';
 
-/**
- * Supported specification implementations:
- *   title_regex   — regex tested against the release title
- *   source        — matches source tag (bluray, web-dl, webrip, hdtv, dvd, cam)
- *   resolution    — matches resolution tag (2160p, 1080p, 720p, 480p, etc.)
- *   language      — matches detected language tag in release title
- */
-class SpecificationDto {
+class CustomFormatSpecDto {
+  @IsIn(CUSTOM_FORMAT_SPEC_TYPES as readonly string[])
+  type: CustomFormatSpecType;
+
   @IsString()
-  name: string;
-
-  @IsIn(['title_regex', 'source', 'resolution', 'language'])
-  implementation: string;
+  @IsNotEmpty()
+  value: string;
 
   @IsBoolean()
   @IsOptional()
@@ -30,22 +30,22 @@ class SpecificationDto {
   @IsBoolean()
   @IsOptional()
   required?: boolean;
-
-  @IsString()
-  value: string;
 }
 
 export class CreateCustomFormatDto {
   @IsString()
+  @IsNotEmpty()
   name: string;
 
   @IsNumber()
   @IsOptional()
   score?: number;
 
+  /** A format with no condition would match every release and apply its score
+   *  to all of them, so an empty list is refused rather than saved. */
   @IsArray()
+  @ArrayNotEmpty()
   @ValidateNested({ each: true })
-  @Type(() => SpecificationDto)
-  @IsOptional()
-  specifications?: SpecificationDto[];
+  @Type(() => CustomFormatSpecDto)
+  specs: CustomFormatSpecDto[];
 }

--- a/backend/src/modules/profiles/dto/create-quality-profile.dto.ts
+++ b/backend/src/modules/profiles/dto/create-quality-profile.dto.ts
@@ -47,6 +47,10 @@ export class CreateQualityProfileDto {
   @IsOptional()
   resolutionUpgradeOnly?: boolean;
 
+  @IsNumber()
+  @IsOptional()
+  minCustomFormatScore?: number;
+
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => QualityItemDto)

--- a/backend/src/modules/profiles/dto/test-custom-format.dto.ts
+++ b/backend/src/modules/profiles/dto/test-custom-format.dto.ts
@@ -1,0 +1,17 @@
+import { IsBoolean, IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class TestCustomFormatDto {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  /** Torrent flags aren't in the title, so a `release_flag` condition can only
+   *  be exercised if the tester says what the release would carry. */
+  @IsBoolean()
+  @IsOptional()
+  freeleech?: boolean;
+
+  @IsNumber()
+  @IsOptional()
+  downloadVolumeFactor?: number;
+}

--- a/backend/src/modules/profiles/entities/custom-format.entity.ts
+++ b/backend/src/modules/profiles/entities/custom-format.entity.ts
@@ -1,23 +1,41 @@
 import { Entity, Column } from 'typeorm';
 import { BaseEntity } from '../../../common/entities/base.entity';
 
+/**
+ * Condition kinds a custom format can test. Every one but `title_regex` and
+ * `release_flag` matches the *parsed* attribute of a release, never a substring
+ * of its name: `language:it` as a substring hits any title containing "it".
+ */
+export const CUSTOM_FORMAT_SPEC_TYPES = [
+  'title_regex',
+  'source',
+  'resolution',
+  'language',
+  'release_flag',
+  'release_group',
+  'edition',
+  'video_codec',
+  'audio_codec',
+] as const;
+
+export type CustomFormatSpecType = (typeof CUSTOM_FORMAT_SPEC_TYPES)[number];
+
+export interface CustomFormatSpec {
+  type: CustomFormatSpecType;
+  value: string;
+  negate?: boolean;
+  required?: boolean;
+}
+
 @Entity('custom_formats')
 export class CustomFormat extends BaseEntity {
   @Column()
   name: string;
 
-  /** Points added to a release score when all required conditions match */
+  /** Points added to a release score when the format matches */
   @Column({ type: 'int', default: 0 })
   score: number;
 
   @Column({ type: 'jsonb', default: [] })
-  specifications: CustomFormatSpecification[];
-}
-
-export interface CustomFormatSpecification {
-  name: string;
-  implementation: string;
-  negate: boolean;
-  required: boolean;
-  value: string;
+  specs: CustomFormatSpec[];
 }

--- a/backend/src/modules/profiles/entities/quality-profile.entity.ts
+++ b/backend/src/modules/profiles/entities/quality-profile.entity.ts
@@ -20,6 +20,12 @@ export class QualityProfile extends BaseEntity {
    *  (e.g. WEBDL-1080p → Bluray-1080p). */
   @Column({ default: false })
   resolutionUpgradeOnly: boolean;
+
+  /** Releases whose total custom-format score falls below this are rejected, not
+   *  merely ranked last — the only way a negative-score format can block a grab
+   *  instead of being taken when nothing better exists. */
+  @Column({ type: 'int', default: 0 })
+  minCustomFormatScore: number;
 }
 
 export interface QualityProfileItem {

--- a/backend/src/modules/profiles/profiles.service.ts
+++ b/backend/src/modules/profiles/profiles.service.ts
@@ -114,6 +114,7 @@ export class ProfilesService {
       cutoff: dto.cutoff,
       upgradeAllowed: dto.upgradeAllowed ?? false,
       resolutionUpgradeOnly: dto.resolutionUpgradeOnly ?? false,
+      minCustomFormatScore: dto.minCustomFormatScore ?? 0,
       items: dto.items.map((i) => ({
         quality: {
           id: i.qualityId,
@@ -150,6 +151,8 @@ export class ProfilesService {
     profile.upgradeAllowed = dto.upgradeAllowed ?? profile.upgradeAllowed;
     profile.resolutionUpgradeOnly =
       dto.resolutionUpgradeOnly ?? profile.resolutionUpgradeOnly;
+    profile.minCustomFormatScore =
+      dto.minCustomFormatScore ?? profile.minCustomFormatScore;
     profile.items = dto.items.map((i) => ({
       quality: {
         id: i.qualityId,

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1721,6 +1721,15 @@
         "edition": "Edition",
         "video_codec": "Video-Codec",
         "audio_codec": "Audio-Codec"
+      },
+      "edition": {
+        "directors-cut": "Director's Cut",
+        "extended": "Langfassung",
+        "theatrical": "Kinofassung",
+        "uncut": "Unzensiert",
+        "remastered": "Remastered",
+        "criterion": "Criterion",
+        "imax": "IMAX"
       }
     },
     "naming": {

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1105,7 +1105,9 @@
       "SEQUEL_MISMATCH": "Fortsetzung {{number}}, nicht der gesuchte Film",
       "YEAR_MISMATCH": "Jahr {{actual}}, erwartet {{expected}}",
       "COLLECTION_PACK": "Mehrfilm-Paket ({{word}})",
-      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Formatpunktzahl zu niedrig ({{actual}} < {{min}})"
+      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Formatpunktzahl zu niedrig ({{actual}} < {{min}})",
+      "RANK_NOT_AN_UPGRADE": "Keine Verbesserung der vorhandenen Datei",
+      "RANK_ABOVE_CUTOFF": "Über dem Profil-Grenzwert"
     },
     "like": "Gefällt mir",
     "metadata_group": "Metadaten",

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1104,7 +1104,8 @@
       "RESOLUTION_NOT_UPGRADED": "Keine Auflösungsverbesserung ({{actual}}p, mehr als {{min}}p nötig)",
       "SEQUEL_MISMATCH": "Fortsetzung {{number}}, nicht der gesuchte Film",
       "YEAR_MISMATCH": "Jahr {{actual}}, erwartet {{expected}}",
-      "COLLECTION_PACK": "Mehrfilm-Paket ({{word}})"
+      "COLLECTION_PACK": "Mehrfilm-Paket ({{word}})",
+      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Formatpunktzahl zu niedrig ({{actual}} < {{min}})"
     },
     "like": "Gefällt mir",
     "metadata_group": "Metadaten",
@@ -1628,7 +1629,9 @@
       "group_with_above": "Mit der vorherigen Qualität gruppieren (gleicher Rang)",
       "size_error_min_gt_max": "Das Minimum muss kleiner als das Maximum sein.",
       "size_error_pref_lt_min": "Der empfohlene Wert muss größer als das Minimum sein.",
-      "size_error_pref_gt_max": "Der empfohlene Wert muss kleiner als das Maximum sein."
+      "size_error_pref_gt_max": "Der empfohlene Wert muss kleiner als das Maximum sein.",
+      "field_min_cf_score": "Mindestpunktzahl für benutzerdefinierte Formate",
+      "field_min_cf_score_hint": "Releases unter dieser Punktzahl werden abgelehnt, nicht nur zuletzt einsortiert. 0 lehnt nur eine negative Summe ab."
     },
     "quality_definitions": {
       "title": "Qualitätsdefinitionen",
@@ -1689,7 +1692,7 @@
       "field_score": "Score",
       "specs": "Bedingungen",
       "add_spec": "Bedingung hinzufügen",
-      "no_specs": "Keine Bedingung — das Format passt immer.",
+      "no_specs": "Noch keine Bedingung. Ein Format braucht mindestens eine.",
       "negate": "Verneinen",
       "required": "Erforderlich",
       "name_required": "Der Name ist erforderlich.",
@@ -1698,7 +1701,27 @@
       "cancel": "Abbrechen",
       "test_title": "Einen Release-Titel testen",
       "test_placeholder": "Z. B.: Movie.Name.2024.1080p.BluRay.x264-GROUP",
-      "test_btn": "Testen"
+      "test_btn": "Testen",
+      "spec_count": "{{count}} Bedingung(en)",
+      "col_match": "Treffer",
+      "spec_required": "Fügen Sie mindestens eine Bedingung hinzu.",
+      "value_required": "Jede Bedingung braucht einen Wert.",
+      "regex_invalid": "Ein regulärer Ausdruck ist ungültig.",
+      "regex_placeholder": "regulärer Ausdruck",
+      "value_placeholder": "Wert",
+      "test_freeleech": "Als Freeleech behandeln",
+      "match_rule_hint": "Bedingungen desselben Typs sind Alternativen; verschiedene Typen müssen alle zutreffen. Eine erforderliche Bedingung muss immer zutreffen.",
+      "spec_type": {
+        "title_regex": "Release-Name (Regex)",
+        "source": "Quelle",
+        "resolution": "Auflösung",
+        "language": "Sprache",
+        "release_flag": "Release-Merkmal",
+        "release_group": "Release-Gruppe",
+        "edition": "Edition",
+        "video_codec": "Video-Codec",
+        "audio_codec": "Audio-Codec"
+      }
     },
     "naming": {
       "title": "Dateibenennung",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1112,7 +1112,8 @@
       "RESOLUTION_NOT_UPGRADED": "Not a resolution upgrade ({{actual}}p, needs above {{min}}p)",
       "SEQUEL_MISMATCH": "Sequel {{number}}, not the film wanted",
       "YEAR_MISMATCH": "Year {{actual}}, expected {{expected}}",
-      "COLLECTION_PACK": "Multi-film pack ({{word}})"
+      "COLLECTION_PACK": "Multi-film pack ({{word}})",
+      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Custom format score too low ({{actual}} < {{min}})"
     },
     "like": "Like",
     "metadata_group": "Metadata",
@@ -1638,7 +1639,9 @@
       "group_with_above": "Group with the previous quality (same rank)",
       "size_error_min_gt_max": "The minimum must be lower than the maximum.",
       "size_error_pref_lt_min": "The preferred value must be higher than the minimum.",
-      "size_error_pref_gt_max": "The preferred value must be lower than the maximum."
+      "size_error_pref_gt_max": "The preferred value must be lower than the maximum.",
+      "field_min_cf_score": "Minimum custom format score",
+      "field_min_cf_score_hint": "Releases scoring below this are refused instead of merely ranked last. 0 refuses only a negative total."
     },
     "quality_definitions": {
       "title": "Quality definitions",
@@ -1706,7 +1709,7 @@
       "field_score": "Score",
       "specs": "Conditions",
       "add_spec": "Add a condition",
-      "no_specs": "No condition — the format will always match.",
+      "no_specs": "No condition yet. A format needs at least one.",
       "negate": "Negate",
       "required": "Required",
       "name_required": "The name is required.",
@@ -1715,7 +1718,27 @@
       "cancel": "Cancel",
       "test_title": "Test a release title",
       "test_placeholder": "e.g. Movie.Name.2024.1080p.BluRay.x264-GROUP",
-      "test_btn": "Test"
+      "test_btn": "Test",
+      "spec_count": "{{count}} condition(s)",
+      "col_match": "Match",
+      "spec_required": "Add at least one condition.",
+      "value_required": "Every condition needs a value.",
+      "regex_invalid": "A regular expression is invalid.",
+      "regex_placeholder": "regular expression",
+      "value_placeholder": "value",
+      "test_freeleech": "Treat as freeleech",
+      "match_rule_hint": "Conditions of the same type are alternatives; different types must all hold. A required condition must always hold.",
+      "spec_type": {
+        "title_regex": "Release name (regex)",
+        "source": "Source",
+        "resolution": "Resolution",
+        "language": "Language",
+        "release_flag": "Release flag",
+        "release_group": "Release group",
+        "edition": "Edition",
+        "video_codec": "Video codec",
+        "audio_codec": "Audio codec"
+      }
     },
     "naming": {
       "title": "File naming",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1113,7 +1113,9 @@
       "SEQUEL_MISMATCH": "Sequel {{number}}, not the film wanted",
       "YEAR_MISMATCH": "Year {{actual}}, expected {{expected}}",
       "COLLECTION_PACK": "Multi-film pack ({{word}})",
-      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Custom format score too low ({{actual}} < {{min}})"
+      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Custom format score too low ({{actual}} < {{min}})",
+      "RANK_NOT_AN_UPGRADE": "Not an upgrade on the file on disk",
+      "RANK_ABOVE_CUTOFF": "Above the profile cutoff"
     },
     "like": "Like",
     "metadata_group": "Metadata",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1738,6 +1738,15 @@
         "edition": "Edition",
         "video_codec": "Video codec",
         "audio_codec": "Audio codec"
+      },
+      "edition": {
+        "directors-cut": "Director's Cut",
+        "extended": "Extended",
+        "theatrical": "Theatrical",
+        "uncut": "Uncut",
+        "remastered": "Remastered",
+        "criterion": "Criterion",
+        "imax": "IMAX"
       }
     },
     "naming": {

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1721,6 +1721,15 @@
         "edition": "Edición",
         "video_codec": "Códec de vídeo",
         "audio_codec": "Códec de audio"
+      },
+      "edition": {
+        "directors-cut": "Montaje del director",
+        "extended": "Versión extendida",
+        "theatrical": "Versión de cine",
+        "uncut": "Sin censura",
+        "remastered": "Remasterizada",
+        "criterion": "Criterion",
+        "imax": "IMAX"
       }
     },
     "naming": {

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1105,7 +1105,9 @@
       "SEQUEL_MISMATCH": "Secuela {{number}}, no la película buscada",
       "YEAR_MISMATCH": "Año {{actual}}, esperado {{expected}}",
       "COLLECTION_PACK": "Pack de varias películas ({{word}})",
-      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Puntuación de formatos demasiado baja ({{actual}} < {{min}})"
+      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Puntuación de formatos demasiado baja ({{actual}} < {{min}})",
+      "RANK_NOT_AN_UPGRADE": "No mejora el archivo en disco",
+      "RANK_ABOVE_CUTOFF": "Por encima del límite del perfil"
     },
     "like": "Me gusta",
     "metadata_group": "Metadatos",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1104,7 +1104,8 @@
       "RESOLUTION_NOT_UPGRADED": "No mejora la resolución ({{actual}}p, se necesita más de {{min}}p)",
       "SEQUEL_MISMATCH": "Secuela {{number}}, no la película buscada",
       "YEAR_MISMATCH": "Año {{actual}}, esperado {{expected}}",
-      "COLLECTION_PACK": "Pack de varias películas ({{word}})"
+      "COLLECTION_PACK": "Pack de varias películas ({{word}})",
+      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Puntuación de formatos demasiado baja ({{actual}} < {{min}})"
     },
     "like": "Me gusta",
     "metadata_group": "Metadatos",
@@ -1628,7 +1629,9 @@
       "group_with_above": "Agrupar con la calidad anterior (mismo rango)",
       "size_error_min_gt_max": "El mínimo debe ser inferior al máximo.",
       "size_error_pref_lt_min": "El recomendado debe ser superior al mínimo.",
-      "size_error_pref_gt_max": "El recomendado debe ser inferior al máximo."
+      "size_error_pref_gt_max": "El recomendado debe ser inferior al máximo.",
+      "field_min_cf_score": "Puntuación mínima de formatos personalizados",
+      "field_min_cf_score_hint": "Las releases por debajo de esta puntuación se rechazan en lugar de quedar solo al final. 0 rechaza únicamente un total negativo."
     },
     "quality_definitions": {
       "title": "Definiciones de calidad",
@@ -1689,7 +1692,7 @@
       "field_score": "Puntuación",
       "specs": "Condiciones",
       "add_spec": "Añadir una condición",
-      "no_specs": "Sin condiciones — el formato coincidirá siempre.",
+      "no_specs": "Sin condiciones. Un formato necesita al menos una.",
       "negate": "Negar",
       "required": "Requerido",
       "name_required": "El nombre es obligatorio.",
@@ -1698,7 +1701,27 @@
       "cancel": "Cancelar",
       "test_title": "Probar un título de release",
       "test_placeholder": "Ej: Movie.Name.2024.1080p.BluRay.x264-GROUP",
-      "test_btn": "Probar"
+      "test_btn": "Probar",
+      "spec_count": "{{count}} condición(es)",
+      "col_match": "Coincide",
+      "spec_required": "Añada al menos una condición.",
+      "value_required": "Cada condición necesita un valor.",
+      "regex_invalid": "Una expresión regular no es válida.",
+      "regex_placeholder": "expresión regular",
+      "value_placeholder": "valor",
+      "test_freeleech": "Tratar como freeleech",
+      "match_rule_hint": "Las condiciones del mismo tipo son alternativas; los tipos distintos deben cumplirse todos. Una condición requerida debe cumplirse siempre.",
+      "spec_type": {
+        "title_regex": "Nombre de la release (regex)",
+        "source": "Fuente",
+        "resolution": "Resolución",
+        "language": "Idioma",
+        "release_flag": "Marca de release",
+        "release_group": "Grupo de release",
+        "edition": "Edición",
+        "video_codec": "Códec de vídeo",
+        "audio_codec": "Códec de audio"
+      }
     },
     "naming": {
       "title": "Nomenclatura de los archivos",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1112,7 +1112,8 @@
       "RESOLUTION_NOT_UPGRADED": "Pas une montée de résolution ({{actual}}p, il faut plus de {{min}}p)",
       "SEQUEL_MISMATCH": "Suite {{number}}, pas le film voulu",
       "YEAR_MISMATCH": "Année {{actual}}, attendue {{expected}}",
-      "COLLECTION_PACK": "Pack multi-films ({{word}})"
+      "COLLECTION_PACK": "Pack multi-films ({{word}})",
+      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Score de formats trop bas ({{actual}} < {{min}})"
     },
     "like": "J’aime",
     "metadata_group": "Métadonnées",
@@ -1638,7 +1639,9 @@
       "group_with_above": "Grouper avec la qualité précédente (même rang)",
       "size_error_min_gt_max": "Le minimum doit être inférieur au maximum.",
       "size_error_pref_lt_min": "Le recommandé doit être supérieur au minimum.",
-      "size_error_pref_gt_max": "Le recommandé doit être inférieur au maximum."
+      "size_error_pref_gt_max": "Le recommandé doit être inférieur au maximum.",
+      "field_min_cf_score": "Score minimum des formats personnalisés",
+      "field_min_cf_score_hint": "Les releases sous ce score sont refusées au lieu d'être seulement classées en dernier. 0 ne refuse qu'un total négatif."
     },
     "quality_definitions": {
       "title": "Définitions de qualité",
@@ -1706,7 +1709,7 @@
       "field_score": "Score",
       "specs": "Conditions",
       "add_spec": "Ajouter une condition",
-      "no_specs": "Aucune condition — le format correspondra toujours.",
+      "no_specs": "Aucune condition. Un format en exige au moins une.",
       "negate": "Nier",
       "required": "Requis",
       "name_required": "Le nom est obligatoire.",
@@ -1715,7 +1718,27 @@
       "cancel": "Annuler",
       "test_title": "Tester un titre de release",
       "test_placeholder": "Ex: Movie.Name.2024.1080p.BluRay.x264-GROUP",
-      "test_btn": "Tester"
+      "test_btn": "Tester",
+      "spec_count": "{{count}} condition(s)",
+      "col_match": "Correspond",
+      "spec_required": "Ajoutez au moins une condition.",
+      "value_required": "Chaque condition doit avoir une valeur.",
+      "regex_invalid": "Une expression régulière est invalide.",
+      "regex_placeholder": "expression régulière",
+      "value_placeholder": "valeur",
+      "test_freeleech": "Considérer comme freeleech",
+      "match_rule_hint": "Les conditions de même type sont des alternatives ; les types différents doivent tous être vérifiés. Une condition requise doit toujours être vérifiée.",
+      "spec_type": {
+        "title_regex": "Nom de la release (regex)",
+        "source": "Source",
+        "resolution": "Résolution",
+        "language": "Langue",
+        "release_flag": "Marqueur de release",
+        "release_group": "Groupe de release",
+        "edition": "Édition",
+        "video_codec": "Codec vidéo",
+        "audio_codec": "Codec audio"
+      }
     },
     "naming": {
       "title": "Nommage des fichiers",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1113,7 +1113,9 @@
       "SEQUEL_MISMATCH": "Suite {{number}}, pas le film voulu",
       "YEAR_MISMATCH": "Année {{actual}}, attendue {{expected}}",
       "COLLECTION_PACK": "Pack multi-films ({{word}})",
-      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Score de formats trop bas ({{actual}} < {{min}})"
+      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Score de formats trop bas ({{actual}} < {{min}})",
+      "RANK_NOT_AN_UPGRADE": "Pas une amélioration du fichier présent",
+      "RANK_ABOVE_CUTOFF": "Au-dessus du seuil du profil"
     },
     "like": "J’aime",
     "metadata_group": "Métadonnées",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1738,6 +1738,15 @@
         "edition": "Édition",
         "video_codec": "Codec vidéo",
         "audio_codec": "Codec audio"
+      },
+      "edition": {
+        "directors-cut": "Director's cut",
+        "extended": "Version longue",
+        "theatrical": "Version cinéma",
+        "uncut": "Non censurée",
+        "remastered": "Remasterisée",
+        "criterion": "Criterion",
+        "imax": "IMAX"
       }
     },
     "naming": {

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1105,7 +1105,9 @@
       "SEQUEL_MISMATCH": "Sequel {{number}}, non il film cercato",
       "YEAR_MISMATCH": "Anno {{actual}}, atteso {{expected}}",
       "COLLECTION_PACK": "Pacchetto multi-film ({{word}})",
-      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Punteggio dei formati troppo basso ({{actual}} < {{min}})"
+      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Punteggio dei formati troppo basso ({{actual}} < {{min}})",
+      "RANK_NOT_AN_UPGRADE": "Non migliora il file presente",
+      "RANK_ABOVE_CUTOFF": "Sopra la soglia del profilo"
     },
     "like": "Mi piace",
     "metadata_group": "Metadati",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1721,6 +1721,15 @@
         "edition": "Edizione",
         "video_codec": "Codec video",
         "audio_codec": "Codec audio"
+      },
+      "edition": {
+        "directors-cut": "Director's cut",
+        "extended": "Versione estesa",
+        "theatrical": "Versione cinematografica",
+        "uncut": "Senza tagli",
+        "remastered": "Rimasterizzata",
+        "criterion": "Criterion",
+        "imax": "IMAX"
       }
     },
     "naming": {

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1104,7 +1104,8 @@
       "RESOLUTION_NOT_UPGRADED": "Non migliora la risoluzione ({{actual}}p, serve più di {{min}}p)",
       "SEQUEL_MISMATCH": "Sequel {{number}}, non il film cercato",
       "YEAR_MISMATCH": "Anno {{actual}}, atteso {{expected}}",
-      "COLLECTION_PACK": "Pacchetto multi-film ({{word}})"
+      "COLLECTION_PACK": "Pacchetto multi-film ({{word}})",
+      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Punteggio dei formati troppo basso ({{actual}} < {{min}})"
     },
     "like": "Mi piace",
     "metadata_group": "Metadati",
@@ -1628,7 +1629,9 @@
       "group_with_above": "Raggruppa con la qualità precedente (stesso rango)",
       "size_error_min_gt_max": "Il minimo deve essere inferiore al massimo.",
       "size_error_pref_lt_min": "Il consigliato deve essere superiore al minimo.",
-      "size_error_pref_gt_max": "Il consigliato deve essere inferiore al massimo."
+      "size_error_pref_gt_max": "Il consigliato deve essere inferiore al massimo.",
+      "field_min_cf_score": "Punteggio minimo dei formati personalizzati",
+      "field_min_cf_score_hint": "Le release sotto questo punteggio vengono rifiutate, non solo messe per ultime. 0 rifiuta solo un totale negativo."
     },
     "quality_definitions": {
       "title": "Definizioni di qualità",
@@ -1689,7 +1692,7 @@
       "field_score": "Punteggio",
       "specs": "Condizioni",
       "add_spec": "Aggiungi una condizione",
-      "no_specs": "Nessuna condizione — il formato corrisponderà sempre.",
+      "no_specs": "Nessuna condizione. Un formato ne richiede almeno una.",
       "negate": "Nega",
       "required": "Richiesto",
       "name_required": "Il nome è obbligatorio.",
@@ -1698,7 +1701,27 @@
       "cancel": "Annulla",
       "test_title": "Testa un titolo di release",
       "test_placeholder": "Es: Movie.Name.2024.1080p.BluRay.x264-GROUP",
-      "test_btn": "Testa"
+      "test_btn": "Testa",
+      "spec_count": "{{count}} condizione/i",
+      "col_match": "Corrisponde",
+      "spec_required": "Aggiungi almeno una condizione.",
+      "value_required": "Ogni condizione richiede un valore.",
+      "regex_invalid": "Un'espressione regolare non è valida.",
+      "regex_placeholder": "espressione regolare",
+      "value_placeholder": "valore",
+      "test_freeleech": "Considera come freeleech",
+      "match_rule_hint": "Le condizioni dello stesso tipo sono alternative; tipi diversi devono valere tutti. Una condizione obbligatoria deve valere sempre.",
+      "spec_type": {
+        "title_regex": "Nome della release (regex)",
+        "source": "Sorgente",
+        "resolution": "Risoluzione",
+        "language": "Lingua",
+        "release_flag": "Contrassegno release",
+        "release_group": "Gruppo release",
+        "edition": "Edizione",
+        "video_codec": "Codec video",
+        "audio_codec": "Codec audio"
+      }
     },
     "naming": {
       "title": "Denominazione dei file",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1104,7 +1104,8 @@
       "RESOLUTION_NOT_UPGRADED": "Não melhora a resolução ({{actual}}p, precisa de mais de {{min}}p)",
       "SEQUEL_MISMATCH": "Sequela {{number}}, não o filme pretendido",
       "YEAR_MISMATCH": "Ano {{actual}}, esperado {{expected}}",
-      "COLLECTION_PACK": "Pacote de vários filmes ({{word}})"
+      "COLLECTION_PACK": "Pacote de vários filmes ({{word}})",
+      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Pontuação dos formatos demasiado baixa ({{actual}} < {{min}})"
     },
     "like": "Gosto",
     "metadata_group": "Metadados",
@@ -1628,7 +1629,9 @@
       "group_with_above": "Agrupar com a qualidade anterior (mesmo nível)",
       "size_error_min_gt_max": "O mínimo deve ser inferior ao máximo.",
       "size_error_pref_lt_min": "O recomendado deve ser superior ao mínimo.",
-      "size_error_pref_gt_max": "O recomendado deve ser inferior ao máximo."
+      "size_error_pref_gt_max": "O recomendado deve ser inferior ao máximo.",
+      "field_min_cf_score": "Pontuação mínima dos formatos personalizados",
+      "field_min_cf_score_hint": "Releases abaixo desta pontuação são recusadas em vez de apenas ficarem no fim. 0 recusa apenas um total negativo."
     },
     "quality_definitions": {
       "title": "Definições de qualidade",
@@ -1689,7 +1692,7 @@
       "field_score": "Pontuação",
       "specs": "Condições",
       "add_spec": "Adicionar uma condição",
-      "no_specs": "Nenhuma condição — o formato corresponderá sempre.",
+      "no_specs": "Nenhuma condição. Um formato exige pelo menos uma.",
       "negate": "Negar",
       "required": "Obrigatório",
       "name_required": "O nome é obrigatório.",
@@ -1698,7 +1701,27 @@
       "cancel": "Cancelar",
       "test_title": "Testar um título de release",
       "test_placeholder": "Ex.: Movie.Name.2024.1080p.BluRay.x264-GROUP",
-      "test_btn": "Testar"
+      "test_btn": "Testar",
+      "spec_count": "{{count}} condição(ões)",
+      "col_match": "Corresponde",
+      "spec_required": "Adicione pelo menos uma condição.",
+      "value_required": "Cada condição precisa de um valor.",
+      "regex_invalid": "Uma expressão regular é inválida.",
+      "regex_placeholder": "expressão regular",
+      "value_placeholder": "valor",
+      "test_freeleech": "Tratar como freeleech",
+      "match_rule_hint": "Condições do mesmo tipo são alternativas; tipos diferentes têm de se verificar todos. Uma condição obrigatória tem de se verificar sempre.",
+      "spec_type": {
+        "title_regex": "Nome da release (regex)",
+        "source": "Fonte",
+        "resolution": "Resolução",
+        "language": "Idioma",
+        "release_flag": "Marca da release",
+        "release_group": "Grupo da release",
+        "edition": "Edição",
+        "video_codec": "Códec de vídeo",
+        "audio_codec": "Códec de áudio"
+      }
     },
     "naming": {
       "title": "Nomenclatura dos ficheiros",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1721,6 +1721,15 @@
         "edition": "Edição",
         "video_codec": "Códec de vídeo",
         "audio_codec": "Códec de áudio"
+      },
+      "edition": {
+        "directors-cut": "Versão do realizador",
+        "extended": "Versão estendida",
+        "theatrical": "Versão de cinema",
+        "uncut": "Sem cortes",
+        "remastered": "Remasterizada",
+        "criterion": "Criterion",
+        "imax": "IMAX"
       }
     },
     "naming": {

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1105,7 +1105,9 @@
       "SEQUEL_MISMATCH": "Sequela {{number}}, não o filme pretendido",
       "YEAR_MISMATCH": "Ano {{actual}}, esperado {{expected}}",
       "COLLECTION_PACK": "Pacote de vários filmes ({{word}})",
-      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Pontuação dos formatos demasiado baixa ({{actual}} < {{min}})"
+      "CUSTOM_FORMAT_SCORE_TOO_LOW": "Pontuação dos formatos demasiado baixa ({{actual}} < {{min}})",
+      "RANK_NOT_AN_UPGRADE": "Não melhora o ficheiro existente",
+      "RANK_ABOVE_CUTOFF": "Acima do limite do perfil"
     },
     "like": "Gosto",
     "metadata_group": "Metadados",

--- a/client/src/app/core/services/api/custom-formats-api.service.ts
+++ b/client/src/app/core/services/api/custom-formats-api.service.ts
@@ -59,7 +59,7 @@ export class CustomFormatsApiService {
     return firstValueFrom(this.http.post<CustomFormat>('/api/custom-formats', body));
   }
 
-  update(id: number, body: Partial<CreateCustomFormatBody>) {
+  update(id: number, body: CreateCustomFormatBody) {
     return firstValueFrom(this.http.put<CustomFormat>(`/api/custom-formats/${id}`, body));
   }
 

--- a/client/src/app/core/services/api/custom-formats-api.service.ts
+++ b/client/src/app/core/services/api/custom-formats-api.service.ts
@@ -2,8 +2,22 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 
+export const CUSTOM_FORMAT_SPEC_TYPES = [
+  'title_regex',
+  'source',
+  'resolution',
+  'language',
+  'release_flag',
+  'release_group',
+  'edition',
+  'video_codec',
+  'audio_codec',
+] as const;
+
+export type CustomFormatSpecType = (typeof CUSTOM_FORMAT_SPEC_TYPES)[number];
+
 export interface CustomFormatSpec {
-  type: 'title_regex' | 'source' | 'resolution' | 'language' | 'release_flag';
+  type: CustomFormatSpecType;
   value: string;
   negate?: boolean;
   required?: boolean;
@@ -19,7 +33,14 @@ export interface CustomFormat {
 export interface CreateCustomFormatBody {
   name: string;
   score?: number;
-  specs?: CustomFormatSpec[];
+  specs: CustomFormatSpec[];
+}
+
+export interface CustomFormatMatch {
+  formatId: number;
+  formatName: string;
+  matched: boolean;
+  score: number;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -46,7 +67,9 @@ export class CustomFormatsApiService {
     return firstValueFrom(this.http.delete<void>(`/api/custom-formats/${id}`));
   }
 
-  testTitle(title: string) {
-    return firstValueFrom(this.http.post<{ formatId: number; formatName: string; matched: boolean; score: number }[]>('/api/custom-formats/test', { title }));
+  testTitle(title: string, meta?: { freeleech?: boolean }) {
+    return firstValueFrom(
+      this.http.post<CustomFormatMatch[]>('/api/custom-formats/test', { title, ...meta }),
+    );
   }
 }

--- a/client/src/app/core/services/api/profiles.service.ts
+++ b/client/src/app/core/services/api/profiles.service.ts
@@ -8,6 +8,7 @@ export interface QualityProfile {
   cutoff: number;
   upgradeAllowed: boolean;
   resolutionUpgradeOnly: boolean;
+  minCustomFormatScore: number;
   items: {
     quality: { id: number; name: string; resolution: number; source: string };
     allowed: boolean;
@@ -21,6 +22,7 @@ export interface CreateQualityProfilePayload {
   cutoff: number;
   upgradeAllowed?: boolean;
   resolutionUpgradeOnly?: boolean;
+  minCustomFormatScore?: number;
   items: {
     qualityId: number;
     qualityName: string;

--- a/client/src/app/features/settings/custom-formats/custom-formats.html
+++ b/client/src/app/features/settings/custom-formats/custom-formats.html
@@ -202,7 +202,13 @@
                 (ngModelChange)="updateSpec($index, { value: $event })"
               >
                 @for (v of options; track v) {
-                  <option [value]="v">{{ v }}</option>
+                  <option [value]="v">
+                    {{
+                      spec.type === 'edition'
+                        ? ('settings.custom_formats.edition.' + v | translate)
+                        : v
+                    }}
+                  </option>
                 }
               </select>
             } @else {

--- a/client/src/app/features/settings/custom-formats/custom-formats.html
+++ b/client/src/app/features/settings/custom-formats/custom-formats.html
@@ -50,7 +50,9 @@
                   {{ cf.score > 0 ? '+' : '' }}{{ cf.score }}
                 </span>
               </td>
-              <td class="text-sm text-base-content/60">{{ cf.specs.length }} spec(s)</td>
+              <td class="text-sm text-base-content/60">
+                {{ 'settings.custom_formats.spec_count' | translate: { count: cf.specs.length } }}
+              </td>
               <td class="text-end">
                 <button
                   type="button"
@@ -77,6 +79,17 @@
       [ngModel]="testTitle()"
       (ngModelChange)="testTitle.set($event)"
     />
+    <label class="label cursor-pointer gap-1.5">
+      <input
+        type="checkbox"
+        class="checkbox checkbox-sm"
+        [ngModel]="testFreeleech()"
+        (ngModelChange)="testFreeleech.set($event)"
+      />
+      <span class="label-text text-sm">{{
+        'settings.custom_formats.test_freeleech' | translate
+      }}</span>
+    </label>
     <button
       type="button"
       class="btn btn-sm btn-outline"
@@ -94,9 +107,9 @@
       <table class="table">
         <thead>
           <tr>
-            <th>Format</th>
-            <th>Match</th>
-            <th class="text-right">Score</th>
+            <th>{{ 'settings.custom_formats.col_name' | translate }}</th>
+            <th>{{ 'settings.custom_formats.col_match' | translate }}</th>
+            <th class="text-right">{{ 'settings.custom_formats.col_score' | translate }}</th>
           </tr>
         </thead>
         <tbody>
@@ -105,9 +118,9 @@
               <td>{{ r.formatName }}</td>
               <td>
                 @if (r.matched) {
-                  <span class="badge badge-success badge-sm">Oui</span>
+                  <span class="badge badge-success badge-sm">{{ 'common.yes' | translate }}</span>
                 } @else {
-                  <span class="badge badge-ghost badge-sm">Non</span>
+                  <span class="badge badge-ghost badge-sm">{{ 'common.no' | translate }}</span>
                 }
               </td>
               <td
@@ -173,20 +186,22 @@
     appTvSelect
               class="select select-bordered select-xs"
               [ngModel]="spec.type"
-              (ngModelChange)="updateSpec($index, { type: $event })"
+              (ngModelChange)="changeSpecType($index, $event)"
             >
               @for (t of specTypes; track t) {
-                <option [value]="t">{{ t }}</option>
+                <option [value]="t">
+                  {{ 'settings.custom_formats.spec_type.' + t | translate }}
+                </option>
               }
             </select>
-            @if (spec.type === 'release_flag') {
+            @if (valueOptions(spec.type); as options) {
               <select
     appTvSelect
                 class="select select-bordered select-xs flex-1 min-w-32"
                 [ngModel]="spec.value"
                 (ngModelChange)="updateSpec($index, { value: $event })"
               >
-                @for (v of releaseFlagValues; track v) {
+                @for (v of options; track v) {
                   <option [value]="v">{{ v }}</option>
                 }
               </select>
@@ -194,9 +209,15 @@
               <input
                 type="text"
                 class="input input-bordered input-xs flex-1 min-w-32"
+                [class.input-error]="specInvalid(spec)"
                 [ngModel]="spec.value"
                 (ngModelChange)="updateSpec($index, { value: $event })"
-                placeholder="{{ spec.type === 'title_regex' ? '/regex/' : 'value' }}"
+                [placeholder]="
+                  (spec.type === 'title_regex'
+                    ? 'settings.custom_formats.regex_placeholder'
+                    : 'settings.custom_formats.value_placeholder'
+                  ) | translate
+                "
               />
             }
             <label class="label cursor-pointer gap-1.5 px-1">
@@ -236,6 +257,10 @@
             {{ 'settings.custom_formats.no_specs' | translate }}
           </p>
         }
+
+        <p class="text-sm text-base-content/60">
+          {{ 'settings.custom_formats.match_rule_hint' | translate }}
+        </p>
       </div>
     </div>
 
@@ -243,7 +268,15 @@
       <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
         {{ 'settings.custom_formats.cancel' | translate }}
       </button>
-      <button type="button" class="btn btn-primary" (click)="save()" [disabled]="saving()">
+      @if (formError(); as error) {
+        <span class="text-sm text-error mr-auto">{{ error | translate }}</span>
+      }
+      <button
+        type="button"
+        class="btn btn-primary"
+        (click)="save()"
+        [disabled]="saving() || !!formError()"
+      >
         @if (saving()) {
           <span class="loading loading-spinner loading-sm"></span>
         }

--- a/client/src/app/features/settings/custom-formats/custom-formats.ts
+++ b/client/src/app/features/settings/custom-formats/custom-formats.ts
@@ -2,6 +2,7 @@ import {
   Component,
   ChangeDetectionStrategy,
   ElementRef,
+  computed,
   signal,
   inject,
   OnInit,
@@ -9,16 +10,41 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
-import { LucideX } from '@lucide/angular';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
   CustomFormatsApiService,
   CustomFormat,
+  CustomFormatMatch,
   CustomFormatSpec,
+  CustomFormatSpecType,
+  CUSTOM_FORMAT_SPEC_TYPES,
 } from '../../../core/services/api/custom-formats-api.service';
+import { ProfilesService } from '../../../core/services/api/profiles.service';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 import { ModalFooterComponent } from '../../../shared/components/modal-footer';
+
+/**
+ * Condition values that come from a closed vocabulary — the backend matches them
+ * against the parsed release attribute, so a free-typed variant simply never
+ * matches. Types absent here take free text (a regex, a release group).
+ */
+const VALUE_OPTIONS: Partial<Record<CustomFormatSpecType, readonly string[]>> = {
+  source: ['remux', 'bluray', 'web-dl', 'webrip', 'hdtv', 'dvd', 'sdtv', 'cam', 'ts', 'tc'],
+  resolution: ['4320p', '2160p', '1080p', '720p', '576p', '480p', '360p'],
+  release_flag: ['freeleech', 'halfleech'],
+  edition: [
+    'directors-cut',
+    'extended',
+    'theatrical',
+    'uncut',
+    'remastered',
+    'criterion',
+    'imax',
+  ],
+  video_codec: ['h265', 'h264', 'av1', 'vp9', 'xvid', 'mpeg2'],
+  audio_codec: ['truehd', 'dts-hd', 'dts', 'eac3', 'ac3', 'flac', 'aac', 'opus', 'mp3'],
+};
 
 @Component({
   selector: 'app-custom-formats-settings',
@@ -28,11 +54,13 @@ import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 })
 export class CustomFormatsSettingsComponent implements OnInit {
   private readonly api = inject(CustomFormatsApiService);
+  private readonly profilesApi = inject(ProfilesService);
   private readonly translate = inject(TranslateService);
   private readonly confirmation = inject(ConfirmationService);
   private readonly editorDialog = viewChild<ElementRef<HTMLDialogElement>>('editorDialog');
 
   readonly rows = signal<CustomFormat[]>([]);
+  readonly languages = signal<{ isoCode: string; name: string }[]>([]);
   readonly loading = signal(true);
   readonly listError = signal('');
   readonly saving = signal(false);
@@ -44,13 +72,22 @@ export class CustomFormatsSettingsComponent implements OnInit {
   readonly formSpecs = signal<CustomFormatSpec[]>([]);
 
   readonly testTitle = signal('');
-  readonly testResults = signal<
-    { formatId: number; formatName: string; matched: boolean; score: number }[]
-  >([]);
+  readonly testFreeleech = signal(false);
+  readonly testResults = signal<CustomFormatMatch[]>([]);
   readonly testLoading = signal(false);
 
-  readonly specTypes = ['title_regex', 'source', 'resolution', 'language', 'release_flag'] as const;
-  readonly releaseFlagValues = ['freeleech', 'halfleech'] as const;
+  readonly specTypes = CUSTOM_FORMAT_SPEC_TYPES;
+
+  /** i18n key of the first thing blocking a save, or null when the form is valid. */
+  readonly formError = computed(() => {
+    if (!this.formName().trim()) return 'settings.custom_formats.name_required';
+    const specs = this.formSpecs();
+    if (!specs.length) return 'settings.custom_formats.spec_required';
+    if (specs.some((s) => !s.value.trim())) return 'settings.custom_formats.value_required';
+    if (specs.some((s) => s.type === 'title_regex' && !isValidRegex(s.value)))
+      return 'settings.custom_formats.regex_invalid';
+    return null;
+  });
 
   ngOnInit() {
     this.reloadAll();
@@ -59,13 +96,23 @@ export class CustomFormatsSettingsComponent implements OnInit {
   async reloadAll() {
     this.loading.set(true);
     try {
-      const list = await this.api.list();
+      const [list, langs] = await Promise.all([
+        this.api.list(),
+        this.profilesApi.getLanguageDefinitions(),
+      ]);
       this.rows.set(list);
+      this.languages.set(langs);
     } catch {
       this.listError.set(this.translate.instant('settings.custom_formats.load_error'));
     } finally {
       this.loading.set(false);
     }
+  }
+
+  /** Null when the type takes free text. */
+  valueOptions(type: CustomFormatSpecType): readonly string[] | null {
+    if (type === 'language') return this.languages().map((l) => l.isoCode);
+    return VALUE_OPTIONS[type] ?? null;
   }
 
   openCreate() {
@@ -103,17 +150,22 @@ export class CustomFormatsSettingsComponent implements OnInit {
     this.formSpecs.update((specs) => specs.map((s, i) => (i === index ? { ...s, ...patch } : s)));
   }
 
+  /** A value from the previous vocabulary would never match the new type. */
+  changeSpecType(index: number, type: CustomFormatSpecType) {
+    this.updateSpec(index, { type, value: this.valueOptions(type)?.[0] ?? '' });
+  }
+
+  specInvalid(spec: CustomFormatSpec): boolean {
+    if (!spec.value.trim()) return true;
+    return spec.type === 'title_regex' && !isValidRegex(spec.value);
+  }
+
   async save() {
-    const name = this.formName().trim();
-    if (!name) return;
+    if (this.formError()) return;
     this.saving.set(true);
-    const body = {
-      name,
-      score: this.formScore(),
-      specs: this.formSpecs(),
-    };
-    const id = this.editingId();
     try {
+      const body = { name: this.formName().trim(), score: this.formScore(), specs: this.formSpecs() };
+      const id = this.editingId();
       await (id == null ? this.api.create(body) : this.api.update(id, body));
       this.closeEditor();
       await this.reloadAll();
@@ -129,7 +181,7 @@ export class CustomFormatsSettingsComponent implements OnInit {
     if (!title) return;
     this.testLoading.set(true);
     try {
-      const results = await this.api.testTitle(title);
+      const results = await this.api.testTitle(title, { freeleech: this.testFreeleech() });
       this.testResults.set(results);
     } finally {
       this.testLoading.set(false);
@@ -154,9 +206,18 @@ export class CustomFormatsSettingsComponent implements OnInit {
       const httpErr = err as { error?: { message?: string } };
       void this.confirmation.alert({
         title: this.translate.instant('common.error'),
-        message: httpErr.error?.message ?? 'Error',
+        message: httpErr.error?.message ?? this.translate.instant('common.error'),
         variant: 'danger',
       });
     }
+  }
+}
+
+function isValidRegex(pattern: string): boolean {
+  try {
+    new RegExp(pattern, 'i');
+    return true;
+  } catch {
+    return false;
   }
 }

--- a/client/src/app/features/settings/quality-profiles/quality-profiles.html
+++ b/client/src/app/features/settings/quality-profiles/quality-profiles.html
@@ -123,6 +123,20 @@
           [hint]="'settings.quality_profiles.field_resolution_upgrade_only_hint' | translate"
         />
       }
+      <label class="form-control w-full">
+        <span class="label-text">{{
+          'settings.quality_profiles.field_min_cf_score' | translate
+        }}</span>
+        <input
+          type="number"
+          class="input input-bordered w-full"
+          [ngModel]="formMinCustomFormatScore()"
+          (ngModelChange)="formMinCustomFormatScore.set(+$event)"
+        />
+        <span class="text-sm text-base-content/60 mt-1">{{
+          'settings.quality_profiles.field_min_cf_score_hint' | translate
+        }}</span>
+      </label>
       <div>
         <p class="text-sm font-medium mb-2">
           {{ 'settings.quality_profiles.qualities_group' | translate }}

--- a/client/src/app/features/settings/quality-profiles/quality-profiles.ts
+++ b/client/src/app/features/settings/quality-profiles/quality-profiles.ts
@@ -52,6 +52,7 @@ export class QualityProfilesComponent implements OnInit {
   readonly formCutoff = signal(16);
   readonly formUpgrade = signal(true);
   readonly formResolutionUpgradeOnly = signal(false);
+  readonly formMinCustomFormatScore = signal(0);
   readonly allowedIds = signal<Set<number>>(new Set());
 
   ngOnInit() {
@@ -90,6 +91,7 @@ export class QualityProfilesComponent implements OnInit {
     this.formCutoff.set(16);
     this.formUpgrade.set(true);
     this.formResolutionUpgradeOnly.set(false);
+    this.formMinCustomFormatScore.set(0);
     this.allowedIds.set(new Set());
     this.editorDialog()?.nativeElement.showModal();
   }
@@ -100,6 +102,7 @@ export class QualityProfilesComponent implements OnInit {
     this.formCutoff.set(p.cutoff);
     this.formUpgrade.set(p.upgradeAllowed);
     this.formResolutionUpgradeOnly.set(p.resolutionUpgradeOnly ?? false);
+    this.formMinCustomFormatScore.set(p.minCustomFormatScore ?? 0);
     const allowed = new Set(p.items.filter((i) => i.allowed).map((i) => i.quality.id));
     this.allowedIds.set(allowed);
     this.editorDialog()?.nativeElement.showModal();
@@ -128,6 +131,7 @@ export class QualityProfilesComponent implements OnInit {
       cutoff: this.formCutoff(),
       upgradeAllowed: this.formUpgrade(),
       resolutionUpgradeOnly: this.formResolutionUpgradeOnly(),
+      minCustomFormatScore: this.formMinCustomFormatScore(),
       items: defs.map((q, index) => ({
         qualityId: q.id,
         qualityName: q.name,


### PR DESCRIPTION
Full review of the custom-formats feature, benchmarked against the reference implementation the concept comes from. Everything below was either broken, semantically wrong, or missing.

## 1. The editor could never save — two independent contract breaks

The settings page posts `{name, score, specs: [{type, value, negate, required}]}`. The DTO expected `{name, score, specifications: [{name, implementation, negate, required, value}]}`, and `main.ts` runs `ValidationPipe({whitelist: true, forbidNonWhitelisted: true})` — so **every create and update answered `400 property specs should not exist`**. Reading was broken the same way: the entity returns `specifications`, the table renders `cf.specs.length` and `openEdit` calls `cf.specs.map`, so the list threw as soon as one format existed.

`release_flag` was a third break stacked on the first two: implemented in the service, offered in the UI dropdown, absent from the DTO's `@IsIn` list.

One shape now — `specs` with a `type` — and the redundant per-condition `name` is dropped.

## 2. A conditionless format matched every release

`matchesFormat` returned `true` for an empty condition list, so such a format added its score to every candidate in the library. The i18n string even documented it (*"No condition — the format will always match"*). It is refused at the edit now (`@ArrayNotEmpty` + a disabled Save), the matcher fails closed for rows that predate the check, and the migration deletes them.

## 3. Conditions were combined wrongly

Every condition was flattened into one global "all required must hold, and at least one non-required must hold". So a format asking for `resolution:1080p` **and** `source:bluray` matched a 1080p WEBRip.

Conditions of the same type are alternatives (OR); different types must all hold (AND); a `required` condition must hold whatever its alternatives do. That is the reference semantics and it makes both "1080p or 2160p" and "1080p and BluRay" expressible, which the old rule could not do at all.

## 4. Matching was substring-based on the raw title

`source`, `resolution` and `language` were `title.toLowerCase().includes(value)`. Consequences:

- `source:web-dl` missed `…WEBDL…`, and `source:dvd` matched a group called `-DVDPirate`.
- `resolution:1080p` missed a title tagged `FullHD` or `1920x1080`.
- `language:it` matched **any** title containing the letters "it" — `Whitewater.2024.1080p…` scored as Italian.

Conditions now test the parsed attributes via the existing `parseReleaseAttributes` / `parseReleaseLanguage`, which already extract resolution, source, codecs, edition and release group. So `release_group`, `edition`, `video_codec` and `audio_codec` join the vocabulary at no parsing cost, and the editor offers the closed vocabularies as dropdowns instead of free text a typo silently kills.

The regex condition tested against a pre-lowercased title, which killed any case-sensitive pattern; it now runs against the untouched title (still case-insensitive by flag).

## 5. An invalid regex failed silently

A pattern that does not compile was caught and treated as "no match" — for ever, with no log. Refused at save time, server-side and in the form.

## 6. The score could only reorder, never block

This is the biggest functional gap. The score was tiebreak #8 in `sortReleasesByRelevance` and nothing else, so a format scoring **-10000** still got auto-grabbed whenever nothing better existed — the standard way to *ban* a release (negative format + profile floor) did not work at all.

Quality profiles now carry `minCustomFormatScore`; a release below it is rejected outright (`CUSTOM_FORMAT_SCORE_TOO_LOW`, surfaced in the manual-search modal like every other rejection). Default 0, which refuses only a negative total.

The score also moved **above** the hardcoded freeleech tiebreak: freeleech is expressible as a `release_flag` condition with its own weight, and the hardcoded preference was overriding what the user configured.

## 7. Smaller fixes

- The tester now takes the freeleech flag, so a `release_flag` condition can actually be exercised (it always reported "no match" before).
- `testRelease` evaluated each format twice per call.
- Edition conditions offered their raw identifiers (`directors-cut`) in the dropdown; they are labelled now. The other vocabularies stay as-is — `bluray`, `1080p`, `h265` are release tags, not prose.
- Hardcoded user-facing strings in the template, including French ones (`Oui`/`Non`, `spec(s)`, `Format`, `Match`, `Score`) and raw identifiers (`title_regex`) as dropdown labels. All keyed, 6 locales.
- The service had no test at all, which is why none of the above was caught.

## 11. The window leaves the contract, and pluginApi 0 with it

Keeping the fields in `want` after core started enforcing the window would have left a hand-kept mirror that is no longer a mirror. They are gone, and that removal is what forces the revision bump: the catalog's compatibility contract states that *within one `pluginApi` value the method set is additive only — any removal or change in existing behaviour requires a new `pluginApi` value.*

A plugin still on `0` would read an absent `minRankExclusive`, compare every rank against `undefined`, and **quietly grab nothing**. So `SUPPORTED_PLUGIN_API_VERSIONS` drops to `[1]` and such a plugin is refused with `incompatible-api` and a reason — the loud form of the same news. Blast radius is exactly one artefact: `fliks.download` <= 0.8.0. The only other `pluginApi: 0` entry in the catalog is `fliks.webhooks` 1.1.2, whose own range is `>=2.0.0 <3.0.0` and which therefore cannot load on any 3.x core already.

Test fixtures that hardcoded `pluginApi: 0` now track `PLUGIN_API_VERSION`, and one spawn-plan test that asserted "some other supported revision exists" no longer depends on a deprecation window being open — it echoes an arbitrary older number, which is all the function under test does.

**Operational note:** after this lands, an installed `fliks.download` 0.8.0 stops loading until the 1.x build is installed. That is the decision this PR implements, not a side effect.

## Companion PRs

- **`fliks-app/fk-plugin-download#47`** — drops the reapplied window, declares `pluginApi: 1` and `fliks: >=3.8.0 <4.0.0`. Blocked until 3.8.0 is published: its CI checks the manifest range against the latest core release. Verified with `FLIKS_CORE_VERSION=3.8.0` (418 pass) and shown to fail on 3.7.0, which is the floor working.
- **`fliks-app/fliks-plugin-catalog#28`** — declares the `pluginApi: 1` row. Required before any `1` archive can be submitted; the catalog refuses a `pluginApi` with no row.
- **`fliks-app/fk-plugin-download#46`** removes a dead `formatRejectionForLog` restated there as `{code, detail}` while core sends `{code, params}` — it would have printed reasons with the numbers stripped, had anything called it — and corrects the pick predicate's note, which said the resolution rule was only *assumed* to be enforced by core. It also mirrors the new `flags` field. No change is required for this PR to work.

## Deliberately not in scope

- **Per-profile scores.** The reference scores each format *per quality profile*; here the score lives on the format and is global. That is a data-model change (join table, editor rework) and a separate call — say the word and I will do it.
- **Upgrade-until-score / minimum-upgrade-score** cutoffs.
- **Scores on imported files**, so format score plays no part in upgrade decisions against what is already on disk.
- **Matched-format names per release** in the search table (only the total is shown). Needs an additive plugin-contract field; the settings tester covers the "why did it score that" need for now.

## 8. The rule that kept being enforced nowhere

Three profile rules reached the same broken state in turn, which makes it a seam problem rather than three accidents. Each was computed by core, shipped inside `want`, and left to the acquisition plugin to reapply:

1. `resolutionUpgradeOnly` — enforced by neither side for a while, because each assumed the other did it. Both repos carry the comment.
2. The custom-format score — advisory only, fixed above.
3. **The rank window** — still split before this PR. `classifyForSearch` computes it, ships it, and never applies it; only the plugin's picker filtered on it.

The consequence of (3) was observable: `releases.score` returned `rejections: []` for releases the scheduler would then refuse, and the search modal, which renders exactly those rejections, had nothing to show. A user saw a clean release the auto-grab silently skipped.

The window now comes back as `RANK_NOT_AN_UPGRADE` / `RANK_ABOVE_CUTOFF`, resolved together with the resolution floor and the score floor from **one** read of what is on disk (that read used to happen twice). The plugin keeps its own check — redundant now instead of load-bearing, and still correct against an older core.

The rule this establishes: **anything a profile expresses leaves core as a rejection, and `want` carries no rule for a plugin to apply itself.**

Note for reviewers: this makes above-cutoff and non-upgrade releases show greyed with a reason in the manual search modal. That is already what auto-grab does with them — it was simply invisible. They stay grabbable by hand, like every other rejected release.

## 9. Torrent economics no longer hardcoded in the scorer

A candidate carried `freeleech: boolean` + `downloadVolumeFactor: number` — two protocol-specific fields core both scored and sorted on, which sits badly with the protocol living in the plugin. They become one open `flags` set: a `release_flag` condition matches whatever a source announces, and the ordering rule reads `flags.includes('freeleech')`. A tracker marker core has never heard of now works with no core change.

The wire keeps accepting both spellings (`flags`, or `freeleech`/`downloadVolumeFactor`), so the installed plugin needs no release. `releaseFlags()` folds them at the seam.

## 10. Test hole this exposed

The host harness's `classifyForSearch` mock returned `undefined`, so every scoring test was silently exempted from the upgrade window — the first version of this change passed the whole suite without the new rule ever running. The mock now returns a window that constrains nothing, so a test has to opt out on purpose.

## Acquisition-plugin compatibility

The acquisition plugin is the only consumer of the scoring path, so this was checked against its source rather than assumed:

- **Contract unchanged.** `ScoredRelease` and the `want` payload are untouched, and the plugin's vendored copy of both is byte-identical to core's. The floor is derived host-side from the profile core already loads (`eager: true`), so nothing new crosses the seam.
- **The new rejection needs no plugin change.** Its picker filters on `rejections.length === 0` and never inspects codes, so a release under the floor stops being auto-grabbed the moment the profile sets one. The frontend falls back to the raw code for an unknown one, and the key is present in all 6 locales.
- **A manual grab still bypasses the floor**, exactly as it already bypasses the size and seeder rules: that path deliberately re-checks only quality-allowed + blocklist. A deliberate user grab is not something a score should veto.
- **Sort order is core's alone** — the plugin documents the response as pre-sorted and does a plain `find`, so moving the score above the freeleech tiebreak takes effect without a plugin release.

Six tests now drive `releases.score` itself (the exact host method the plugin calls) with the real matcher wired in: the floor rejecting a negative total, letting an at-floor release through, refusing a positive total under a positive floor, a two-type condition set applied end to end, a scored release outranking a freeleech one, and no floor at all on an unprofiled title.

## Verification

- Backend: 1881 tests pass (13 new on the matcher, 2 on the floor), `tsc --noEmit` clean.
- Client: 683 tests pass, `ng build` clean.
- Live dev stack: create / update / edit round-trip, same-type alternatives, a failing `required` condition, the freeleech flag, and both refusals (empty conditions, bad regex) exercised over the real API.
- Migration: chain runs on a throwaway Postgres, `down()` then `up()` with seeded old-shape rows converts both ways, a condition of an unknown kind is dropped and a format left with none is deleted, and the CI drift check reports `No changes in database schema were found`.

