### PR TITLE
chore(i18n): trim the direct-play label in the nerd stats

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -86,7 +86,7 @@
     "auto": "Auto",
     "auto_resolution": "Auto ({{res}})",
     "stats_direct_playback": "Direktwiedergabe",
-    "stats_stream_type_direct": "Direktwiedergabe (Datei unverändert)",
+    "stats_stream_type_direct": "Direktwiedergabe",
     "stats_stream_type_remux": "Remux (Streams kopiert, HLS-Container)",
     "stats_stream_type_transcode": "Transcodierung (Video neu codiert)",
     "stats_transcoding": "Transkodierung ({{hw}})",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -91,7 +91,7 @@
     "auto": "Auto",
     "auto_resolution": "Auto ({{res}})",
     "stats_direct_playback": "Direct Play",
-    "stats_stream_type_direct": "Direct Play (file served as-is)",
+    "stats_stream_type_direct": "Direct Play",
     "stats_stream_type_remux": "Remux (streams copied, HLS container)",
     "stats_stream_type_transcode": "Transcode (video re-encoded)",
     "stats_transcoding": "Transcoding ({{hw}})",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -86,7 +86,7 @@
     "auto": "Auto",
     "auto_resolution": "Auto ({{res}})",
     "stats_direct_playback": "Reproducción directa",
-    "stats_stream_type_direct": "Reproducción directa (archivo sin cambios)",
+    "stats_stream_type_direct": "Reproducción directa",
     "stats_stream_type_remux": "Remux (flujos copiados, contenedor HLS)",
     "stats_stream_type_transcode": "Transcodificación (vídeo recodificado)",
     "stats_transcoding": "Transcodificación ({{hw}})",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -91,7 +91,7 @@
     "auto": "Auto",
     "auto_resolution": "Auto ({{res}})",
     "stats_direct_playback": "Lecture directe",
-    "stats_stream_type_direct": "Lecture directe (fichier servi tel quel)",
+    "stats_stream_type_direct": "Lecture directe",
     "stats_stream_type_remux": "Remux (flux copiés, conteneur HLS)",
     "stats_stream_type_transcode": "Transcodage (flux vidéo réencodé)",
     "stats_transcoding": "Transcodage ({{hw}})",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -86,7 +86,7 @@
     "auto": "Auto",
     "auto_resolution": "Auto ({{res}})",
     "stats_direct_playback": "Direct Play",
-    "stats_stream_type_direct": "Direct Play (file servito così com'è)",
+    "stats_stream_type_direct": "Direct Play",
     "stats_stream_type_remux": "Remux (flussi copiati, contenitore HLS)",
     "stats_stream_type_transcode": "Transcodifica (video ricodificato)",
     "stats_transcoding": "Transcodifica ({{hw}})",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -86,7 +86,7 @@
     "auto": "Auto",
     "auto_resolution": "Auto ({{res}})",
     "stats_direct_playback": "Reprodução direta",
-    "stats_stream_type_direct": "Reprodução direta (ficheiro tal como está)",
+    "stats_stream_type_direct": "Reprodução direta",
     "stats_stream_type_remux": "Remux (fluxos copiados, contentor HLS)",
     "stats_stream_type_transcode": "Transcodificação (vídeo recodificado)",
     "stats_transcoding": "Transcodificação ({{hw}})",


### PR DESCRIPTION
"Lecture directe" says it. The parenthetical added in #1175 restated it, in all six locales.

The remux and transcode labels keep theirs, which do carry a distinction worth stating: streams copied into a new container versus a video that was re-encoded.

```
Lecture directe
Remux (flux copiés, conteneur HLS)
Transcodage (flux vidéo réencodé)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)