### PR TITLE
feat(plugins): gate unsigned installs on a setting, not an env var

### DIFF
--- a/backend/scripts/package-plugin.ts
+++ b/backend/scripts/package-plugin.ts
@@ -18,7 +18,7 @@ function main(): void {
   writeFileSync(outPath, archive);
 
   console.log(`wrote ${outPath} (${archive.length} bytes) for ${manifest.id}@${manifest.version}`);
-  console.log('unsigned — installable only where the core process allowlists this id in FLIKS_UNSIGNED_PLUGINS');
+  console.log('unsigned: installable only on a core whose "allow unsigned plugins" plugin setting is on');
 }
 
 try {

--- a/backend/src/common/constants/plugin-flags.ts
+++ b/backend/src/common/constants/plugin-flags.ts
@@ -9,14 +9,3 @@ export const FLIKS_PLUGINS_DISABLED_ENV = 'FLIKS_PLUGINS_DISABLED';
 export function arePluginsDisabled(): boolean {
   return process.env[FLIKS_PLUGINS_DISABLED_ENV] === '1';
 }
-
-/** The only way a `process` plugin may ship unsigned — for local development against the production signing key. */
-export const FLIKS_UNSIGNED_PLUGINS_ENV = 'FLIKS_UNSIGNED_PLUGINS';
-
-/** Comma-separated `FLIKS_UNSIGNED_PLUGINS` ids, trimmed, empties dropped. */
-export function unsignedProcessAllowlist(): string[] {
-  return (process.env[FLIKS_UNSIGNED_PLUGINS_ENV] ?? '')
-    .split(',')
-    .map((id) => id.trim())
-    .filter((id) => id.length > 0);
-}

--- a/backend/src/modules/plugins/archive/package-plugin.spec.ts
+++ b/backend/src/modules/plugins/archive/package-plugin.spec.ts
@@ -34,7 +34,7 @@ function pack(dir: string): Buffer {
 
 describe('package-plugin', () => {
   it('produces an archive the real inspector accepts, with the hashes it computed itself', async () => {
-    const result = await inspect(pack(pluginDir()), { unsignedProcessAllowlist: ['fliks.testprocessplugin'] });
+    const result = await inspect(pack(pluginDir()), { allowUnsigned: true });
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;

--- a/backend/src/modules/plugins/archive/zip-inspector.spec.ts
+++ b/backend/src/modules/plugins/archive/zip-inspector.spec.ts
@@ -353,7 +353,7 @@ describe('inspect() — guards', () => {
     await expectRefusal(buffer, 'PLUGIN_UNSIGNED');
   });
 
-  it('unsignedProcessAllowlist: an unsigned process archive is accepted when its id is on the list', async () => {
+  it('allowUnsigned: an unsigned process archive is accepted when the setting is on', async () => {
     const pluginJs = Buffer.from('module.exports = {};');
     const logo = pngLogo();
     const manifest = minimalProcessManifest(
@@ -366,11 +366,11 @@ describe('inspect() — guards', () => {
       { name: 'logo.png', content: logo },
     ]);
 
-    const result = await inspect(buffer, { unsignedProcessAllowlist: ['fliks.allowedunsigned'] });
+    const result = await inspect(buffer, { allowUnsigned: true });
     expect(result.ok).toBe(true);
   });
 
-  it('unsignedProcessAllowlist: an unsigned process archive is still refused when its id is not on the list', async () => {
+  it('allowUnsigned: an unsigned process archive is still refused when the setting is off', async () => {
     const pluginJs = Buffer.from('module.exports = {};');
     const logo = pngLogo();
     const manifest = minimalProcessManifest(
@@ -383,7 +383,7 @@ describe('inspect() — guards', () => {
       { name: 'logo.png', content: logo },
     ]);
 
-    const result = await inspect(buffer, { unsignedProcessAllowlist: ['fliks.allowedunsigned'] });
+    const result = await inspect(buffer, { allowUnsigned: false });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.code).toBe('PLUGIN_UNSIGNED');
   });

--- a/backend/src/modules/plugins/archive/zip-inspector.ts
+++ b/backend/src/modules/plugins/archive/zip-inspector.ts
@@ -42,8 +42,8 @@ function hasControlChar(name: string): boolean {
 export interface InspectOptions {
   /** Test-only override of the compiled-in official key set. Defaults to {@link OFFICIAL_KEYS}. */
   officialKeys?: ReadonlyMap<string, Buffer>;
-  /** `FLIKS_UNSIGNED_PLUGINS` ids — the only way a `process` plugin may ship unsigned. */
-  unsignedProcessAllowlist?: readonly string[];
+  /** The admin setting `plugins.allow_unsigned`: the only way a `process` plugin may ship unsigned. */
+  allowUnsigned?: boolean;
 }
 
 export interface InspectSuccess {
@@ -240,8 +240,8 @@ export async function inspect(buffer: Buffer, options: InspectOptions = {}): Pro
     return refuse('PLUGIN_TIER_VIOLATION', 'a process-tier archive must carry plugin.js');
   }
   if (manifest.kind === 'process') {
-    if (trust.trust === 'unsigned' && !(options.unsignedProcessAllowlist ?? []).includes(manifest.id)) {
-      return refuse('PLUGIN_UNSIGNED', 'process-tier plugins must be signed unless allowlisted');
+    if (trust.trust === 'unsigned' && !options.allowUnsigned) {
+      return refuse('PLUGIN_UNSIGNED', 'process-tier plugins must be signed unless unsigned plugins are allowed');
     }
     const codeNames = new Set(
       walked.map((w) => w.name).filter((n) => PROCESS_ONLY_ENTRY_NAMES.has(n) || n.startsWith('logo.')),

--- a/backend/src/modules/plugins/plugin-install.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-install.service.spec.ts
@@ -3,7 +3,7 @@ import { PLUGIN_UID_MIN } from './supervisor/spawn-plan';
 import { createHash } from 'crypto';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { PluginInstallService, installedPluginDir } from './plugin-install.service';
+import { PluginInstallService, installedPluginDir, PLUGIN_ALLOW_UNSIGNED_SETTING } from './plugin-install.service';
 import { PluginInstallException } from './plugin-install.exception';
 import { PluginStagingService } from './plugin-staging.service';
 import { PluginRegistryService } from './plugin-registry.service';
@@ -70,6 +70,18 @@ function signedProcessArchive(overrides: Partial<ProcessPluginManifest> = {}): {
     { name: 'logo.png', content: logo },
   ]);
   return { buffer, manifest };
+}
+
+function unsignedProcessArchive(overrides: Partial<ProcessPluginManifest> = {}): Buffer {
+  const pluginJs = Buffer.from('module.exports = {};', 'utf8');
+  const logo = pngLogo();
+  const files = { 'plugin.js': sha256Hex(pluginJs), 'logo.png': sha256Hex(logo) };
+  const manifest = minimalProcessManifest(files, { fliks: COMPATIBLE_RANGE, ...overrides });
+  return buildZip([
+    { name: 'plugin.json', content: Buffer.from(JSON.stringify(manifest), 'utf8') },
+    { name: 'plugin.js', content: pluginJs },
+    { name: 'logo.png', content: logo },
+  ]);
 }
 
 function fakePluginDb() {
@@ -246,6 +258,20 @@ describe('PluginInstallService', () => {
         }),
       );
       expect(existsSync(stagedArchivePath(report.stagingId!))).toBe(true);
+    });
+
+    it('refuses an unsigned process archive while plugins.allow_unsigned is unset', async () => {
+      const report = await service.inspectUpload(unsignedProcessArchive({ id: 'fliks.unsignedoff' }));
+
+      expect(report).toEqual({ installable: false, refusalCode: 'PLUGIN_UNSIGNED', detail: expect.any(String) });
+    });
+
+    it('accepts the same unsigned process archive once plugins.allow_unsigned is true', async () => {
+      await settings.set(PLUGIN_ALLOW_UNSIGNED_SETTING, 'true');
+
+      const report = await service.inspectUpload(unsignedProcessArchive({ id: 'fliks.unsignedon' }));
+
+      expect(report).toEqual(expect.objectContaining({ installable: true, signature: 'unsigned' }));
     });
 
     it('refuses a malformed archive with its specific refusal code and stages nothing', async () => {

--- a/backend/src/modules/plugins/plugin-install.service.ts
+++ b/backend/src/modules/plugins/plugin-install.service.ts
@@ -15,7 +15,6 @@ import { PluginDatabaseService } from './plugin-database.service';
 import { SettingsService } from '../settings/settings.service';
 import { PluginInstallException } from './plugin-install.exception';
 import { installedPluginDir, pluginDataDir, promoteDir } from './plugin-paths';
-import { unsignedProcessAllowlist } from '../../common/constants/plugin-flags';
 import {
   inspect,
   refuse,
@@ -34,6 +33,9 @@ import type { ConfirmImportDto } from './dto/confirm-import.dto';
 import type { SupervisorState } from './supervisor/plugin-supervisor';
 
 const ARCHIVE_FETCH_TIMEOUT_MS = 30_000;
+
+/** Admin opt-in to installing unsigned `process` plugins. Off unless the stored value is 'true'. */
+export const PLUGIN_ALLOW_UNSIGNED_SETTING = 'plugins.allow_unsigned';
 
 export interface PluginInspectReport {
   installable: boolean;
@@ -138,6 +140,11 @@ export class PluginInstallService {
     private readonly settings: SettingsService,
   ) {}
 
+  /** Read live, never cached: an admin flipping it expects the next install to obey it. */
+  private async allowUnsigned(): Promise<boolean> {
+    return (await this.settings.get(PLUGIN_ALLOW_UNSIGNED_SETTING)) === 'true';
+  }
+
   /** `inspect()` refuses every malformed archive by itself; a throw reaching here is a defect in
    *  core, so it is logged rather than reported as the author's malformed manifest and forgotten. */
   private async safeInspect(buffer: Buffer, options: InspectOptions): Promise<InspectResult> {
@@ -151,7 +158,7 @@ export class PluginInstallService {
 
   /** V1-V7 in memory, then stages the raw bytes. Nothing is activated. */
   async inspectUpload(buffer: Buffer): Promise<PluginInspectReport> {
-    const result = await this.safeInspect(buffer, { unsignedProcessAllowlist: unsignedProcessAllowlist() });
+    const result = await this.safeInspect(buffer, { allowUnsigned: await this.allowUnsigned() });
     if (!result.ok) return { installable: false, refusalCode: result.code, detail: result.detail };
 
     const { stagingId } = this.staging.stage(buffer);
@@ -174,7 +181,7 @@ export class PluginInstallService {
       );
     }
 
-    const result = await this.safeInspect(buffer, { unsignedProcessAllowlist: unsignedProcessAllowlist() });
+    const result = await this.safeInspect(buffer, { allowUnsigned: await this.allowUnsigned() });
     if (!result.ok) {
       throw new PluginInstallException(HttpStatus.UNPROCESSABLE_ENTITY, result.code, result.detail);
     }
@@ -217,7 +224,7 @@ export class PluginInstallService {
       );
     }
 
-    const result = await this.safeInspect(buffer, { unsignedProcessAllowlist: unsignedProcessAllowlist() });
+    const result = await this.safeInspect(buffer, { allowUnsigned: await this.allowUnsigned() });
     if (!result.ok) return { installable: false, refusalCode: result.code, detail: result.detail };
 
     const { stagingId } = this.staging.stage(buffer, 'catalog');
@@ -363,6 +370,10 @@ export class PluginInstallService {
   /** P2 (fsync + rename) -> P3 (upsert the row) -> P4a (register). A P4a refusal leaves the row `failed`, install stands. */
   private async promote(buffer: Buffer, result: InspectSuccess, origin: PluginPackageOrigin): Promise<PluginInstallResult> {
     const { manifest } = result;
+
+    if (result.signature === 'unsigned') {
+      this.logger.warn(`installing "${manifest.id}" ${manifest.version} unsigned: nothing vouches for its code`);
+    }
 
     const denial = await this.checkDenial(manifest.id, manifest.version, result.sha256, result.signedByKeyId ?? null);
     if (denial) {

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2349,7 +2349,9 @@
         "skip_compatibility": "Kompatibilitätsprüfung deaktivieren",
         "skip_compatibility_hint": "Installiert und lädt eine Plugin-Version auch dann, wenn sie diese Fliks-Version nicht als unterstützt angibt. Die Prüfung der Plugin-API gilt weiterhin.",
         "allow_older_versions": "Installation älterer Versionen erlauben",
-        "allow_older_versions_hint": "Ergänzt die Installations- und Aktualisierungsknöpfe im Katalog um eine Versionsauswahl."
+        "allow_older_versions_hint": "Ergänzt die Installations- und Aktualisierungsknöpfe im Katalog um eine Versionsauswahl.",
+        "allow_unsigned": "Unsignierte Plugins zulassen",
+        "allow_unsigned_hint": "Erlaubt die Installation eines Plugins, dessen Code niemand signiert hat, für die Entwicklung eigener Plugins. Ein bereits so installiertes Plugin wird beim Ausschalten nicht entfernt."
       }
     }
   },

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2376,7 +2376,9 @@
         "skip_compatibility": "Disable the compatibility check",
         "skip_compatibility_hint": "Installs and loads a plugin version even when it does not declare support for this Fliks version. The plugin API check still applies.",
         "allow_older_versions": "Allow installing older versions",
-        "allow_older_versions_hint": "Adds a version picker next to the catalogue's install and update buttons."
+        "allow_older_versions_hint": "Adds a version picker next to the catalogue's install and update buttons.",
+        "allow_unsigned": "Allow unsigned plugins",
+        "allow_unsigned_hint": "Lets a plugin whose code nobody signed be installed, for developing your own. Turning it back off does not remove a plugin already installed this way."
       }
     }
   },

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2349,7 +2349,9 @@
         "skip_compatibility": "Desactivar la comprobación de compatibilidad",
         "skip_compatibility_hint": "Instala y carga una versión de plugin aunque no declare compatibilidad con esta versión de Fliks. La comprobación de la API de plugins sigue aplicándose.",
         "allow_older_versions": "Permitir instalar versiones anteriores",
-        "allow_older_versions_hint": "Añade un selector de versión junto a los botones de instalación y actualización del catálogo."
+        "allow_older_versions_hint": "Añade un selector de versión junto a los botones de instalación y actualización del catálogo.",
+        "allow_unsigned": "Permitir plugins sin firmar",
+        "allow_unsigned_hint": "Permite instalar un plugin cuyo código nadie ha firmado, para desarrollar el tuyo. Desactivarlo no elimina un plugin ya instalado así."
       }
     }
   },

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2376,7 +2376,9 @@
         "skip_compatibility": "Désactiver la vérification de compatibilité",
         "skip_compatibility_hint": "Installe et charge une version de plugin même si elle ne déclare pas prendre en charge cette version de Fliks. La vérification de l'API plugin s'applique toujours.",
         "allow_older_versions": "Autoriser l'installation d'anciennes versions",
-        "allow_older_versions_hint": "Ajoute un sélecteur de version à côté des boutons d'installation et de mise à jour du catalogue."
+        "allow_older_versions_hint": "Ajoute un sélecteur de version à côté des boutons d'installation et de mise à jour du catalogue.",
+        "allow_unsigned": "Autoriser les plugins non signés",
+        "allow_unsigned_hint": "Permet d'installer un plugin dont le code n'est signé par personne, pour développer le sien. Le désactiver ne supprime pas un plugin déjà installé ainsi."
       }
     }
   },

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2349,7 +2349,9 @@
         "skip_compatibility": "Disattiva il controllo di compatibilità",
         "skip_compatibility_hint": "Installa e carica una versione di plugin anche se non dichiara il supporto per questa versione di Fliks. Il controllo dell’API dei plugin resta valido.",
         "allow_older_versions": "Consenti l’installazione di versioni precedenti",
-        "allow_older_versions_hint": "Aggiunge un selettore di versione accanto ai pulsanti di installazione e aggiornamento del catalogo."
+        "allow_older_versions_hint": "Aggiunge un selettore di versione accanto ai pulsanti di installazione e aggiornamento del catalogo.",
+        "allow_unsigned": "Consenti plugin non firmati",
+        "allow_unsigned_hint": "Permette di installare un plugin il cui codice non è firmato da nessuno, per sviluppare il proprio. Disattivarlo non rimuove un plugin già installato in questo modo."
       }
     }
   },

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2349,7 +2349,9 @@
         "skip_compatibility": "Desativar a verificação de compatibilidade",
         "skip_compatibility_hint": "Instala e carrega uma versão de plugin mesmo que não declare suporte para esta versão do Fliks. A verificação da API de plugins continua a aplicar-se.",
         "allow_older_versions": "Permitir instalar versões anteriores",
-        "allow_older_versions_hint": "Adiciona um seletor de versão junto aos botões de instalação e atualização do catálogo."
+        "allow_older_versions_hint": "Adiciona um seletor de versão junto aos botões de instalação e atualização do catálogo.",
+        "allow_unsigned": "Permitir plugins não assinados",
+        "allow_unsigned_hint": "Permite instalar um plugin cujo código ninguém assinou, para desenvolver o seu. Desativá-lo não remove um plugin já instalado dessa forma."
       }
     }
   },

--- a/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.html
+++ b/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.html
@@ -36,6 +36,13 @@
           [label]="'settings.plugins.settings.allow_older_versions' | translate"
           [hint]="'settings.plugins.settings.allow_older_versions_hint' | translate"
         />
+        <app-toggle-field
+          [value]="allowUnsigned()"
+          (valueChange)="toggleAllowUnsigned($event)"
+          [disabled]="saving()"
+          [label]="'settings.plugins.settings.allow_unsigned' | translate"
+          [hint]="'settings.plugins.settings.allow_unsigned_hint' | translate"
+        />
       </div>
     }
 

