### PR TITLE
fix(tizen): declare the containers Samsung publishes, not what the WebView says

### DIFF
--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -230,7 +230,7 @@ export class StreamBuilderService {
     // we can see, from a single log line, why a 5.1 EAC-3 source ended up
     // being downmixed to AAC stereo.
     this.log.log(
-      `audioDecision[file=${resolved.mediaFile.id}] source={codec=${source.audioCodec}, channels=${source.audioChannels}, layout=${source.audioChannelLayout}, bitrate=${source.audioBitRate}} profile={audioCodecs=${JSON.stringify(profile.directPlayProfiles.map((p) => p.audioCodecs))}, maxAudioChannels=${profile.maxAudioChannels}}`,
+      `audioDecision[file=${resolved.mediaFile.id}] source={codec=${source.audioCodec}, channels=${source.audioChannels}, layout=${source.audioChannelLayout}, bitrate=${source.audioBitRate}} profile={containers=${JSON.stringify(profile.directPlayProfiles.map((p) => p.containers))}, audioCodecs=${JSON.stringify(profile.directPlayProfiles.map((p) => p.audioCodecs))}, maxAudioChannels=${profile.maxAudioChannels}}`,
     );
 
     // --- Step 1: Try DirectPlay ---

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -154,6 +154,12 @@ export interface DeviceProfile {
   supportsAbr?: boolean;
 }
 
+/** Containers AVPlay demuxes, from Samsung's published media specification
+ *  (identical across the 2019-2025 model years). Over-declaring is safe: Direct
+ *  Play also requires the video AND audio codec to match the same profile
+ *  entry, so an AVI carrying MPEG-4 ASP still falls through to a transcode. */
+const TIZEN_CONTAINERS = ['mp4', 'mkv', 'mov', 'ts', 'm2ts', 'avi', 'webm'];
+
 /** True when `localStorage['fliks.useTs']` is set to a truthy value.
  *  See `DeviceProfile.useTs` for the rationale. */
 function readUseTsOverride(): boolean {
@@ -386,9 +392,14 @@ export class BrowserDeviceProfileService {
       });
     }
 
-    // AVPlay demuxes Matroska natively, so the raw file Direct Plays. Declared
-    // rather than probed: Tizen exposes codec capabilities, never containers.
-    if (tvPlatform === 'tizen') containers.push('mkv');
+    // Tizen: take the containers Samsung publishes for the TV's own demuxer.
+    // The WebView probe above answers for a pipeline that never plays here.
+    // https://developer.samsung.com/smarttv/develop/specifications/media-specifications/2022-tv-video-specifications.html
+    if (tvPlatform === 'tizen') {
+      for (const c of TIZEN_CONTAINERS) {
+        if (!containers.includes(c)) containers.push(c);
+      }
+    }
 
     // --- Detect supported audio codecs ---
     // On native, the platform plugin (AudioCapabilities) is the source of


### PR DESCRIPTION
#1174 gave Tizen its Direct Play back and declared `mkv` by hand, leaving the rest of the container list to the WebView's `MediaSource.isTypeSupported` probe. That probe answers nothing useful on this firmware.

Proof, from the profile the TV actually sent (the decision log now dumps it):

```
profile={containers=[["mkv"]], audioCodecs=[["flac","aac","ac3","eac3","opus"]], maxAudioChannels=6}
audioDecision[file=47] tryDirectPlay -> audioSupported=true, containerSupported=false, videoSupported=true
```

`mkv` is there only because #1174 pushed it explicitly. Nothing else survived, so the probe rejects even a bare `video/mp4` on this WebView. Every MP4 was consequently remuxed to HLS while the panel demuxes it natively.

## The fix

The container list comes from [Samsung's published media specification](https://developer.samsung.com/smarttv/develop/specifications/media-specifications/2022-tv-video-specifications.html) (`*.avi *.mkv *.asf *.wmv *.mp4 *.mov *.3gp ... *.ts *.m2ts`, identical across the 2019-2025 model years), not from a pipeline that never plays anything on this platform.

Over-declaring is safe by construction: `tryDirectPlay` requires the container **and** the video codec **and** the audio codec to match the same profile entry, so an AVI carrying MPEG-4 ASP still falls through to a transcode on the codec gate.

## Diagnostics

The playback-decision log now dumps the profile's containers next to its audio codecs. That line exists to explain a decision from a single entry, and the container was the one input it omitted, which is what made this take a detour through the database to diagnose.

## Verification

On a QE85Q80BATXXC:

```
profile={containers=[["mp4","mkv","mov","ts","m2ts","avi","webm"]], ...}
DirectPlay for file 47: mp4/h264/aac
```

Same file, same TV, previously `containerSupported=false` followed by a full `h264_qsv` re-encode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)