### PR TITLE
feat(data-table): move the acting row actions into a per-row menu

### DIFF
--- a/client/src/app/shared/components/data-table/data-table.html
+++ b/client/src/app/shared/components/data-table/data-table.html
@@ -172,20 +172,49 @@
               }
               @if (rowActions().length) {
                 <td class="text-end">
-                  @for (item of visibleActions(row); track item.action.labelKey) {
-                    <button
-                      type="button"
-                      class="btn btn-ghost btn-xs"
-                      [class.text-error]="item.action.kind === 'proxy' && item.action.tone === 'danger'"
-                      (click)="item.run()"
-                      [disabled]="
-                        busy() ===
-                        row.id + ':' + (item.action.kind === 'proxy' ? item.action.path : '')
-                      "
-                    >
-                      {{ item.action.labelKey | translate }}
-                    </button>
-                  }
+                  <div class="inline-flex items-center gap-1 whitespace-nowrap">
+                    @for (item of inlineActions(row); track item.action.labelKey) {
+                      <!-- pt-1: optical centring of the label against the menu glyph beside it. -->
+                      <button type="button" class="btn btn-ghost btn-xs pt-1" (click)="item.run()">
+                        {{ item.action.labelKey | translate }}
+                      </button>
+                    }
+                    @if (menuActions(row); as menu) {
+                      @if (menu.length) {
+                        <button
+                          #menuTrigger
+                          type="button"
+                          class="btn btn-ghost btn-xs btn-circle"
+                          [attr.aria-label]="'common.actions' | translate"
+                          (click)="toggleRowMenu(row)"
+                        >
+                          <svg lucideEllipsisVertical class="h-4 w-4"></svg>
+                        </button>
+                        <app-popover-menu
+                          [open]="openMenuRow() === row.id"
+                          [anchor]="menuTrigger"
+                          (closed)="openMenuRow.set(null)"
+                        >
+                          @for (item of menu; track item.action.labelKey) {
+                            <button
+                              type="button"
+                              class="dropdown-item"
+                              [class.text-error]="
+                                item.action.kind === 'proxy' && item.action.tone === 'danger'
+                              "
+                              (click)="runFromMenu(item.run)"
+                              [disabled]="
+                                busy() ===
+                                row.id + ':' + (item.action.kind === 'proxy' ? item.action.path : '')
+                              "
+                            >
+                              {{ item.action.labelKey | translate }}
+                            </button>
+                          }
+                        </app-popover-menu>
+                      }
+                    }
+                  </div>
                 </td>
               }
             </tr>
@@ -204,8 +233,8 @@
   }
 </div>
 
-@if (rowDetail(); as open) {
-  <dialog class="modal modal-open">
+<dialog #rowDetailDialog class="modal">
+  @if (rowDetail(); as open) {
     <div class="modal-box max-w-lg">
       <app-modal-header [title]="open.titleKey | translate" (closed)="closeRowDetail()" />
       <dl class="flex flex-col gap-3 py-2">
@@ -228,16 +257,16 @@
         </button>
       </app-modal-footer>
     </div>
-    <form method="dialog" class="modal-backdrop">
-      <button type="button" (click)="closeRowDetail()" [attr.aria-label]="'common.close' | translate">
-        close
-      </button>
-    </form>
-  </dialog>
-}
+  }
+  <form method="dialog" class="modal-backdrop">
+    <button type="button" (click)="closeRowDetail()" [attr.aria-label]="'common.close' | translate">
+      close
+    </button>
+  </form>
+</dialog>
 
-@if (detail(); as open) {
-  <dialog class="modal modal-open">
+<dialog #detailDialog class="modal">
+  @if (detail(); as open) {
     <div class="modal-box max-w-2xl">
       <app-modal-header [title]="open.titleKey | translate" (closed)="closeDetail()" />
       <pre
@@ -250,10 +279,10 @@
         </button>
       </app-modal-footer>
     </div>
-    <form method="dialog" class="modal-backdrop">
-      <button type="button" (click)="closeDetail()" [attr.aria-label]="'common.close' | translate">
-        close
-      </button>
-    </form>
-  </dialog>
-}
+  }
+  <form method="dialog" class="modal-backdrop">
+    <button type="button" (click)="closeDetail()" [attr.aria-label]="'common.close' | translate">
+      close
+    </button>
+  </form>
+</dialog>

--- a/client/src/app/shared/components/data-table/data-table.spec.ts
+++ b/client/src/app/shared/components/data-table/data-table.spec.ts
@@ -12,6 +12,23 @@ import { ListAction, RowAction, TableColumn, TableFilter, TableRow } from './dat
 
 const COLUMNS: TableColumn[] = [{ key: 'name', labelKey: 'x.name' }];
 
