### PR TITLE
fix(library): stop the suggestions tab blanking itself on every return

### DIFF
--- a/client/src/app/core/services/playable-media.service.ts
+++ b/client/src/app/core/services/playable-media.service.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { CastService } from './cast.service';
 import { CastPlayerService } from './cast-player.service';
 import { MediaService } from './api/media.service';
-import { StreamingApiService } from './api/streaming-api.service';
+import { ContinueWatchingItem, StreamingApiService } from './api/streaming-api.service';
 import { PlaybackQueueService, QueueItem } from './playback-queue.service';
 import { RemoteService } from './remote.service';
 import { resolvePlayableFile } from '../../shared/utils/media-play.util';
@@ -41,6 +41,23 @@ export class PlayableMediaService {
 
   /** Play a media file: on a selected remote target, else Cast if connected,
    *  else navigate to the local player. */
+  /** Resume a continue-watching row where the viewer left off. */
+  resume(item: ContinueWatchingItem): Promise<void> {
+    return this.play(
+      {
+        fileId: item.mediaFileId,
+        mediaId: item.mediaId,
+        positionSeconds: item.positionSeconds,
+        episodeId: item.episodeId ?? undefined,
+        title: item.mediaTitle,
+        episodeTitle: item.episodeLabel ?? undefined,
+        fanartUrl: item.fanartUrl ?? item.posterUrl ?? null,
+        stillUrl: item.stillUrl ?? null,
+      },
+      false,
+    );
+  }
+
   async play(ctx: PlayContext, fromStart: boolean) {
     // A standalone play is never part of a queue — drop any playlist queue so
     // the player doesn't inherit stale "up next" context from a prior session.

--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -84,7 +84,7 @@
             @for (item of continueWatching(); track item.mediaId + '-' + (item.episodeId ?? '')) {
               <app-media-card [aspect]="'landscape'"
                 [attr.data-home-focus]="'cw:' + item.mediaId + '-' + (item.episodeId ?? '')"
-                [imageUrl]="item.stillUrl ?? item.fanartUrl ?? item.posterUrl"
+                [imageUrl]="itemArtwork(item)"
                 [title]="item.mediaTitle"
                 [subtitle]="item.episodeLabel ?? undefined"
                 [progressPercent]="item.progressPercent"
@@ -138,7 +138,7 @@
               <app-media-card
                 [aspect]="'landscape'"
                 [attr.data-home-focus]="'like:' + item.mediaId + '-' + (item.seasonId ?? '') + '-' + (item.episodeId ?? '')"
-                [imageUrl]="item.stillUrl ?? item.fanartUrl ?? item.posterUrl"
+                [imageUrl]="itemArtwork(item)"
                 [title]="item.title"
                 [subtitle]="item.label ?? undefined"
                 [link]="likeLink(item)"

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -42,6 +42,7 @@ import { RequestCardComponent } from '../requests/request-card/request-card';
 import { RequestDeclineModalComponent } from '../requests/request-decline-modal/request-decline-modal.component';
 import { libraryColorVar } from '../../core/constants/library-appearance';
 import { StorageScopeService } from '../../core/services/storage-scope.service';
+import { itemArtwork } from '../../shared/utils/media-artwork.util';
 
 /**
  * # Home page
@@ -123,6 +124,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly injector = inject(Injector);
   private readonly route = inject(ActivatedRoute);
   private readonly reuseStrategy = inject(CachingReuseStrategy);
+  protected readonly itemArtwork = itemArtwork;
 
   private static readonly SCROLL_KEY = 'home';
   private attachedSub?: Subscription;
@@ -714,16 +716,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   async playContinueWatching(item: ContinueWatchingItem) {
-    await this.playableMedia.play({
-      fileId: item.mediaFileId,
-      mediaId: item.mediaId,
-      positionSeconds: item.positionSeconds,
-      episodeId: item.episodeId ?? undefined,
-      title: item.mediaTitle,
-      episodeTitle: item.episodeLabel ?? undefined,
-      fanartUrl: item.fanartUrl ?? item.posterUrl ?? null,
-      stillUrl: item.stillUrl ?? null,
-    }, false);
+    await this.playableMedia.resume(item);
   }
 
   /** "Mark as watched" can only fire on a movie with at least one file

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -481,7 +481,7 @@
           @for (item of recommendedForYou(); track item.id) {
             <app-media-card
               [aspect]="'landscape'"
-              [imageUrl]="item.stillUrl ?? item.fanartUrl ?? item.posterUrl"
+              [imageUrl]="itemArtwork(item)"
               [title]="item.title"
               [subtitle]="item.label ?? ('recommend.received_by' | translate: { username: item.sender.username })"
               [link]="contentLink(item.mediaType, item.mediaId, item.episodeId)"
@@ -497,12 +497,17 @@
           @for (item of suggestionsContinue(); track item.mediaId + '-' + (item.episodeId ?? '')) {
             <app-media-card
               [aspect]="'landscape'"
-              [imageUrl]="item.fanartUrl ?? item.posterUrl"
+              [imageUrl]="itemArtwork(item)"
               [title]="item.mediaTitle"
               [subtitle]="item.episodeLabel ?? undefined"
               [progressPercent]="item.progressPercent"
               [link]="contentLink(item.mediaType, item.mediaId, item.episodeId)"
               [titleLink]="item.episodeId ? ['/' + (item.mediaType === 'series' ? 'series' : 'movies'), '' + item.mediaId] : null"
+              [playlistMediaId]="item.mediaId"
+              [playlistEpisodeId]="item.episodeId"
+              [playable]="true"
+              [clickIntent]="'play'"
+              (clicked)="playContinueWatching(item)"
             />
           }
         </app-horizontal-scroller>
@@ -620,7 +625,7 @@
         @for (item of likesList(); track item.mediaId + '-' + (item.seasonId ?? '') + '-' + (item.episodeId ?? '')) {
           <app-media-card
             [aspect]="'landscape'"
-            [imageUrl]="item.stillUrl ?? item.fanartUrl ?? item.posterUrl"
+            [imageUrl]="itemArtwork(item)"
             [title]="item.title"
             [subtitle]="item.label ?? undefined"
             [link]="contentLink(item.mediaType, item.mediaId, item.episodeId)"

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -44,6 +44,8 @@ import { LucideSearch, LucideSlidersHorizontal, LucideArrowUp, LucideArrowDown, 
 import { MosaicCardComponent } from '../../shared/components/mosaic-card/mosaic-card';
 import { CardSkeletonComponent } from '../../shared/components/card-skeleton';
 import { NgTemplateOutlet } from '@angular/common';
+import { itemArtwork } from '../../shared/utils/media-artwork.util';
+import { PlayableMediaService } from '../../core/services/playable-media.service';
 import {
   CdkVirtualScrollViewport,
   CdkFixedSizeVirtualScroll,
@@ -103,6 +105,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   private readonly mediaService = inject(MediaService);
   private readonly streamingApi = inject(StreamingApiService);
   private readonly offlineSync = inject(OfflinePlaybackSyncService);
+  private readonly playableMedia = inject(PlayableMediaService);
   private readonly socialApi = inject(SocialApiService);
   private readonly likesApi = inject(LikesApiService);
   private readonly profilesService = inject(ProfilesService);
@@ -116,6 +119,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   private readonly translate = inject(TranslateService);
   private readonly reuseStrategy = inject(CachingReuseStrategy);
   private readonly appResume = inject(AppResumeService);
+  protected readonly itemArtwork = itemArtwork;
   private paramSub?: Subscription;
   private attachedSub?: Subscription;
   private detachedSub?: Subscription;
@@ -159,6 +163,18 @@ export class LibraryComponent implements OnInit, OnDestroy {
   /** Content other members have recommended to the viewer. */
   readonly recommendedForYou = signal<ReceivedRecommendation[]>([]);
   readonly suggestionsLoading = signal(true);
+  /**
+   * A revalidation must not blank a panel that already has content: the tab is
+   * replaced by its skeleton, which drops whatever the viewer was looking at,
+   * including the card a back transition is morphing into.
+   */
+  private readonly hasSuggestions = computed(
+    () =>
+      this.suggestionsContinueRaw().length > 0 ||
+      this.suggestionsRecommendations().length > 0 ||
+      this.suggestionsFromFollowing().length > 0 ||
+      this.recommendedForYou().length > 0,
+  );
 
   // ── Genres view ─────────────────────────────────────────────────────
   /** Distinct genres in the library + sample posters for the mosaic. */
@@ -573,7 +589,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   private async loadCollections(): Promise<void> {
     const lib = this.library();
     if (!lib) return;
-    this.collectionsLoading.set(true);
+    if (!this.collectionsList().length) this.collectionsLoading.set(true);
     try {
       const rows = await this.mediaService.getCollections(lib.id).catch(() => null);
       if (rows) this.collectionsList.set(rows);
@@ -595,11 +611,15 @@ export class LibraryComponent implements OnInit, OnDestroy {
     return [mediaType === 'series' ? '/series' : '/movies', String(mediaId)];
   }
 
+  async playContinueWatching(item: ContinueWatchingItem) {
+    await this.playableMedia.resume(item);
+  }
+
   /** Fetches the viewer's liked content scoped to the active library. */
   private async loadLikes(): Promise<void> {
     const lib = this.library();
     if (!lib) return;
-    this.likesLoading.set(true);
+    if (!this.likesList().length) this.likesLoading.set(true);
     try {
       const rows = await this.likesApi.mine(lib.id, { force: true }).catch(() => null);
       if (rows) this.likesList.set(rows);
@@ -613,7 +633,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   private async loadGenres(): Promise<void> {
     const lib = this.library();
     if (!lib) return;
-    this.genresLoading.set(true);
+    if (!this.genresList().length) this.genresLoading.set(true);
     try {
       const rows = await this.mediaService.getGenres(lib.id).catch(() => null);
       if (rows) this.genresList.set(rows);
@@ -631,7 +651,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   private async loadSuggestions(): Promise<void> {
     const lib = this.library();
     if (!lib) return;
-    this.suggestionsLoading.set(true);
+    if (!this.hasSuggestions()) this.suggestionsLoading.set(true);
     try {
       const [cw, recs, following, forYou] = await Promise.all([
         this.streamingApi.getContinueWatching(lib.id).catch(() => null),

--- a/client/src/app/features/profile/profile-overview.html
+++ b/client/src/app/features/profile/profile-overview.html
@@ -64,7 +64,7 @@
         @for (item of p.recentlyWatched; track item.id) {
           <app-media-card
             [aspect]="'landscape'"
-            [imageUrl]="item.stillUrl ?? item.fanartUrl ?? item.posterUrl"
+            [imageUrl]="itemArtwork(item)"
             [title]="item.mediaTitle"
             [subtitle]="item.episodeLabel ?? undefined"
             [link]="mediaLink(item.mediaType, item.mediaId)"
@@ -79,7 +79,7 @@
         @for (item of p.likes; track item.mediaId + '-' + (item.seasonId ?? '') + '-' + (item.episodeId ?? '')) {
           <app-media-card
             [aspect]="'landscape'"
-            [imageUrl]="item.stillUrl ?? item.fanartUrl ?? item.posterUrl"
+            [imageUrl]="itemArtwork(item)"
             [title]="item.title"
             [subtitle]="item.label ?? undefined"
             [link]="likeLink(item)"

--- a/client/src/app/features/profile/profile-overview.ts
+++ b/client/src/app/features/profile/profile-overview.ts
@@ -15,6 +15,7 @@ import { MetadataService, TmdbGenre } from '../../core/services/api/metadata.ser
 import { SearchStateService } from '../../core/services/search-state.service';
 import { resolveTmdbGenreId } from '../../core/utils/tmdb-genres';
 import { ProfileContextService } from './profile-context.service';
+import { itemArtwork } from '../../shared/utils/media-artwork.util';
 
 /** The profile "overview" tab: tastes, playlists, recommendations, recently
  *  watched and likes, each behind its share toggle. Reads the profile aggregate
@@ -35,6 +36,7 @@ export class ProfileOverviewComponent {
   private readonly metadata = inject(MetadataService);
   private readonly searchState = inject(SearchStateService);
   protected readonly ctx = inject(ProfileContextService);
+  protected readonly itemArtwork = itemArtwork;
 
   readonly profile = this.ctx.profile;
 

--- a/client/src/app/features/profile/profile-recommendations.html
+++ b/client/src/app/features/profile/profile-recommendations.html
@@ -26,7 +26,7 @@
                 <td>
                   <a [routerLink]="contentLink(item)" class="flex items-center gap-3 min-w-0">
                     <div class="w-14 aspect-video rounded bg-base-300 overflow-hidden shrink-0">
-                      @if (item.stillUrl ?? item.fanartUrl ?? item.posterUrl; as img) {
+                      @if (itemArtwork(item); as img) {
                         <img [cachedSrc]="img | resolveUrl:'thumb'" [alt]="item.title" class="w-full h-full object-cover" loading="lazy" />
                       }
                     </div>
@@ -71,7 +71,7 @@
                 <td>
                   <a [routerLink]="contentLink(item)" class="flex items-center gap-3 min-w-0">
                     <div class="w-14 aspect-video rounded bg-base-300 overflow-hidden shrink-0">
-                      @if (item.stillUrl ?? item.fanartUrl ?? item.posterUrl; as img) {
+                      @if (itemArtwork(item); as img) {
                         <img [cachedSrc]="img | resolveUrl:'thumb'" [alt]="item.title" class="w-full h-full object-cover" loading="lazy" />
                       }
                     </div>

--- a/client/src/app/features/profile/profile-recommendations.ts
+++ b/client/src/app/features/profile/profile-recommendations.ts
@@ -17,6 +17,7 @@ import {
 import { AuthService } from '../../core/services/auth.service';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 import { CachedSrcDirective } from '../../shared/directives/cached-src.directive';
+import { itemArtwork } from '../../shared/utils/media-artwork.util';
 
 /** The profile "recommendations" tab, own-profile only: content other members
  *  recommended to the viewer, and content the viewer recommended to others.
@@ -33,6 +34,7 @@ export class ProfileRecommendationsComponent {
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
   private readonly auth = inject(AuthService);
+  protected readonly itemArtwork = itemArtwork;
 
   readonly loading = signal(true);
   readonly received = signal<ReceivedRecommendation[]>([]);

--- a/client/src/app/shared/components/horizontal-scroller.ts
+++ b/client/src/app/shared/components/horizontal-scroller.ts
@@ -54,9 +54,6 @@ export class HorizontalScrollerComponent implements AfterViewInit, OnDestroy {
     if (el) {
       this.resizeObserver = new ResizeObserver(() => this.updateArrows());
       this.resizeObserver.observe(el);
-      // The rail's own box doesn't change as cards fill it, so a first pass
-      // that ran before layout would leave atEnd stuck and hide the arrow.
-      requestAnimationFrame(() => this.updateArrows());
     }
     // Routes flagged `reuse: true` detach this row's DOM on navigate-away and
     // reattach it on return without re-running ngAfterViewInit. The reattach

--- a/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.html
+++ b/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.html
@@ -14,7 +14,7 @@
               <li appTvRow class="flex items-center gap-4 py-3 first:pt-0 last:pb-0">
                 <a [routerLink]="mediaLink(item)" class="shrink-0 rounded-md">
                   <div class="w-24 aspect-video rounded-md bg-base-300 overflow-hidden">
-                    @if (item.stillUrl ?? item.fanartUrl ?? item.posterUrl; as img) {
+                    @if (itemArtwork(item); as img) {
                       <img [cachedSrc]="img | resolveUrl:'thumb'" [alt]="item.title" class="w-full h-full object-cover" loading="lazy" />
                     }
                   </div>

--- a/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.ts
+++ b/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.ts
@@ -27,6 +27,7 @@ import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import { AddToPlaylistService } from '../../../core/services/add-to-playlist.service';
 import { LikesApiService } from '../../../core/services/api/likes-api.service';
 import { CachedSrcDirective } from '../../directives/cached-src.directive';
+import { itemArtwork } from '../../utils/media-artwork.util';
 
 /**
  * Home widget listing content other members have recommended to the viewer,
@@ -59,6 +60,7 @@ export class ReceivedRecommendationsCardComponent implements OnInit {
   private readonly addToPlaylistService = inject(AddToPlaylistService);
   private readonly likesApi = inject(LikesApiService);
   readonly tv = inject(TvService);
+  protected readonly itemArtwork = itemArtwork;
 
   readonly items = signal<ReceivedRecommendation[]>([]);
   readonly busyId = signal<number | null>(null);

--- a/client/src/app/shared/utils/media-artwork.util.spec.ts
+++ b/client/src/app/shared/utils/media-artwork.util.spec.ts
@@ -1,0 +1,10 @@
+import { itemArtwork } from './media-artwork.util';
+
+describe('itemArtwork', () => {
+  it('prefers the still, then the fanart, then the poster', () => {
+    expect(itemArtwork({ stillUrl: '/s.jpg', fanartUrl: '/f.jpg', posterUrl: '/p.jpg' })).toBe('/s.jpg');
+    expect(itemArtwork({ fanartUrl: '/f.jpg', posterUrl: '/p.jpg' })).toBe('/f.jpg');
+    expect(itemArtwork({ posterUrl: '/p.jpg' })).toBe('/p.jpg');
+    expect(itemArtwork({})).toBeNull();
+  });
+});

--- a/client/src/app/shared/utils/media-artwork.util.ts
+++ b/client/src/app/shared/utils/media-artwork.util.ts
@@ -1,0 +1,12 @@
+/**
+ * Artwork for a feed row (continue-watching, likes, recommendations). The still
+ * wins when there is one: the row points at an episode, so the series poster
+ * would show the wrong thing.
+ */
+export function itemArtwork(item: {
+  stillUrl?: string | null;
+  fanartUrl?: string | null;
+  posterUrl?: string | null;
+}): string | null {
+  return item.stillUrl ?? item.fanartUrl ?? item.posterUrl ?? null;
+}

--- a/client/src/app/shared/utils/view-transition.ts
+++ b/client/src/app/shared/utils/view-transition.ts
@@ -56,7 +56,7 @@ export function clearStalePosterStamps(from: RouteNode, to: RouteNode): void {
   clearPosterStamps();
 }
 
-export const VIEW_TRANSITION_CLASS = 'view-transitioning';
+const VIEW_TRANSITION_CLASS = 'view-transitioning';
 
 /**
  * Flag the document for as long as the transition runs, so an entry animation


### PR DESCRIPTION
## Problem

Three symptoms on the library's **Suggestions** tab, all on the "Continue watching" row:

1. The card showed the series poster instead of the episode still.
2. It had no play button.
3. The poster morph ran on the way in but not on the way back.

The third one turned out to be the interesting one. `loadSuggestions()` runs on every `attached$`, and it set `suggestionsLoading` to `true` before the revalidation even started — so returning to the tab replaced the whole panel with its skeleton. The viewer lost what they were looking at, the rows were rebuilt, and the card the back transition was morphing into simply wasn't in the DOM when the browser captured the new state. The method's own doc comment claims the opposite ("Signals keep their previous value until each response lands, so flipping between tabs never blanks the panel") — the flag was the part that didn't honour it.

`loadLikes`, `loadGenres` and `loadCollections` had the same shape, so they get the same guard: the skeleton now shows only when there is genuinely nothing to display yet.

## The other two

- **Artwork.** `stillUrl ?? fanartUrl ?? posterUrl` was hand-rolled in eight templates and this row was the one that forgot `stillUrl`. It now goes through `itemArtwork()`, so a caller can't get the precedence wrong.
- **Play button.** The row had no `[playable]`, no `clickIntent` and no handler. Rather than copy the home handler, resuming a row became `PlayableMediaService.resume(item)` and both pages call it.

## Notes

Two things from the previous round were removed again rather than kept:

- A self-restoring stamp on `media-card` (the morph target held as state so a rebuilt row could re-claim its name). It fixed a symptom of the blanking above, and it stole the name from the episode hero — the active episode's own card in the "More from season N" rail matched the target, and `stampPoster` clears every other named element, so the back transition started from a card at the bottom of the page instead of the hero.
- A `requestAnimationFrame` recompute in `horizontal-scroller`: speculative, the cards have fixed widths so `scrollWidth` is already correct at `ngAfterViewInit`.

692 tests pass, `ng build` clean.