### PR TITLE
feat(tizen): direct play MKV and read codec support from the TV

### DIFF
--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -5,6 +5,7 @@ import { DeviceService } from './device.service';
 import { ServerConfigService } from './server-config.service';
 import { ENGINE_TRAITS, engineKindFor } from './engine-traits';
 import { SystemInfoService } from './system-info.service';
+import { applyTizenAudioCodecs, tizenSupportsHevc } from './tizen-capabilities';
 import { getDeviceName } from '../utils/device-info';
 import { environment } from '../../../environments/environment';
 
@@ -113,13 +114,9 @@ export interface DeviceProfile {
    *  for future firmware regressions. */
   useTs?: boolean;
 
-  /** Force MPEG-TS only when the source has at most one audio track.
-   *  Set by Tizen profiles: AVPlay HLS-fMP4 needs demuxed audio per
-   *  Samsung spec, but with a single audio rendition AVPlay never
-   *  engages the rendition probe and the variant stalls after the
-   *  video init (issue #148 bisection). MPEG-TS muxes A+V natively,
-   *  side-stepping the probe — at the cost of Dolby pass-through.
-   *  Multi-audio Tizen sources stay on fMP4 + var_stream_map. */
+  /** Force MPEG-TS only when the source has at most one audio track. Required
+   *  by Tizen: AVPlay fetches init.mp4 then seg-0 and stalls there on a
+   *  single-audio fMP4 variant, CMAF rewrite notwithstanding (issue #148). */
   useTsOnSingleAudio?: boolean;
 
   /** Client consumes HLS `SUBTITLES` renditions from the master playlist
@@ -146,9 +143,8 @@ export interface DeviceProfile {
   probesSegZero?: boolean;
 
   /** Client engine can play a raw progressive file (DirectPlay served as-is).
-   *  True for Shaka (web), ExoPlayer/AVPlayer (native) and webOS `<video>`.
-   *  False for Tizen AVPlay (HLS-only): the backend then never returns
-   *  DirectPlay and falls back to DirectStream (remux to HLS). Unset = true. */
+   *  True for every shipping engine; `false` makes the backend skip DirectPlay
+   *  and fall back to DirectStream (remux to HLS). Unset = true. */
   supportsDirectPlay?: boolean;
 
   /** Client can switch HLS variants at runtime (real ABR). `false` (e.g.
@@ -255,9 +251,8 @@ export class BrowserDeviceProfileService {
     const containers: string[] = [];
     if (this.testType(video, hasMSE, 'video/mp4')) containers.push('mp4', 'm4v', 'mov');
     if (this.testType(video, hasMSE, 'video/webm')) containers.push('webm');
-    // MKV: browsers can NOT play MKV containers directly. Do NOT add 'mkv' here.
-    // MKV files with supported codecs will be handled via DirectStream (remux to HLS)
-    // by the StreamBuilder, which checks video/audio codec support independently.
+    // MKV: no browser demuxes Matroska, so it stays out of the probed list. A
+    // supported codec inside MKV still remuxes to HLS via DirectStream.
 
     // --- Detect supported video codecs ---
     const videoCodecs: string[] = [];
@@ -380,7 +375,8 @@ export class BrowserDeviceProfileService {
       }
     } else if (
       (tvPlatform === 'tizen' || tvPlatform === 'webos') &&
-      !videoCodecs.includes('hevc')
+      !videoCodecs.includes('hevc') &&
+      (tvPlatform !== 'tizen' || tizenSupportsHevc() !== false)
     ) {
       videoCodecs.push('hevc', 'h265', 'hvc1', 'hev1');
       codecConditions.push({
@@ -389,6 +385,10 @@ export class BrowserDeviceProfileService {
         maxBitDepth: 10,
       });
     }
+
+    // AVPlay demuxes Matroska natively, so the raw file Direct Plays. Declared
+    // rather than probed: Tizen exposes codec capabilities, never containers.
+    if (tvPlatform === 'tizen') containers.push('mkv');
 
     // --- Detect supported audio codecs ---
     // On native, the platform plugin (AudioCapabilities) is the source of
@@ -418,6 +418,9 @@ export class BrowserDeviceProfileService {
       if (this.testCodec(video, hasMSE, 'audio/mp4', 'flac') ||
           this.testCodec(video, hasMSE, 'audio/flac', '')) audioCodecs.push('flac');
       if (this.testCodec(video, hasMSE, 'audio/mp4', 'alac')) audioCodecs.push('alac');
+      // AVPlay decodes the stream on Tizen, so its own capability API overrides
+      // the MSE probe for every codec that API enumerates.
+      if (tvPlatform === 'tizen') audioCodecs = applyTizenAudioCodecs(audioCodecs);
     }
 
     // --- Max audio channels ---
@@ -439,12 +442,12 @@ export class BrowserDeviceProfileService {
     if (this.nativeAudio) {
       maxAudioChannels = Math.max(maxAudioChannels, this.nativeAudio.maxChannels);
     }
-    // webOS: the WebView's AudioContext caps at 2ch, but the native <video>
-    // pipeline decodes Dolby and renders/passes it (TV speakers downmix, eARC
-    // passes through). Declaring 5.1 when AC3/EAC3 is supported lets the
-    // backend DirectStream multichannel Dolby instead of downmixing to stereo.
+    // TVs: the WebView's AudioContext caps at 2ch, but the playback pipeline
+    // (webOS <video>, Tizen AVPlay) decodes Dolby and renders/passes it (TV
+    // speakers downmix, eARC passes through). Declaring 5.1 when AC3/EAC3 is
+    // supported lets the backend copy multichannel Dolby instead of downmixing.
     if (
-      tvPlatform === 'webos' &&
+      (tvPlatform === 'webos' || tvPlatform === 'tizen') &&
       (audioCodecs.includes('eac3') || audioCodecs.includes('ac3'))
     ) {
       maxAudioChannels = Math.max(maxAudioChannels, 6);
@@ -532,12 +535,7 @@ export class BrowserDeviceProfileService {
       deviceName: getDeviceName(),
       appVersion: isWeb ? undefined : environment.version,
       useTs,
-      // Tizen opts into MPEG-TS on single-audio sources (AVPlay's HLS-fMP4
-      // rendition-probe stall, issue #148). Multi-audio sources stay on
-      // fMP4 + var_stream_map — that path works because the master exposes
-      // ≥2 audio renditions and AVPlay engages its probe. webOS, browser,
-      // Cast and native mobile consume muxed fMP4 across the board (webOS's
-      // native <video> has no such stall and fMP4 keeps Dolby pass-through).
+      // Tizen alone needs MPEG-TS on single-audio sources (issue #148).
       useTsOnSingleAudio: traits.useTsOnSingleAudio,
       // Players that decode the master SUBTITLES renditions natively (iOS
       // AVPlayer, Android ExoPlayer — phone and TV alike, web Shaka) render
@@ -552,10 +550,9 @@ export class BrowserDeviceProfileService {
       // through native players that seek straight to the resume segment). The
       // Cast receiver sets this true in its own profile.
       probesSegZero: traits.probesSegZero,
-      // Samsung Tizen AVPlay is HLS-only and cannot open a raw progressive
-      // file, so it must never receive a DirectPlay decision — the backend
-      // falls back to DirectStream (remux to HLS, codec-copy). Every other
-      // engine (Shaka, ExoPlayer/AVPlayer, webOS <video>) plays raw files.
+      // Every shipping engine opens a raw progressive file: Shaka, ExoPlayer/
+      // AVPlayer, webOS <video>, and Tizen AVPlay, whose `open()` takes any
+      // remote URI and demuxes MKV itself.
       supportsDirectPlay: traits.supportsDirectPlay,
       // `false` only for the desktop mpv engine (see engine-traits.ts): the
       // backend then collapses the master to a single variant instead of

--- a/client/src/app/core/services/engine-traits.spec.ts
+++ b/client/src/app/core/services/engine-traits.spec.ts
@@ -42,7 +42,7 @@ const EXPECTED: Record<EngineKind, EngineTraits> = {
     supportsIFrameTrickPlay: true,
     supportsImageSubtitles: false,
     probesSegZero: false,
-    supportsDirectPlay: false,
+    supportsDirectPlay: true,
     supportsAbr: true,
   },
   [EngineKind.WEBOS]: {
@@ -130,7 +130,7 @@ describe('ENGINE_TRAITS reproduces the original ternaries', () => {
         tvPlatform !== 'tizen' && tvPlatform !== 'webos',
       );
       expect(traits.probesSegZero).toBe(!isNative);
-      expect(traits.supportsDirectPlay).toBe(tvPlatform !== 'tizen');
+      expect(traits.supportsDirectPlay).toBe(true);
     });
   }
 });

--- a/client/src/app/core/services/engine-traits.ts
+++ b/client/src/app/core/services/engine-traits.ts
@@ -113,13 +113,15 @@ export const ENGINE_TRAITS: Record<EngineKind, EngineTraits> = {
     supportsDirectPlay: true,
     supportsAbr: true,
   },
+  // AVPlay `open()` takes any remote URI, not just a manifest, and demuxes
+  // MKV natively, so a compatible source Direct Plays without a remux.
   [EngineKind.TIZEN]: {
     useTsOnSingleAudio: true,
     supportsHlsSubtitles: false,
     supportsIFrameTrickPlay: true,
     supportsImageSubtitles: false,
     probesSegZero: false,
-    supportsDirectPlay: false,
+    supportsDirectPlay: true,
     supportsAbr: true,
   },
   [EngineKind.WEBOS]: {

--- a/client/src/app/core/services/tizen-capabilities.spec.ts
+++ b/client/src/app/core/services/tizen-capabilities.spec.ts
@@ -1,0 +1,61 @@
+import { applyTizenAudioCodecs, tizenSupportsHevc } from './tizen-capabilities';
+
+function installWebapis(
+  audio: Record<string, boolean> | null,
+  video: Record<string, boolean> | null = null,
+): void {
+  (window as any).webapis = {
+    systeminfo: {
+      ...(audio
+        ? { isSupportedAudioCodec: (c: string) => audio[c] ?? false }
+        : {}),
+      ...(video
+        ? { isSupportedVideoCodec: (c: string) => video[c] ?? false }
+        : {}),
+    },
+  };
+}
+
+describe('tizen-capabilities', () => {
+  afterEach(() => {
+    delete (window as any).webapis;
+  });
+
+  it('keeps the probed list untouched when the API is missing', () => {
+    expect(applyTizenAudioCodecs(['aac', 'flac'])).toEqual(['aac', 'flac']);
+    expect(tizenSupportsHevc()).toBeNull();
+  });
+
+  it('adds Dolby the MSE probe missed and keeps non-enumerated codecs', () => {
+    installWebapis({ AAC: true, AC3: true, 'E-AC3': true, OPUS: false });
+    expect(applyTizenAudioCodecs(['aac', 'flac'])).toEqual([
+      'flac',
+      'aac',
+      'ac3',
+      'eac3',
+    ]);
+  });
+
+  it('drops a codec the TV says it cannot decode', () => {
+    installWebapis({ AAC: true, AC3: false, 'E-AC3': false, OPUS: false });
+    expect(applyTizenAudioCodecs(['aac', 'ac3', 'eac3'])).toEqual(['aac']);
+  });
+
+  it('survives a throwing API and keeps the probed answer', () => {
+    (window as any).webapis = {
+      systeminfo: {
+        isSupportedAudioCodec: () => {
+          throw new Error('not implemented');
+        },
+      },
+    };
+    expect(applyTizenAudioCodecs(['aac', 'eac3'])).toEqual(['aac', 'eac3']);
+  });
+
+  it('reports HEVC support from the video probe', () => {
+    installWebapis(null, { HEVC: true });
+    expect(tizenSupportsHevc()).toBe(true);
+    installWebapis(null, { HEVC: false });
+    expect(tizenSupportsHevc()).toBe(false);
+  });
+});

--- a/client/src/app/core/services/tizen-capabilities.ts
+++ b/client/src/app/core/services/tizen-capabilities.ts
@@ -1,0 +1,69 @@
+/**
+ * Samsung's codec-capability API, the only runtime capability source on Tizen.
+ *
+ * `webapis.systeminfo.isSupported{Audio,Video}Codec(name)` is synchronous and
+ * answers for the AVPlay decoders that actually play the stream, unlike the
+ * WebView's `MediaSource.isTypeSupported` (which speaks for a Chromium 85 MSE
+ * pipeline we never use on this platform). Containers have no equivalent API,
+ * so they stay declared from the media specifications.
+ *
+ * https://developer.samsung.com/smarttv/develop/api-references/samsung-product-api-references/systeminfo-api.html
+ */
+
+interface TizenSystemInfo {
+  isSupportedAudioCodec?(codec: string): boolean;
+  isSupportedVideoCodec?(codec: string): boolean;
+}
+
+/** Fliks codec id → Samsung enum name, for the codecs the API enumerates and
+ *  the backend can copy into an HLS segment. Codecs absent here (flac, alac,
+ *  mp3) have no enum and keep whatever the MSE probe answered. */
+const AUDIO_ENUM: Record<string, string> = {
+  aac: 'AAC',
+  ac3: 'AC3',
+  eac3: 'E-AC3',
+  opus: 'OPUS',
+};
+
+function systemInfo(): TizenSystemInfo | null {
+  const w = window as unknown as { webapis?: { systeminfo?: TizenSystemInfo } };
+  return w.webapis?.systeminfo ?? null;
+}
+
+/** `null` when the firmware doesn't expose the call, so callers keep their
+ *  existing answer instead of treating a missing API as "unsupported". */
+function isSupported(kind: 'audio' | 'video', name: string): boolean | null {
+  const si = systemInfo();
+  const fn = kind === 'audio' ? si?.isSupportedAudioCodec : si?.isSupportedVideoCodec;
+  if (typeof fn !== 'function') return null;
+  try {
+    return !!fn.call(si, name);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Merge the MSE-probed audio codec list with what AVPlay really decodes: the
+ * API decides every codec it enumerates, the rest pass through untouched.
+ * Returns the input unchanged when the API is unavailable.
+ */
+export function applyTizenAudioCodecs(probed: string[]): string[] {
+  const merged = probed.filter((c) => !(c in AUDIO_ENUM));
+  let answered = false;
+  for (const [codec, samsungName] of Object.entries(AUDIO_ENUM)) {
+    const supported = isSupported('audio', samsungName);
+    if (supported === null) {
+      if (probed.includes(codec)) merged.push(codec);
+      continue;
+    }
+    answered = true;
+    if (supported) merged.push(codec);
+  }
+  return answered ? merged : probed;
+}
+
+/** Whether AVPlay decodes HEVC. `null` keeps the caller's assumption. */
+export function tizenSupportsHevc(): boolean | null {
+  return isSupported('video', 'HEVC');
+}


### PR DESCRIPTION
Every playback on a Samsung TV went through a transcode, including sources the panel decodes natively. Three declarations in the device profile were wrong, all for the same reason: **they answered for the WebView's MSE pipeline, which never plays anything on this platform**, instead of for AVPlay, which does.

## What was wrong

| Declaration | Was | Consequence |
|---|---|---|
| `maxAudioChannels` | `AudioContext.destination.maxChannelCount`, capped at 2 in the WebView | a 5.1 EAC-3 track downmixed to AAC stereo server-side, on a set that passes Dolby through eARC |
| `supportsDirectPlay` | `false`, on the claim that AVPlay is HLS-only | no source could ever be served as-is |
| audio/video codecs | `MediaSource.isTypeSupported` | answers for a Chromium 85 MSE pipeline that is not in the playback path |

## What changed

**Channels.** webOS already carried an override for exactly this (its native `<video>` decodes Dolby while the WebView reports stereo); Tizen now shares it.

**Direct play.** The [AVPlay guide](https://developer.samsung.com/smarttv/develop/guides/multimedia/media-playback/using-avplay.html) states `open()` takes "absolute local paths and remote network URIs", not just manifests, and the [media specifications](https://developer.samsung.com/smarttv/develop/specifications/media-specifications/2022-tv-video-specifications.html) list MKV as a first-class container. A compatible source now plays untouched. MKV is declared rather than probed because Tizen exposes codec capabilities but never containers.

**Codecs.** New `tizen-capabilities.ts` reads [`webapis.systeminfo.isSupported{Audio,Video}Codec`](https://developer.samsung.com/smarttv/develop/api-references/samsung-product-api-references/systeminfo-api.html), the platform's own synchronous capability API, which answers for the AVPlay decoders. It wins over the MSE probe for every codec it enumerates, and falls back to the probe when the firmware lacks the call or it throws, so nothing is declared blind. This also replaced a hardcoded Dolby assumption from an earlier draft of this change: the TV is asked instead of guessed.

## Verification

On a QE85Q80BATXXC (Tizen), before:

```
profile={audioCodecs=[["aac","opus","flac"]], maxAudioChannels=2}
tryDirectPlay -> audioSupported=false, containerSupported=false
reasons=AudioChannelsNotSupported|AudioCodecNotSupported|ContainerNotSupported
```

After:

```
profile={audioCodecs=[["flac","aac","ac3","eac3","opus"]], maxAudioChannels=6}
tryDirectPlay -> audioSupported=true, containerSupported=true, videoSupported=true, reasons=-
DirectPlay for file 26: mkv/h264/eac3
```

No `FFmpeg start` follows that decision: the file is served over Range requests with zero transcode. The codec ordering (`flac` first, from the MSE probe, then the four the API enumerates) confirms the capability API answered on this firmware rather than falling back.

`useTsOnSingleAudio` stays `true` for Tizen. Turning it off was tested on several single-audio sources and every one stalled with the issue #148 signature: `init.mp4` and `seg-0000.m4s` requested, then silence. The CMAF rewrite does not lift that, contrary to what the old comment implied, and the comment is corrected.

5 new tests cover the capability module: API absent, Dolby added where the probe missed it, a codec the TV refuses being dropped, a throwing API, and the video probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)