### PR TITLE
chore(i18n): name the plugin waiver after the check it actually skips

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2346,7 +2346,7 @@
         "auto_update": "Plugins automatisch aktualisieren",
         "auto_update_hint": "Standardmäßig aktiviert. Installiert einmal täglich, nach dem Aktualisieren der Quellen, die neueste angebotene Version eines installierten Plugins. Unbeaufsichtigt wird nur ein Archiv installiert, das der Quellkatalog signiert hat; alles andere braucht weiterhin deine Bestätigung.",
         "saved": "Plugin-Einstellungen gespeichert",
-        "skip_compatibility": "Kompatibilitätsprüfung deaktivieren",
+        "skip_compatibility": "Erforderliche Fliks-Version ignorieren",
         "skip_compatibility_hint": "Installiert und lädt eine Plugin-Version auch dann, wenn sie diese Fliks-Version nicht als unterstützt angibt. Die Prüfung der Plugin-API gilt weiterhin.",
         "allow_older_versions": "Installation älterer Versionen erlauben",
         "allow_older_versions_hint": "Ergänzt die Installations- und Aktualisierungsknöpfe im Katalog um eine Versionsauswahl.",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2373,7 +2373,7 @@
         "auto_update": "Update plugins automatically",
         "auto_update_hint": "On by default. Once a day, after the sources are refreshed, installs the newest version each source offers for an installed plugin. Only an archive signed by the source catalogue is installed unattended: anything else still needs your acknowledgement.",
         "saved": "Plugin settings saved",
-        "skip_compatibility": "Disable the compatibility check",
+        "skip_compatibility": "Ignore the required Fliks version",
         "skip_compatibility_hint": "Installs and loads a plugin version even when it does not declare support for this Fliks version. The plugin API check still applies.",
         "allow_older_versions": "Allow installing older versions",
         "allow_older_versions_hint": "Adds a version picker next to the catalogue's install and update buttons.",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2346,7 +2346,7 @@
         "auto_update": "Actualizar los plugins automáticamente",
         "auto_update_hint": "Activado por defecto. Una vez al día, tras actualizar las fuentes, instala la versión más reciente ofrecida para un plugin instalado. Solo se instala sin intervención un archivo firmado por el catálogo de la fuente: el resto requiere tu confirmación.",
         "saved": "Ajustes de plugins guardados",
-        "skip_compatibility": "Desactivar la comprobación de compatibilidad",
+        "skip_compatibility": "Ignorar la versión de Fliks requerida",
         "skip_compatibility_hint": "Instala y carga una versión de plugin aunque no declare compatibilidad con esta versión de Fliks. La comprobación de la API de plugins sigue aplicándose.",
         "allow_older_versions": "Permitir instalar versiones anteriores",
         "allow_older_versions_hint": "Añade un selector de versión junto a los botones de instalación y actualización del catálogo.",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2373,7 +2373,7 @@
         "auto_update": "Mettre à jour automatiquement les plugins",
         "auto_update_hint": "Activé par défaut. Une fois par jour, après le rafraîchissement des sources, installe la version la plus récente proposée pour un plugin installé. Seule une archive signée par le catalogue de la source est installée sans intervention : le reste demande toujours une validation.",
         "saved": "Paramètres des plugins enregistrés",
-        "skip_compatibility": "Désactiver la vérification de compatibilité",
+        "skip_compatibility": "Ignorer la version de Fliks requise",
         "skip_compatibility_hint": "Installe et charge une version de plugin même si elle ne déclare pas prendre en charge cette version de Fliks. La vérification de l'API plugin s'applique toujours.",
         "allow_older_versions": "Autoriser l'installation d'anciennes versions",
         "allow_older_versions_hint": "Ajoute un sélecteur de version à côté des boutons d'installation et de mise à jour du catalogue.",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2346,7 +2346,7 @@
         "auto_update": "Aggiorna automaticamente i plugin",
         "auto_update_hint": "Attivo per impostazione predefinita. Una volta al giorno, dopo l’aggiornamento delle sorgenti, installa la versione più recente offerta per un plugin installato. Senza intervento viene installato solo un archivio firmato dal catalogo della sorgente: il resto richiede la tua conferma.",
         "saved": "Impostazioni dei plugin salvate",
-        "skip_compatibility": "Disattiva il controllo di compatibilità",
+        "skip_compatibility": "Ignora la versione di Fliks richiesta",
         "skip_compatibility_hint": "Installa e carica una versione di plugin anche se non dichiara il supporto per questa versione di Fliks. Il controllo dell’API dei plugin resta valido.",
         "allow_older_versions": "Consenti l’installazione di versioni precedenti",
         "allow_older_versions_hint": "Aggiunge un selettore di versione accanto ai pulsanti di installazione e aggiornamento del catalogo.",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2346,7 +2346,7 @@
         "auto_update": "Atualizar os plugins automaticamente",
         "auto_update_hint": "Ativado por predefinição. Uma vez por dia, após atualizar as fontes, instala a versão mais recente oferecida para um plugin instalado. Sem intervenção só é instalado um arquivo assinado pelo catálogo da fonte: o resto continua a exigir a tua confirmação.",
         "saved": "Definições dos plugins guardadas",
-        "skip_compatibility": "Desativar a verificação de compatibilidade",
+        "skip_compatibility": "Ignorar a versão do Fliks requerida",
         "skip_compatibility_hint": "Instala e carrega uma versão de plugin mesmo que não declare suporte para esta versão do Fliks. A verificação da API de plugins continua a aplicar-se.",
         "allow_older_versions": "Permitir instalar versões anteriores",
         "allow_older_versions_hint": "Adiciona um seletor de versão junto aos botões de instalação e atualização do catálogo.",


### PR DESCRIPTION
## Why

The plugin settings toggle (`plugins.skip_compatibility_check`) waives **only** the `fliks` semver range. The `pluginApi` gate is deliberately not waivable: `pluginApi 0` was retired when `AcquisitionTarget.want` left the shape, so loading such a plugin anyway would hand it an absent field it filters releases on, and fail silently at the first grab instead of loudly at load.

Labelled "Disable the compatibility check", the toggle reads as covering both checks. An admin ticks it, installs a plugin, and still gets `incompatible-api: manifest declares pluginApi 0, this core accepts 1` with no way to connect the two. That happened in practice.

## What

Label only, six locales. The hint already spelled out that the plugin API check still applies; the label now agrees with it.

| | before | after |
|---|---|---|
| en | Disable the compatibility check | Ignore the required Fliks version |
| fr | Désactiver la vérification de compatibilité | Ignorer la version de Fliks requise |

No behaviour change: the setting key, the backend gate and the catalog filter are untouched.