### PR TITLE
fix(provider-list): keep url and credentials out of the bulk editor

### DIFF
--- a/client/src/app/shared/components/provider-list/provider-list.spec.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.spec.ts
@@ -598,33 +598,29 @@ describe('ProviderListComponent: bulk selection', () => {
     expect(second['settings']).toEqual({ url: 'http://b', minSeeders: 2 });
   });
 
-  it('VERDICT: a ticked but blank secret is skipped rather than blanking the stored one', async () => {
-    const put = vi.fn((_url: string, _body: unknown, _opts?: unknown) => of({}));
-    const fixture = await createComponent({ get: () => of(THREE), put }, { bulkSelect: true });
-    const c = fixture.componentInstance;
-    c.toggleSelected(1);
-    c.openBulkEditor();
-    c.toggleBulkApply('apiKey');
-    await c.saveBulkEdit();
-
-    const body = put.mock.calls[0]![1] as { settings: Record<string, unknown> };
-    expect('apiKey' in body.settings).toBe(false);
-  });
-
-  it('writes a ticked secret to every selected row', async () => {
-    const put = vi.fn((_url: string, _body: unknown, _opts?: unknown) => of({}));
-    const fixture = await createComponent({ get: () => of(THREE), put }, { bulkSelect: true });
+  it('VERDICT: offers no url and no credential, whatever the implementation declares', async () => {
+    const fixture = await createComponent({ get: () => of(THREE) }, { bulkSelect: true });
     const c = fixture.componentInstance;
     c.toggleSelected(1);
     c.toggleSelected(2);
+    // `url` identifies the row and `apiKey` belongs to it: the same value on every selected row
+    // is meaningless there, so neither is offered even though both are editable one row at a time.
+    expect(c.bulkFields().map((f) => f.key)).toEqual(['delay']);
+  });
+
+  it('never writes a field the editor does not offer, even if its key is ticked', async () => {
+    const put = vi.fn((_url: string, _body: unknown, _opts?: unknown) => of({}));
+    const fixture = await createComponent({ get: () => of(THREE), put }, { bulkSelect: true });
+    const c = fixture.componentInstance;
+    c.toggleSelected(1);
     c.openBulkEditor();
-    c.bulkValue.update((v) => ({ ...v, apiKey: 'ROTATED' }));
+    c.bulkValue.update((v) => ({ ...v, apiKey: 'ROTATED', url: 'http://shared' }));
     c.toggleBulkApply('apiKey');
+    c.toggleBulkApply('url');
     await c.saveBulkEdit();
 
-    for (const call of put.mock.calls) {
-      expect((call[1] as { settings: Record<string, unknown> }).settings['apiKey']).toBe('ROTATED');
-    }
+    const body = put.mock.calls[0]![1] as { settings: Record<string, unknown> };
+    expect(body.settings).toEqual({ url: 'http://a', minSeeders: 1 });
   });
 
   it('applies priority only when its own box is ticked', async () => {

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -193,11 +193,17 @@ export class ProviderListComponent implements OnInit {
     return this.implementations().find((i) => i.implementation === first) ?? null;
   });
 
-  /** Fields the bulk editor offers: the implementation's own, plus priority when the page has one.
-   *  A secret is included on purpose (rotating one key across a dozen imported rows is the case
-   *  this exists for) and, like every other field, is written only when ticked. */
+  /**
+   * Fields the bulk editor offers: the implementation's tuning knobs, plus priority when the page
+   * has one. What identifies one instance is left out, because the same value written to every
+   * selected row is meaningless or destructive there: a `url` is the row (twelve indexers pointed
+   * at one tracker), and a credential belongs to whatever that url is.
+   */
   readonly bulkFields = computed<readonly FieldDef[]>(
-    () => this.bulkImplementation()?.fields.filter((f): f is FieldDef => !('kind' in f) || f.kind === 'field') ?? [],
+    () =>
+      this.bulkImplementation()
+        ?.fields.filter((f): f is FieldDef => !('kind' in f) || f.kind === 'field')
+        .filter((f) => !f.secret && f.type !== 'url') ?? [],
   );
 
   readonly currentImplementation = computed(
@@ -610,11 +616,7 @@ export class ProviderListComponent implements OnInit {
     const topLevel: Record<string, unknown> = {};
     for (const field of this.bulkFields()) {
       if (!applied.has(field.key)) continue;
-      const v = value[field.key];
-      // A ticked secret left blank would erase nothing and mean nothing: skip it rather than
-      // write an empty credential over a dozen rows.
-      if (field.secret && (v === '' || v === undefined)) continue;
-      (field.topLevel ? topLevel : settings)[field.key] = v;
+      (field.topLevel ? topLevel : settings)[field.key] = value[field.key];
     }
     const priority = applied.has('priority') ? this.bulkPriority() : null;
 


### PR DESCRIPTION
## Problem

The bulk editor listed every field of the shared implementation, base URL and API key included. A base URL **identifies** one instance: the same value written to twelve selected indexers points them all at a single tracker. A credential belongs to whatever that URL is.

I had argued the API key earned its place there (rotating one key over a whole imported list), but that case is already covered by the source import itself, which refreshes the key on the rows it created. It does not justify a field whose neighbour is destructive.

## Fix

`bulkFields` now drops every `secret` field and every `type: 'url'` field. What remains on the indexers page is exactly the tuning set: request delay, use in search, min seeders, seed ratio, retention days, unknown language, plus priority.

Both stay editable one row at a time, where they are the row's own. The now-unreachable "ticked but blank secret" branch in `saveBulkEdit` is gone with them.

## Test

41 pass. Two specs replaced by two that pin the new rule: the editor offers neither key for an implementation declaring both, and a key that is not offered is never written even if its name is ticked in the applied set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)