### PR TITLE
fix(nav): highlight the active route in the left sidebars

### DIFF
--- a/client/src/app/features/account/account-shell.html
+++ b/client/src/app/features/account/account-shell.html
@@ -6,9 +6,9 @@
   <svg drawerIcon lucideUser class="h-5 w-5"></svg>
 
   <ng-container drawerMenu>
-    <li><a routerLink="/account/password" routerLinkActive="active"><svg lucideLock class="h-4 w-4"></svg>{{ 'account_settings.nav.password' | translate }}</a></li>
-    <li><a routerLink="/account/recommendations" routerLinkActive="active"><svg lucideSparkles class="h-4 w-4"></svg>{{ 'account_settings.nav.recommendations' | translate }}</a></li>
-    <li><a routerLink="/account/privacy" routerLinkActive="active"><svg lucideUsers class="h-4 w-4"></svg>{{ 'account_settings.nav.privacy' | translate }}</a></li>
-    <li><a routerLink="/account/spoilers" routerLinkActive="active"><svg lucideEyeOff class="h-4 w-4"></svg>{{ 'account_settings.nav.spoilers' | translate }}</a></li>
+    <li><a routerLink="/account/password" routerLinkActive="menu-active"><svg lucideLock class="h-4 w-4"></svg>{{ 'account_settings.nav.password' | translate }}</a></li>
+    <li><a routerLink="/account/recommendations" routerLinkActive="menu-active"><svg lucideSparkles class="h-4 w-4"></svg>{{ 'account_settings.nav.recommendations' | translate }}</a></li>
+    <li><a routerLink="/account/privacy" routerLinkActive="menu-active"><svg lucideUsers class="h-4 w-4"></svg>{{ 'account_settings.nav.privacy' | translate }}</a></li>
+    <li><a routerLink="/account/spoilers" routerLinkActive="menu-active"><svg lucideEyeOff class="h-4 w-4"></svg>{{ 'account_settings.nav.spoilers' | translate }}</a></li>
   </ng-container>
 </app-settings-drawer>

