### PR TITLE
feat(player): animate the close on the platforms without view transitions

### DIFF
--- a/client/src/app/features/player/player.html
+++ b/client/src/app/features/player/player.html
@@ -3,6 +3,7 @@
   #playerContainer
   appDefaultFocus="[data-default-focus]"
   class="player-container"
+  [class.closing]="closing()"
   [class.hide-cursor]="!controlsVisible()"
   [class.native-player]="!!nativeEngine"
   [class.hidden]="castService.isConnected()"

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -184,12 +184,31 @@ class PausableTimeout {
         transform: translateZ(0) scale(1);
       }
     }
+    /* Closing where view transitions are unavailable (native, TV): the player
+       shrinks over the shell, since the destination page is not painted yet. */
+    .player-container.closing {
+      animation: player-close 200ms cubic-bezier(0.4, 0, 1, 1) both;
+    }
+    @keyframes player-close {
+      to {
+        opacity: 0;
+        transform: translateZ(0) scale(0.8);
+      }
+    }
     @media (prefers-reduced-motion: reduce) {
       .player-container {
         animation-name: player-open-fade;
       }
       @keyframes player-open-fade {
         from {
+          opacity: 0;
+        }
+      }
+      .player-container.closing {
+        animation-name: player-close-fade;
+      }
+      @keyframes player-close-fade {
+        to {
           opacity: 0;
         }
       }
@@ -538,6 +557,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
    *  friendly defaults. Sourced from ServerConfigService so the rule
    *  matches the rest of the app instead of probing Capacitor directly. */
   readonly isNative = this.serverConfig.isNative;
+  /** Player-close animation duration; must match the `player-close` keyframes. */
+  private static readonly closeAnimationMs = 200;
+  /** Set while the closing animation runs, on the platforms that play it here. */
+  readonly closing = signal(false);
 
   // Sync local playback with Cast connection state
   private wasCasting = false;
@@ -3845,15 +3868,31 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // send the user straight back into the player.
     this.navbar.markAsBackNavigation();
     const prev = this.navHistory.previousUrl;
-    if (prev && prev.split('?')[0] === target) {
-      history.back();
-      return;
-    }
-    if (target === '/') {
-      void this.router.navigate(['/'], { replaceUrl: true });
-      return;
-    }
-    void this.router.navigateByUrl(target, { replaceUrl: true });
+    void this.animateClose().then(() => {
+      if (prev && prev.split('?')[0] === target) {
+        history.back();
+        return;
+      }
+      if (target === '/') {
+        void this.router.navigate(['/'], { replaceUrl: true });
+        return;
+      }
+      void this.router.navigateByUrl(target, { replaceUrl: true });
+    });
+  }
+
+  /**
+   * Hold the navigation back for the closing animation, where it has to run on
+   * the player itself. A view transition does it instead on web, animating the
+   * player over the page it returns to, which is the better effect but needs
+   * both painted at once.
+   */
+  private async animateClose(): Promise<void> {
+    if (!this.isNative && !this.device.isTv()) return;
+    this.closing.set(true);
+    await new Promise((resolve) =>
+      setTimeout(resolve, PlayerComponent.closeAnimationMs),
+    );
   }
 
   /** Retry a cold-open failure (playback never started). */


### PR DESCRIPTION
The closing animation from #1173 lives entirely in view-transition pseudo elements:

```css
html.vt-player-close::view-transition-old(root) {
  animation: player-close 200ms cubic-bezier(0.4, 0, 1, 1) both;
}
```

That is deliberate, because the effect it wants is the player shrinking **over the page it returns to**, and the two only coexist inside a transition. But view transitions are off on native and TV (the 1080p snapshot measured ~400 ms of held first paint on a Tizen panel), and Tizen's Chromium has no such API at all. Closing there was a hard cut.

Those platforms now play the mirror of the open animation on the player container itself, and the navigation waits for it. Reduced-motion gets the fade alone, as on open.

## The trade-off, stated plainly

The destination page is not painted at that moment, so the player shrinks over the shell rather than over the page behind it. It is less than the web effect. With #1181 caching the detail page, what appears afterwards is at least instant rather than a skeleton.

**Not yet seen on a TV**: no test panel was reachable from this network when this was written, so this is the one piece here that wants an eye on it before it is trusted. If it reads worse than the hard cut it replaces, the gate is a single condition in `animateClose`.

`tsc` clean, player specs 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)