### PR TITLE
feat(streaming): serve an i-frame rendition for tizen trick play

### DIFF
--- a/backend/src/modules/streaming/dto/device-profile.dto.ts
+++ b/backend/src/modules/streaming/dto/device-profile.dto.ts
@@ -123,6 +123,16 @@ export class DeviceProfileDto {
   supportsHlsSubtitles?: boolean;
 
   /**
+   * Client accelerates HLS through an `EXT-X-I-FRAME-STREAM-INF` rendition
+   * (Tizen AVPlay's `setSpeed`). Only clients that declare it get the tag: any
+   * player that reads one will fetch the frames behind it, and each frame costs
+   * its own ffmpeg pass.
+   */
+  @IsBoolean()
+  @IsOptional()
+  supportsIFrameTrickPlay?: boolean;
+
+  /**
    * Engine renders bitmap (PGS/VOBSUB) subtitles itself (ExoPlayer, mpv), so
    * they're shown natively rather than burned in. Client-side hint; the backend
    * accepts it for forward-compat (burn-in is client-initiated via

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -112,6 +112,9 @@ export interface LiveSession {
    *  cues show in PiP / AirPlay / lock-screen. Web (Shaka) leaves this false
    *  and keeps fetching sidecar VTT. Sourced from the device profile. */
   supportsHlsSubtitles: boolean;
+  /** Client drives HLS trick play from an `EXT-X-I-FRAME-STREAM-INF`
+   *  rendition (Tizen AVPlay). Sourced from the device profile. */
+  supportsIFrameTrickPlay: boolean;
   /** Engine fetches seg-0 on a load-then-seek (Shaka / Cast), so the seg-0
    *  early-start companion is worth spawning. Native engines seek straight to
    *  the resume segment and never request seg-0 — false skips the companion.
@@ -175,6 +178,7 @@ export interface CreateLiveSessionInput {
   deviceType?: 'mobile' | 'desktop';
   hdrLadder?: boolean;
   supportsHlsSubtitles?: boolean;
+  supportsIFrameTrickPlay?: boolean;
   probesSegZero?: boolean;
   supportsAbr?: boolean;
   videoVariant?: CodecVariant | null;
@@ -282,6 +286,7 @@ export function buildLiveSession(
       deviceType: input.deviceType ?? 'desktop',
       hdrLadder: input.hdrLadder ?? false,
       supportsHlsSubtitles: input.supportsHlsSubtitles ?? false,
+      supportsIFrameTrickPlay: input.supportsIFrameTrickPlay ?? false,
       // Default true: only a client that explicitly declares it seeks straight
       // to the resume segment opts out of the seg-0 companion. Pre-flag clients
       // keep the companion (a wasted seg-0 probe is harmless; a missing one

--- a/backend/src/modules/streaming/streaming.controller.spec.ts
+++ b/backend/src/modules/streaming/streaming.controller.spec.ts
@@ -3,12 +3,31 @@ import {
   withTimestampMap,
   buildVodPlaylist,
   buildVariableVodPlaylist,
+  buildIFramePlaylist,
   resolvePreRoll,
 } from './streaming.controller';
 import { buildLiveSession, type LiveSession } from './live-session.service';
 import type { PreRollItem } from '../../common/plugin-contract';
 import type { User } from '../users/entities/user.entity';
 import { ForbiddenException } from '@nestjs/common';
+
+describe('buildIFramePlaylist', () => {
+  const url = (i: string): string => `iframe/seg-${i}.ts`;
+
+  it('declares I-frames-only and no init segment', () => {
+    const m = buildIFramePlaylist(12, url, 4);
+    expect(m).toContain('#EXT-X-I-FRAMES-ONLY');
+    expect(m).not.toContain('#EXT-X-MAP');
+  });
+
+  it('keeps one entry per grid keyframe', () => {
+    const m = buildIFramePlaylist(12, url, 4);
+    expect(m.split('\n').filter((l) => l.startsWith('#EXTINF'))).toHaveLength(
+      3,
+    );
+    expect(m).toContain('iframe/seg-0002.ts');
+  });
+});
 
 describe('buildVodPlaylist', () => {
   const url = (i: string): string => `seg-${i}.m4s`;

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -59,6 +59,10 @@ import { SegmentPackagingService } from './services/segment-packaging.service';
 import { SessionRouter } from './services/session-router.service';
 import { SessionContextBuilder } from './services/session-context-builder.service';
 import { pickAudioLayout } from './transcoding/audio-layout';
+import {
+  buildIFrameSegmentArgs,
+  iframeResolution,
+} from './transcoding/iframe-trick-play';
 import { resolveTonemapPath } from './transcoding/tonemap-path';
 import { resolveTonemapCurve } from './transcoding/ffmpeg-filter-graph';
 import { isOpenclTonemapEnabled } from './transcoding/codec/opencl-tonemap-probe';
@@ -259,6 +263,33 @@ export function buildVodPlaylist(
   }
   lines.push('#EXT-X-ENDLIST');
   return lines.join('\n');
+}
+
+/** I-frames-only playlist for AVPlay trick play: the variant's uniform grid
+ *  (one forced IDR per segment), each entry pointing at a single-keyframe
+ *  segment. See `iframe-trick-play.ts` for why the frames get their own URIs
+ *  instead of byte ranges into the variant's segments. */
+export function buildIFramePlaylist(
+  duration: number,
+  segmentUrl: (index: string) => string,
+  segDuration: number,
+): string {
+  return buildVodPlaylist(duration, segmentUrl, undefined, segDuration).replace(
+    '#EXT-X-INDEPENDENT-SEGMENTS',
+    '#EXT-X-INDEPENDENT-SEGMENTS\n#EXT-X-I-FRAMES-ONLY',
+  );
+}
+
+/** Trick-play grid: the variant's real segment length, so entry N is the IDR
+ *  the encoder forces at N * that. */
+function iframeGrid(
+  streamInfo: { video?: { frameRate?: string }[] } | null | undefined,
+  segmentDuration: number,
+): number {
+  return realSegmentSeconds(
+    segmentDuration,
+    parseSourceFps(streamInfo?.video?.[0]?.frameRate),
+  );
 }
 
 /** VOD playlist with explicit per-segment durations. Used by the remux/copy
@@ -975,6 +1006,7 @@ export class StreamingController {
       deviceType,
       hdrLadder: useHdrLadder,
       supportsHlsSubtitles: !!deviceProfile.supportsHlsSubtitles,
+      supportsIFrameTrickPlay: !!deviceProfile.supportsIFrameTrickPlay,
       probesSegZero: deviceProfile.probesSegZero,
       supportsAbr: deviceProfile.supportsAbr,
       videoVariant,
@@ -1307,6 +1339,11 @@ export class StreamingController {
         (si?.audio ?? []).reduce((sum, a) => sum + (a?.bitRate ?? 0), 0),
       ),
       sourceVideoCodec: (v?.codec ?? '').toLowerCase() || undefined,
+      // Trick play rides the same IDR grid as the variant, so the frame the
+      // playlist promises at index N is the one the encoder puts there.
+      iFrameTrickPlaySegmentSeconds: (live?.supportsIFrameTrickPlay ?? false)
+        ? realSegmentSeconds(this.segDur(), sourceFrameRate)
+        : undefined,
     });
 
     res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
@@ -1327,6 +1364,94 @@ export class StreamingController {
       startAt,
       deviceType,
     );
+  }
+
+  // Trick-play routes, like the subtitle ones below, MUST be registered before
+  // :mediaFileId/:quality/*, or "iframe" parses as a quality.
+
+  /** I-frames-only playlist backing the master's `EXT-X-I-FRAME-STREAM-INF`. */
+  @Get(':mediaFileId/iframe/index.m3u8')
+  async iframePlaylist(
+    @Param('mediaFileId', ParseIntPipe) mediaFileId: number,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    this.sessionRouter.assertFresh(req);
+    const resolved = await this.streamingService.resolveFile(
+      mediaFileId,
+      req.user as User,
+    );
+    const durationHint = firstQueryString(req.query, 'duration');
+    const duration =
+      (durationHint ? parseFloat(durationHint) : 0) ||
+      (await this.resolveDuration(
+        mediaFileId,
+        resolved.absolutePath,
+        resolved.mediaFile.streamInfo,
+      ));
+    if (!duration) {
+      res.status(404).send('Duration unknown — rescan the file first');
+      return;
+    }
+    const tokenParam = buildTokenParam(req);
+    const playlist = buildIFramePlaylist(
+      duration,
+      (seg) => `/api/stream/${mediaFileId}/iframe/seg-${seg}.ts${tokenParam}`,
+      iframeGrid(resolved.mediaFile.streamInfo, this.segDur()),
+    );
+    res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Cache-Control', 'no-store');
+    res.send(playlist);
+  }
+
+  /** One trick-play keyframe, decoded from the source and muxed to MPEG-TS.
+   *  Independent of the transcode session: a scan must not seek the running
+   *  ffmpeg and respawn it at every frame. */
+  @Get(':mediaFileId/iframe/:segment')
+  async iframeSegment(
+    @Param('mediaFileId', ParseIntPipe) mediaFileId: number,
+    @Param('segment') segment: string,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const match = /^seg-(\d+)\.ts$/.exec(segment);
+    if (!match) {
+      throw new BadRequestException(`Invalid trick-play segment: ${segment}`);
+    }
+    const resolved = await this.streamingService.resolveFile(
+      mediaFileId,
+      req.user as User,
+    );
+    const si = resolved.mediaFile.streamInfo;
+    const v = si?.video?.[0];
+    const crop = v?.crop;
+    const { width, height } = iframeResolution(
+      crop?.width ?? v?.width ?? 1920,
+      crop?.height ?? v?.height ?? 1080,
+    );
+    const args = buildIFrameSegmentArgs({
+      inputPath: resolved.absolutePath,
+      seekSeconds: parseInt(match[1], 10) * iframeGrid(si, this.segDur()),
+      width,
+      height,
+      crop,
+    });
+    try {
+      // One ffmpeg pass per frame, uncached: a 16x scan over a 4K source
+      // will feel it.
+      const { stdout } = await execFileAsync('ffmpeg', args, {
+        encoding: 'buffer',
+        maxBuffer: 8 * 1024 * 1024,
+        timeout: 20_000,
+      });
+      res.setHeader('Content-Type', 'video/mp2t');
+      res.setHeader('Cache-Control', 'public, max-age=3600');
+      res.send(stdout);
+    } catch {
+      // A refused frame must stay retryable: AVPlay drops trick play on a 404.
+      sendTransientUnavailable(res);
+    }
   }
 
   // Subtitle VTT routes MUST be registered before :mediaFileId/:quality/* — otherwise

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1438,8 +1438,8 @@ export class StreamingController {
       crop,
     });
     try {
-      // One ffmpeg pass per frame, uncached: a 16x scan over a 4K source
-      // will feel it.
+      // One ffmpeg pass per frame, uncached (~380 ms on 1080p): this is why
+      // the client stops at 2x.
       const { stdout } = await execFileAsync('ffmpeg', args, {
         encoding: 'buffer',
         maxBuffer: 8 * 1024 * 1024,

--- a/backend/src/modules/streaming/transcoding/iframe-trick-play.spec.ts
+++ b/backend/src/modules/streaming/transcoding/iframe-trick-play.spec.ts
@@ -1,0 +1,62 @@
+import {
+  buildIFrameSegmentArgs,
+  iframeBandwidthBps,
+  iframeResolution,
+} from './iframe-trick-play';
+
+describe('iframeResolution', () => {
+  it('caps the height at 720 and keeps the aspect', () => {
+    expect(iframeResolution(3840, 2160)).toEqual({ width: 1280, height: 720 });
+  });
+
+  it('leaves a smaller source alone', () => {
+    expect(iframeResolution(640, 480)).toEqual({ width: 640, height: 480 });
+  });
+
+  it('keeps both axes even for yuv420p', () => {
+    // 1918x872 scope crop: the width scales to an odd value before rounding.
+    const { width, height } = iframeResolution(1918, 1081);
+    expect(width % 2).toBe(0);
+    expect(height % 2).toBe(0);
+  });
+});
+
+describe('buildIFrameSegmentArgs', () => {
+  const base = {
+    inputPath: '/media/file.mkv',
+    seekSeconds: 24,
+    width: 1280,
+    height: 720,
+  };
+
+  it('seeks before the input and keeps the source timestamps', () => {
+    const args = buildIFrameSegmentArgs(base);
+    expect(args.indexOf('-ss')).toBeLessThan(args.indexOf('-i'));
+    expect(args).toContain('-copyts');
+  });
+
+  it('emits exactly one frame as MPEG-TS on stdout', () => {
+    const args = buildIFrameSegmentArgs(base);
+    expect(
+      args.slice(args.indexOf('-frames:v'), args.indexOf('-frames:v') + 2),
+    ).toEqual(['-frames:v', '1']);
+    expect(args[args.length - 1]).toBe('pipe:1');
+    expect(args[args.indexOf('-f') + 1]).toBe('mpegts');
+  });
+
+  it('crops before scaling so the frame keeps the variant aspect', () => {
+    const args = buildIFrameSegmentArgs({
+      ...base,
+      crop: { width: 1920, height: 800, x: 0, y: 140 },
+    });
+    expect(args[args.indexOf('-vf') + 1]).toBe(
+      'crop=1920:800:0:140,scale=1280:720',
+    );
+  });
+});
+
+describe('iframeBandwidthBps', () => {
+  it('scales with the grid', () => {
+    expect(iframeBandwidthBps(4)).toBeGreaterThan(iframeBandwidthBps(8));
+  });
+});

--- a/backend/src/modules/streaming/transcoding/iframe-trick-play.ts
+++ b/backend/src/modules/streaming/transcoding/iframe-trick-play.ts
@@ -1,0 +1,84 @@
+/**
+ * Single-I-frame segments for HLS trick play.
+ *
+ * AVPlay only accelerates HLS when the master advertises an
+ * `EXT-X-I-FRAME-STREAM-INF` rendition, and RFC 8216 4.3.3.6 wants one I-frame
+ * per media segment. The transcode ladder can't back that with byte ranges (its
+ * segments are produced on demand, so their offsets aren't known when the
+ * playlist is written), so the rendition gets its own segments: one keyframe,
+ * decoded straight from the source at the grid position the player asks for.
+ */
+
+/** Trick-play frames are decoration, not playback: 720p keeps the per-frame
+ *  encode cheap enough to answer a 16x scan. */
+const MAX_HEIGHT = 720;
+
+/** H.264 Main@3.1, what {@link buildIFrameSegmentArgs} emits at 720p. */
+export const IFRAME_CODEC = 'avc1.4d401f';
+
+/** One 720p keyframe every `segmentSeconds`, rounded up from ~120 kB. */
+export function iframeBandwidthBps(segmentSeconds: number): number {
+  return Math.round((120_000 * 8) / Math.max(1, segmentSeconds));
+}
+
+/** Output size for the trick-play rendition: source aspect, capped at
+ *  {@link MAX_HEIGHT}, both axes even (yuv420p). */
+export function iframeResolution(
+  sourceWidth: number,
+  sourceHeight: number,
+): { width: number; height: number } {
+  const even = (n: number) => Math.max(2, Math.round(n / 2) * 2);
+  if (sourceHeight <= MAX_HEIGHT) {
+    return { width: even(sourceWidth), height: even(sourceHeight) };
+  }
+  return {
+    width: even((sourceWidth * MAX_HEIGHT) / sourceHeight),
+    height: MAX_HEIGHT,
+  };
+}
+
+/** ffmpeg argv for one keyframe at `seekSeconds`, muxed to MPEG-TS on stdout.
+ *  `-ss` before `-i` is the demuxer keyframe seek (the grid is IDR-aligned, so
+ *  it lands on the frame the playlist promised) and `-copyts` keeps the source
+ *  PTS, so the frame carries its real presentation time. */
+export function buildIFrameSegmentArgs(opts: {
+  inputPath: string;
+  seekSeconds: number;
+  width: number;
+  height: number;
+  crop?: { width: number; height: number; x: number; y: number };
+}): string[] {
+  const crop = opts.crop
+    ? `crop=${opts.crop.width}:${opts.crop.height}:${opts.crop.x}:${opts.crop.y},`
+    : '';
+  return [
+    '-hide_banner',
+    '-loglevel',
+    'error',
+    '-ss',
+    opts.seekSeconds.toFixed(3),
+    '-copyts',
+    '-i',
+    opts.inputPath,
+    '-frames:v',
+    '1',
+    '-an',
+    '-sn',
+    '-dn',
+    '-vf',
+    `${crop}scale=${opts.width}:${opts.height}`,
+    '-c:v',
+    'libx264',
+    '-preset',
+    'veryfast',
+    '-pix_fmt',
+    'yuv420p',
+    '-f',
+    'mpegts',
+    '-muxdelay',
+    '0',
+    '-muxpreload',
+    '0',
+    'pipe:1',
+  ];
+}

--- a/backend/src/modules/streaming/transcoding/master-playlist.spec.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.spec.ts
@@ -146,3 +146,42 @@ describe('generateMasterPlaylist — audio bitrate in BANDWIDTH', () => {
     expect(maxAvgBandwidth(hi) - maxAvgBandwidth(lo)).toBe(540_000);
   });
 });
+
+describe('generateMasterPlaylist: trick-play rendition', () => {
+  const master = (iFrameTrickPlaySegmentSeconds?: number) =>
+    generateMasterPlaylist({
+      mediaFileId: 7,
+      sourceWidth: 3840,
+      sourceHeight: 2160,
+      tokenParam: '?token=t',
+      sourceFrameRate: 24,
+      iFrameTrickPlaySegmentSeconds,
+    });
+
+  it('stays out of the master unless the client asked for it', () => {
+    expect(master()).not.toContain('EXT-X-I-FRAME-STREAM-INF');
+  });
+
+  it('points at the I-frame playlist with the capped resolution', () => {
+    const line = master(4)
+      .split('\n')
+      .find((l) => l.startsWith('#EXT-X-I-FRAME-STREAM-INF'))!;
+    expect(line).toContain('RESOLUTION=1280x720');
+    expect(line).toContain('CODECS="avc1.4d401f"');
+    expect(line).toContain('URI="/api/stream/7/iframe/index.m3u8?token=t"');
+  });
+
+  it('rides the HDR ladder too, since AVPlay needs it whatever the variant', () => {
+    const hdr = generateMasterPlaylist({
+      mediaFileId: 7,
+      sourceWidth: 3840,
+      sourceHeight: 2160,
+      tokenParam: '',
+      sourceFrameRate: 24,
+      hdrPassThrough: { hdrFormat: 'HDR10', hdrVariant: HEVC_HDR10 },
+      canEmitHdrLadder: true,
+      iFrameTrickPlaySegmentSeconds: 4,
+    });
+    expect(hdr).toContain('#EXT-X-I-FRAME-STREAM-INF');
+  });
+});

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -11,6 +11,11 @@ import type {
   TranscodeProfile,
 } from './types';
 import type { CodecVariant } from './codec/types';
+import {
+  IFRAME_CODEC,
+  iframeBandwidthBps,
+  iframeResolution,
+} from './iframe-trick-play';
 import { audioCodecString } from './codec/codec-strings';
 import {
   buildUniqueAudioNames,
@@ -145,6 +150,10 @@ export interface MasterPlaylistOptions {
    *  `onlyQuality` pin — see {@link applyQualityPin}. Missing/undefined
    *  defaults to `true` (existing full-ladder behaviour). */
   supportsAbr?: boolean;
+  /** Segment grid length, in seconds, of the trick-play rendition to advertise.
+   *  Unset omits it: only AVPlay needs the `EXT-X-I-FRAME-STREAM-INF` tag, and
+   *  every player that reads one will fetch the frames behind it. */
+  iFrameTrickPlaySegmentSeconds?: number;
 }
 
 /** Generate the HLS master playlist listing available qualities. */
@@ -171,6 +180,7 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
     sourceVideoBitrateBps,
     sourceVideoCodec,
     supportsAbr = true,
+    iFrameTrickPlaySegmentSeconds,
   } = opts;
   // The "multi-audio" flag is really an "EXT-X-MEDIA layout" toggle —
   // the caller decided whether to split audio into renditions. Single-
@@ -215,6 +225,15 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
         `#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="${names[i]}",LANGUAGE="${lang}",DEFAULT=NO,AUTOSELECT=NO,FORCED=${s.forced ? 'YES' : 'NO'},URI="/api/stream/${mediaFileId}/${path}/index.m3u8${tokenParam}"`,
       );
     });