--- a/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.ts
+++ b/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.ts
@@ -22,6 +22,8 @@ const AUTO_UPDATE_KEY = 'plugins.auto_update';
 const SKIP_COMPATIBILITY_KEY = 'plugins.skip_compatibility_check';
 /** Read by the catalogue alone: it decides whether a card offers other versions to pick. */
 const ALLOW_OLDER_VERSIONS_KEY = 'plugins.allow_older_versions';
+/** Mirrors the backend's `PLUGIN_ALLOW_UNSIGNED_SETTING`. */
+const ALLOW_UNSIGNED_KEY = 'plugins.allow_unsigned';
 
 @Component({
   selector: 'app-plugin-settings',
@@ -42,6 +44,7 @@ export class PluginSettingsComponent {
   /** Both off unless the stored value is the explicit 'true' — same reading as the backend. */
   readonly skipCompatibility = signal(false);
   readonly allowOlderVersions = signal(false);
+  readonly allowUnsigned = signal(false);
   readonly loading = signal(true);
   readonly saving = signal(false);
 
@@ -50,18 +53,21 @@ export class PluginSettingsComponent {
     this.dialogRef().nativeElement.showModal();
     this.loading.set(true);
     try {
-      const [auto, skip, older] = await Promise.all([
+      const [auto, skip, older, unsigned] = await Promise.all([
         this.settings.get(AUTO_UPDATE_KEY),
         this.settings.get(SKIP_COMPATIBILITY_KEY),
         this.settings.get(ALLOW_OLDER_VERSIONS_KEY),
+        this.settings.get(ALLOW_UNSIGNED_KEY),
       ]);
       this.autoUpdate.set(auto?.value !== 'false');
       this.skipCompatibility.set(skip?.value === 'true');
       this.allowOlderVersions.set(older?.value === 'true');
+      this.allowUnsigned.set(unsigned?.value === 'true');
     } catch {
       this.autoUpdate.set(true);
       this.skipCompatibility.set(false);
       this.allowOlderVersions.set(false);
+      this.allowUnsigned.set(false);
     } finally {
       this.loading.set(false);
     }
@@ -93,6 +99,10 @@ export class PluginSettingsComponent {
 
   async toggleAllowOlderVersions(next: boolean): Promise<void> {
     await this.persist(ALLOW_OLDER_VERSIONS_KEY, next, this.allowOlderVersions);
+  }
+
+  async toggleAllowUnsigned(next: boolean): Promise<void> {
+    await this.persist(ALLOW_UNSIGNED_KEY, next, this.allowUnsigned);
   }
 
   /** False when the write failed, so a caller does not act on a value the server refused. */

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -321,8 +321,9 @@ staged, and the consent sheet in between is the only place an unverified plugin 
 Signature outcomes are `official` (a catalogue release key), `unverified`, or `unsigned`. Only the
 catalogue key verifies: there is no registry of third-party signing keys, so an archive signed by
 anyone else is `unverified` and reaches an operator behind the consent sheet's acknowledgement. A
-`process` plugin must be signed unless its id is in `FLIKS_UNSIGNED_PLUGINS`, which exists for local
-development only.
+`process` plugin must be signed unless the admin setting `plugins.allow_unsigned` is on, which
+exists for local development only. The setting gates installs, not loads: switching it back off
+leaves an unsigned plugin already installed running, uninstall it instead.
 
 ### Packaging
 
@@ -334,7 +335,7 @@ would refuse later: a missing `plugin.js` for a `process` manifest, a `plugin.js
 `data` one, a `logo` field that doesn't match what's on disk or whose bytes are not the format its
 name claims, a bad id or version, an oversized entry, and any file an archive may not carry (rather
 than dropping it silently and leaving you to find out at runtime). The archive it writes is always unsigned; a `process` plugin built this way installs only
-when its id is in the installing core's `FLIKS_UNSIGNED_PLUGINS`. Signing an archive for real
+when the installing core has `plugins.allow_unsigned` on. Signing an archive for real
 distribution is a separate, later step this tool does not perform.
 
 ### Deadlines and ceilings

--- a/examples/plugin-scaffold/README.md
+++ b/examples/plugin-scaffold/README.md
@@ -30,14 +30,7 @@ npm run package          # bundle → dist/, then core's packaging tool → scaf
 ```
 
 Then install `scaffold.fkplugin` through **Settings → Plugins → Import**. Unsigned archives are
-refused unless the core process allowlists the id:
-
-```
-FLIKS_UNSIGNED_PLUGINS=example.scaffold
-```
-
-On Docker that is an `env_file` value, which is read when the container is *created* — a
-`docker compose restart` will not pick it up, `docker compose up -d --force-recreate backend` will.
+refused unless *Allow unsigned plugins* is on in **Settings → Plugins → Settings**.
 
 Reinstalling the same id replaces the running plugin; there is no need to uninstall first.
 


### PR DESCRIPTION
## Why

Installing an unsigned `process` plugin required `FLIKS_UNSIGNED_PLUGINS=<id>` in the environment, so trying a locally built plugin meant editing `env_file` and recreating the container (a `restart` does not re-read it). That is deploy-level ceremony for a routine development choice.

## What

- New admin setting `plugins.allow_unsigned`, off by default, read live on every inspect, exactly like `plugins.skip_compatibility_check` is read on every load.
- `FLIKS_UNSIGNED_PLUGINS` and `unsignedProcessAllowlist()` removed; `InspectOptions.unsignedProcessAllowlist` becomes `allowUnsigned?: boolean`.
- Fourth toggle in **Settings → Plugins → Settings**, translated in the six locales.
- Every unsigned promotion logs a warning naming the plugin and version.
- `docs/plugins.md`, the scaffold README and the `package-plugin` output line point at the setting.

## Trade-offs worth knowing

- **Broader than the allowlist it replaces.** The env var named one id; the toggle accepts any unsigned archive while it is on.
- **Install-time gate only.** `reverifyTrust()` passes a package with no verifying key straight through, so turning the toggle back off does not stop a plugin already installed under it. The toggle hint and the docs say to uninstall instead.

## Tests

`backend`: 967 pass (`src/modules/plugins`, `src/common`), including two new install-service cases (refused while unset, accepted once `true`). `client`: 708 pass. Both typecheck clean.