--- a/client/src/app/features/admin/admin-shell.html
+++ b/client/src/app/features/admin/admin-shell.html
@@ -10,7 +10,7 @@
       <li class="menu-title text-xs uppercase tracking-wider" [class.mt-2]="i === 0" [class.mt-4]="i !== 0">{{ section.label | translate }}</li>
       @for (item of section.items; track item.id) {
         <li>
-          <a [routerLink]="item.route" routerLinkActive="active">
+          <a [routerLink]="item.route" routerLinkActive="menu-active">
             @if (item.icon) {
               <app-settings-icon [name]="item.icon" class="h-4 w-4" />
             }

--- a/client/src/app/features/app-settings/app-settings-shell.html
+++ b/client/src/app/features/app-settings/app-settings-shell.html
@@ -6,21 +6,21 @@
   <svg drawerIcon lucideSettings class="h-5 w-5"></svg>
 
   <ng-container drawerMenu>
-    <li><a routerLink="/app-settings/home" routerLinkActive="active"><svg lucideHouse class="h-4 w-4"></svg>{{ 'app_settings.nav.home' | translate }}</a></li>
-    <li><a routerLink="/app-settings/display" routerLinkActive="active"><svg lucideMonitor class="h-4 w-4"></svg>{{ 'app_settings.nav.display' | translate }}</a></li>
-    <li><a routerLink="/app-settings/player" routerLinkActive="active"><svg lucidePlay class="h-4 w-4"></svg>{{ 'app_settings.nav.player' | translate }}</a></li>
-    <li><a routerLink="/app-settings/subtitles" routerLinkActive="active"><svg lucideCaptions class="h-4 w-4"></svg>{{ 'app_settings.nav.subtitles' | translate }}</a></li>
+    <li><a routerLink="/app-settings/home" routerLinkActive="menu-active"><svg lucideHouse class="h-4 w-4"></svg>{{ 'app_settings.nav.home' | translate }}</a></li>
+    <li><a routerLink="/app-settings/display" routerLinkActive="menu-active"><svg lucideMonitor class="h-4 w-4"></svg>{{ 'app_settings.nav.display' | translate }}</a></li>
+    <li><a routerLink="/app-settings/player" routerLinkActive="menu-active"><svg lucidePlay class="h-4 w-4"></svg>{{ 'app_settings.nav.player' | translate }}</a></li>
+    <li><a routerLink="/app-settings/subtitles" routerLinkActive="menu-active"><svg lucideCaptions class="h-4 w-4"></svg>{{ 'app_settings.nav.subtitles' | translate }}</a></li>
     <!-- No Chromecast sender on a TV: it is a target, and the section would
          only offer settings for a session it cannot start. -->
     @if (!tv.isTv()) {
-      <li><a routerLink="/app-settings/cast" routerLinkActive="active"><svg lucideCast class="h-4 w-4"></svg>{{ 'app_settings.nav.cast' | translate }}</a></li>
+      <li><a routerLink="/app-settings/cast" routerLinkActive="menu-active"><svg lucideCast class="h-4 w-4"></svg>{{ 'app_settings.nav.cast' | translate }}</a></li>
     }
-    <li><a routerLink="/app-settings/remote" routerLinkActive="active"><svg lucideMonitorSmartphone class="h-4 w-4"></svg>{{ 'app_settings.nav.remote' | translate }}</a></li>
+    <li><a routerLink="/app-settings/remote" routerLinkActive="menu-active"><svg lucideMonitorSmartphone class="h-4 w-4"></svg>{{ 'app_settings.nav.remote' | translate }}</a></li>
     @if (!tv.isTv()) {
-      <li><a routerLink="/app-settings/storage" routerLinkActive="active"><svg lucideHardDrive class="h-4 w-4"></svg>{{ 'app_settings.nav.storage' | translate }}</a></li>
+      <li><a routerLink="/app-settings/storage" routerLinkActive="menu-active"><svg lucideHardDrive class="h-4 w-4"></svg>{{ 'app_settings.nav.storage' | translate }}</a></li>
     }
     @if (device.isDesktopNative()) {
-      <li><a routerLink="/app-settings/update" routerLinkActive="active"><svg lucideDownload class="h-4 w-4"></svg>{{ 'app_settings.nav.update' | translate }}</a></li>
+      <li><a routerLink="/app-settings/update" routerLinkActive="menu-active"><svg lucideDownload class="h-4 w-4"></svg>{{ 'app_settings.nav.update' | translate }}</a></li>
     }
   </ng-container>
 </app-settings-drawer>

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -234,7 +234,7 @@
             <ul class="menu p-2 gap-0.5">
               @for (lib of customLibraries(); track lib.id) {
                 <li>
-                  <a [routerLink]="libraryUrl(lib)" routerLinkActive="active" class="justify-between" (click)="resetNavHistory()">
+                  <a [routerLink]="libraryUrl(lib)" routerLinkActive="menu-active" class="justify-between" (click)="resetNavHistory()">
                     <span class="flex items-center gap-2">
                       <app-lucide-icon [name]="libraryIcon(lib)" class="h-5 w-5" />
                       {{ lib.name }}
@@ -247,7 +247,7 @@
               }
               @for (item of sheetMainItems(); track item.id) {
                 <li>
-                  <a [routerLink]="item.route" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: item.exact }" class="justify-between" (click)="resetNavHistory()">
+                  <a [routerLink]="item.route" routerLinkActive="menu-active" [routerLinkActiveOptions]="{ exact: item.exact }" class="justify-between" (click)="resetNavHistory()">
                     <span class="flex items-center gap-2">
                       <app-nav-icon [name]="item.icon" class="h-5 w-5" />
                       {{ item.labelKey | translate }}
@@ -260,7 +260,7 @@
               }
               @for (item of sheetAcquisitionItems(); track item.id) {
                 <li>
-                  <a [routerLink]="item.route" routerLinkActive="active" class="justify-between" (click)="resetNavHistory()">
+                  <a [routerLink]="item.route" routerLinkActive="menu-active" class="justify-between" (click)="resetNavHistory()">
                     <span class="flex items-center gap-2">
                       <app-nav-icon [name]="item.icon" class="h-5 w-5" />
                       {{ item.labelKey | translate }}
@@ -330,7 +330,7 @@
       <ul class="menu p-4 flex-1 gap-0.5 min-w-64">
         @for (item of mainItemsBeforeLibraries(); track item.id) {
           <li>
-            <a [routerLink]="item.route" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: item.exact }" class="justify-between">
+            <a [routerLink]="item.route" routerLinkActive="menu-active" [routerLinkActiveOptions]="{ exact: item.exact }" class="justify-between">
               <span class="flex items-center gap-2">
                 <app-nav-icon [name]="item.icon" class="h-5 w-5" />
                 {{ item.labelKey | translate }}
@@ -345,7 +345,7 @@
         <li class="menu-title text-xs uppercase tracking-wider mt-3">{{ 'nav.section_library' | translate }}</li>
         @for (lib of displayLibraries(); track lib.id) {
           <li>
-            <a [routerLink]="libraryUrl(lib)" routerLinkActive="active" class="justify-between">
+            <a [routerLink]="libraryUrl(lib)" routerLinkActive="menu-active" class="justify-between">
               <span class="flex items-center gap-2">
                 <app-lucide-icon [name]="libraryIcon(lib)" class="h-5 w-5" />
                 {{ lib.name }}
@@ -358,7 +358,7 @@
         }
         @for (item of mainItemsAfterLibraries(); track item.id) {
           <li>
-            <a [routerLink]="item.route" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: item.exact }" class="justify-between">
+            <a [routerLink]="item.route" routerLinkActive="menu-active" [routerLinkActiveOptions]="{ exact: item.exact }" class="justify-between">
               <span class="flex items-center gap-2">
                 <app-nav-icon [name]="item.icon" class="h-5 w-5" />
                 {{ item.labelKey | translate }}
@@ -372,7 +372,7 @@
         <li class="menu-title text-xs uppercase tracking-wider mt-3">{{ 'nav.section_downloads' | translate }}</li>
         @for (item of acquisitionItems(); track item.id) {
           <li>
-            <a [routerLink]="item.route" routerLinkActive="active" class="justify-between">
+            <a [routerLink]="item.route" routerLinkActive="menu-active" class="justify-between">
               <span class="flex items-center gap-2">
                 <app-nav-icon [name]="item.icon" class="h-5 w-5" />
                 {{ item.labelKey | translate }}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -16,6 +16,13 @@
   --radius-box: 0.5rem;
 }
 
+/* Active menu item styled like the hover state. daisyUI's neutral default is
+   darker than base-100 in the dark theme, so it reads as a hole. */
+.menu {
+  --menu-active-bg: color-mix(in oklab, var(--color-base-content) 10%, transparent);
+  --menu-active-fg: var(--color-base-content);
+}
+
 /* Thinner focus outline on form fields. Suppress daisyUI's border on focus —
    the focus ring (outline) is the only visual cue we want, the extra white
    border doubled up with the ring looks noisy.


### PR DESCRIPTION
## Problem

Every left sidebar (main layout, admin, app settings, account) already marked its links with `routerLinkActive="active"`, but daisyUI 5 renamed the menu state class to `menu-active`. `.active` is styled nowhere (neither daisyUI nor `styles.css`), so the class was applied to the anchor and had no effect: no sidebar gave any visual feedback about the current page.

## Fix

- `routerLinkActive="active"` → `routerLinkActive="menu-active"` on the 20 sidebar links (`layout.html`, `admin-shell.html`, `app-settings-shell.html`, `account-shell.html`).
- Repoint `--menu-active-bg` / `--menu-active-fg` on `.menu` to the same `color-mix` the hover state uses. daisyUI's default is `neutral`, which in the dark theme is darker than `base-100` and reads as a hole rather than a highlight.

Tab bars (`tab-active`) and the mobile dock (`dock-active`) were already using the right class names and are untouched.