+  };
+
+  const pushIFrameStream = (out: string[]): void => {
+    if (!iFrameTrickPlaySegmentSeconds) return;
+    const { width, height } = iframeResolution(sourceWidth, sourceHeight);
+    const bw = iframeBandwidthBps(iFrameTrickPlaySegmentSeconds);
+    out.push(
+      `#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=${bw},RESOLUTION=${width}x${height},CODECS="${IFRAME_CODEC}",URI="/api/stream/${mediaFileId}/iframe/index.m3u8${tokenParam}"`,
+    );
   };
 
   // HDR pass-through path — emitted when the source is HEVC HDR and
@@ -286,6 +305,7 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
         tokenParam,
       });
     }
+    pushIFrameStream(lines);
     return lines.join('\n');
   }
 
@@ -351,6 +371,7 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
     mediaFileId,
     tokenParam,
   });
+  pushIFrameStream(lines);
   return lines.join('\n');
 }
 

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -129,6 +129,8 @@ export interface DeviceProfile {
    *  VTT. True for phone/desktop (iOS, Android, web/Shaka); false for TVs,
    *  whose AVPlay/webOS cue APIs are limited so they keep a DOM overlay. */
   supportsHlsSubtitles?: boolean;
+  /** Engine accelerates HLS from an `EXT-X-I-FRAME-STREAM-INF` rendition. */
+  supportsIFrameTrickPlay?: boolean;
 
   /** Engine renders bitmap (PGS/VOBSUB) subtitles itself (ExoPlayer, mpv), so
    *  they're shown natively rather than burned into the video. False engines
@@ -543,6 +545,7 @@ export class BrowserDeviceProfileService {
       // AVPlay/webOS cue APIs are limited, so those engines drive a DOM
       // overlay fed by sidecar VTT instead of the HLS renditions.
       supportsHlsSubtitles: traits.supportsHlsSubtitles,
+      supportsIFrameTrickPlay: traits.supportsIFrameTrickPlay,
       supportsImageSubtitles: traits.supportsImageSubtitles,
       // Only the web/Shaka path probes seg-0 on a load-then-seek; that is
       // exactly the `!isNative` engine branch (Capacitor mobile + every TV go

--- a/client/src/app/core/services/engine-traits.spec.ts
+++ b/client/src/app/core/services/engine-traits.spec.ts
@@ -39,6 +39,7 @@ const EXPECTED: Record<EngineKind, EngineTraits> = {
   [EngineKind.TIZEN]: {
     useTsOnSingleAudio: true,
     supportsHlsSubtitles: false,
+    supportsIFrameTrickPlay: true,
     supportsImageSubtitles: false,
     probesSegZero: false,
     supportsDirectPlay: false,

--- a/client/src/app/core/services/engine-traits.ts
+++ b/client/src/app/core/services/engine-traits.ts
@@ -38,6 +38,9 @@ export interface EngineTraits {
   useTsOnSingleAudio?: boolean;
   /** Engine consumes HLS `SUBTITLES` renditions natively. */
   supportsHlsSubtitles?: boolean;
+  /** Engine accelerates HLS from an `EXT-X-I-FRAME-STREAM-INF` rendition
+   *  (Tizen AVPlay `setSpeed`). */
+  supportsIFrameTrickPlay?: boolean;
   /** Engine renders bitmap (PGS/VOBSUB) subtitle tracks itself, so they're
    *  shown natively instead of burned into the video server-side. */
   supportsImageSubtitles?: boolean;
@@ -113,6 +116,7 @@ export const ENGINE_TRAITS: Record<EngineKind, EngineTraits> = {
   [EngineKind.TIZEN]: {
     useTsOnSingleAudio: true,
     supportsHlsSubtitles: false,
+    supportsIFrameTrickPlay: true,
     supportsImageSubtitles: false,
     probesSegZero: false,
     supportsDirectPlay: false,

--- a/client/src/app/core/services/playback-engine/tizen-engine.ts
+++ b/client/src/app/core/services/playback-engine/tizen-engine.ts
@@ -469,12 +469,13 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
   get buffered(): number { return this._buffered; }
   get playbackRate(): number { return this._playbackRate; }
   set playbackRate(rate: number) {
-    // Valid from READY, PLAYING and PAUSED; out-of-range values raise
-    // PLAYER_ERROR_INVALID_PARAMETER. Either way this is a convenience control,
-    // not playback itself: a refusal must not escalate to a fatal `error`
-    // (that would cover healthy video with the error card). The getter keeps
-    // reporting the last rate that actually applied, so the caller can read it
-    // back instead of trusting the request.
+    // setSpeed takes a long (1/2/4/8/16, negatives for reverse) from
+    // READY/PLAYING/PAUSED; a refusal stays silent, and the getter keeps
+    // reporting the rate that really applied.
+    if (!Number.isInteger(rate)) {
+      console.warn('[tizen-engine] setSpeed', rate, 'dropped, not an integer');
+      return;
+    }
     const state = webapis.avplay.getState();
     if (state !== 'READY' && state !== 'PLAYING' && state !== 'PAUSED') {
       console.warn('[tizen-engine] setSpeed', rate, 'dropped, state=', state);

--- a/client/src/app/core/services/playback-engine/tizen-engine.ts
+++ b/client/src/app/core/services/playback-engine/tizen-engine.ts
@@ -187,6 +187,9 @@ export class TizenEngine extends AbstractPlaybackEngine implements PlaybackEngin
     this.resetFirstFrame();
     this._currentTime = 0;
     this._duration = 0;
+    // open() restarts AVPlay at 1x; keeping the old value here would make the
+    // getter report a speed nothing is playing.
+    this._playbackRate = 1;
 
     const safeUrl = resolveAvtestUrl(url);
 

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -396,10 +396,12 @@ export class PlayerControlsComponent {
    */
   readonly panelOpenChange = output<boolean>();
 
-  /** AVPlay's documented forward rates are 0.5/1/2 only; the fractional steps
-   *  (0.25/0.75/1.25/1.5/1.75) throw PLAYER_ERROR_INVALID_PARAMETER on Tizen. */
-  readonly speedOptions = computed(() =>
-    this.tv.isTizen() ? [0.5, 1, 2] : [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
+  /** AVPlay only takes integer trick-play rates (it drives them from the HLS
+   *  I-frame rendition), so fractional steps raise INVALID_PARAMETER there. */
+  readonly speedOptions = computed<number[]>(() =>
+    this.tv.isTizen()
+      ? [1, 2, 4, 8]
+      : [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
   );
 
   /** Settings dropdown panel navigation */

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -397,11 +397,10 @@ export class PlayerControlsComponent {
   readonly panelOpenChange = output<boolean>();
 
   /** AVPlay only takes integer trick-play rates (it drives them from the HLS
-   *  I-frame rendition), so fractional steps raise INVALID_PARAMETER there. */
+   *  I-frame rendition, one on-demand encode per frame), so fractional steps
+   *  raise INVALID_PARAMETER and anything past 2x outruns the server. */
   readonly speedOptions = computed<number[]>(() =>
-    this.tv.isTizen()
-      ? [1, 2, 4, 8]
-      : [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
+    this.tv.isTizen() ? [1, 2] : [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
   );
 
   /** Settings dropdown panel navigation */

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2580,6 +2580,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       const { url, mimeType } = this.buildPlayUrl({ startTime });
       await this.engine.load(url, startTime, mimeType);
       this.qualityManager.applyQualityPreferenceAfterLoad(this.engine, this.playbackMode());
+      this.restorePlaybackRate();
 
       // Fresh subtitle + audio track lists for the new file, then auto-select.
       const subs = await this.trackManager.loadSubtitles(
@@ -3269,6 +3270,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         this.engine,
         this.playbackMode(),
       );
+      this.restorePlaybackRate();
       // Shaka/webOS and the desktop mpv engine drop sidecar text tracks on a fresh
       // load(), so a recovery reload silently loses the user's subtitle. Re-add +
       // re-select the active soft subtitle. The Capacitor native players restore
@@ -3707,6 +3709,16 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         { source, code, message: (e as any)?.message ?? String(e) },
       );
     }
+  }
+
+  /** A reload rebuilds the engine's pipeline at the default rate, so the UI
+   *  would keep advertising a speed nothing is playing. Re-apply, then read
+   *  back: an engine that refuses moves the control instead of lying. */
+  private restorePlaybackRate(): void {
+    if (!this.engine) return;
+    const wanted = this.playbackRate();
+    if (wanted !== 1) this.engine.playbackRate = wanted;
+    this.playbackRate.set(this.engine.playbackRate);
   }
 
   onSpeedChange(rate: number) {
@@ -4502,6 +4514,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       this.reloadReachedPlayback = true;
 
       this.qualityManager.applyQualityPreferenceAfterLoad(this.engine, mode);
+      this.restorePlaybackRate();
       this.restorePlayState(wasPaused);
 
       // Restore active subtitle (non burn-in) after Shaka reload

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -2139,6 +2139,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       // the playback-error state surfaces via `state.error`.
       return;
     }
+    // AVPlay has no getSpeed(), so a rate it drops on its own is invisible:
+    // re-assert the user's pick after every seek rather than trust it held.
+    this.restorePlaybackRate();
     await this.pollSeekConverge(target, gen);
   }
 
@@ -2278,7 +2281,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   skipIntro(): void {
     const m = this.introMarker();
     if (!m || !this.engine) return;
-    this.engine.seek(m.endSeconds).catch(() => {});
+    this.engine
+      .seek(m.endSeconds)
+      .then(() => this.restorePlaybackRate())
+      .catch(() => {});
     this.state.currentTime.set(m.endSeconds);
     this.resetHideTimer();
   }


### PR DESCRIPTION
## Why

Changing the playback speed on a Samsung TV did nothing, down to the select never moving.

Two independent reasons, both from Samsung's own documentation:

- **`setSpeed` takes a `long`.** The [AVPlay API reference](https://developer.samsung.com/smarttv/develop/api-references/samsung-product-api-references/avplay-api.html) lists `void setSpeed(long playbackSpeed)` with `-16x, -8x, -4x, -2x, 1x, 2x, 4x, 8x, 16x`. Every fractional step the menu offered (`0.5`, `1.25`, `1.5`, ...) is out of range and raises `PLAYER_ERROR_INVALID_PARAMETER`. The engine swallowed the refusal and the getter kept reporting the old rate, so the UI correctly showed nothing had changed.
- **HLS trick play needs an I-frame rendition.** [General specifications, table 4](https://developer.samsung.com/tv/develop/specifications/general-specifications/#streaming-feature-support): HLS trick play is `Yes (-16x ~ 16x)` but "Trick Play of HLS is available for content with EXT-X-I-FRAME-STREAM_INF tag". The ladder never emitted one. Tizen also has `supportsDirectPlay: false`, so there was no progressive stream to fall back on either.

## What

- **`iframe-trick-play.ts`** builds the ffmpeg argv for one keyframe: `-ss` before `-i` (demuxer keyframe seek, and the grid is IDR-aligned so it lands on the frame the playlist promised), `-copyts` to keep the source PTS, scaled to 720p and muxed to MPEG-TS on stdout.
- **`buildIFramePlaylist`** reuses the VOD playlist builder and adds `EXT-X-I-FRAMES-ONLY`. RFC 8216 wants one I-frame per media segment; byte ranges into the variant's segments are impossible here because those segments are produced on demand, so their offsets aren't known when the playlist is written. The rendition gets its own segment URIs instead.
- **Two routes** (`/:mediaFileId/iframe/index.m3u8` and `/iframe/seg-N.ts`), registered before `:quality/*` like the subtitle routes. The frames are decoded straight from the source, independent of the running transcode, so a scan never seeks the live ffmpeg and respawns it.
- **`supportsIFrameTrickPlay`** is a per-client capability (Tizen only) threaded profile → session → master. Any player that reads an I-frame rendition will fetch the frames behind it, and each frame costs its own ffmpeg pass, so the tag is opt-in rather than always on.
- The speed menu on Tizen offers `1 / 2`, and the engine rejects non-integer rates outright. Higher rates work but each trick-play frame is its own on-demand encode (~380 ms on 1080p), so a scan past 2x outruns a server doing live transcoding.
- A reload (quality switch, session refresh) rebuilds the engine pipeline at the default rate, so the rate is re-applied and read back afterwards: the control moves instead of advertising a speed nothing is playing.

## Verification

Against the dev stack (file 42, 1920x824, 3 s grid):

- `iframe/index.m3u8` → 200, `EXT-X-I-FRAMES-ONLY`, no `EXT-X-MAP`, one entry per grid keyframe.
- `iframe/seg-0020.ts` → 200, `video/mp2t`, 44 KB in ~380 ms; `ffprobe` reports exactly one frame, `pict_type=I`, `pts_time=60.000` (20 x 3 s).
- `iframe/nope.ts` → 400; `master.m3u8` without the capability → no `EXT-X-I-FRAME-STREAM-INF`.
- Backend: `tsc` clean, 491 streaming tests green (13 new). Client: `tsc` clean, AOT build clean, 683 tests green.

**Confirmed on a Samsung QE85Q80BATXXC (Tizen, DUID ZPCNK7JIGTWJK):** 2x plays. AVPlay accepts this rendition shape, per-frame URIs rather than byte ranges from a packager. Trick play is also I-frame playback: no audio, and it is a fast-forward rather than a 1.25x "watch slightly faster" mode, which AVPlay cannot do at all.

## Known ceiling

One ffmpeg pass per frame, uncached. A 16x scan over a 4K source will feel it; a cache keyed by (file, index) is the upgrade if it shows up in practice.
