### PR TITLE
fix(media-detail): release the hero chrome when the cached page detaches

### DIFF
--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -272,7 +272,28 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   private readonly routeFresh = keepRouteFresh({
     refresh: () => this.refreshOnReturn(),
     scrollKey: () => this.scrollKey(),
+    onDetach: () => this.releaseChrome(),
+    onAttach: () => this.restoreChrome(),
   });
+
+  /** Backdrop pick held across a detach so the page comes back on the same
+   *  image instead of re-randomising from the pool. */
+  private parkedBackground: string | null = null;
+
+  /** The hero navbar and page backdrop are global state, so a cached page has
+   *  to hand them back on the way out and reclaim them on return. */
+  private releaseChrome(): void {
+    this.parkedBackground = this.backgroundService.url();
+    this.navbarService.leaveHeroPage();
+    this.backgroundService.clear();
+  }
+
+  private restoreChrome(): void {
+    this.backgroundService.setBackground(this.parkedBackground);
+    const m = this.media();
+    if (m) this.applyEpisodeFocus(m, this.route.snapshot.paramMap.get('episodeId'));
+    else this.navbarService.enterHeroPage('');
+  }
 
   /**
    * Angular reuses this component between two `movies/:id` URLs — the similar
@@ -845,9 +866,11 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    // Evicted from the route cache while another page is on screen: the chrome
+    // and scroll key already belong to that page, so leave them alone.
+    if (this.routeFresh()) return;
     this.scrollMemory.deactivate();
-    this.navbarService.leaveHeroPage();
-    this.backgroundService.clear();
+    this.releaseChrome();
   }
 
   ngOnInit() {


### PR DESCRIPTION
## Problem

Opening a movie or series and pressing back left the detail page's hero clearlogo in the topbar and its fanart backdrop behind the home page.

## Cause

`movies/:id`, `series/:id` and `series/:id/episode/:episodeId` are `reuse: true` routes, so the component is detached instead of destroyed. `ngOnDestroy` — the only place that called `NavbarService.leaveHeroPage()` and `BackgroundService.clear()` — therefore never ran on navigate-away.

## Fix

Move the teardown onto the cache lifecycle via `keepRouteFresh`:

- `onDetach` releases the hero navbar and the backdrop, parking the current backdrop URL so the page returns on the same image rather than re-randomising from the fanart pool.
- `onAttach` reclaims both from the loaded media.
- `ngOnDestroy` now returns early while detached. It only fires on an LRU eviction from the route cache, and at that point the hero chrome and the scroll-memory key belong to the page currently on screen — clearing them there was stealing state from another page.

Not done centrally in `NavbarService` on `NavigationEnd`: `attached$` fires in a microtask, so the clear/restore ordering would not be guaranteed.

## Test

- `npx tsc -p client/tsconfig.app.json --noEmit` clean.
- Manual: home → movie → back, home → series → episode → back, and movie → similar movie (same route, different param).

🤖 Generated with [Claude Code](https://claude.com/claude-code)