### PR TITLE
fix(player): drop the loading spinner when the browser refuses autoplay

### DIFF
--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -83,7 +83,7 @@
     </div>
   }
 
-  @if (loading() || buffering() || (!videoStarted() && !error())) {
+  @if (spinnerVisible()) {
     <div class="loading-overlay absolute inset-0 flex flex-col items-center justify-center gap-3 z-50 pointer-events-none">
       <span class="loading loading-spinner loading-lg text-white"></span>
       <!-- A long buffer is almost always a cold transcode start; say so rather

--- a/client/src/app/features/player/player.spec.ts
+++ b/client/src/app/features/player/player.spec.ts
@@ -727,3 +727,45 @@ describe('PlayerComponent remote control', () => {
     expect(h.streamingApi.updatePlaybackState).toHaveBeenCalled();
   });
 });
+
+describe('PlayerComponent loading spinner', () => {
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  /** Ready to play, nothing painted yet: the state a refused autoplay leaves. */
+  function ready() {
+    const h = createHarness();
+    h.state.loading.set(false);
+    h.state.buffering.set(false);
+    h.state.videoStarted.set(false);
+    h.state.error.set(null);
+    return h;
+  }
+
+  it('hides the spinner when the browser refused autoplay', () => {
+    const h = ready();
+    expect(h.component.spinnerVisible()).toBe(true);
+
+    h.component.autoplayBlocked.set(true);
+
+    // The media is ready and paused; the play button under the spinner is the
+    // real state, and a spinner over it reads as a stuck load.
+    expect(h.component.spinnerVisible()).toBe(false);
+  });
+
+  it('keeps the spinner for a genuine load or rebuffer', () => {
+    const h = ready();
+    h.component.autoplayBlocked.set(true);
+
+    h.state.loading.set(true);
+    expect(h.component.spinnerVisible()).toBe(false);
+
+    h.component.autoplayBlocked.set(false);
+    expect(h.component.spinnerVisible()).toBe(true);
+
+    h.state.loading.set(false);
+    h.state.buffering.set(true);
+    expect(h.component.spinnerVisible()).toBe(true);
+  });
+});

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -394,6 +394,16 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   readonly muted = this.state.muted;
   readonly buffering = this.state.buffering;
   readonly bufferedEnd = this.state.bufferedEnd;
+  /** Nothing has painted yet, so the spinner stands in for the video. A refused
+   *  autoplay is not that: the media is ready and paused, and the play button
+   *  under the spinner is the real state to show. */
+  readonly spinnerVisible = computed(
+    () =>
+      !this.autoplayBlocked() &&
+      (this.loading() ||
+        this.buffering() ||
+        (!this.videoStarted() && !this.error())),
+  );
   readonly playbackMode = this.state.playbackMode;
   readonly hwAccel = this.state.hwAccel;
   readonly activeQualityId = this.qualityManager.activeQualityId;


### PR DESCRIPTION
A refresh in the browser can land on a ready, paused player showing a spinner forever.

The overlay condition was:

```html
@if (loading() || buffering() || (!videoStarted() && !error())) {
```

`videoStarted` only flips on the engine's `firstFrame` event, so a refused autoplay satisfies `!videoStarted()` indefinitely: `loading` has been cleared, nothing is buffering, the media is loaded and playable, and the spinner sits on top of the play button that is the actual state to show. It reads as a stuck load.

`autoplayBlocked` was already tracked on the player, set when `engine.play()` rejects, and the remote already reports this case plainly to a controller (`remote.autoplay_blocked`). The local player now reads the same signal.

The condition moves out of the template into a `spinnerVisible` computed, which is also what makes it testable.

## Tests

Two cases in `player.spec.ts` (29/29 in that file): the spinner disappears once `autoplayBlocked` is set on an otherwise-ready player, and it still appears for a genuine load or rebuffer.

Note on the edge this documents: while `autoplayBlocked` is still set, a genuine reload shows no spinner. It is short-lived in practice, since any interaction that starts playback (including opening the quality menu) is a user gesture, and the existing effect clears the flag as soon as a frame paints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)