### PR TITLE
fix(streaming): stop the remux dragging a subtitle rendition, copy HDR too

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.golden.spec.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.golden.spec.ts
@@ -1334,6 +1334,7 @@ describe('buildRemuxArgs / buildAudioOnlyFfmpegArgs — golden (characterization
        "0",
        "-c:v",
        "copy",
+       "-sn",
        "-c:a",
        "copy",
        "-tag:v",
@@ -1399,6 +1400,7 @@ describe('buildRemuxArgs / buildAudioOnlyFfmpegArgs — golden (characterization
        "0",
        "-c:v",
        "copy",
+       "-sn",
        "-c:a",
        "aac",
        "-b:a",
@@ -1426,6 +1428,20 @@ describe('buildRemuxArgs / buildAudioOnlyFfmpegArgs — golden (characterization
        "/cache/out/index.m3u8",
      ]
     `);
+  });
+
+  it('remux: never lets ffmpeg default-select a subtitle stream into the output', () => {
+    const args = buildRemuxArgs(
+      {
+        inputPath: '/media/in.mkv',
+        outputDir: '/cache/out',
+        copyAudio: true,
+        trustedStreamInfo: true,
+        sourceVideoCodec: 'h264',
+      },
+      silentLog,
+    );
+    expect(args).toContain('-sn');
   });
 
   it('audio-only: resume applies a single input -ss', () => {

--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -1352,7 +1352,9 @@ export function buildRemuxArgs(
       args.push('-c:a', 'aac', '-b:a', audioBitrate, '-ac', '2');
     }
   } else {
-    args.push('-c:v', 'copy');
+    // No explicit `-map` here, so ffmpeg's default stream selection
+    // picks video+audio itself; `-sn` stops it also grabbing a subtitle.
+    args.push('-c:v', 'copy', '-sn');
     if (copyAudio) {
       args.push('-c:a', 'copy');
     } else {

--- a/backend/src/modules/streaming/transcoding/master-playlist.spec.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.spec.ts
@@ -257,3 +257,58 @@ describe('generateMasterPlaylist — remux variant (copy path)', () => {
     expect(streamInfLines(m).length).toBeGreaterThan(1);
   });
 });
+
+describe('generateMasterPlaylist: HDR remux variant (copy path)', () => {
+  const hdrRemuxMaster = (
+    opts: Partial<Parameters<typeof generateMasterPlaylist>[0]> = {},
+  ): string =>
+    generateMasterPlaylist({
+      mediaFileId: 26,
+      sourceWidth: 3840,
+      sourceHeight: 2160,
+      tokenParam: '?token=t',
+      includeRemux: true,
+      sourceBitrate: 40_000_000,
+      sourceFrameRate: 23.976,
+      remuxCodecs: 'hvc1.2.4.L153.B0',
+      outputAudioCodec: 'eac3',
+      hdrPassThrough: { hdrFormat: 'HDR10', hdrVariant: HEVC_HDR10 },
+      canEmitHdrLadder: true,
+      ...opts,
+    });
+
+  it('publishes the copy variant alone, not the HDR transcode ladder', () => {
+    const m = hdrRemuxMaster();
+    const lines = streamInfLines(m);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('NAME="remux"');
+    expect(m).toContain('/api/stream/26/remux/index.m3u8?token=t');
+    expect(m).not.toMatch(/\/api\/stream\/26\/(eco-)?\d+p-hdr\/index\.m3u8/);
+  });
+
+  it('declares the probed source CODECS, never a rung-derived one', () => {
+    const lines = streamInfLines(hdrRemuxMaster());
+    expect(lines[0]).toContain('CODECS="hvc1.2.4.L153.B0,ec-3"');
+  });
+
+  it('carries VIDEO-RANGE and the source resolution', () => {
+    const line = streamInfLines(hdrRemuxMaster())[0];
+    expect(line).toContain('VIDEO-RANGE=PQ');
+    expect(line).toContain('RESOLUTION=3840x2160');
+  });
+
+  it('is published even when the host has no HDR encoder (copy needs none)', () => {
+    const m = hdrRemuxMaster({ canEmitHdrLadder: false });
+    const lines = streamInfLines(m);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('NAME="remux"');
+  });
+
+  it('falls back to the HDR ladder when the user pinned a rung', () => {
+    const m = hdrRemuxMaster({ onlyQuality: '1080p' });
+    const lines = streamInfLines(m);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('NAME="1080p-hdr"');
+    expect(m).not.toContain('/remux/index.m3u8');
+  });
+});

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -28,6 +28,56 @@ import {
  *  Only a manifest formality: the variant is alone, so nothing selects on it. */
 const REMUX_FALLBACK_BANDWIDTH_BPS = 8_000_000;
 
+interface RemuxVariantOptions {
+  mediaFileId: number;
+  tokenParam: string;
+  sourceWidth: number;
+  sourceHeight: number;
+  frameRateAttr: string;
+  audioAttr: string;
+  subsAttr: string;
+  codecsTail: string;
+  /** VIDEO-RANGE attribute value; omitted (SDR) leaves the attribute off. */
+  range?: 'PQ' | 'HLG';
+  remuxCodecs?: string | null;
+  remuxBandwidthBps?: number;
+  sourceBitrate?: number;
+  sourceVideoBitrateBps?: number;
+}
+
+/** Push the copy variant (`/remux/`), alone, at source resolution. Shared by
+ *  the SDR and HDR branches, which differ only in the audio group and
+ *  VIDEO-RANGE. */
+function pushRemuxVariant(lines: string[], opts: RemuxVariantOptions): void {
+  const {
+    mediaFileId,
+    tokenParam,
+    sourceWidth,
+    sourceHeight,
+    frameRateAttr,
+    audioAttr,
+    subsAttr,
+    codecsTail,
+    range,
+    remuxCodecs,
+    remuxBandwidthBps,
+    sourceBitrate,
+    sourceVideoBitrateBps,
+  } = opts;
+  // BANDWIDTH is required and must be a peak, so keep the ladder's 1.5x
+  // convention over the source average; the fallback only fires when ffprobe
+  // reported no bitrate at all.
+  const avg =
+    Math.round(remuxBandwidthBps || sourceBitrate || sourceVideoBitrateBps || 0) ||
+    REMUX_FALLBACK_BANDWIDTH_BPS;
+  const codecsAttr = remuxCodecs ? `,CODECS="${remuxCodecs}${codecsTail}"` : '';
+  const rangeAttr = range ? `,VIDEO-RANGE=${range}` : '';
+  lines.push(
+    `#EXT-X-STREAM-INF:BANDWIDTH=${Math.round(avg * 1.5)},AVERAGE-BANDWIDTH=${avg},RESOLUTION=${sourceWidth}x${sourceHeight}${rangeAttr}${frameRateAttr},NAME="remux"${codecsAttr}${audioAttr}${subsAttr}`,
+    `/api/stream/${mediaFileId}/remux/index.m3u8${tokenParam}`,
+  );
+}
+
 /** Format frame rate for the HLS `FRAME-RATE` attribute. Apple's spec
  *  says "decimal-floating-point describing the maximum frame rate …
  *  rounded to three decimal places". Whole numbers stay integer to
@@ -252,15 +302,9 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
     );
   };
 
-  // HDR pass-through path — emitted when the source is HEVC HDR and
-  // the client claims HDR support. Outputs a full HEVC HDR ladder
-  // (one remux rung at source resolution + HEVC HDR transcode rungs
-  // below) so the user can switch resolution while keeping HDR
-  // signaling (BT.2020/PQ or HLG). The H.264 SDR ladder is omitted in
-  // this branch — mixing SDR and HDR rungs in one master playlist
-  // confuses AVPlayer's ABR and triggers display-mode flips. Clients
-  // that want SDR explicitly disable HDR client-side (which flips
-  // `clientSupportsHdr` to false and re-routes to the SDR ladder).
+  // HDR pass-through path: the source is HDR and the client claims support.
+  // Either the copy variant alone or an HDR ladder, never both, and never
+  // mixed with the SDR ladder below (that mix flips AVPlayer's display mode).
   if (hdrPassThrough) {
     const range = hdrPassThrough.hdrFormat === 'HLG' ? 'HLG' : 'PQ';
 
@@ -279,13 +323,31 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
     const hdrAudioAttr = multiAudio ? ',AUDIO="audio"' : '';
     pushSubtitleMedia(lines);
 
+    // Copy path (`?remux=1`): publish the variant alone with VIDEO-RANGE.
+    // A copy needs no HDR encoder, so this skips `canEmitHdrLadder`.
+    if (includeRemux && !onlyQuality) {
+      pushRemuxVariant(lines, {
+        mediaFileId,
+        tokenParam,
+        sourceWidth,
+        sourceHeight,
+        frameRateAttr,
+        audioAttr: hdrAudioAttr,
+        subsAttr,
+        codecsTail,
+        range,
+        remuxCodecs,
+        remuxBandwidthBps,
+        sourceBitrate,
+        sourceVideoBitrateBps,
+      });
+      pushIFrameStream(lines);
+      return lines.join('\n');
+    }
+
     // HDR rungs are pure transcodes (HEVC Main10 or native AV1 HDR with forced
-    // keyframes), gated on `canEmitHdrLadder`. The former top "remux" pass-
-    // through was dropped: `-c:v copy` cuts on existing source IDRs (variable
-    // durations) which mis-aligns with the synthetic uniform VOD playlist, and
-    // ExoPlayer's buffer scheduler drifts behind audio. A transcode is visually
-    // transparent and gives perfectly uniform segments. Includes the source-
-    // resolution rung if there's an HDR profile at or below source height.
+    // keyframes), gated on `canEmitHdrLadder`. Includes the source-resolution
+    // rung if there's an HDR profile at or below source height.
     if (canEmitHdrLadder) {
       const hdrVariant = hdrPassThrough.hdrVariant;
       const baseHdrLadder = getHdrLadderForDevice(deviceType).filter((p) =>
@@ -356,17 +418,20 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
   // wants a lighter rung pins one, which arrives here as `onlyQuality` and
   // takes the ladder branch below.
   if (includeRemux && !onlyQuality) {
-    // BANDWIDTH is required and must be a peak, so keep the ladder's 1.5x
-    // convention over the source average; the fallback only fires when ffprobe
-    // reported no bitrate at all.
-    const avg =
-      Math.round(remuxBandwidthBps || sourceBitrate || sourceVideoBitrateBps || 0) ||
-      REMUX_FALLBACK_BANDWIDTH_BPS;
-    const codecsAttr = remuxCodecs ? `,CODECS="${remuxCodecs}${codecsTail}"` : '';
-    lines.push(
-      `#EXT-X-STREAM-INF:BANDWIDTH=${Math.round(avg * 1.5)},AVERAGE-BANDWIDTH=${avg},RESOLUTION=${sourceWidth}x${sourceHeight}${frameRateAttr},NAME="remux"${codecsAttr}${audioAttr}${subsAttr}`,
-      `/api/stream/${mediaFileId}/remux/index.m3u8${tokenParam}`,
-    );
+    pushRemuxVariant(lines, {
+      mediaFileId,
+      tokenParam,
+      sourceWidth,
+      sourceHeight,
+      frameRateAttr,
+      audioAttr,
+      subsAttr,
+      codecsTail,
+      remuxCodecs,
+      remuxBandwidthBps,
+      sourceBitrate,
+      sourceVideoBitrateBps,
+    });
     pushIFrameStream(lines);
     return lines.join('\n');
   }


### PR DESCRIPTION
Two follow-ups to #1175, both on the copy path.

## The remux was writing a WebVTT rendition nobody reads

`buildRemuxArgs` reaches ffmpeg with **no `-map`** on its common branch (audio present, not video-only, no user-picked track), so default stream selection stays in charge and also picks a text subtitle stream, transcoding it to WebVTT one segment at a time.

Measured on a source carrying 5 `subrip` streams: **951 stray `.vtt` files** next to its 951 segments, doubling the file count in the session's cache directory. A source with no subtitle stream at all produced zero, which is what pinned the cause. Nothing ever reads them: subtitles are served by the subtitle service.

`-sn` disables it. The two sibling branches pass explicit `-map` arguments, which restrict the output to mapped streams, and were already immune.

## HDR sources can now be copied instead of re-encoded

The HDR branch of the master playlist never published the copy variant, so an HDR source the client can present as-is was still re-encoded through `hevc_qsv` Main10: the most expensive work this server does.

The justification in the code was that `-c:v copy` cuts on source IDRs and mis-aligns with a *synthetic uniform* VOD playlist, drifting ExoPlayer's buffer scheduler behind audio. That playlist is keyframe-aligned since #1175, and was measured exact to **0.0 ms over 205 segments** (cumulative identical to the millisecond), so the objection no longer applies. The other historical objection, ExoPlayer ABR-downgrading from the copy rung to an identical-resolution transcode rung, is answered the same way the SDR branch answers it: the variant is published **alone**.

It deliberately bypasses `canEmitHdrLadder`. That flag asks whether an HDR *encoder* is available, and a copy needs no encoder.

The two branches now share a `pushRemuxVariant` helper rather than duplicating the `EXT-X-STREAM-INF` construction; the HDR call adds `VIDEO-RANGE=PQ`/`HLG`.

### Is that path actually reachable?

Yes. `sourceCopyable` requires only `clientCanPresentDynamicRange`, the same gate DirectPlay already passed, so a source whose container or audio needs adjusting while its video and HDR are presentable lands on DirectStream with `hdrPassThrough` set on the same request. Dolby Vision P5 stays excluded as before, since the fMP4 muxer drops its configuration box on copy.

## Tests

`510/510` across the streaming module, 29 snapshots. New cases: a remux argv carries no subtitle output (plus the two golden snapshots updated, the diff being exactly that one flag), and 5 HDR remux cases mirroring the SDR suite (variant alone with no `*-hdr` rungs beside it, source-probed CODECS rather than a rung-derived string, `VIDEO-RANGE` and source resolution present, published even with `canEmitHdrLadder: false`, and the HDR ladder returning when a rung is pinned).

Worth an end-to-end smoke test on a real HDR source before considering the HDR half fully proven: no one has yet forced `includeRemux` and `hdrPassThrough` together against a live session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)