### PR TITLE
fix(popover-menu): follow the anchor by frame instead of by event

### DIFF
--- a/client/src/app/shared/components/popover-menu.spec.ts
+++ b/client/src/app/shared/components/popover-menu.spec.ts
@@ -1,0 +1,107 @@
+import { Component, ElementRef, provideZonelessChangeDetection, signal, viewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PopoverMenuComponent } from './popover-menu';
+import { DeviceService } from '../../core/services/device.service';
+import { TvService } from '../../core/services/tv.service';
+import { DismissableStackService } from '../../core/services/dismissable-stack.service';
+
+/** A trigger whose box the test moves under the open menu, the way a scrolling form does. */
+@Component({
+  imports: [PopoverMenuComponent],
+  template: `
+    <button #trigger type="button">open</button>
+    <app-popover-menu [open]="open()" [anchor]="anchorEl()">
+      <button type="button" class="dropdown-item">an item</button>
+    </app-popover-menu>
+  `,
+})
+class HostComponent {
+  readonly open = signal(false);
+  readonly trigger = viewChild.required<ElementRef<HTMLElement>>('trigger');
+  anchorEl(): HTMLElement {
+    return this.trigger().nativeElement;
+  }
+}
+
+function rectAt(top: number): DOMRect {
+  return { top, bottom: top + 32, left: 40, right: 240, width: 200, height: 32, x: 40, y: top, toJSON: () => ({}) } as DOMRect;
+}
+
+async function settle(fixture: ComponentFixture<unknown>) {
+  fixture.detectChanges();
+  await fixture.whenStable();
+  await new Promise((r) => setTimeout(r, 0));
+  fixture.detectChanges();
+}
+
+/** Drives the component's own `requestAnimationFrame` follow loop one turn. */
+async function nextFrames(fixture: ComponentFixture<unknown>, turns = 2) {
+  for (let i = 0; i < turns; i++) {
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+    await settle(fixture);
+  }
+}
+
+describe('PopoverMenuComponent: following its anchor', () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeAll(() => {
+    Element.prototype.scrollIntoView ??= () => {};
+  });
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        // Desktop with a mouse is the anchored-dropdown branch; touch and TV get a sheet, which
+        // has no position to follow.
+        { provide: DeviceService, useValue: { isTouch: () => false, isDesktop: () => true } },
+        { provide: TvService, useValue: { isTv: () => false } },
+        { provide: DismissableStackService, useValue: { push: () => {}, remove: () => {} } },
+      ],
+    });
+    fixture = TestBed.createComponent(HostComponent);
+    await settle(fixture);
+  });
+
+  /** The popover moves its host out of the fixture, under `<html>`, so it can escape any
+   *  scrolling or stacking ancestor. */
+  function panel(): HTMLElement | null {
+    return document.querySelector('[data-tv-modal]') as HTMLElement | null;
+  }
+
+  it('VERDICT: repositions when the trigger moves with no scroll or resize event at all', async () => {
+    const trigger = fixture.componentInstance.trigger().nativeElement;
+    trigger.getBoundingClientRect = () => rectAt(500);
+
+    fixture.componentInstance.open.set(true);
+    await settle(fixture);
+    const opened = panel();
+    expect(opened).not.toBeNull();
+    expect(opened!.style.top).toBe('540px');
+
+    // The container behind the menu scrolls: only the trigger's box changes, and nothing
+    // dispatches an event the popover listens to.
+    trigger.getBoundingClientRect = () => rectAt(120);
+    await nextFrames(fixture);
+
+    expect(panel()!.style.top).toBe('160px');
+  });
+
+  it('stops following once closed', async () => {
+    const trigger = fixture.componentInstance.trigger().nativeElement;
+    trigger.getBoundingClientRect = () => rectAt(200);
+    fixture.componentInstance.open.set(true);
+    await settle(fixture);
+    expect(panel()!.style.top).toBe('240px');
+
+    fixture.componentInstance.open.set(false);
+    await settle(fixture);
+    expect(panel()).toBeNull();
+
+    // Moving the trigger now must not throw or schedule anything: the loop is cancelled.
+    trigger.getBoundingClientRect = () => rectAt(600);
+    await nextFrames(fixture);
+    expect(panel()).toBeNull();
+  });
+});

