### PR TITLE
feat(player): animate the player opening and closing

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -68,6 +68,8 @@ export function loadPersistedState(): Promise<unknown> {
 }
 
 const EPISODE_PATH = 'series/:id/episode/:episodeId';
+const WATCH_PATH = 'watch/:mediaFileId';
+const PLAYER_CLOSE_CLASS = 'vt-player-close';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -100,6 +102,15 @@ export const appConfig: ApplicationConfig = {
                 }
                 // A stamp outlives its navigation so the back morph can pair it.
                 clearStalePosterStamps(from, to);
+                // Leaving the player is the one navigation that re-enables the
+                // root pair: the closing player has to shrink over the page
+                // behind it, which only exists inside the transition.
+                if (leafRoutePath(from) === WATCH_PATH && leafRoutePath(to) !== WATCH_PATH) {
+                  const root = document.documentElement;
+                  root.classList.add(PLAYER_CLOSE_CLASS);
+                  const done = () => root.classList.remove(PLAYER_CLOSE_CLASS);
+                  void transition.finished.then(done, done);
+                }
                 markViewTransition(transition);
               },
             }),

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -170,6 +170,29 @@ class PausableTimeout {
       /* iOS WKWebView rotation fix: force GPU compositing so WebKit
          recalculates the fixed position after orientation change. */
       -webkit-transform: translateZ(0);
+      animation: player-open 260ms cubic-bezier(0.2, 0, 0, 1);
+    }
+    /* translateZ(0) is repeated in the keyframes so the iOS compositing hint
+       above survives the animation, which would otherwise replace transform. */
+    @keyframes player-open {
+      from {
+        opacity: 0;
+        transform: translateZ(0) scale(0.8);
+      }
+      to {
+        opacity: 1;
+        transform: translateZ(0) scale(1);
+      }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .player-container {
+        animation-name: player-open-fade;
+      }
+      @keyframes player-open-fade {
+        from {
+          opacity: 0;
+        }
+      }
     }
     /* When using native player, make WebView layers transparent so ExoPlayer/AVPlayer shows through */
     .player-container.native-player {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1181,3 +1181,44 @@ body.tablet [data-touch-only] {
   z-index: 0;
 }
 
+/* Closing the player: the only navigation that opts the root pair back in.
+   The old snapshot IS the player, so it shrinks and fades above the page it
+   returns to, mirroring the open animation in `player.ts`. */
+html.vt-player-close::view-transition-old(root),
+html.vt-player-close::view-transition-new(root) {
+  /* The UA cross-fades with `plus-lighter`, which adds the two snapshots
+     instead of letting the player occlude the page it shrinks over. */
+  mix-blend-mode: normal;
+}
+/* The new snapshot paints above the old inside the image pair, and its
+   `animation: none` above makes it opaque from the first frame, so without this
+   the closing player animates entirely behind the destination page. */
+html.vt-player-close::view-transition-new(root) {
+  z-index: 0;
+}
+html.vt-player-close::view-transition-old(root) {
+  z-index: 1;
+  animation: player-close 200ms cubic-bezier(0.4, 0, 1, 1) both;
+}
+/* Above the named groups (z-index 1): a hero poster stamped by an earlier card
+   click has no old counterpart here, so it would fade in through the player. */
+html.vt-player-close::view-transition-group(root) {
+  z-index: 2;
+}
+@keyframes player-close {
+  to {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  html.vt-player-close::view-transition-old(root) {
+    animation-name: player-close-fade;
+  }
+  @keyframes player-close-fade {
+    to {
+      opacity: 0;
+    }
+  }
+}
+


### PR DESCRIPTION
## Opening

A CSS animation on `.player-container` itself: `scale(0.8)` + fade to `scale(1)` over 260ms. The player covers the whole viewport, so there is nothing behind it to reveal and no coordination with the router is needed — this works on web, native and TV alike. `translateZ(0)` is repeated in the keyframes so the iOS compositing hint on the container survives the animation, and `prefers-reduced-motion` falls back to a plain fade.

## Closing

The exit is the harder direction: the destination page has to be painted **behind** the shrinking player, and it does not exist yet — `/watch` is a sibling of the layout route, so Angular destroys the player before the detail page mounts. The only place both coexist is inside a view transition.

So leaving `/watch` is the one navigation that opts the root pair back out of the blanket `animation: none` in `styles.css`. That keeps the cost that rule was added for (root snapshots on weak GPUs) confined to player open/close instead of every navigation.

Two non-obvious details, both of which made the first attempt render nothing at all:

- Inside `::view-transition-image-pair`, `new` paints **above** `old`, and `new` keeps `animation: none`, so it is opaque from frame 0 and hides the closing player entirely. Explicit `z-index` on both halves.
- The UA sets `mix-blend-mode: plus-lighter` on the pair for a correct cross-fade. That *adds* the snapshots rather than letting the player occlude the page, so it has to go back to `normal`.

`z-index: 2` on the root *group* is a separate concern: a hero poster stamped by an earlier card click has no `old` counterpart on this navigation and would otherwise fade in through the player.

## Scope

**Close is web only.** View transitions are disabled on Capacitor and TV (the WebView never completes a snapshot capture, costing a 4s timeout per navigation — see the comment in `app.config.ts`), so there is no exit animation there and there cannot be one without paying that. Open works everywhere.

## Test plan

- `ng build` clean.
- **Not yet confirmed on screen:** the close animation's first version rendered nothing, and the stacking/blend fix above has not been eyeballed yet. Verify a player close on desktop web before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)