### PR TITLE
feat(navigation): cache the detail page and revalidate cached pages in one hook

### DIFF
--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -209,7 +209,7 @@ export const routes: Routes = [
           import('./features/media-detail/media-detail').then(
             (m) => m.MediaDetailComponent,
           ),
-        data: { kind: 'movie' },
+        data: { kind: 'movie', reuse: true },
       },
       {
         path: 'series/:id',
@@ -217,7 +217,7 @@ export const routes: Routes = [
           import('./features/media-detail/media-detail').then(
             (m) => m.MediaDetailComponent,
           ),
-        data: { kind: 'series' },
+        data: { kind: 'series', reuse: true },
       },
       {
         path: 'series/:id/episode/:episodeId',
@@ -225,7 +225,7 @@ export const routes: Routes = [
           import('./features/media-detail/media-detail').then(
             (m) => m.MediaDetailComponent,
           ),
-        data: { kind: 'series' },
+        data: { kind: 'series', reuse: true },
       },
       {
         path: 'requests',

--- a/client/src/app/core/services/keep-route-fresh.spec.ts
+++ b/client/src/app/core/services/keep-route-fresh.spec.ts
@@ -1,0 +1,114 @@
+import { provideZonelessChangeDetection, runInInjectionContext, Injector } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { Subject } from 'rxjs';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { keepRouteFresh } from './keep-route-fresh';
+import { AppResumeService } from './app-resume.service';
+import { CachingReuseStrategy } from './route-reuse.strategy';
+import { ScrollMemoryService } from './scroll-memory.service';
+
+const OWN_KEY = 'route-7::id=1';
+
+describe('keepRouteFresh', () => {
+  let attached$: Subject<string>;
+  let detached$: Subject<string>;
+  let resume$: Subject<void>;
+  let calls: string[];
+  let scrollMemory: { activate: ReturnType<typeof vi.fn>; restoreSticky: ReturnType<typeof vi.fn>; deactivateIf: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    attached$ = new Subject<string>();
+    detached$ = new Subject<string>();
+    resume$ = new Subject<void>();
+    calls = [];
+    scrollMemory = {
+      activate: vi.fn((k: string) => calls.push(`activate:${k}`)),
+      restoreSticky: vi.fn((k: string) => calls.push(`restore:${k}`)),
+      deactivateIf: vi.fn((k: string) => calls.push(`deactivateIf:${k}`)),
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: CachingReuseStrategy, useValue: { attached$, detached$, keyFor: () => OWN_KEY } },
+        { provide: ScrollMemoryService, useValue: scrollMemory },
+        { provide: AppResumeService, useValue: { resume$ } },
+        { provide: ActivatedRoute, useValue: { snapshot: {} } },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  const bind = (opts: Parameters<typeof keepRouteFresh>[0]) =>
+    runInInjectionContext(TestBed.inject(Injector), () => keepRouteFresh(opts));
+
+  it('revalidates on return, between claiming and restoring the scroll key', () => {
+    bind({ refresh: () => calls.push('refresh'), scrollKey: 'home' });
+
+    attached$.next(OWN_KEY);
+
+    // The order matters: the key has to be ours before the refresh can shift
+    // content, and the restore has to come after it.
+    expect(calls).toEqual(['activate:home', 'refresh', 'restore:home']);
+  });
+
+  it('ignores another route reattaching', () => {
+    bind({ refresh: () => calls.push('refresh'), scrollKey: 'home' });
+
+    attached$.next('someone-else');
+    detached$.next('someone-else');
+
+    expect(calls).toEqual([]);
+  });
+
+  it('tracks the detached state and releases the key only if it is still ours', () => {
+    const detached = bind({ scrollKey: 'home' });
+    expect(detached()).toBe(false);
+
+    detached$.next(OWN_KEY);
+    expect(detached()).toBe(true);
+    expect(scrollMemory.deactivateIf).toHaveBeenCalledWith('home');
+
+    attached$.next(OWN_KEY);
+    expect(detached()).toBe(false);
+  });
+
+  it('refreshes on app-resume only while the page is on screen', () => {
+    bind({ refresh: () => calls.push('refresh') });
+
+    resume$.next();
+    expect(calls).toEqual(['refresh']);
+
+    detached$.next(OWN_KEY);
+    resume$.next();
+    expect(calls).toEqual(['refresh']);
+  });
+
+  it('prefers refreshOnResume when the page is already painted', () => {
+    bind({
+      refresh: () => calls.push('refresh'),
+      refreshOnResume: () => calls.push('forced'),
+    });
+
+    resume$.next();
+    expect(calls).toEqual(['forced']);
+
+    attached$.next(OWN_KEY);
+    expect(calls).toEqual(['forced', 'refresh']);
+  });
+
+  it('skips scroll handling while a computed key is still unknown', () => {
+    let key: string | null = null;
+    bind({ refresh: () => calls.push('refresh'), scrollKey: () => key });
+
+    attached$.next(OWN_KEY);
+    expect(calls).toEqual(['refresh']);
+
+    key = 'library-3';
+    attached$.next(OWN_KEY);
+    expect(calls).toEqual(['refresh', 'activate:library-3', 'refresh', 'restore:library-3']);
+  });
+});

--- a/client/src/app/core/services/keep-route-fresh.ts
+++ b/client/src/app/core/services/keep-route-fresh.ts
@@ -1,0 +1,84 @@
+import { DestroyRef, inject, Signal, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
+import { AppResumeService } from './app-resume.service';
+import { CachingReuseStrategy } from './route-reuse.strategy';
+import { ScrollMemoryService } from './scroll-memory.service';
+
+export interface KeepRouteFreshOptions {
+  /**
+   * Bring the page up to date. The cached DOM is what the user sees the instant
+   * they return, so this runs behind it: no spinner, no flash, and the screen is
+   * never left on whatever the data looked like when they navigated away. Also
+   * fires when the native app comes back to the foreground on this page.
+   */
+  refresh?: () => void;
+  /** Overrides {@link refresh} for the app-resume case, where the page is
+   *  already on screen and a cache-first pass would repaint nothing. */
+  refreshOnResume?: () => void;
+  /** Scroll-memory key held while this route is on screen. Pass a function when
+   *  the key depends on data that loads later (a library id, say); returning
+   *  null skips the scroll handling for that pass. */
+  scrollKey?: string | (() => string | null);
+  onAttach?: () => void;
+  onDetach?: () => void;
+}
+
+/**
+ * Wire a `data: { reuse: true }` route to the cache that keeps it alive.
+ *
+ * Such a route is detached instead of destroyed, so `ngOnInit` does not run
+ * again on return and `ngOnDestroy` does not run on the way out. Every cached
+ * page therefore needs the same four things, which is what this does:
+ *
+ *  - revalidate on return, so the cache preloads the screen and a request still
+ *    goes out to confirm it,
+ *  - hold the scroll-memory key while attached, and release it on detach only
+ *    if it is still ours (the next page claims its own in `ngOnInit`),
+ *  - refresh on native app-resume, but only when this page is the visible one,
+ *  - track whether the instance is parked in the cache.
+ *
+ * Call it from an injection context (a field initializer or the constructor).
+ * Returns that detached state for anything else the page gates on it.
+ */
+export function keepRouteFresh(
+  opts: KeepRouteFreshOptions,
+): Signal<boolean> {
+  const reuse = inject(CachingReuseStrategy);
+  const route = inject(ActivatedRoute);
+  const scrollMemory = inject(ScrollMemoryService);
+  const appResume = inject(AppResumeService);
+  const destroyRef = inject(DestroyRef);
+
+  const detached = signal(false);
+  const ownKey = reuse.keyFor(route.snapshot);
+  const scrollKey = (): string | null =>
+    typeof opts.scrollKey === 'function'
+      ? opts.scrollKey()
+      : (opts.scrollKey ?? null);
+
+  reuse.attached$.pipe(takeUntilDestroyed(destroyRef)).subscribe((key) => {
+    if (key !== ownKey) return;
+    detached.set(false);
+    const sk = scrollKey();
+    if (sk) scrollMemory.activate(sk);
+    opts.onAttach?.();
+    opts.refresh?.();
+    if (sk) scrollMemory.restoreSticky(sk);
+  });
+
+  reuse.detached$.pipe(takeUntilDestroyed(destroyRef)).subscribe((key) => {
+    if (key !== ownKey) return;
+    detached.set(true);
+    const sk = scrollKey();
+    if (sk) scrollMemory.deactivateIf(sk);
+    opts.onDetach?.();
+  });
+
+  appResume.resume$.pipe(takeUntilDestroyed(destroyRef)).subscribe(() => {
+    if (detached()) return;
+    (opts.refreshOnResume ?? opts.refresh)?.();
+  });
+
+  return detached.asReadonly();
+}

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy, inject, signal, computed, effect, OnInit, OnDestroy, Injector, viewChild } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { Subscription, filter } from 'rxjs';
-import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
+import { filter } from 'rxjs';
+import { keepRouteFresh } from '../../core/services/keep-route-fresh';
 import { LocaleDatePipe } from '../../core/pipes/locale-date.pipe';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { MediaService, Media, CalendarEntry } from '../../core/services/api/media.service';
@@ -23,7 +23,6 @@ import { PlayableMediaService } from '../../core/services/playable-media.service
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
 import { DefaultFocusDirective } from '../../shared/directives/default-focus.directive';
 import { NavbarService } from '../../core/services/navbar.service';
-import { AppResumeService } from '../../core/services/app-resume.service';
 import { BackgroundService } from '../../core/services/background.service';
 import { DisplaySettingsService } from '../../core/services/display-settings.service';
 import { HomeSettingsService, HomeSectionType, ResolvedHomeSection } from '../../core/services/home-settings.service';
@@ -115,7 +114,6 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly scrollMemory = inject(ScrollMemoryService);
   private readonly navbar = inject(NavbarService);
   private readonly translate = inject(TranslateService);
-  private readonly appResume = inject(AppResumeService);
   private readonly backgroundService = inject(BackgroundService);
   private readonly displaySettings = inject(DisplaySettingsService);
   private readonly home = inject(HomeSettingsService);
@@ -123,16 +121,21 @@ export class HomeComponent implements OnInit, OnDestroy {
   readonly auth = inject(AuthService);
   private readonly injector = inject(Injector);
   private readonly route = inject(ActivatedRoute);
-  private readonly reuseStrategy = inject(CachingReuseStrategy);
   protected readonly itemArtwork = itemArtwork;
 
   private static readonly SCROLL_KEY = 'home';
-  private attachedSub?: Subscription;
-  private detachedSub?: Subscription;
-  private resumeSub?: Subscription;
-  /** True while this cached instance is detached (some other route is shown).
-   *  Gates the app-resume refresh so only the visible home refetches. */
-  private detached = false;
+  /** Cached route: the stale signals stay on screen while a cache-first pass
+   *  repaints and a forced pass brings in what changed elsewhere. */
+  private readonly routeFresh = keepRouteFresh({
+    refresh: () => {
+      void this.loadAllSections();
+      queueMicrotask(() => void this.loadAllSections({ force: true }));
+    },
+    // On resume the sections are already rendered, so a cache-first pass would
+    // repaint nothing.
+    refreshOnResume: () => void this.loadAllSections({ force: true }),
+    scrollKey: HomeComponent.SCROLL_KEY,
+  });
   private readonly declineModal = viewChild(RequestDeclineModalComponent);
   private readonly detailModal = viewChild(DownloadDetailModalComponent);
 
@@ -411,50 +414,11 @@ export class HomeComponent implements OnInit, OnDestroy {
     // overwrites in place; no spinner, no flash.
     queueMicrotask(() => void this.loadAllSections({ force: true }));
     this.scrollMemory.restore(HomeComponent.SCROLL_KEY, this.injector);
-    // The route is detached/cached on navigate-away (see CachingReuseStrategy
-    // + `data: { reuse: true }` on the home route). On return, ngOnInit does
-    // NOT fire again — refresh data + scroll + focus through this hook
-    // instead. Stale signals stay visible during the background refetch (HTTP
-    // cache makes that near-instant when warm), so the user never sees a
-    // spinner on a back navigation.
-    const ownKey = this.reuseStrategy.keyFor(this.route.snapshot);
-    this.attachedSub = this.reuseStrategy.attached$.subscribe((key) => {
-      if (key !== ownKey) return;
-      this.detached = false;
-      this.scrollMemory.activate(HomeComponent.SCROLL_KEY);
-      // The cached signals stay visible; refresh cache-first for an instant
-      // repaint, then force a network round-trip so a return to home reflects
-      // additions / watched flips made elsewhere — same SWR contract as the
-      // initial ngOnInit load (a plain reuse-attach would otherwise sit on
-      // stale data until the cache TTL expired).
-      void this.loadAllSections();
-      queueMicrotask(() => void this.loadAllSections({ force: true }));
-      this.scrollMemory.restoreSticky(HomeComponent.SCROLL_KEY);
-    });
-    // ngOnDestroy doesn't fire when detaching, so the active scroll key would
-    // stay pointing at us — and a NavigationStart on the next page would then
-    // overwrite our saved scroll position. Deactivate iff still ours: if the
-    // next route already claimed scrollMemory in its own ngOnInit, we leave
-    // its key alone.
-    this.detachedSub = this.reuseStrategy.detached$.subscribe((key) => {
-      if (key !== ownKey) return;
-      this.detached = true;
-      this.scrollMemory.deactivateIf(HomeComponent.SCROLL_KEY);
-    });
-    // Native app-resume: refresh home when it is the page on screen. Forced only
-    // — its signals are still rendered, so a cache-first pass would repaint nothing.
-    this.resumeSub = this.appResume.resume$.subscribe(() => {
-      if (this.detached) return;
-      void this.loadAllSections({ force: true });
-    });
   }
 
   ngOnDestroy() {
     this.scrollMemory.deactivate();
     this.playbackStopped.unsubscribe();
-    this.attachedSub?.unsubscribe();
-    this.detachedSub?.unsubscribe();
-    this.resumeSub?.unsubscribe();
     this.backgroundService.clear();
   }
 

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -37,8 +37,7 @@ import { DefaultFocusDirective } from '../../shared/directives/default-focus.dir
 import { TvRowDirective } from '../../shared/directives/tv-row.directive';
 import { NavbarService } from '../../core/services/navbar.service';
 import { TvService } from '../../core/services/tv.service';
-import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
-import { AppResumeService } from '../../core/services/app-resume.service';
+import { keepRouteFresh } from '../../core/services/keep-route-fresh';
 import { InfiniteScrollList } from '../../shared/utils/infinite-scroll-list';
 import { LucideSearch, LucideSlidersHorizontal, LucideArrowUp, LucideArrowDown, LucideX, LucideFilm } from '@lucide/angular';
 import { MosaicCardComponent } from '../../shared/components/mosaic-card/mosaic-card';
@@ -117,17 +116,22 @@ export class LibraryComponent implements OnInit, OnDestroy {
   private readonly tv = inject(TvService);
   private readonly injector = inject(Injector);
   private readonly translate = inject(TranslateService);
-  private readonly reuseStrategy = inject(CachingReuseStrategy);
-  private readonly appResume = inject(AppResumeService);
   protected readonly itemArtwork = itemArtwork;
   private paramSub?: Subscription;
-  private attachedSub?: Subscription;
-  private detachedSub?: Subscription;
+  /** Cached per library name: revalidate the grid on return, and re-claim the
+   *  scroll key, which is only known once the library itself has loaded. */
+  private readonly routeFresh = keepRouteFresh({
+    refresh: () => this.refreshCurrentView(),
+    scrollKey: () => {
+      const lib = this.library();
+      return lib ? `library-${lib.id}` : null;
+    },
+    onAttach: () => {
+      const lib = this.library();
+      if (lib) this.navbar.setPageTitle(lib.name);
+    },
+  });
   private queryParamSub?: Subscription;
-  private resumeSub?: Subscription;
-  /** True while this cached instance is detached (some other route is shown).
-   *  Gates the app-resume refresh so only the visible library refetches. */
-  private detached = false;
   /** Set while a state-driven `syncQueryParams` is being applied to the
    *  URL, so the `queryParamMap` subscription that fires right after
    *  can ignore the round-trip instead of re-applying our own write. */
@@ -399,44 +403,6 @@ export class LibraryComponent implements OnInit, OnDestroy {
       this.scrollMemory.restore(scrollKey, this.injector);
     });
 
-    // Each /libraries/:libraryName has its own cache slot (CachingReuseStrategy
-    // keys per param). On return, ngOnInit doesn't re-fire — refresh data,
-    // re-claim scroll/focus, and rebind the navbar title via attached$.
-    const ownKey = this.reuseStrategy.keyFor(this.route.snapshot);
-    this.attachedSub = this.reuseStrategy.attached$.subscribe((key) => {
-      if (key !== ownKey) return;
-      this.detached = false;
-      const lib = this.library();
-      if (!lib) return;
-      const scrollKey = `library-${lib.id}`;
-      this.scrollMemory.activate(scrollKey);
-      this.navbar.setPageTitle(lib.name);
-      void this.load(lib.id, true);
-      // Re-fire suggestions / genres when we're on that tab so the SWR
-      // cache has a chance to bring in fresh data on a back-navigation.
-      if (this.viewMode() === 'suggestions') {
-        void this.loadSuggestions();
-      } else if (this.viewMode() === 'genres') {
-        void this.loadGenres();
-      } else if (this.viewMode() === 'likes') {
-        void this.loadLikes();
-      }
-      this.scrollMemory.restoreSticky(scrollKey);
-    });
-    this.detachedSub = this.reuseStrategy.detached$.subscribe((key) => {
-      if (key !== ownKey) return;
-      this.detached = true;
-      const lib = this.library();
-      if (lib) this.scrollMemory.deactivateIf(`library-${lib.id}`);
-    });
-    // Native app-resume: refresh the grid when the app returns to the
-    // foreground after a spell away and this library is the visible page.
-    this.resumeSub = this.appResume.resume$.subscribe(() => {
-      if (this.detached) return;
-      const lib = this.library();
-      if (lib) void this.load(lib.id, true);
-    });
-
     // Re-apply state on browser back/forward (same route, queryParams
     // change). Initial load + state-driven `syncQueryParams` writes are
     // skipped via the `skipQueryParamSync` flag so we don't recurse.
@@ -467,6 +433,17 @@ export class LibraryComponent implements OnInit, OnDestroy {
     });
   }
 
+  /** Bring the visible library up to date: the grid always, plus whichever tab
+   *  is on screen so its SWR cache gets a chance to bring in fresh data. */
+  private refreshCurrentView(): void {
+    const lib = this.library();
+    if (!lib) return;
+    void this.load(lib.id, true);
+    if (this.viewMode() === 'suggestions') void this.loadSuggestions();
+    else if (this.viewMode() === 'genres') void this.loadGenres();
+    else if (this.viewMode() === 'likes') void this.loadLikes();
+  }
+
   ngOnDestroy() {
     this.scrollMemory.deactivate();
     this.list.destroy();
@@ -475,10 +452,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
     if (this.letterRaf !== null) cancelAnimationFrame(this.letterRaf);
     this.navbar.clearPageTitle();
     this.paramSub?.unsubscribe();
-    this.attachedSub?.unsubscribe();
-    this.detachedSub?.unsubscribe();
+
     this.queryParamSub?.unsubscribe();
-    this.resumeSub?.unsubscribe();
   }
 
   scrollToLetter(letter: string) {

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -93,6 +93,7 @@ import { SeasonLabelPipe } from '../../core/pipes/season-label.pipe';
 import { TvSectionDirective } from '../../shared/directives/tv-section.directive';
 import { ImgFadeInDirective } from '../../shared/directives/img-fade-in.directive';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
+import { keepRouteFresh } from '../../core/services/keep-route-fresh';
 import { CachedSrcDirective } from '../../shared/directives/cached-src.directive';
 import { ModalHeaderComponent } from '../../shared/components/modal-header';
 import { ModalFooterComponent } from '../../shared/components/modal-footer';
@@ -265,6 +266,13 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   private readonly routeParams = toSignal(this.route.paramMap);
 
   private loadedId: number | null = null;
+
+  /** Cached route: coming back from the player repaints the page as it was, so
+   *  only what playback changed has to be re-read, plus a forced media refetch. */
+  private readonly routeFresh = keepRouteFresh({
+    refresh: () => this.refreshOnReturn(),
+    scrollKey: () => this.scrollKey(),
+  });
 
   /**
    * Angular reuses this component between two `movies/:id` URLs — the similar
@@ -1014,66 +1022,89 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       if (this.canRequestDeletion()) {
         void this.loadDeleteRequestState(m.tmdbId, m.type);
       }
-      // Resume/watched/progress hit uncacheable /api/playback/media/* — load
-      // them off the render path so a slow server never holds the spinner.
-      void (async () => {
-        const [resumeInfo, watchedIds, progress] = await Promise.all([
-          this.streamingApi.getMediaResumeInfo(m.id).catch(() => null),
-          m.type === 'series'
-            ? this.streamingApi.getWatchedEpisodeIds(m.id).catch(() => [] as number[])
-            : Promise.resolve([] as number[]),
-          m.type === 'series'
-            ? this.streamingApi.getEpisodeProgress(m.id).catch(() => ({}) as Record<number, number>)
-            : Promise.resolve({} as Record<number, number>),
-        ]);
-        this.resumeInfo.set(resumeInfo);
-        const watchedSet = new Set(watchedIds);
-        this.watchedEpisodeIds.set(watchedSet);
-        this.episodeProgress.set(progress);
-
-        // Pre-select the last-played file if available
-        if (resumeInfo?.mediaFileId) {
-          const files = m.files ?? [];
-          if (files.some((f) => f.id === resumeInfo.mediaFileId)) {
-            this.selectedFileId.set(resumeInfo.mediaFileId);
-          }
-        }
-
-        // Series: preselect the season the user is currently watching.
-        //   1. Latest in-progress episode (resumeInfo).
-        //   2. Season of the first unwatched-with-file episode — handles the
-        //      between-episodes case (last ep completed, next not started yet)
-        //      where resumeInfo is null.
-        let resumeHandled = false;
-        if (m.type === 'series' && m.seasons?.length) {
-          let targetSeasonId: number | null = null;
-          if (resumeInfo?.episodeId) {
-            targetSeasonId =
-              m.seasons.find((s) => s.episodes?.some((e) => e.id === resumeInfo.episodeId))?.id ??
-              null;
-          }
-          if (targetSeasonId == null) {
-            targetSeasonId =
-              m.seasons.find((s) => s.episodes?.some((e) => e.hasFile && !watchedSet.has(e.id)))
-                ?.id ?? null;
-          }
-          if (targetSeasonId != null) {
-            this.activeSeasonId.set(targetSeasonId);
-            this.persistActiveSeason(targetSeasonId);
-            resumeHandled = true;
-          }
-        }
-
-        if (m.type === 'series' && m.seasons?.length) {
-          if (!resumeHandled) this.syncActiveSeasonForSeriesFilter();
-        } else {
-          this.activeSeasonId.set(null);
-        }
-      })();
+      void this.loadPlaybackState(m);
     } catch {
       this.notFound.set(true);
     } finally {
       this.loading.set(false);
+    }
+  }
+
+  /**
+   * Re-read what a playback session can have changed under this page, without
+   * touching the cast/crew/similar rails the cached DOM still holds.
+   */
+  private refreshOnReturn(): void {
+    const m = this.media();
+    if (!m) return;
+    void this.loadPlaybackState(m);
+    void this.mediaService
+      .getOne(m.id, { force: true })
+      .then((fresh) => {
+        if (fresh.id === m.id) this.media.set(fresh);
+      })
+      .catch(() => {
+        /* network failure — the cached page keeps showing */
+      });
+  }
+
+  /**
+   * Resume position, watched episodes and per-episode progress. These hit the
+   * uncacheable /api/playback/media/* routes, so they stay off the render path
+   * and are re-run on their own whenever the page comes back on screen.
+   */
+  private async loadPlaybackState(m: Media): Promise<void> {
+    const [resumeInfo, watchedIds, progress] = await Promise.all([
+      this.streamingApi.getMediaResumeInfo(m.id).catch(() => null),
+      m.type === 'series'
+        ? this.streamingApi.getWatchedEpisodeIds(m.id).catch(() => [] as number[])
+        : Promise.resolve([] as number[]),
+      m.type === 'series'
+        ? this.streamingApi.getEpisodeProgress(m.id).catch(() => ({}) as Record<number, number>)
+        : Promise.resolve({} as Record<number, number>),
+    ]);
+    this.resumeInfo.set(resumeInfo);
+    const watchedSet = new Set(watchedIds);
+    this.watchedEpisodeIds.set(watchedSet);
+    this.episodeProgress.set(progress);
+
+    // Pre-select the last-played file if available
+    if (resumeInfo?.mediaFileId) {
+      const files = m.files ?? [];
+      if (files.some((f) => f.id === resumeInfo.mediaFileId)) {
+        this.selectedFileId.set(resumeInfo.mediaFileId);
+      }
+    }
+
+    // Series: preselect the season the user is currently watching.
+    //   1. Latest in-progress episode (resumeInfo).
+    //   2. Season of the first unwatched-with-file episode — handles the
+    //      between-episodes case (last ep completed, next not started yet)
+    //      where resumeInfo is null.
+    let resumeHandled = false;
+    if (m.type === 'series' && m.seasons?.length) {
+      let targetSeasonId: number | null = null;
+      if (resumeInfo?.episodeId) {
+        targetSeasonId =
+          m.seasons.find((s) => s.episodes?.some((e) => e.id === resumeInfo.episodeId))?.id ??
+          null;
+      }
+      if (targetSeasonId == null) {
+        targetSeasonId =
+          m.seasons.find((s) => s.episodes?.some((e) => e.hasFile && !watchedSet.has(e.id)))
+            ?.id ?? null;
+      }
+      if (targetSeasonId != null) {
+        this.activeSeasonId.set(targetSeasonId);
+        this.persistActiveSeason(targetSeasonId);
+        resumeHandled = true;
+      }
+    }
+
+    if (m.type === 'series' && m.seasons?.length) {
+      if (!resumeHandled) this.syncActiveSeasonForSeriesFilter();
+    } else {
+      this.activeSeasonId.set(null);
     }
   }
 

--- a/client/src/app/features/persons/persons.ts
+++ b/client/src/app/features/persons/persons.ts
@@ -11,12 +11,11 @@ import {
 } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TvSelectDirective } from '../../shared/directives/tv-select.directive';
-import { Subscription } from 'rxjs';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { PersonsApiService, Person } from '../../core/services/api/persons-api.service';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
-import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
+import { keepRouteFresh } from '../../core/services/keep-route-fresh';
 import { InfiniteScrollList } from '../../shared/utils/infinite-scroll-list';
 import { LucideSearch, LucideUsers } from '@lucide/angular';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
@@ -36,11 +35,15 @@ export class PersonsComponent implements OnInit, OnDestroy {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly scrollMemory = inject(ScrollMemoryService);
-  private readonly reuseStrategy = inject(CachingReuseStrategy);
+
   private readonly injector = inject(Injector);
   private readonly scrollKey = 'persons';
-  private attachedSub?: Subscription;
-  private detachedSub?: Subscription;
+  /** Cached route: revalidate on return, keeping the listed people on screen
+   *  while the request goes out. */
+  private readonly routeFresh = keepRouteFresh({
+    refresh: () => void this.load(true),
+    scrollKey: this.scrollKey,
+  });
 
   readonly list = new InfiniteScrollList<Person>();
   readonly loading = signal(false);
@@ -68,26 +71,11 @@ export class PersonsComponent implements OnInit, OnDestroy {
       this.scrollMemory.restore(this.scrollKey, this.injector),
     );
 
-    // Route is cached on navigate-away (data: { reuse: true }). On return,
-    // ngOnInit doesn't fire — refresh via attached$ instead, keeping stale
-    // results visible during the silent revalidation.
-    const ownKey = this.reuseStrategy.keyFor(this.route.snapshot);
-    this.attachedSub = this.reuseStrategy.attached$.subscribe((key) => {
-      if (key !== ownKey) return;
-      this.scrollMemory.activate(this.scrollKey);
-      void this.load(true);
-      this.scrollMemory.restoreSticky(this.scrollKey);
-    });
-    this.detachedSub = this.reuseStrategy.detached$.subscribe((key) => {
-      if (key === ownKey) this.scrollMemory.deactivateIf(this.scrollKey);
-    });
   }
 
   ngOnDestroy() {
     this.scrollMemory.deactivate();
     this.list.destroy();
-    this.attachedSub?.unsubscribe();
-    this.detachedSub?.unsubscribe();
   }
 
   scrollToLetter(letter: string) {

--- a/client/src/app/features/playlists/playlists.ts
+++ b/client/src/app/features/playlists/playlists.ts
@@ -1,15 +1,13 @@
 import {
   Component,
   ChangeDetectionStrategy,
-  DestroyRef,
   ElementRef,
   OnInit,
   inject,
   signal,
   viewChild,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { LucidePlus } from '@lucide/angular';
@@ -17,7 +15,7 @@ import { MosaicCardComponent } from '../../shared/components/mosaic-card/mosaic-
 import { ModalHeaderComponent } from '../../shared/components/modal-header';
 import { Playlist, PlaylistsApiService } from '../../core/services/api/playlists-api.service';
 import { ToastService } from '../../core/services/toast.service';
-import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
+import { keepRouteFresh } from '../../core/services/keep-route-fresh';
 import { ModalFooterComponent } from '../../shared/components/modal-footer';
 
 @Component({
@@ -36,11 +34,8 @@ import { ModalFooterComponent } from '../../shared/components/modal-footer';
 export class PlaylistsComponent implements OnInit {
   private readonly api = inject(PlaylistsApiService);
   private readonly router = inject(Router);
-  private readonly route = inject(ActivatedRoute);
   private readonly toast = inject(ToastService);
   private readonly translate = inject(TranslateService);
-  private readonly reuseStrategy = inject(CachingReuseStrategy);
-  private readonly destroyRef = inject(DestroyRef);
 
   private readonly createDialog = viewChild<ElementRef<HTMLDialogElement>>('createDialog');
 
@@ -49,15 +44,14 @@ export class PlaylistsComponent implements OnInit {
   readonly creating = signal(false);
   readonly newName = signal('');
 
+  /** Cached route: revalidate on return so a playlist created or deleted
+   *  elsewhere shows up behind the DOM the cache paints instantly. */
+  private readonly routeFresh = keepRouteFresh({
+    refresh: () => void this.load(true),
+  });
+
   ngOnInit() {
     void this.load();
-    // This route is `reuse: true`, so ngOnInit does NOT re-run when the user
-    // navigates back to a cached instance — refresh on reattach so a playlist
-    // created/deleted elsewhere shows up (mirrors home/search/history).
-    const ownKey = this.reuseStrategy.keyFor(this.route.snapshot);
-    this.reuseStrategy.attached$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((key) => {
-      if (key === ownKey) void this.load(true);
-    });
   }
 
   private async load(force = false): Promise<void> {

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -15,7 +15,6 @@ import {
 import { FormsModule } from '@angular/forms';
 import { TvSelectDirective } from '../../shared/directives/tv-select.directive';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Subscription } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { MediaService, Media, SearchParams } from '../../core/services/api/media.service';
 import { StreamingApiService, RecommendationItem } from '../../core/services/api/streaming-api.service';
@@ -31,7 +30,7 @@ import { SocialApiService } from '../../core/services/api/social-api.service';
 import { TvService } from '../../core/services/tv.service';
 import { DeviceService } from '../../core/services/device.service';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
-import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
+import { keepRouteFresh } from '../../core/services/keep-route-fresh';
 import { MediaType } from '../../core/enums/media-type.enum';
 import { MediaCardComponent, CardBadge } from '../../shared/components/media-card/media-card';
 import { HorizontalScrollerComponent } from '../../shared/components/horizontal-scroller';
@@ -53,13 +52,11 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly mediaService = inject(MediaService);
   private readonly metadata = inject(MetadataService);
   private readonly router = inject(Router);
-  private readonly route = inject(ActivatedRoute);
   private readonly auth = inject(AuthService);
   /** Opted out of the social layer → the people tab is hidden. */
   protected readonly sharingDisabled = this.auth.sharingDisabled;
   private readonly requestsApi = inject(RequestsService);
   private readonly scrollMemory = inject(ScrollMemoryService);
-  private readonly reuseStrategy = inject(CachingReuseStrategy);
   private readonly injector = inject(Injector);
   private readonly streamingApi = inject(StreamingApiService);
   private readonly social = inject(SocialApiService);
@@ -179,25 +176,15 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
   private filterDebounce: ReturnType<typeof setTimeout> | null = null;
   /** Movie/series bucket the discover genre list was last loaded for. */
   private lastGenreType = '';
-  private attachedSub?: Subscription;
-  private detachedSub?: Subscription;
+  /** Cached route, with nothing to refetch: results live in SearchStateService,
+   *  so only the scroll key has to change hands. */
+  private readonly routeFresh = keepRouteFresh({
+    scrollKey: SearchComponent.SCROLL_KEY,
+  });
 
   ngOnInit() {
     this.scrollMemory.activate(SearchComponent.SCROLL_KEY);
     this.scrollMemory.restore(SearchComponent.SCROLL_KEY, this.injector);
-
-    // Route is cached on navigate-away (data: { reuse: true }). Search results
-    // already live in SearchStateService so there's nothing to refetch — we
-    // only need to re-claim the scroll key and put scroll back where it was.
-    const ownKey = this.reuseStrategy.keyFor(this.route.snapshot);
-    this.attachedSub = this.reuseStrategy.attached$.subscribe((key) => {
-      if (key !== ownKey) return;
-      this.scrollMemory.activate(SearchComponent.SCROLL_KEY);
-      this.scrollMemory.restoreSticky(SearchComponent.SCROLL_KEY);
-    });
-    this.detachedSub = this.reuseStrategy.detached$.subscribe((key) => {
-      if (key === ownKey) this.scrollMemory.deactivateIf(SearchComponent.SCROLL_KEY);
-    });
   }
 
   ngAfterViewInit() {
@@ -213,8 +200,6 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.searchTimer) clearTimeout(this.searchTimer);
     if (this.filterDebounce) clearTimeout(this.filterDebounce);
     this.scrollMemory.deactivate();
-    this.attachedSub?.unsubscribe();
-    this.detachedSub?.unsubscribe();
     this.removeOutsidePointerListener();
   }
 

--- a/client/src/app/features/watch-history/watch-history.ts
+++ b/client/src/app/features/watch-history/watch-history.ts
@@ -1,14 +1,12 @@
 import { Component, ChangeDetectionStrategy, inject, signal, computed, Injector, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Subscription } from 'rxjs';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { LucideHistory, LucideTrash2, LucidePlay, LucideFilm, LucideTv, LucideCheck, LucideEllipsisVertical } from '@lucide/angular';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 import { PlaybackState, StreamingApiService, WatchHistoryItem } from '../../core/services/api/streaming-api.service';
 import { ConfirmationService } from '../../core/services/confirmation.service';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
-import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
-import { AppResumeService } from '../../core/services/app-resume.service';
+import { keepRouteFresh } from '../../core/services/keep-route-fresh';
 import { PaginationComponent } from '../../shared/components/pagination/pagination';
 import { DropdownMenuComponent } from '../../shared/components/dropdown-menu';
 import { CachedSrcDirective } from '../../shared/directives/cached-src.directive';
@@ -26,17 +24,15 @@ export class WatchHistoryComponent implements OnInit, OnDestroy {
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
   private readonly scrollMemory = inject(ScrollMemoryService);
-  private readonly reuseStrategy = inject(CachingReuseStrategy);
-  private readonly appResume = inject(AppResumeService);
   private readonly injector = inject(Injector);
   private readonly translate = inject(TranslateService);
   private static readonly SCROLL_KEY = 'history';
-  private attachedSub?: Subscription;
-  private detachedSub?: Subscription;
-  private resumeSub?: Subscription;
-  /** True while this cached instance is detached (some other route is shown).
-   *  Gates the app-resume refresh so only the visible history refetches. */
-  private detached = false;
+  /** Cached route: revalidate on return and on app-resume so items watched or
+   *  deleted elsewhere land, without the spinner coming back. */
+  private readonly routeFresh = keepRouteFresh({
+    refresh: () => void this.load(true),
+    scrollKey: WatchHistoryComponent.SCROLL_KEY,
+  });
 
   readonly loading = signal(true);
   readonly items = signal<WatchHistoryItem[]>([]);
@@ -51,35 +47,10 @@ export class WatchHistoryComponent implements OnInit, OnDestroy {
     await this.load();
     this.scrollMemory.restore(WatchHistoryComponent.SCROLL_KEY, this.injector);
 
-    // Route is cached on navigate-away (data: { reuse: true }). On return,
-    // ngOnInit doesn't fire — silently revalidate the current page so any
-    // changes elsewhere (newly watched items, deletions) reflect on the way
-    // back, without showing the spinner.
-    const ownKey = this.reuseStrategy.keyFor(this.route.snapshot);
-    this.attachedSub = this.reuseStrategy.attached$.subscribe((key) => {
-      if (key !== ownKey) return;
-      this.detached = false;
-      this.scrollMemory.activate(WatchHistoryComponent.SCROLL_KEY);
-      void this.load(true);
-      this.scrollMemory.restoreSticky(WatchHistoryComponent.SCROLL_KEY);
-    });
-    this.detachedSub = this.reuseStrategy.detached$.subscribe((key) => {
-      if (key !== ownKey) return;
-      this.detached = true;
-      this.scrollMemory.deactivateIf(WatchHistoryComponent.SCROLL_KEY);
-    });
-    // Native app-resume: silently revalidate the current page when the app
-    // returns to the foreground after a spell away and history is on screen.
-    this.resumeSub = this.appResume.resume$.subscribe(() => {
-      if (!this.detached) void this.load(true);
-    });
   }
 
   ngOnDestroy() {
     this.scrollMemory.deactivate();
-    this.attachedSub?.unsubscribe();
-    this.detachedSub?.unsubscribe();
-    this.resumeSub?.unsubscribe();
   }
 
   async load(silent = false) {


### PR DESCRIPTION
## The detail page was rebuilt every time the player closed

Its routes were not flagged `reuse: true`:

```ts
{ path: 'movies/:id', ... data: { kind: 'movie' } },      // home, search, persons,
{ path: 'series/:id', ... data: { kind: 'series' } },     // playlists and history
                                                          // all carry reuse: true
```

So the component was destroyed on the way into the player and recreated on the way back, refetching and showing its skeleton. This happens on **every** platform. It looks tolerable in a browser only because the closing view transition covers the reload and a desktop refetch is quick. On a TV, view transitions are deliberately off (the 1080p snapshot costs ~400 ms of first paint) and the render is slow, so the skeleton is the whole experience.

The detail routes now join the cached ones. The component was already built for it: the load is driven by the route params with a `loadedId` guard rather than by `ngOnInit`, so a return with unchanged params repaints instantly and refetches nothing.

What a playback session can have changed underneath is re-read on its own, which is why the resume / watched / progress block moves out of `loadMedia` into `loadPlaybackState` and is called from both places. The cast, crew and similar rails the cached DOM still holds are left alone rather than cleared and refetched.

## One hook instead of six copies

Every cached page needed the same four things around the cache, and each of the six had written its own:

- revalidate on return, since `ngOnInit` does not run again,
- hold the scroll-memory key while attached, releasing it on detach only if it is still ours,
- refresh on native app-resume, but only when this page is the visible one,
- track whether the instance is parked in the cache, to gate the above.

`keepRouteFresh` owns all four. A page now states its intent in one call:

```ts
private readonly routeFresh = keepRouteFresh({
  refresh: () => void this.load(true),
  scrollKey: WatchHistoryComponent.SCROLL_KEY,
});
```

Net 190 lines lighter across the six, with the subscription bookkeeping and the `detached` flags gone.

The contract is the one the cache implies, and it is worth stating explicitly: **the cached DOM is what the user sees the instant they return, and a request still goes out behind it**, so the screen is never left showing data from when they navigated away.

Two pages keep a specific shape:
- **Home** passes `refreshOnResume`, because on resume its sections are already painted and a cache-first pass would repaint nothing.
- **Library** gains `refreshCurrentView`, which also refreshes the visible tab on app-resume where it previously refreshed only the grid.

## Tests

6 new cases for the hook: refresh lands between claiming and restoring the scroll key, another route's key is ignored, the detached state flips and releases the key, resume refreshes only while on screen, `refreshOnResume` wins when given, and a computed scroll key that is still null skips the scroll handling. Full client suite `708/708`, `tsc` clean.

## Worth watching

`MAX_CACHE_SIZE` is 10 across all cached routes, and detail pages are keyed per id, so visiting ten titles without returning home can evict home. The worst case is simply today's behaviour (recreate and refetch), and evicted handles are destroyed properly, so this is a missed optimisation rather than a regression, but it is the number to revisit if it shows.

Not yet seen on a TV: no test panel was reachable from this network when this was finished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)