--- a/client/src/app/shared/components/popover-menu.ts
+++ b/client/src/app/shared/components/popover-menu.ts
@@ -9,6 +9,7 @@ import {
   input,
   output,
   signal,
+  untracked,
 } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 import { BottomSheetComponent } from './bottom-sheet';
@@ -188,6 +189,8 @@ export class PopoverMenuComponent {
       // hardware back button (Capacitor / Tizen) close the popover. Return
       // focus to the opener so keyboard / D-pad users don't lose their place
       // (a submenu returns to its parent entry, a menu to its trigger).
+      const anchorOf = () => untracked(() => this.anchor());
+      const bump = () => this.viewportTick.update((v) => v + 1);
       const close = () => {
         restoreOpenerFocus(this.anchor());
         this.close();
@@ -195,18 +198,28 @@ export class PopoverMenuComponent {
       this.dismissStack.push(close);
       onCleanup(() => this.dismissStack.remove(close));
 
-      // Re-tick on scroll / resize so the `position()` computed
-      // re-reads `getBoundingClientRect` and the fixed-positioned box
-      // stays glued to its trigger. `capture: true` catches scrolls in
-      // any nested overflow container, not just window.
+      // Follow the anchor by frame rather than by event, for as long as the menu is open, so
+      // `position()` re-reads `getBoundingClientRect` whenever the trigger actually moved.
+      // Events cannot answer this on their own: a nested `overflow-y: auto` container (a
+      // `.modal-box` around a long form is the case that showed it), an ancestor transform, a
+      // programmatic scroll, a font or image that lands late and reflows the form, all move the
+      // trigger without every one of them firing a `scroll` or a `resize` the popover sees.
+      //
+      // The tick only bumps when the rect changed, so an idle menu costs one rect read per frame
+      // and schedules no change detection at all.
       if (typeof window === 'undefined' || !this.useDropdown()) return;
-      const tick = () => this.viewportTick.update((v) => v + 1);
-      window.addEventListener('scroll', tick, { capture: true, passive: true });
-      window.addEventListener('resize', tick);
-      onCleanup(() => {
-        window.removeEventListener('scroll', tick, { capture: true } as never);
-        window.removeEventListener('resize', tick);
+      let previous = '';
+      let frame = requestAnimationFrame(function follow(this: void) {
+        const a = anchorOf();
+        const r = a?.getBoundingClientRect();
+        const current = r ? `${r.top}|${r.left}|${r.width}|${r.height}` : '';
+        if (current !== previous) {
+          previous = current;
+          bump();
+        }
+        frame = requestAnimationFrame(follow);
       });
+      onCleanup(() => cancelAnimationFrame(frame));
     });
   }
 


### PR DESCRIPTION
## Problem

Reported on the indexer editor: open the `Use for` select, scroll the form, and the option panel stays where the trigger used to be, several hundred pixels away from it.

The panel is `position: fixed` and was repositioned from `scroll` (capture) and `resize` listeners. That set is a guess: a nested `overflow-y: auto` container is the case that showed it here, but an ancestor transform, a programmatic scroll, or a font or image that lands late and reflows the form all move the trigger too, and adding one more listener per case is the same guess repeated.

## Fix

While a menu is open, re-read the anchor's `getBoundingClientRect` each frame and reposition only when it changed. This is what a positioning library calls its `animationFrame` mode, and it is correct regardless of what moved the trigger or whether anything dispatched an event.

Cost: one rect read per frame for as long as a menu is open, no change detection scheduled while the box is unchanged, and the loop is cancelled on close. Only the anchored-dropdown branch runs it; touch and TV get a bottom sheet, which has no position to follow.

## Test

New `popover-menu.spec.ts`, two cases:

- **The regression guard**: the trigger's box is moved with nothing dispatched at all, and the panel's `top` must follow. Verified to **fail on `origin/main`** and pass here, so it pins the fix rather than the framework.
- The loop stops on close: moving the trigger afterwards changes nothing and throws nothing.

Full client suite: 727 pass across 78 files.

Note: I could not reproduce the exact trigger by reading alone (a capture `scroll` listener on `window` does fire for a nested scroller, verified in a headless page), which is why the fix removes the dependency on which event fires rather than adding another listener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)