### PR TITLE
feat(provider-list): one toolbar the bulk actions take over

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2619,7 +2619,14 @@
     "bulk_enabled_done": "{{count}} Einträge aktiviert",
     "bulk_disabled_done": "{{count}} Einträge deaktiviert",
     "bulk_deleted_done": "{{count}} Einträge gelöscht",
-    "bulk_partial": "{{done}} erledigt, {{failed}} fehlgeschlagen"
+    "bulk_partial": "{{done}} erledigt, {{failed}} fehlgeschlagen",
+    "filter_placeholder": "Nach Name filtern",
+    "filter_no_match": "Kein Eintrag passt zu diesem Filter.",
+    "row_count": "{{shown}} von {{total}}",
+    "sort_label": "Sortieren nach",
+    "sort_priority": "Priorität",
+    "sort_name": "Name",
+    "sort_default": "Standardreihenfolge"
   },
   "data_table": {
     "load_error": "Liste konnte nicht geladen werden.",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2647,7 +2647,14 @@
     "bulk_enabled_done": "{{count}} entries activated",
     "bulk_disabled_done": "{{count}} entries deactivated",
     "bulk_deleted_done": "{{count}} entries deleted",
-    "bulk_partial": "{{done}} done, {{failed}} failed"
+    "bulk_partial": "{{done}} done, {{failed}} failed",
+    "filter_placeholder": "Filter by name",
+    "filter_no_match": "No entry matches this filter.",
+    "row_count": "{{shown}} of {{total}}",
+    "sort_label": "Sort by",
+    "sort_priority": "Priority",
+    "sort_name": "Name",
+    "sort_default": "Default order"
   },
   "data_table": {
     "load_error": "Unable to load the list.",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2619,7 +2619,14 @@
     "bulk_enabled_done": "{{count}} entradas activadas",
     "bulk_disabled_done": "{{count}} entradas desactivadas",
     "bulk_deleted_done": "{{count}} entradas eliminadas",
-    "bulk_partial": "{{done}} hechas, {{failed}} con error"
+    "bulk_partial": "{{done}} hechas, {{failed}} con error",
+    "filter_placeholder": "Filtrar por nombre",
+    "filter_no_match": "Ninguna entrada coincide con este filtro.",
+    "row_count": "{{shown}} de {{total}}",
+    "sort_label": "Ordenar por",
+    "sort_priority": "Prioridad",
+    "sort_name": "Nombre",
+    "sort_default": "Orden predeterminado"
   },
   "data_table": {
     "load_error": "No se pudo cargar la lista.",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2647,7 +2647,14 @@
     "bulk_enabled_done": "{{count}} entrées activées",
     "bulk_disabled_done": "{{count}} entrées désactivées",
     "bulk_deleted_done": "{{count}} entrées supprimées",
-    "bulk_partial": "{{done}} traitées, {{failed}} en échec"
+    "bulk_partial": "{{done}} traitées, {{failed}} en échec",
+    "filter_placeholder": "Filtrer par nom",
+    "filter_no_match": "Aucune entrée ne correspond à ce filtre.",
+    "row_count": "{{shown}} sur {{total}}",
+    "sort_label": "Trier par",
+    "sort_priority": "Priorité",
+    "sort_name": "Nom",
+    "sort_default": "Ordre par défaut"
   },
   "data_table": {
     "load_error": "Impossible de charger la liste.",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2619,7 +2619,14 @@
     "bulk_enabled_done": "{{count}} voci attivate",
     "bulk_disabled_done": "{{count}} voci disattivate",
     "bulk_deleted_done": "{{count}} voci eliminate",
-    "bulk_partial": "{{done}} completate, {{failed}} non riuscite"
+    "bulk_partial": "{{done}} completate, {{failed}} non riuscite",
+    "filter_placeholder": "Filtra per nome",
+    "filter_no_match": "Nessuna voce corrisponde a questo filtro.",
+    "row_count": "{{shown}} su {{total}}",
+    "sort_label": "Ordina per",
+    "sort_priority": "Priorità",
+    "sort_name": "Nome",
+    "sort_default": "Ordine predefinito"
   },
   "data_table": {
     "load_error": "Impossibile caricare l'elenco.",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2619,7 +2619,14 @@
     "bulk_enabled_done": "{{count}} entradas ativadas",
     "bulk_disabled_done": "{{count}} entradas desativadas",
     "bulk_deleted_done": "{{count}} entradas eliminadas",
-    "bulk_partial": "{{done}} concluídas, {{failed}} falharam"
+    "bulk_partial": "{{done}} concluídas, {{failed}} falharam",
+    "filter_placeholder": "Filtrar por nome",
+    "filter_no_match": "Nenhuma entrada corresponde a este filtro.",
+    "row_count": "{{shown}} de {{total}}",
+    "sort_label": "Ordenar por",
+    "sort_priority": "Prioridade",
+    "sort_name": "Nome",
+    "sort_default": "Ordem predefinida"
   },
   "data_table": {
     "load_error": "Não foi possível carregar a lista.",

--- a/client/src/app/shared/components/provider-list/provider-list.html
+++ b/client/src/app/shared/components/provider-list/provider-list.html
@@ -23,10 +23,39 @@
     </div>
   </div>
 
-  @if (bulkSelect() && selectedIds().size > 0) {
+  @if (bulkSelect() && !loading() && !listError() && rows().length > 0) {
     <div
       class="flex flex-wrap items-center gap-2 rounded-lg border border-base-200 bg-base-200/40 px-3 py-2"
     >
+      @if (selectedIds().size === 0) {
+        <label class="input input-sm input-bordered flex items-center gap-2 w-full sm:w-64">
+          <svg lucideSearch class="h-4 w-4 opacity-60"></svg>
+          <input
+            type="search"
+            class="grow"
+            [value]="filterText()"
+            [placeholder]="'provider_list.filter_placeholder' | translate"
+            [attr.aria-label]="'provider_list.filter_placeholder' | translate"
+            (input)="filterText.set($any($event.target).value)"
+          />
+        </label>
+        <span class="text-sm text-base-content/60">
+          {{ 'provider_list.row_count' | translate: { shown: visibleRows().length, total: rows().length } }}
+        </span>
+        <label class="flex items-center gap-2 text-sm ms-auto">
+          <span class="text-base-content/60">{{ 'provider_list.sort_label' | translate }}</span>
+          <select
+            class="select select-sm select-bordered"
+            [value]="sortBy()"
+            (change)="sortBy.set($any($event.target).value)"
+          >
+            <option value="default">
+              {{ (showPriority() ? 'provider_list.sort_priority' : 'provider_list.sort_default') | translate }}
+            </option>
+            <option value="name">{{ 'provider_list.sort_name' | translate }}</option>
+          </select>
+        </label>
+      } @else {
       <span class="text-sm font-medium">
         {{ 'provider_list.bulk_selected' | translate: { count: selectedIds().size } }}
       </span>
@@ -61,6 +90,7 @@
           {{ 'provider_list.bulk_clear' | translate }}
         </button>
       </div>
+      }
     </div>
   }
 
@@ -72,6 +102,8 @@
     <div role="alert" class="alert alert-error">{{ listError() }}</div>
   } @else if (rows().length === 0) {
     <p class="text-center py-12 text-base-content/50">{{ labels().emptyKey | translate }}</p>
+  } @else if (visibleRows().length === 0) {
+    <p class="text-center py-12 text-base-content/50">{{ 'provider_list.filter_no_match' | translate }}</p>
   } @else {
     <div class="overflow-x-auto rounded-lg border border-base-200">
       <table class="table table-zebra">
@@ -107,7 +139,7 @@
           </tr>
         </thead>
         <tbody>
-          @for (row of orderedRows(); track row.id; let i = $index) {
+          @for (row of visibleRows(); track row.id) {
             <tr>
               @if (bulkSelect()) {
                 <td>
@@ -182,7 +214,7 @@
                     <button
                       type="button"
                       class="btn btn-ghost btn-xs btn-square"
-                      [disabled]="i === 0"
+                      [disabled]="isFirstInOrder(row)"
                       (click)="moveRow(row, -1)"
                       [attr.aria-label]="'provider_list.move_up' | translate"
                     >
@@ -191,7 +223,7 @@
                     <button
                       type="button"
                       class="btn btn-ghost btn-xs btn-square"
-                      [disabled]="i === orderedRows().length - 1"
+                      [disabled]="isLastInOrder(row)"
                       (click)="moveRow(row, 1)"
                       [attr.aria-label]="'provider_list.move_down' | translate"
                     >
@@ -337,10 +369,10 @@
       <p class="text-sm text-base-content/60">{{ 'provider_list.bulk_edit_hint' | translate }}</p>
 
       @if (showPriority()) {
-        <div class="flex items-start gap-3">
+        <div class="flex items-center gap-3">
           <input
             type="checkbox"
-            class="checkbox checkbox-sm mt-3"
+            class="checkbox checkbox-sm"
             [checked]="isBulkApplied('priority')"
             [attr.aria-label]="'provider_list.bulk_apply_field' | translate"
             (change)="toggleBulkApply('priority')"
@@ -358,10 +390,10 @@
       }
 
       @for (field of bulkFields(); track field.key) {
-        <div class="flex items-start gap-3">
+        <div class="flex items-center gap-3">
           <input
             type="checkbox"
-            class="checkbox checkbox-sm mt-3"
+            class="checkbox checkbox-sm"
             [checked]="isBulkApplied(field.key)"
             [attr.aria-label]="'provider_list.bulk_apply_field' | translate"
             (change)="toggleBulkApply(field.key)"

--- a/client/src/app/shared/components/provider-list/provider-list.spec.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.spec.ts
@@ -642,3 +642,92 @@ describe('ProviderListComponent: bulk selection', () => {
     expect((put.mock.calls[1]![1] as Record<string, unknown>)['priority']).toBe(50);
   });
 });
+
+describe('ProviderListComponent: filter, sort and the shared toolbar', () => {
+  const ROWS = [
+    { id: 1, name: 'Zeta tracker', implementation: 'demo', enabled: true, priority: 1, settings: {} },
+    { id: 2, name: 'alpha tracker', implementation: 'demo', enabled: true, priority: 2, settings: {} },
+    { id: 3, name: 'Mid tracker', implementation: 'demo', enabled: true, priority: 3, settings: {} },
+  ];
+
+  it('filters on the name, ignoring case, and leaves the real order alone', async () => {
+    const fixture = await createComponent({ get: () => of(ROWS) }, { bulkSelect: true });
+    const c = fixture.componentInstance;
+
+    c.filterText.set('ALPHA');
+    expect(c.visibleRows().map((r) => r.id)).toEqual([2]);
+
+    c.filterText.set('  tracker ');
+    expect(c.visibleRows().map((r) => r.id)).toEqual([1, 2, 3]);
+
+    c.filterText.set('nothing');
+    expect(c.visibleRows()).toHaveLength(0);
+  });
+
+  it('sorts by name on request, and by the server order otherwise', async () => {
+    const fixture = await createComponent({ get: () => of(ROWS) }, { bulkSelect: true });
+    const c = fixture.componentInstance;
+
+    expect(c.visibleRows().map((r) => r.id)).toEqual([1, 2, 3]);
+    c.sortBy.set('name');
+    expect(c.visibleRows().map((r) => r.name)).toEqual(['alpha tracker', 'Mid tracker', 'Zeta tracker']);
+  });
+
+  it('VERDICT: the header box covers the rows on screen and leaves a hidden selection untouched', async () => {
+    const fixture = await createComponent({ get: () => of(ROWS) }, { bulkSelect: true });
+    const c = fixture.componentInstance;
+
+    c.toggleSelected(1);
+    c.filterText.set('tracker!');
+    expect(c.visibleRows()).toHaveLength(0);
+    expect(c.allSelected()).toBe(false);
+
+    c.filterText.set('alpha');
+    c.toggleAllSelected();
+    // Row 1 is filtered out and stays selected: the bar states the real count, so nothing acts
+    // on more than it claims.
+    expect([...c.selectedIds()].sort()).toEqual([1, 2]);
+    expect(c.allSelected()).toBe(true);
+
+    c.toggleAllSelected();
+    expect([...c.selectedIds()]).toEqual([1]);
+  });
+
+  it('VERDICT: one bar, whose content swaps on selection, so the table never shifts', async () => {
+    const fixture = await createComponent({ get: () => of(ROWS) }, { bulkSelect: true });
+    const c = fixture.componentInstance;
+    const bars = () => fixture.nativeElement.querySelectorAll('.bg-base-200\\/40').length;
+    const searchBox = () => fixture.nativeElement.querySelector('input[type="search"]');
+
+    expect(bars()).toBe(1);
+    expect(searchBox()).not.toBeNull();
+
+    c.toggleSelected(1);
+    fixture.detectChanges();
+    // The bulk actions replace the filter bar rather than stacking above it.
+    expect(bars()).toBe(1);
+    expect(searchBox()).toBeNull();
+
+    c.clearSelection();
+    fixture.detectChanges();
+    expect(bars()).toBe(1);
+    expect(searchBox()).not.toBeNull();
+  });
+
+  it('no bar at all on a page that did not opt into selection', async () => {
+    const fixture = await createComponent({ get: () => of(ROWS) });
+    expect(fixture.nativeElement.querySelector('input[type="search"]')).toBeNull();
+  });
+
+  it('the reorder arrows follow the real priority order, not the filtered view', async () => {
+    const fixture = await createComponent({ get: () => of(ROWS) }, { bulkSelect: true, reorderable: true });
+    const c = fixture.componentInstance;
+    c.filterText.set('mid');
+
+    const mid = ROWS[2]!;
+    expect(c.visibleRows()).toHaveLength(1);
+    // Alone on screen, but last in priority order: only the down arrow is dead.
+    expect(c.isFirstInOrder(mid)).toBe(false);
+    expect(c.isLastInOrder(mid)).toBe(true);
+  });
+});

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -15,7 +15,7 @@ import { HttpClient, HttpContext } from '@angular/common/http';
 import { NgTemplateOutlet } from '@angular/common';
 import { firstValueFrom } from 'rxjs';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { LucideArrowUp, LucideArrowDown, LucideRotateCcw } from '@lucide/angular';
+import { LucideArrowUp, LucideArrowDown, LucideRotateCcw, LucideSearch } from '@lucide/angular';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { SKIP_ERROR_TOAST } from '../../../core/interceptors/error.interceptor';
 import { ToastService } from '../../../core/services/toast.service';
@@ -75,6 +75,7 @@ export function resolveRowActionRoute(route: string, id: number | string): strin
     LucideArrowUp,
     LucideArrowDown,
     LucideRotateCcw,
+    LucideSearch,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './provider-list.html',
@@ -155,6 +156,11 @@ export class ProviderListComponent implements OnInit {
   readonly bulkValue = signal<SchemaFormValue>({});
   readonly bulkPriority = signal(0);
 
+  /** Free-text filter on the row name, and the display order chosen over the server's own.
+   *  Both live in the same bar the bulk actions take over, so selecting a row moves nothing. */
+  readonly filterText = signal('');
+  readonly sortBy = signal<'default' | 'name'>('default');
+
   readonly listActionBusy = signal<string | null>(null);
   readonly rowActionBusy = signal<string | null>(null);
 
@@ -173,14 +179,33 @@ export class ProviderListComponent implements OnInit {
     this.reorderable() ? [...this.rows()].sort((a, b) => a.priority - b.priority) : this.rows(),
   );
 
+  /**
+   * What the table renders: the display order, then the name filter, then the chosen sort.
+   *
+   * `moveRow` deliberately keeps reading `orderedRows`: the swap it performs is over the real
+   * priority order, and a filtered or renamed-sorted view would swap the wrong pair.
+   */
+  readonly visibleRows = computed(() => {
+    const needle = this.filterText().trim().toLowerCase();
+    const rows = needle
+      ? this.orderedRows().filter((r) => r.name.toLowerCase().includes(needle))
+      : this.orderedRows();
+    if (this.sortBy() !== 'name') return rows;
+    return [...rows].sort((a, b) => a.name.localeCompare(b.name));
+  });
+
   readonly selectedRows = computed(() => {
     const ids = this.selectedIds();
     return this.rows().filter((r) => ids.has(r.id));
   });
 
-  readonly allSelected = computed(
-    () => this.rows().length > 0 && this.selectedIds().size === this.rows().length,
-  );
+  /** Over the rows on screen, not the whole list: with a filter applied, ticking the header box
+   *  must mean "these", which is also what makes it usable as "select the eight matching X". */
+  readonly allSelected = computed(() => {
+    const rows = this.visibleRows();
+    const ids = this.selectedIds();
+    return rows.length > 0 && rows.every((r) => ids.has(r.id));
+  });
 
   /** The one implementation every selected row shares, or null when they differ: the bulk editor
    *  is built from an implementation's own fields, so a mixed selection has no form to render. */
@@ -407,6 +432,17 @@ export class ProviderListComponent implements OnInit {
     }
   }
 
+  /** Whether this row is at one end of the real priority order. Read from the row rather than
+   *  from the loop index, which now counts a filtered, possibly re-sorted view. */
+  isFirstInOrder(row: ProviderInstance): boolean {
+    return this.orderedRows()[0]?.id === row.id;
+  }
+
+  isLastInOrder(row: ProviderInstance): boolean {
+    const ordered = this.orderedRows();
+    return ordered[ordered.length - 1]?.id === row.id;
+  }
+
   /** Swaps this row's priority with its neighbour in display order and persists both. */
   async moveRow(row: ProviderInstance, direction: -1 | 1): Promise<void> {
     const ordered = this.orderedRows();
@@ -495,10 +531,19 @@ export class ProviderListComponent implements OnInit {
     });
   }
 
-  /** The header box: all or nothing, over every row rather than the page's visible order (there
-   *  is no paging here, so they are the same set). */
+  /** The header box: ticks or unticks the rows on screen, leaving any selection the filter hides
+   *  alone. The bulk bar always states the real count, so nothing acts on more than it claims. */
   toggleAllSelected(): void {
-    this.selectedIds.set(this.allSelected() ? new Set() : new Set(this.rows().map((r) => r.id)));
+    const visible = this.visibleRows().map((r) => r.id);
+    const all = this.allSelected();
+    this.selectedIds.update((ids) => {
+      const next = new Set(ids);
+      for (const id of visible) {
+        if (all) next.delete(id);
+        else next.add(id);
+      }
+      return next;
+    });
   }
 
   clearSelection(): void {


### PR DESCRIPTION
## Problem

Ticking the first row made the bulk bar appear above the table, pushing every row down. Untick, and everything jumped back.

## Fix

One bar, two states, same container and padding:

- **Nothing selected**: a name filter, the `shown / total` count, and a sort choice (the resource's own order, or by name).
- **Something selected**: the batch actions, exactly as before.

Nothing is added or removed from the layout, so the table does not move. It renders only on a page that opted into selection (`bulkSelect`) and only once there are rows, so the other provider lists are untouched.

The filter is also what makes selection usable on a list an import filled: type a word, tick the header box, act on the matches. Two consequences, both deliberate:

- The header box covers **the rows on screen**, not the whole list.
- A selection the filter hides is left alone rather than silently dropped, because the bar always states the real count. Nothing acts on more than it claims.

The reorder arrows read their end-of-list state from the row's place in the priority order (`isFirstInOrder` / `isLastInOrder`) instead of the loop index, which no longer counts the same rows. `moveRow` still swaps over the real order.

Also centres the "apply this field" boxes against their fields in the bulk editor.

## Test

- 725 pass across 77 files. 6 new specs: case-insensitive and trimmed filtering, sort by name vs the server order, the header box covering only what is visible while a hidden selection survives, exactly **one** bar in both states with the search input appearing and disappearing (the actual regression guard for the jump), no bar at all without `bulkSelect`, and the arrows following the priority order under a filter.
- `tsc -p tsconfig.app.json --noEmit` clean.

Known limit: on a narrow viewport the five batch buttons wrap onto more lines than the filter row, so the bar can still grow there. On the desktop widths these admin pages are used at, both states are one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)