### PR TITLE
feat(schema-form): a multiselect field type, and the polish it needed

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -99,9 +99,10 @@ export interface FieldDef {
    * "unchanged", so removal needs a spelling of its own (the one JSON Merge Patch uses).
    */
   secret?: boolean;
-  default?: string | number | boolean;
+  /** A `string[]` only for `multiselect`, which is the set a new row starts from. */
+  default?: string | number | boolean | string[];
   /** Required for `multiselect`. For that type the value is a `string[]` of the declared
-   *  `options[].value`; `default` is not honoured, an unset value reads as `[]`. */
+   *  `options[].value`. */
   options?: { value: string; labelKey: string }[];
   /** Written to a column on the row itself rather than into its `settings` bag.
    *  Without this a declared field silently stops persisting an entity column. */

--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -1,7 +1,7 @@
 /**
- * UI-facing contribution types carried by the manifest's `ui.*` block.
- * `client/src/app/core/plugin-ui/contribution.types.ts` mirrors this file
- * verbatim (types only); the CI drift gate diffs the two.
+ * UI-facing contribution types carried by the manifest's `ui.*` block. The client imports this
+ * very file through its `@fliks/plugin-contract/ui` path alias, so there is nothing to keep in
+ * sync: a change here reaches both sides or compiles on neither.
  */
 
 /** The six slots a contribution can render into. */
@@ -69,8 +69,16 @@ export interface UiContribution {
  */
 export const SECRETS_SET_KEY = 'secretsSet';
 
-/** The seven field kinds `<app-schema-form>` renders, over three form components. */
-export type FieldType = 'text' | 'email' | 'password' | 'url' | 'number' | 'toggle' | 'select';
+/** The eight field kinds `<app-schema-form>` renders, over four form components. */
+export type FieldType =
+  | 'text'
+  | 'email'
+  | 'password'
+  | 'url'
+  | 'number'
+  | 'toggle'
+  | 'select'
+  | 'multiselect';
 
 /**
  * One input of a plugin's settings form. `kind` is optional and defaults to `'field'` —
@@ -92,6 +100,8 @@ export interface FieldDef {
    */
   secret?: boolean;
   default?: string | number | boolean;
+  /** Required for `multiselect`. For that type the value is a `string[]` of the declared
+   *  `options[].value`; `default` is not honoured, an unset value reads as `[]`. */
   options?: { value: string; labelKey: string }[];
   /** Written to a column on the row itself rather than into its `settings` bag.
    *  Without this a declared field silently stops persisting an entity column. */

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2623,7 +2623,7 @@
     "filter_placeholder": "Nach Name filtern",
     "filter_no_match": "Kein Eintrag passt zu diesem Filter.",
     "row_count": "{{shown}} von {{total}}",
-    "sort_label": "Sortieren nach",
+    "sort_label": "Sortieren nach:",
     "sort_priority": "Priorität",
     "sort_name": "Name",
     "sort_default": "Standardreihenfolge"

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2651,7 +2651,7 @@
     "filter_placeholder": "Filter by name",
     "filter_no_match": "No entry matches this filter.",
     "row_count": "{{shown}} of {{total}}",
-    "sort_label": "Sort by",
+    "sort_label": "Sort by:",
     "sort_priority": "Priority",
     "sort_name": "Name",
     "sort_default": "Default order"

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2623,7 +2623,7 @@
     "filter_placeholder": "Filtrar por nombre",
     "filter_no_match": "Ninguna entrada coincide con este filtro.",
     "row_count": "{{shown}} de {{total}}",
-    "sort_label": "Ordenar por",
+    "sort_label": "Ordenar por:",
     "sort_priority": "Prioridad",
     "sort_name": "Nombre",
     "sort_default": "Orden predeterminado"

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2651,7 +2651,7 @@
     "filter_placeholder": "Filtrer par nom",
     "filter_no_match": "Aucune entrée ne correspond à ce filtre.",
     "row_count": "{{shown}} sur {{total}}",
-    "sort_label": "Trier par",
+    "sort_label": "Trier par :",
     "sort_priority": "Priorité",
     "sort_name": "Nom",
     "sort_default": "Ordre par défaut"

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2623,7 +2623,7 @@
     "filter_placeholder": "Filtra per nome",
     "filter_no_match": "Nessuna voce corrisponde a questo filtro.",
     "row_count": "{{shown}} su {{total}}",
-    "sort_label": "Ordina per",
+    "sort_label": "Ordina per:",
     "sort_priority": "Priorità",
     "sort_name": "Nome",
     "sort_default": "Ordine predefinito"

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2623,7 +2623,7 @@
     "filter_placeholder": "Filtrar por nome",
     "filter_no_match": "Nenhuma entrada corresponde a este filtro.",
     "row_count": "{{shown}} de {{total}}",
-    "sort_label": "Ordenar por",
+    "sort_label": "Ordenar por:",
     "sort_priority": "Prioridade",
     "sort_name": "Nome",
     "sort_default": "Ordem predefinida"

--- a/client/src/app/features/admin/admin-shell.html
+++ b/client/src/app/features/admin/admin-shell.html
@@ -10,7 +10,7 @@
       <li class="menu-title text-xs uppercase tracking-wider" [class.mt-2]="i === 0" [class.mt-4]="i !== 0">{{ section.label | translate }}</li>
       @for (item of section.items; track item.id) {
         <li>
-          <a [routerLink]="item.route" routerLinkActive="menu-active">
+          <a [routerLink]="item.route" [class.menu-active]="activeItemId() === item.id">
             @if (item.icon) {
               <app-settings-icon [name]="item.icon" class="h-4 w-4" />
             }

--- a/client/src/app/features/admin/admin-shell.ts
+++ b/client/src/app/features/admin/admin-shell.ts
@@ -1,5 +1,5 @@
 import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
-import { RouterLink, RouterLinkActive } from '@angular/router';
+import { RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { LucideShield } from '@lucide/angular';
 import { SettingsDrawerComponent } from '../../shared/components/settings-drawer/settings-drawer';
@@ -9,7 +9,7 @@ import { SettingsSectionsService } from './settings-sections.service';
 @Component({
   selector: 'app-admin-shell',
   imports: [
-    RouterLink, RouterLinkActive, TranslateModule,
+    RouterLink, TranslateModule,
     SettingsDrawerComponent, SettingsIconComponent,
     LucideShield,
   ],
@@ -17,5 +17,7 @@ import { SettingsSectionsService } from './settings-sections.service';
   templateUrl: './admin-shell.html',
 })
 export class AdminShellComponent {
-  readonly sections = inject(SettingsSectionsService).sections;
+  private readonly settings = inject(SettingsSectionsService);
+  readonly sections = this.settings.sections;
+  readonly activeItemId = this.settings.activeItemId;
 }

--- a/client/src/app/features/admin/settings-sections.service.spec.ts
+++ b/client/src/app/features/admin/settings-sections.service.spec.ts
@@ -1,5 +1,7 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { Subject } from 'rxjs';
 import { SettingsSectionsService } from './settings-sections.service';
 import { AuthService } from '../../core/services/auth.service';
 import { DeviceService } from '../../core/services/device.service';
@@ -24,7 +26,7 @@ const entry = (pluginId: string, contributions: UiContribution[], extra: Partial
   ...extra,
 });
 
-function createService(opts: { isAdmin?: boolean; entries?: PluginUiEntry[] } = {}) {
+function createService(opts: { isAdmin?: boolean; entries?: PluginUiEntry[]; url?: string } = {}) {
   TestBed.resetTestingModule();
   TestBed.configureTestingModule({
     providers: [
@@ -36,6 +38,8 @@ function createService(opts: { isAdmin?: boolean; entries?: PluginUiEntry[] } = 
       { provide: TvService, useValue: { isTv: () => false } },
       { provide: DeviceService, useValue: { isTouch: () => false } },
       { provide: PluginUiRegistryService, useValue: { pluginEntries: () => opts.entries ?? [] } },
+      // Only the current URL matters here; the service never navigates.
+      { provide: Router, useValue: { events: new Subject(), url: opts.url ?? '/admin/settings' } },
     ],
   });
   return TestBed.inject(SettingsSectionsService);
@@ -87,5 +91,42 @@ describe('SettingsSectionsService', () => {
     const withAdmin = createService({ isAdmin: true }).sections();
     const withoutAdmin = createService({ isAdmin: false }).sections();
     expect(withoutAdmin).toEqual(withAdmin);
+  });
+});
+
+describe('SettingsSectionsService: which entry the sidebar lights', () => {
+  const pages = [
+    contribution('general', 100),
+    contribution('indexers', 110),
+  ];
+
+  it('lights the Plugins page on its own route', () => {
+    const service = createService({ isAdmin: true, url: '/admin/settings/plugins' });
+    expect(service.activeItemId()).toBe('core.plugins');
+  });
+
+  it("VERDICT: a plugin's own page lights that page, not the Plugins entry it sits under", () => {
+    // The plugin page URL continues `/admin/settings/plugins`, so prefix matching lit both.
+    const service = createService({
+      isAdmin: true,
+      entries: [entry('x', pages)],
+      url: '/admin/settings/plugins/x/indexers',
+    });
+    expect(service.activeItemId()).toBe('indexers');
+  });
+
+  it('still lights a core entry from a deeper URL that no other entry claims', () => {
+    const service = createService({ isAdmin: true, url: '/admin/settings/libraries/42' });
+    expect(service.activeItemId()).toBe('core.libraries');
+  });
+
+  it('lights nothing on a URL no entry claims, rather than the closest prefix', () => {
+    const service = createService({ isAdmin: true, url: '/admin/settings/pluginsomething' });
+    expect(service.activeItemId()).toBeNull();
+  });
+
+  it('ignores a query string and a fragment', () => {
+    const service = createService({ isAdmin: true, url: '/admin/settings/libraries?tab=2#top' });
+    expect(service.activeItemId()).toBe('core.libraries');
   });
 });

--- a/client/src/app/features/admin/settings-sections.service.ts
+++ b/client/src/app/features/admin/settings-sections.service.ts
@@ -1,4 +1,7 @@
 import { Injectable, computed, inject } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { filter, map } from 'rxjs';
 import { AuthService } from '../../core/services/auth.service';
 import { DeviceService } from '../../core/services/device.service';
 import { TvService } from '../../core/services/tv.service';
@@ -42,6 +45,16 @@ export class SettingsSectionsService {
   private readonly auth = inject(AuthService);
   private readonly tv = inject(TvService);
   private readonly device = inject(DeviceService);
+  private readonly router = inject(Router);
+
+  /** Path only: a query string or a fragment is never part of what a nav entry addresses. */
+  private readonly url = toSignal(
+    this.router.events.pipe(
+      filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+      map((e) => e.urlAfterRedirects.split(/[?#]/)[0] ?? ''),
+    ),
+    { initialValue: this.router.url.split(/[?#]/)[0] ?? '' },
+  );
 
   readonly sections = computed<ResolvedSettingsSection[]>(() => {
     const ctx: WhenContext = {
@@ -69,6 +82,24 @@ export class SettingsSectionsService {
       }));
 
     return [...core, ...plugins].filter((s) => s.items.length > 0);
+  });
+
+  /**
+   * The entry the current URL belongs to: the longest route that prefixes it, so a deeper entry
+   * wins over the shallower one it happens to sit under. `/admin/settings/plugins/<id>/<view>`
+   * therefore lights that plugin's own entry and not the Plugins page, while a library detail
+   * still lights Libraries, which has no deeper entry to lose to.
+   */
+  readonly activeItemId = computed<string | null>(() => {
+    const url = this.url();
+    let best: ResolvedSettingsItem | null = null;
+    for (const section of this.sections()) {
+      for (const item of section.items) {
+        if (url !== item.route && !url.startsWith(`${item.route}/`)) continue;
+        if (!best || item.route.length > best.route.length) best = item;
+      }
+    }
+    return best?.id ?? null;
   });
 
   /** `when`-filters and resolves the action to a route; drops a contribution

--- a/client/src/app/shared/components/forms/multi-select/multi-select.html
+++ b/client/src/app/shared/components/forms/multi-select/multi-select.html
@@ -11,10 +11,18 @@
     @for (opt of chips(); track opt.value) {
       <span class="badge badge-sm badge-primary gap-1 max-w-full">
         <span class="truncate">{{ opt.label }}</span>
+        <!-- `mousedown` is where the trigger would take focus and paint its ring: a chip
+             removal is not a visit to the field. -->
         <span
           role="button"
           tabindex="-1"
-          class="cursor-pointer opacity-70 hover:opacity-100"
+          class="hover:opacity-100"
+          [class.cursor-pointer]="!disabled()"
+          [class.opacity-70]="!disabled()"
+          [class.opacity-40]="disabled()"
+          [class.pointer-events-none]="disabled()"
+          [attr.aria-disabled]="disabled() ? 'true' : null"
+          (mousedown)="onChipMouseDown($event)"
           (click)="remove(opt.value, $event)"
           >✕</span
         >
@@ -33,17 +41,20 @@
   placement="bottom-start"
   (closed)="open.set(false)"
 >
-  <!-- Pinned: the popover owns the scroll, so the filter would scroll away. -->
-  <div class="sticky -top-2 z-10 bg-base-200 pt-2 pb-1">
-    <input
-      autofocus
-      type="text"
-      class="input input-bordered input-sm w-full"
-      [placeholder]="'common.search' | translate"
-      [ngModel]="query()"
-      (ngModelChange)="query.set($event)"
-    />
-  </div>
+  @if (showFilter()) {
+    <!-- Pinned: the popover owns the scroll, so the filter would scroll away. Its background is
+         the surface the popover reports, since a dropdown and a bottom sheet are not the same one. -->
+    <div class="sticky top-0 z-10 pt-2 pb-1" style="background-color: var(--popover-surface, var(--color-base-200))">
+      <input
+        autofocus
+        type="text"
+        class="input input-bordered input-sm w-full"
+        [placeholder]="'common.search' | translate"
+        [ngModel]="query()"
+        (ngModelChange)="query.set($event)"
+      />
+    </div>
+  }
   <ul>
     @for (opt of filtered(); track opt.value) {
       <li>

--- a/client/src/app/shared/components/forms/multi-select/multi-select.spec.ts
+++ b/client/src/app/shared/components/forms/multi-select/multi-select.spec.ts
@@ -103,4 +103,68 @@ describe('MultiSelectComponent: number values (existing behaviour)', () => {
     await openTrigger(fixture);
     expect(checkboxes()).toHaveLength(0);
   });
+
+  it('VERDICT: a disabled field keeps its chips whatever reaches the ✕', async () => {
+    const picked = [OPTIONS[0]!.value, OPTIONS[1]!.value];
+    const fixture = createFixture(OPTIONS, [...picked]);
+    fixture.componentRef.setInput('disabled', true);
+    await settle(fixture);
+
+    // Shown but inert: dimmed, not hoverable, and the handler refuses even a synthetic click,
+    // which is what a `pointer-events: none` alone would still let through.
+    const remover = chipRemovers()[0]!;
+    expect(remover.className).toContain('pointer-events-none');
+    expect(remover.getAttribute('aria-disabled')).toBe('true');
+    remover.click();
+    await settle(fixture);
+    expect(fixture.componentInstance.value()).toEqual(picked);
+  });
+
+  it('a chip removal does not focus the trigger, so the field does not light its focus ring', async () => {
+    const fixture = createFixture(OPTIONS, [OPTIONS[0]!.value]);
+    const remover = chipRemovers()[0]!;
+    const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+    remover.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
 });
+
+describe('MultiSelectComponent: the filter earns its place', () => {
+  const many = Array.from({ length: 9 }, (_, i) => ({ value: `v${i}`, label: `Option ${i}` }));
+
+  const few: MultiSelectOption<string>[] = [
+    { value: 'a', label: 'Alpha' },
+    { value: 'b', label: 'Beta' },
+  ];
+
+  it('VERDICT: no filter for a list that fits on screen, one for a list that does not', async () => {
+    const short = createFixture(few);
+    await openTrigger(short);
+    expect(filterInput()).toBeNull();
+
+    TestBed.resetTestingModule();
+    const long = createFixture(many);
+    await openTrigger(long);
+    expect(filterInput()).not.toBeNull();
+  });
+
+  it('still filters the list it is shown for', async () => {
+    const fixture = createFixture(many);
+    await openTrigger(fixture);
+    const input = filterInput()!;
+    input.value = 'Option 3';
+    input.dispatchEvent(new Event('input'));
+    await settle(fixture);
+    expect(checkboxes()).toHaveLength(1);
+  });
+});
+
+/** The panel's own filter box, distinct from the checkboxes it filters. */
+function filterInput(): HTMLInputElement | null {
+  return document.querySelector('[data-tv-modal] input[type="text"]');
+}
+
+/** The ✕ inside each chip, which only exists while the field is editable. */
+function chipRemovers(): HTMLElement[] {
+  return Array.from(document.querySelectorAll('button [role="button"]'));
+}

--- a/client/src/app/shared/components/forms/multi-select/multi-select.spec.ts
+++ b/client/src/app/shared/components/forms/multi-select/multi-select.spec.ts
@@ -1,0 +1,106 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { MultiSelectComponent, MultiSelectOption } from './multi-select';
+import { DeviceService } from '../../../../core/services/device.service';
+import { TvService } from '../../../../core/services/tv.service';
+import { DismissableStackService } from '../../../../core/services/dismissable-stack.service';
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView ??= () => {};
+});
+
+async function settle(fixture: ComponentFixture<unknown>) {
+  fixture.detectChanges();
+  await fixture.whenStable();
+  await new Promise((r) => setTimeout(r, 0));
+  fixture.detectChanges();
+}
+
+function createFixture<T extends string | number>(options: readonly MultiSelectOption<T>[], value: T[] = []) {
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideTranslateService({
+        lang: 'en',
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+      }),
+      // Desktop with a mouse renders the anchored dropdown, not the bottom sheet.
+      { provide: DeviceService, useValue: { isTouch: () => false, isDesktop: () => true } },
+      { provide: TvService, useValue: { isTv: () => false } },
+      { provide: DismissableStackService, useValue: { push: () => {}, remove: () => {} } },
+    ],
+  });
+  const fixture = TestBed.createComponent<MultiSelectComponent<T>>(MultiSelectComponent);
+  fixture.componentRef.setInput('options', options);
+  fixture.componentRef.setInput('value', value);
+  fixture.detectChanges();
+  return fixture;
+}
+
+/** The open panel is reparented under `<html>` (see PopoverMenuComponent), so its checkboxes
+ *  live outside the fixture's own DOM once open. */
+function checkboxes(): HTMLInputElement[] {
+  return Array.from(document.querySelectorAll('input[type="checkbox"]'));
+}
+
+async function openTrigger(fixture: ComponentFixture<unknown>): Promise<void> {
+  (fixture.nativeElement.querySelector('button') as HTMLButtonElement).click();
+  await settle(fixture);
+}
+
+describe('MultiSelectComponent: string values', () => {
+  const OPTIONS: MultiSelectOption<string>[] = [
+    { value: 'sub', label: 'Subtitles' },
+    { value: 'meta', label: 'Metadata' },
+  ];
+
+  it('ticking an option writes a string[] value', async () => {
+    const fixture = createFixture(OPTIONS);
+    await openTrigger(fixture);
+
+    const box = checkboxes()[0]!;
+    box.checked = true;
+    box.dispatchEvent(new Event('change'));
+
+    expect(fixture.componentInstance.value()).toEqual(['sub']);
+  });
+
+  it('unticking removes it from the array', async () => {
+    const fixture = createFixture(OPTIONS, ['sub', 'meta']);
+    await openTrigger(fixture);
+
+    checkboxes()[0]!.dispatchEvent(new Event('change'));
+
+    expect(fixture.componentInstance.value()).toEqual(['meta']);
+  });
+
+  it('renders a chip per picked option, labelled from `options`', () => {
+    const fixture = createFixture(OPTIONS, ['meta']);
+    expect(fixture.nativeElement.textContent).toContain('Metadata');
+  });
+});
+
+describe('MultiSelectComponent: number values (existing behaviour)', () => {
+  const OPTIONS: MultiSelectOption<number>[] = [
+    { value: 1, label: 'Library A' },
+    { value: 2, label: 'Library B' },
+  ];
+
+  it('ticking an option writes a number[] value', async () => {
+    const fixture = createFixture(OPTIONS);
+    await openTrigger(fixture);
+
+    checkboxes()[1]!.dispatchEvent(new Event('change'));
+
+    expect(fixture.componentInstance.value()).toEqual([2]);
+  });
+
+  it('does not open while disabled', async () => {
+    const fixture = createFixture(OPTIONS);
+    fixture.componentRef.setInput('disabled', true);
+    await openTrigger(fixture);
+    expect(checkboxes()).toHaveLength(0);
+  });
+});

--- a/client/src/app/shared/components/forms/multi-select/multi-select.ts
+++ b/client/src/app/shared/components/forms/multi-select/multi-select.ts
@@ -18,6 +18,10 @@ export interface MultiSelectOption<T extends string | number = number> {
   label: string;
 }
 
+/** Below this many options the whole list is on screen at once, and a filter is one more control
+ *  to skip past (plus a keyboard popping up on mobile). */
+const FILTER_FROM_OPTIONS = 8;
+
 /**
  * Multi-select with a built-in filter: the trigger shows the picked options
  * as removable chips, the panel stays open while ticking several. Sibling of
@@ -78,6 +82,8 @@ export class MultiSelectComponent<T extends string | number = number> {
     });
   }
 
+  protected readonly showFilter = computed(() => this.options().length > FILTER_FROM_OPTIONS);
+
   protected isPicked(value: T) {
     return this.value().includes(value);
   }
@@ -95,8 +101,18 @@ export class MultiSelectComponent<T extends string | number = number> {
     );
   }
 
+  /** Keeps a chip removal from focusing the trigger, which would light its focus ring for a
+   *  click that never entered the field. */
+  protected onChipMouseDown(event: Event) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  /** The ✕ stays visible while disabled, dimmed and inert: `pointer-events` alone would still
+   *  let a synthetic click through, and a form that said no must not lose a value. */
   protected remove(value: T, event: Event) {
     event.stopPropagation();
+    if (this.disabled()) return;
     this.value.update((list) => list.filter((v) => v !== value));
   }
 }

--- a/client/src/app/shared/components/forms/multi-select/multi-select.ts
+++ b/client/src/app/shared/components/forms/multi-select/multi-select.ts
@@ -13,8 +13,8 @@ import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { PopoverMenuComponent } from '../../popover-menu';
 
-export interface MultiSelectOption {
-  value: number;
+export interface MultiSelectOption<T extends string | number = number> {
+  value: T;
   label: string;
 }
 
@@ -38,9 +38,9 @@ export interface MultiSelectOption {
   templateUrl: './multi-select.html',
   host: { class: 'block' },
 })
-export class MultiSelectComponent {
-  readonly options = input.required<readonly MultiSelectOption[]>();
-  readonly value = model<number[]>([]);
+export class MultiSelectComponent<T extends string | number = number> {
+  readonly options = input.required<readonly MultiSelectOption<T>[]>();
+  readonly value = model<T[]>([]);
   readonly placeholder = input<string>('');
   readonly disabled = input<boolean>(false);
   /** Chips shown on the trigger before collapsing the rest into "+N". */
@@ -78,7 +78,7 @@ export class MultiSelectComponent {
     });
   }
 
-  protected isPicked(value: number) {
+  protected isPicked(value: T) {
     return this.value().includes(value);
   }
 
@@ -89,13 +89,13 @@ export class MultiSelectComponent {
     this.open.update((v) => !v);
   }
 
-  protected toggleOption(value: number) {
+  protected toggleOption(value: T) {
     this.value.update((list) =>
       list.includes(value) ? list.filter((v) => v !== value) : [...list, value],
     );
   }
 
-  protected remove(value: number, event: Event) {
+  protected remove(value: T, event: Event) {
     event.stopPropagation();
     this.value.update((list) => list.filter((v) => v !== value));
   }

--- a/client/src/app/shared/components/popover-menu.ts
+++ b/client/src/app/shared/components/popover-menu.ts
@@ -66,6 +66,7 @@ import { initialOverlayFocus, restoreOpenerFocus } from '../../core/services/foc
         [attr.data-tv-submenu]="submenu() ? '' : null"
         (focusout)="onSubmenuFocusOut($event)"
         animate.leave="popover-pop-leaving"
+        style="--popover-surface: var(--color-base-200)"
         class="popover-pop-in fixed z-[101] bg-base-200 rounded-box shadow-xl overflow-y-auto p-2 [scroll-padding:0.5rem] [scroll-behavior:smooth]"
         [style.top.px]="position().top"
         [style.bottom.px]="position().bottom"
@@ -82,7 +83,13 @@ import { initialOverlayFocus, restoreOpenerFocus } from '../../core/services/foc
            projected content (and its bindings) is only instantiated while the
            sheet is on screen — safe to leave the outlet unguarded here. -->
       <app-bottom-sheet [open]="open()" (closed)="close()">
-        <div data-tv-modal [attr.data-tv-submenu]="submenu() ? '' : null" (focusout)="onSubmenuFocusOut($event)" class="px-2 pb-2">
+        <div
+          data-tv-modal
+          [attr.data-tv-submenu]="submenu() ? '' : null"
+          (focusout)="onSubmenuFocusOut($event)"
+          style="--popover-surface: var(--color-neutral)"
+          class="px-2 pb-2"
+        >
           <ng-container *ngTemplateOutlet="content"></ng-container>
         </div>
       </app-bottom-sheet>

--- a/client/src/app/shared/components/provider-list/provider-list.html
+++ b/client/src/app/shared/components/provider-list/provider-list.html
@@ -30,7 +30,10 @@
       @if (selectedIds().size === 0) {
         <label class="input input-sm input-bordered flex items-center gap-2 w-full sm:w-64">
           <svg lucideSearch class="h-4 w-4 opacity-60"></svg>
+          <!-- The `.input` wrapper is what shows focus; the field's own ring would stack a
+               second and third circle inside it. -->
           <input
+            data-no-focus-ring
             type="search"
             class="grow"
             [value]="filterText()"
@@ -42,7 +45,7 @@
         <span class="text-sm text-base-content/60">
           {{ 'provider_list.row_count' | translate: { shown: visibleRows().length, total: rows().length } }}
         </span>
-        <label class="flex items-center gap-2 text-sm ms-auto">
+        <label class="flex items-center gap-2 text-sm ms-auto whitespace-nowrap">
           <span class="text-base-content/60">{{ 'provider_list.sort_label' | translate }}</span>
           <select
             class="select select-sm select-bordered"

--- a/client/src/app/shared/components/provider-list/provider-list.spec.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.spec.ts
@@ -227,6 +227,75 @@ describe('ProviderListComponent — characterisation', () => {
     expect(del).toHaveBeenCalledWith('/api/x/7');
   });
 
+  it("seeds a multiselect field from the row's own array, and [] when absent or not an array", async () => {
+    const impls: ProviderImplementation[] = [
+      {
+        implementation: 'demo',
+        labelKey: 'x.impl_demo',
+        fields: [
+          {
+            key: 'useFor',
+            type: 'multiselect',
+            labelKey: 'x.field_use_for',
+            options: [
+              { value: 'search', labelKey: 'x.search' },
+              { value: 'grab', labelKey: 'x.grab' },
+            ],
+          },
+        ],
+      },
+    ];
+    const fixture = await createComponent(
+      {
+        get: () =>
+          of([
+            { id: 1, name: 'A', implementation: 'demo', enabled: true, priority: 1, settings: { useFor: ['search'] } },
+            { id: 2, name: 'B', implementation: 'demo', enabled: true, priority: 2, settings: {} },
+          ]),
+      },
+      { implementations: impls },
+    );
+    const c = fixture.componentInstance;
+
+    c.openEdit(c.rows()[0]);
+    expect(c.draftValue()['useFor']).toEqual(['search']);
+
+    c.openEdit(c.rows()[1]);
+    expect(c.draftValue()['useFor']).toEqual([]);
+  });
+
+  it('blocks save while a required multiselect is empty, the way a blank required text field does', async () => {
+    const post = vi.fn((_url: string, _body: unknown) => of({}));
+    const impls: ProviderImplementation[] = [
+      {
+        implementation: 'demo',
+        labelKey: 'x.impl_demo',
+        fields: [
+          {
+            key: 'useFor',
+            type: 'multiselect',
+            labelKey: 'x.field_use_for',
+            required: true,
+            options: [{ value: 'search', labelKey: 'x.search' }],
+          },
+        ],
+      },
+    ];
+    const fixture = await createComponent({ get: () => of([]), post }, { implementations: impls });
+    const c = fixture.componentInstance;
+
+    c.openCreate();
+    c.draftName.set('New');
+    expect(c.requiredFieldMissing()).toBe(true);
+    await c.save();
+    expect(post).not.toHaveBeenCalled();
+
+    c.draftValue.update((v) => ({ ...v, useFor: ['search'] }));
+    expect(c.requiredFieldMissing()).toBe(false);
+    await c.save();
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
   it('VERDICT: editing seeds a topLevel field from the row itself, not from settings', async () => {
     const fixture = await createComponent({
       get: () =>

--- a/client/src/app/shared/components/provider-list/provider-list.spec.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.spec.ts
@@ -264,6 +264,42 @@ describe('ProviderListComponent — characterisation', () => {
     expect(c.draftValue()['useFor']).toEqual([]);
   });
 
+  it('VERDICT: a new row starts a multiselect on its declared default, an existing one on what it stored', async () => {
+    const impls: ProviderImplementation[] = [
+      {
+        implementation: 'demo',
+        labelKey: 'x.impl_demo',
+        fields: [
+          {
+            key: 'useFor',
+            type: 'multiselect',
+            labelKey: 'x.field_use_for',
+            default: ['rss', 'auto', 'manual'],
+            options: [
+              { value: 'rss', labelKey: 'x.rss' },
+              { value: 'auto', labelKey: 'x.auto' },
+              { value: 'manual', labelKey: 'x.manual' },
+            ],
+          },
+        ],
+      },
+    ];
+    const fixture = await createComponent(
+      {
+        get: () =>
+          of([{ id: 1, name: 'A', implementation: 'demo', enabled: true, priority: 1, settings: { useFor: ['rss'] } }]),
+      },
+      { implementations: impls },
+    );
+    const c = fixture.componentInstance;
+
+    c.openCreate();
+    expect(c.draftValue()['useFor']).toEqual(['rss', 'auto', 'manual']);
+
+    c.openEdit(c.rows()[0]);
+    expect(c.draftValue()['useFor']).toEqual(['rss']);
+  });
+
   it('blocks save while a required multiselect is empty, the way a blank required text field does', async () => {
     const post = vi.fn((_url: string, _body: unknown) => of({}));
     const impls: ProviderImplementation[] = [

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -240,7 +240,11 @@ export class ProviderListComponent implements OnInit {
     const impl = this.currentImplementation();
     if (!impl) return false;
     const value = this.draftValue();
-    return impl.fields.some((f) => f.required && !f.secret && !String(value[f.key] ?? '').trim());
+    return impl.fields.some((f) => {
+      if (!f.required || f.secret) return false;
+      const v = value[f.key];
+      return Array.isArray(v) ? v.length === 0 : !String(v ?? '').trim();
+    });
   });
 
   ngOnInit(): void {
@@ -279,6 +283,10 @@ export class ProviderListComponent implements OnInit {
       }
       const source = f.topLevel ? row : (row?.settings as Record<string, unknown> | undefined);
       const raw = source ? source[f.key] : undefined;
+      if (f.type === 'multiselect') {
+        value[f.key] = Array.isArray(raw) ? raw : [];
+        continue;
+      }
       value[f.key] = (raw ?? f.default ?? '') as string | number | boolean;
     }
     return value;

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -284,7 +284,9 @@ export class ProviderListComponent implements OnInit {
       const source = f.topLevel ? row : (row?.settings as Record<string, unknown> | undefined);
       const raw = source ? source[f.key] : undefined;
       if (f.type === 'multiselect') {
-        value[f.key] = Array.isArray(raw) ? raw : [];
+        // A new row starts from the declared default; an existing one from what it stored.
+        const fallback = Array.isArray(f.default) ? [...f.default] : [];
+        value[f.key] = Array.isArray(raw) ? raw : fallback;
         continue;
       }
       value[f.key] = (raw ?? f.default ?? '') as string | number | boolean;

--- a/client/src/app/shared/components/schema-form/schema-form.html
+++ b/client/src/app/shared/components/schema-form/schema-form.html
@@ -62,6 +62,23 @@
         }
       </div>
     }
+    @case ('multiselect') {
+      <div class="form-control w-full flex flex-col gap-1">
+        <div class="label"><span class="label-text font-medium">{{ field.labelKey | translate }}</span></div>
+        <app-multi-select
+          [options]="multiOptions(field)"
+          [disabled]="disabled()"
+          [value]="multiValue(field)"
+          (valueChange)="setMulti(field, $event)"
+        />
+        @if (field.hint) {
+          <div class="label"><span class="label-text-alt text-base-content/50">{{ field.hint | translate }}</span></div>
+        }
+        @for (err of fieldErrors(field); track err.key) {
+          <p class="text-error text-xs">{{ err.key | translate: err.params }}</p>
+        }
+      </div>
+    }
   }
 </ng-template>
 

--- a/client/src/app/shared/components/schema-form/schema-form.spec.ts
+++ b/client/src/app/shared/components/schema-form/schema-form.spec.ts
@@ -1,9 +1,12 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
 import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 import { SchemaFormComponent } from './schema-form';
 import type { FieldDef, FormItem } from '@fliks/plugin-contract/ui';
+import { DeviceService } from '../../../core/services/device.service';
+import { TvService } from '../../../core/services/tv.service';
+import { DismissableStackService } from '../../../core/services/dismissable-stack.service';
 
 function createComponent(
   fields: readonly FormItem[],
@@ -17,6 +20,11 @@ function createComponent(
         lang: 'en',
         loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
       }),
+      // Desktop with a mouse, so a `multiselect` field's popover opens as an anchored
+      // dropdown rather than a bottom sheet.
+      { provide: DeviceService, useValue: { isTouch: () => false, isDesktop: () => true } },
+      { provide: TvService, useValue: { isTv: () => false } },
+      { provide: DismissableStackService, useValue: { push: () => {}, remove: () => {} } },
     ],
   });
   const fixture = TestBed.createComponent(SchemaFormComponent);
@@ -31,6 +39,19 @@ function setInputAndDispatch(el: HTMLInputElement | HTMLSelectElement, value: st
   el.value = value;
   el.dispatchEvent(new Event(el.tagName === 'SELECT' ? 'change' : 'input'));
 }
+
+async function settle(fixture: ComponentFixture<unknown>) {
+  fixture.detectChanges();
+  await fixture.whenStable();
+  await new Promise((r) => setTimeout(r, 0));
+  fixture.detectChanges();
+}
+
+beforeAll(() => {
+  // The shared popover focuses and scrolls to the panel's first item on open; jsdom has no
+  // scrollIntoView.
+  Element.prototype.scrollIntoView ??= () => {};
+});
 
 describe('SchemaFormComponent — field type coverage', () => {
   it('renders text/toggle/select for known types and nothing for an unknown one, without breaking the rest', () => {
@@ -289,6 +310,50 @@ describe('SchemaFormComponent — declared validation constraints', () => {
     expect(fixture.componentInstance.invalid()).toBe(true);
   });
 
+});
+
+describe('SchemaFormComponent: multiselect', () => {
+  const field: FieldDef = {
+    key: 'useFor',
+    type: 'multiselect',
+    labelKey: 'x.use_for',
+    options: [
+      { value: 'search', labelKey: 'x.search' },
+      { value: 'grab', labelKey: 'x.grab' },
+      { value: 'rss', labelKey: 'x.rss' },
+    ],
+  };
+
+  it('renders its declared options and reads an absent value as []', async () => {
+    const fixture = createComponent([field], {});
+    const trigger = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+    trigger.click();
+    await settle(fixture);
+
+    // The open panel is reparented under <html> by the shared popover, outside the fixture.
+    expect(document.querySelectorAll('input[type="checkbox"]').length).toBe(3);
+    expect(fixture.componentInstance.value()['useFor']).toBeUndefined();
+  });
+
+  it('ticking one option writes a string[]', async () => {
+    const fixture = createComponent([field], {});
+    const trigger = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+    trigger.click();
+    await settle(fixture);
+
+    const box = document.querySelectorAll('input[type="checkbox"]')[0] as HTMLInputElement;
+    box.dispatchEvent(new Event('change'));
+
+    expect(fixture.componentInstance.value()['useFor']).toEqual(['search']);
+  });
+
+  it('propagates disabled down to the multi-select trigger', () => {
+    const fixture = createComponent([{ ...field }], {}, []);
+    fixture.componentRef.setInput('disabled', true);
+    fixture.detectChanges();
+    const trigger = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+    expect(trigger.disabled).toBe(true);
+  });
 });
 
 it('VERDICT: reads a stringified boolean, so a stored "false" renders off', async () => {

--- a/client/src/app/shared/components/schema-form/schema-form.ts
+++ b/client/src/app/shared/components/schema-form/schema-form.ts
@@ -1,19 +1,20 @@
-import { ChangeDetectionStrategy, Component, computed, input, model } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, model } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { FieldDef, FormCaption, FormGroup, FormItem, FormStatus } from '@fliks/plugin-contract/ui';
 import { InputFieldComponent, InputFieldType } from '../forms/input-field/input-field';
 import { SelectFieldComponent } from '../forms/select-field/select-field';
 import { ToggleFieldComponent } from '../forms/toggle-field/toggle-field';
+import { MultiSelectComponent, MultiSelectOption } from '../forms/multi-select/multi-select';
 
 /** Keyed by `FieldDef.key`; a select/text/number value is always a string here, coerced on read.
  *  A `status` item's current value is keyed by its own `settingKey` in this same bag. */
-export type SchemaFormValue = Record<string, string | number | boolean | null>;
+export type SchemaFormValue = Record<string, string | number | boolean | null | string[]>;
 
 /** Shown in place of a stored credential the server never echoes back. */
 export const SECRET_MASK = '●●●●●●●●';
 
-type FieldKind = 'input' | 'toggle' | 'select';
+type FieldKind = 'input' | 'toggle' | 'select' | 'multiselect';
 type ItemKind = 'field' | 'caption' | 'group' | 'status';
 
 interface FieldError {
@@ -23,7 +24,7 @@ interface FieldError {
 
 
 /**
- * Renders a `FormItem[]` as DaisyUI controls, delegating to the three shared
+ * Renders a `FormItem[]` as DaisyUI controls, delegating to the shared
  * `forms/` components. An unmatched `field.type` renders nothing — it must
  * never blank out or break the rest of the form.
  *
@@ -40,11 +41,20 @@ interface FieldError {
  */
 @Component({
   selector: 'app-schema-form',
-  imports: [InputFieldComponent, SelectFieldComponent, ToggleFieldComponent, NgTemplateOutlet, TranslateModule],
+  imports: [
+    InputFieldComponent,
+    SelectFieldComponent,
+    ToggleFieldComponent,
+    MultiSelectComponent,
+    NgTemplateOutlet,
+    TranslateModule,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './schema-form.html',
 })
 export class SchemaFormComponent {
+  private readonly translate = inject(TranslateService);
+
   readonly fields = input.required<readonly FormItem[]>();
   readonly value = model.required<SchemaFormValue>();
   readonly disabled = input(false);
@@ -102,9 +112,28 @@ export class SchemaFormComponent {
         return 'toggle';
       case 'select':
         return 'select';
+      case 'multiselect':
+        return 'multiselect';
       default:
         return null;
     }
+  }
+
+  /** `field.options` translated into what `<app-multi-select>` renders. */
+  protected multiOptions(field: FieldDef): MultiSelectOption<string>[] {
+    return (field.options ?? []).map((o) => ({
+      value: o.value,
+      label: this.translate.instant(o.labelKey),
+    }));
+  }
+
+  protected multiValue(field: FieldDef): string[] {
+    const v = this.value()[field.key];
+    return Array.isArray(v) ? v : [];
+  }
+
+  protected setMulti(field: FieldDef, next: string[]): void {
+    this.value.set({ ...this.value(), [field.key]: next });
   }
 
   protected inputType(field: FieldDef): InputFieldType {
@@ -159,9 +188,11 @@ export class SchemaFormComponent {
     if (field.secret) return [];
     const errors: FieldError[] = [];
     const raw = this.value()[field.key];
-    const isEmpty = raw === undefined || raw === null || String(raw).trim() === '';
+    const isEmpty = Array.isArray(raw)
+      ? raw.length === 0
+      : raw === undefined || raw === null || String(raw).trim() === '';
     if (field.required && isEmpty) errors.push({ key: 'common.field_required' });
-    if (isEmpty) return errors;
+    if (isEmpty || Array.isArray(raw)) return errors;
 
     const str = String(raw);
     if (field.type === 'number') {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -31,7 +31,7 @@
    tap has nothing left to show once the ring is suppressed, and dropping the
    border too made a tapped field look borderless. Text fields keep `:focus` —
    their caret is the indication and the ring is not the only cue. */
-.select:focus-visible, .input:focus, .textarea:focus {
+.select:focus-visible, .input:focus, .input:focus-within, .textarea:focus {
   outline-width: 1px;
   outline-offset: 0px;
   border-color: transparent;


### PR DESCRIPTION
Two commits: the field type, then everything found while exercising it on the indexers page.

## The field type

`multiselect` in the plugin UI contract, rendered by `schema-form` through the existing `app-multi-select`. A plugin declares one field with fixed options and the form offers "tick several of these".

- `SchemaFormValue` widened to carry a `string[]`.
- `app-multi-select` is generic over its value type (`<T extends string | number>`); its one existing consumer (auto-approval, library ids) keeps its `number[]` behaviour.
- `provider-list` seeds such a field from the row, and a `required` one counts as missing while empty, the way a blank required text field does.
- A `multiselect` may declare an array `default`: the set a new row starts from.
- Fixed a stale header comment in the contract that claimed a client mirror and a CI drift gate diffing the two. Neither exists: the client imports that very file through its `@fliks/plugin-contract/ui` path alias.

## The polish

- **Three focus rings on the filter box.** The `.input` wrapper paints one on `:focus-within` and the field inside matched the app's global two-layer ring on top. The field takes the existing `data-no-focus-ring` opt-out, and the thin-outline rule for form fields now covers `:focus-within` so a wrapped field looks like an unwrapped one.
- **A disabled multi-select was still losing values.** A click reaches the children of a disabled `<button>` (verified in a browser: `pointer-events` stays `auto` there), so a chip's ✕ was live while the bulk editor had the field unticked. It is now dimmed and inert, and refused in the handler too, because `pointer-events: none` alone still lets a synthetic click through.
- **Removing a chip lit the field's focus ring.** Its `mousedown` no longer focuses the trigger: dropping a chip is not a visit to the field.
- **The panel's filter bar looked wrong on mobile.** It hardcoded `bg-base-200`, the desktop dropdown's surface, over a bottom sheet that is `bg-neutral/95`. The popover now reports its surface as `--popover-surface` and the bar paints itself with that. Its negative sticky offset is gone as well: it compensated the dropdown's padding and rode over the sheet's drag handle.
- **The filter bar only appears past eight options.** Below that the whole list is on screen, and a filter is one control to skip plus a keyboard popping up on a phone.
- **The settings sidebar lit two entries at once** on a plugin's own page, since `routerLinkActive` lights every entry whose route prefixes the URL. The active entry is now the longest route that prefixes it: a plugin page lights that page, a library detail still lights Libraries, and a URL no entry claims lights nothing (a prefix has to stop on a segment boundary). No URL was changed, so no installed plugin manifest has to be republished.
- `Sort by` gained its colon in all six locales, with the no-break space French wants, and the label no longer wraps.

## Test

747 pass across 79 files, `tsc -p client/tsconfig.app.json --noEmit` clean. New specs pin: the multiselect render and its array writes, the default-vs-stored seed, the required-empty block, string and number values in the generic component, the inert ✕ under `disabled`, the chip `mousedown` not focusing, the filter threshold both ways, and five cases of the sidebar's active-entry rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)