+// jsdom has no scrollIntoView; the row menu focuses its first item through it.
+Element.prototype.scrollIntoView ??= () => {};
+
+// …nor the <dialog> methods the detail dialogs are driven by.
+beforeAll(() => {
+  if (!HTMLDialogElement.prototype.showModal) {
+    HTMLDialogElement.prototype.showModal = function (this: HTMLDialogElement) {
+      this.setAttribute('open', '');
+    };
+  }
+  if (!HTMLDialogElement.prototype.close) {
+    HTMLDialogElement.prototype.close = function (this: HTMLDialogElement) {
+      this.removeAttribute('open');
+    };
+  }
+});
+
 interface FakeHttp {
   get: (...args: unknown[]) => unknown;
   post?: (...args: unknown[]) => unknown;
@@ -116,18 +133,46 @@ describe('DataTableComponent — characterisation', () => {
     expect(handler).toHaveBeenCalled();
   });
 
-  it('VERDICT: a resolved `action`-kind row action renders a real button that invokes the handler on click', async () => {
+  it('VERDICT: a resolved `action`-kind row action renders a real button in the row menu that invokes the handler on click', async () => {
     const handler = vi.fn();
     const fixture = await createComponent({
       http: { get: () => of([{ id: 1, name: 'A' }]) },
       rowActions: [{ kind: 'action', labelKey: 'x.doit', actionId: 'core.known' }],
       resolveAction: (id) => (id === 'core.known' ? handler : undefined),
     });
-    const buttons = Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[];
-    const button = buttons.find((b) => b.textContent?.includes('x.doit'));
+    const kebab = fixture.nativeElement.querySelector('tbody td button') as HTMLButtonElement;
+    kebab.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    // The popover moves its content under <html>, so it is no longer inside the fixture.
+    const button = Array.from(document.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('x.doit'),
+    ) as HTMLButtonElement | undefined;
     expect(button).toBeDefined();
     button!.click();
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('VERDICT: keeps a `detail` action on the row and moves the acting ones into the menu', async () => {
+    const fixture = await createComponent({
+      http: { get: () => of([{ id: 1, name: 'A' }]) },
+      rowActions: [
+        { kind: 'detail', labelKey: 'x.info', fields: [] },
+        { kind: 'proxy', labelKey: 'x.stop', method: 'DELETE', path: '/api/x/:id' },
+      ],
+    });
+    const row = { id: 1, name: 'A' };
+    expect(fixture.componentInstance.inlineActions(row).map((i) => i.action.labelKey)).toEqual([
+      'x.info',
+    ]);
+    expect(fixture.componentInstance.menuActions(row).map((i) => i.action.labelKey)).toEqual([
+      'x.stop',
+    ]);
+    // The row shows the detail button plus the menu trigger (icon only), nothing else.
+    const cellButtons = Array.from(
+      fixture.nativeElement.querySelectorAll('tbody td button'),
+    ) as HTMLButtonElement[];
+    expect(cellButtons.map((b) => b.textContent?.trim())).toEqual(['x.info', '']);
   });
 
   it('formats a bytes/percent/date column instead of printing the raw value', async () => {
@@ -377,10 +422,16 @@ describe('DataTableComponent — declared filters', () => {
     expect(c.detail()).toEqual({ titleKey: 'x.detail_title', text: 'tracker refused: 403' });
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('dialog pre').textContent).toContain('403');
+    const dialog = Array.from(
+      fixture.nativeElement.querySelectorAll('dialog') as NodeListOf<HTMLDialogElement>,
+    ).find((d) => d.querySelector('pre'))!;
+    expect(dialog.hasAttribute('open')).toBe(true);
 
     c.closeDetail();
     fixture.detectChanges();
-    expect(fixture.nativeElement.querySelector('dialog')).toBeNull();
+    // The element stays mounted so daisyUI can animate the close; `open` is what shows it.
+    expect(dialog.hasAttribute('open')).toBe(false);
+    expect(dialog.isConnected).toBe(true);
   });
 
   it('renders declared sub-values under the cell, skipping the ones the row has no value for', async () => {

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -9,8 +9,11 @@ import {
   input,
   signal,
   untracked,
+  viewChild,
+  ElementRef,
 } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
+import { LucideEllipsisVertical } from '@lucide/angular';
 import { TvSelectDirective } from '../../directives/tv-select.directive';
 import { Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
@@ -36,6 +39,7 @@ import {
   TableSubValue,
 } from './data-table.types';
 import { ModalHeaderComponent } from '../modal-header';
+import { PopoverMenuComponent } from '../popover-menu';
 import { ModalFooterComponent } from '../modal-footer';
 
 /** Keystroke-to-request debounce for a `search` filter — see `onSearchInput`. */
@@ -67,6 +71,8 @@ const BADGE_CLASSES: Readonly<Record<BadgeTone, string>> = {
 @Component({
   selector: 'app-data-table',
   imports: [TvSelectDirective, 
+    PopoverMenuComponent,
+    LucideEllipsisVertical,
     ModalFooterComponent,
     ModalHeaderComponent,
     TranslateModule,
@@ -116,10 +122,16 @@ export class DataTableComponent implements OnInit {
   readonly busy = signal<string | null>(null);
   readonly listActionBusy = signal<string | null>(null);
 
-  /** The open detail dialog's title key and text, or null when it is closed. */
+  /** Both dialogs stay mounted and are driven by `showModal()`/`close()`: an `@if` around the
+   *  element unmounts it on close, and daisyUI animates the exit on the element that remains. */
+  private readonly rowDetailDialog = viewChild<ElementRef<HTMLDialogElement>>('rowDetailDialog');
+  private readonly detailDialog = viewChild<ElementRef<HTMLDialogElement>>('detailDialog');
+
+  /** The detail dialog's title key and text. Kept after a close so the box has something to
+   *  render while it animates out. */
   readonly detail = signal<{ titleKey: string; text: string } | null>(null);
 
-  /** The open `detail` row action's dialog: its title and the lines that had a value. */
+  /** The `detail` row action's dialog: its title and the lines that had a value. */
   readonly rowDetail = signal<{
     titleKey: string;
     lines: { labelKey: string; text: string; href?: string }[];
@@ -310,7 +322,7 @@ export class DataTableComponent implements OnInit {
   }
 
   closeRowDetail(): void {
-    this.rowDetail.set(null);
+    this.rowDetailDialog()?.nativeElement.close();
   }
 
   /** The 0–100 fill for a badged cell that declares `progressField`, or null to render the
@@ -344,10 +356,11 @@ export class DataTableComponent implements OnInit {
     const text = this.detailText(col, row);
     if (!text) return;
     this.detail.set({ titleKey: col.detailTitleKey ?? col.labelKey, text });
+    this.detailDialog()?.nativeElement.showModal();
   }
 
   closeDetail(): void {
-    this.detail.set(null);
+    this.detailDialog()?.nativeElement.close();
   }
 
   /** Sub-values render as their own badge or text, reusing the column rules one level down. */
@@ -417,11 +430,7 @@ export class DataTableComponent implements OnInit {
       } else if (action.kind === 'detail') {
         result.push({
           action,
-          run: () =>
-            this.rowDetail.set({
-              titleKey: action.titleKey ?? action.labelKey,
-              lines: this.detailLines(action.fields, row),
-            }),
+          run: () => this.openRowDetail(action.titleKey ?? action.labelKey, action.fields, row),
         });
       } else if (action.kind === 'route') {
         result.push({
@@ -435,6 +444,34 @@ export class DataTableComponent implements OnInit {
       }
     }
     return result;
+  }
+
+  /** Row whose action menu is open, by row id. */
+  readonly openMenuRow = signal<CellValue | null>(null);
+
+  toggleRowMenu(row: TableRow): void {
+    this.openMenuRow.update((open) => (open === row.id ? null : row.id));
+  }
+
+  /** The menu is a popover, not a dropdown, so it doesn't close itself on a pick. */
+  runFromMenu(run: () => void | Promise<void>): void {
+    this.openMenuRow.set(null);
+    void run();
+  }
+
+  /** `detail` is the one action that only reads, so it stays on the row; everything that acts
+   *  moves into the row menu, which keeps the Actions column from swallowing the table. */
+  inlineActions(row: TableRow): { action: RowAction; run: () => void | Promise<void> }[] {
+    return this.visibleActions(row).filter((i) => i.action.kind === 'detail');
+  }
+
+  menuActions(row: TableRow): { action: RowAction; run: () => void | Promise<void> }[] {
+    return this.visibleActions(row).filter((i) => i.action.kind !== 'detail');
+  }
+
+  private openRowDetail(titleKey: string, fields: readonly TableDetailField[], row: TableRow): void {
+    this.rowDetail.set({ titleKey, lines: this.detailLines(fields, row) });
+    this.rowDetailDialog()?.nativeElement.showModal();
   }
 
   private async runProxy(


### PR DESCRIPTION
## Problem

On the queue and history pages every declared row action rendered as its own inline button. Four actions ("Info", pause, resume, cancel) wrapped over three lines inside the cell and overlapped the row above.

## Fix

- `detail` — the one action that only reads — stays inline. Everything that acts moves behind a per-row `⋯` menu (`inlineActions()` / `menuActions()`).
- The menu is `app-popover-menu`, not `app-dropdown-menu`: the table sits in an `overflow-x-auto` box which clips an anchored dropdown on the last rows. The popover positions itself `fixed`, and falls back to a bottom sheet on touch and TV.
- `pt-1` on the inline label so it sits on the menu glyph's line.

## Also fixed here

Both detail dialogs were `@if`-wrapped `<dialog class="modal modal-open">`. daisyUI animates the close by transitioning `.modal-box` on the element that stays, so unmounting the node on close skipped the exit animation entirely. They are now mounted for the component's lifetime and driven by native `showModal()` / `close()`, matching every other modal in the app — which also gets Escape-to-close and focus restoration for free. The content signal is kept after a close so the box has something to render while it animates out.

## Test

- `npx tsc -p client/tsconfig.app.json --noEmit` clean.
- `ng test --include='**/data-table.spec.ts'` — 55 pass. The `action`-kind test now opens the menu first; one new test pins the inline/menu split; the close test asserts the dialog stays connected with `open` removed instead of asserting it was unmounted (which was the bug).
- Exercised on the local stack against `fliks.download` 0.9.0 (queue + history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)