### PR TITLE
feat(data-table): add row selection with batch proxy actions

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -376,6 +376,9 @@ export interface TableConfigPage extends ConfigPageBase {
   list: string;
   columns: TableColumn[];
   filters?: TableFilter[];
+  /** Adds a selection column and turns the declared `proxy` row actions into batch actions,
+   *  one confirmation for the whole selection instead of one per row. */
+  bulkSelect?: boolean;
   /**
    * `when` gates on the viewer (the same closed predicate vocabulary `ui.contributions[]` uses —
    * a mutating action names the permission its route is declared under, so the button is absent

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2602,10 +2602,6 @@
     "test_unknown_result": "Der Test ist abgeschlossen, aber das Ergebnis konnte nicht übersetzt werden.",
     "move_up": "Nach oben",
     "move_down": "Nach unten",
-    "bulk_selected": "{{count}} ausgewählt",
-    "bulk_select_all": "Alle Zeilen auswählen",
-    "bulk_select_row": "{{name}} auswählen",
-    "bulk_clear": "Auswahl aufheben",
     "bulk_edit": "Bearbeiten",
     "bulk_enable": "Aktivieren",
     "bulk_disable": "Deaktivieren",
@@ -2615,11 +2611,9 @@
     "bulk_edit_title": "{{count}} Einträge bearbeiten",
     "bulk_edit_hint": "Nur angehakte Felder werden geschrieben. Alles andere behält den Wert des jeweiligen Eintrags.",
     "bulk_apply_field": "Dieses Feld anwenden",
-    "bulk_edited_done": "{{count}} Einträge aktualisiert",
     "bulk_enabled_done": "{{count}} Einträge aktiviert",
     "bulk_disabled_done": "{{count}} Einträge deaktiviert",
     "bulk_deleted_done": "{{count}} Einträge gelöscht",
-    "bulk_partial": "{{done}} erledigt, {{failed}} fehlgeschlagen",
     "filter_placeholder": "Nach Name filtern",
     "filter_no_match": "Kein Eintrag passt zu diesem Filter.",
     "row_count": "{{shown}} von {{total}}",
@@ -2632,5 +2626,15 @@
     "load_error": "Liste konnte nicht geladen werden.",
     "empty": "Nichts anzuzeigen.",
     "refresh": "Aktualisieren"
+  },
+  "bulk": {
+    "selected": "{{count}} ausgewählt",
+    "select_all": "Alle Zeilen auswählen",
+    "select_row": "{{name}} auswählen",
+    "clear": "Auswahl aufheben",
+    "partial": "{{done}} erledigt, {{failed}} fehlgeschlagen",
+    "done": "{{count}} Einträge verarbeitet",
+    "unavailable": "Gilt nicht für alle ausgewählten Zeilen",
+    "rows": "{{count}} Einträge"
   }
 }

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2630,10 +2630,6 @@
     "test_unknown_result": "Test finished, but the result could not be translated.",
     "move_up": "Move up",
     "move_down": "Move down",
-    "bulk_selected": "{{count}} selected",
-    "bulk_select_all": "Select every row",
-    "bulk_select_row": "Select {{name}}",
-    "bulk_clear": "Clear",
     "bulk_edit": "Edit",
     "bulk_enable": "Activate",
     "bulk_disable": "Deactivate",
@@ -2643,11 +2639,9 @@
     "bulk_edit_title": "Edit {{count}} entries",
     "bulk_edit_hint": "Only the ticked fields are written. Everything else keeps the value each entry already has.",
     "bulk_apply_field": "Apply this field",
-    "bulk_edited_done": "{{count}} entries updated",
     "bulk_enabled_done": "{{count}} entries activated",
     "bulk_disabled_done": "{{count}} entries deactivated",
     "bulk_deleted_done": "{{count}} entries deleted",
-    "bulk_partial": "{{done}} done, {{failed}} failed",
     "filter_placeholder": "Filter by name",
     "filter_no_match": "No entry matches this filter.",
     "row_count": "{{shown}} of {{total}}",
@@ -2660,5 +2654,15 @@
     "load_error": "Unable to load the list.",
     "empty": "Nothing to show.",
     "refresh": "Refresh"
+  },
+  "bulk": {
+    "selected": "{{count}} selected",
+    "select_all": "Select every row",
+    "select_row": "Select {{name}}",
+    "clear": "Clear",
+    "partial": "{{done}} done, {{failed}} failed",
+    "done": "{{count}} entries processed",
+    "unavailable": "Doesn't apply to every selected row",
+    "rows": "{{count}} entries"
   }
 }

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2602,10 +2602,6 @@
     "test_unknown_result": "La prueba terminó, pero no se pudo traducir el resultado.",
     "move_up": "Subir",
     "move_down": "Bajar",
-    "bulk_selected": "{{count}} seleccionados",
-    "bulk_select_all": "Seleccionar todas las filas",
-    "bulk_select_row": "Seleccionar {{name}}",
-    "bulk_clear": "Quitar la selección",
     "bulk_edit": "Editar",
     "bulk_enable": "Activar",
     "bulk_disable": "Desactivar",
@@ -2615,11 +2611,9 @@
     "bulk_edit_title": "Editar {{count}} entradas",
     "bulk_edit_hint": "Solo se escriben los campos marcados. El resto conserva el valor de cada entrada.",
     "bulk_apply_field": "Aplicar este campo",
-    "bulk_edited_done": "{{count}} entradas actualizadas",
     "bulk_enabled_done": "{{count}} entradas activadas",
     "bulk_disabled_done": "{{count}} entradas desactivadas",
     "bulk_deleted_done": "{{count}} entradas eliminadas",
-    "bulk_partial": "{{done}} hechas, {{failed}} con error",
     "filter_placeholder": "Filtrar por nombre",
     "filter_no_match": "Ninguna entrada coincide con este filtro.",
     "row_count": "{{shown}} de {{total}}",
@@ -2632,5 +2626,15 @@
     "load_error": "No se pudo cargar la lista.",
     "empty": "Nada que mostrar.",
     "refresh": "Actualizar"
+  },
+  "bulk": {
+    "selected": "{{count}} seleccionados",
+    "select_all": "Seleccionar todas las filas",
+    "select_row": "Seleccionar {{name}}",
+    "clear": "Quitar la selección",
+    "partial": "{{done}} hechas, {{failed}} con error",
+    "done": "{{count}} entradas procesadas",
+    "unavailable": "No se aplica a todas las filas seleccionadas",
+    "rows": "{{count}} entradas"
   }
 }

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2630,10 +2630,6 @@
     "test_unknown_result": "Le test est terminé, mais le résultat n'a pas pu être traduit.",
     "move_up": "Monter",
     "move_down": "Descendre",
-    "bulk_selected": "{{count}} sélectionnés",
-    "bulk_select_all": "Tout sélectionner",
-    "bulk_select_row": "Sélectionner {{name}}",
-    "bulk_clear": "Annuler la sélection",
     "bulk_edit": "Modifier",
     "bulk_enable": "Activer",
     "bulk_disable": "Désactiver",
@@ -2643,11 +2639,9 @@
     "bulk_edit_title": "Modifier {{count}} entrées",
     "bulk_edit_hint": "Seuls les champs cochés sont écrits. Le reste conserve la valeur propre à chaque entrée.",
     "bulk_apply_field": "Appliquer ce champ",
-    "bulk_edited_done": "{{count}} entrées modifiées",
     "bulk_enabled_done": "{{count}} entrées activées",
     "bulk_disabled_done": "{{count}} entrées désactivées",
     "bulk_deleted_done": "{{count}} entrées supprimées",
-    "bulk_partial": "{{done}} traitées, {{failed}} en échec",
     "filter_placeholder": "Filtrer par nom",
     "filter_no_match": "Aucune entrée ne correspond à ce filtre.",
     "row_count": "{{shown}} sur {{total}}",
@@ -2660,5 +2654,15 @@
     "load_error": "Impossible de charger la liste.",
     "empty": "Rien à afficher.",
     "refresh": "Actualiser"
+  },
+  "bulk": {
+    "selected": "{{count}} sélectionnés",
+    "select_all": "Tout sélectionner",
+    "select_row": "Sélectionner {{name}}",
+    "clear": "Annuler la sélection",
+    "partial": "{{done}} traitées, {{failed}} en échec",
+    "done": "{{count}} entrées traitées",
+    "unavailable": "Ne s’applique pas à toutes les lignes sélectionnées",
+    "rows": "{{count}} entrées"
   }
 }

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2602,10 +2602,6 @@
     "test_unknown_result": "Il test è terminato, ma non è stato possibile tradurre il risultato.",
     "move_up": "Sposta su",
     "move_down": "Sposta giù",
-    "bulk_selected": "{{count}} selezionati",
-    "bulk_select_all": "Seleziona tutte le righe",
-    "bulk_select_row": "Seleziona {{name}}",
-    "bulk_clear": "Annulla la selezione",
     "bulk_edit": "Modifica",
     "bulk_enable": "Attiva",
     "bulk_disable": "Disattiva",
@@ -2615,11 +2611,9 @@
     "bulk_edit_title": "Modifica {{count}} voci",
     "bulk_edit_hint": "Vengono scritti solo i campi spuntati. Il resto conserva il valore di ogni voce.",
     "bulk_apply_field": "Applica questo campo",
-    "bulk_edited_done": "{{count}} voci aggiornate",
     "bulk_enabled_done": "{{count}} voci attivate",
     "bulk_disabled_done": "{{count}} voci disattivate",
     "bulk_deleted_done": "{{count}} voci eliminate",
-    "bulk_partial": "{{done}} completate, {{failed}} non riuscite",
     "filter_placeholder": "Filtra per nome",
     "filter_no_match": "Nessuna voce corrisponde a questo filtro.",
     "row_count": "{{shown}} su {{total}}",
@@ -2632,5 +2626,15 @@
     "load_error": "Impossibile caricare l'elenco.",
     "empty": "Niente da visualizzare.",
     "refresh": "Aggiorna"
+  },
+  "bulk": {
+    "selected": "{{count}} selezionati",
+    "select_all": "Seleziona tutte le righe",
+    "select_row": "Seleziona {{name}}",
+    "clear": "Annulla la selezione",
+    "partial": "{{done}} completate, {{failed}} non riuscite",
+    "done": "{{count}} voci elaborate",
+    "unavailable": "Non si applica a tutte le righe selezionate",
+    "rows": "{{count}} voci"
   }
 }

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2602,10 +2602,6 @@
     "test_unknown_result": "O teste terminou, mas o resultado não pôde ser traduzido.",
     "move_up": "Subir",
     "move_down": "Descer",
-    "bulk_selected": "{{count}} selecionados",
-    "bulk_select_all": "Selecionar todas as linhas",
-    "bulk_select_row": "Selecionar {{name}}",
-    "bulk_clear": "Limpar a seleção",
     "bulk_edit": "Editar",
     "bulk_enable": "Ativar",
     "bulk_disable": "Desativar",
@@ -2615,11 +2611,9 @@
     "bulk_edit_title": "Editar {{count}} entradas",
     "bulk_edit_hint": "Apenas os campos marcados são escritos. O resto mantém o valor de cada entrada.",
     "bulk_apply_field": "Aplicar este campo",
-    "bulk_edited_done": "{{count}} entradas atualizadas",
     "bulk_enabled_done": "{{count}} entradas ativadas",
     "bulk_disabled_done": "{{count}} entradas desativadas",
     "bulk_deleted_done": "{{count}} entradas eliminadas",
-    "bulk_partial": "{{done}} concluídas, {{failed}} falharam",
     "filter_placeholder": "Filtrar por nome",
     "filter_no_match": "Nenhuma entrada corresponde a este filtro.",
     "row_count": "{{shown}} de {{total}}",
@@ -2632,5 +2626,15 @@
     "load_error": "Não foi possível carregar a lista.",
     "empty": "Nada para exibir.",
     "refresh": "Atualizar"
+  },
+  "bulk": {
+    "selected": "{{count}} selecionados",
+    "select_all": "Selecionar todas as linhas",
+    "select_row": "Selecionar {{name}}",
+    "clear": "Limpar a seleção",
+    "partial": "{{done}} concluídas, {{failed}} falharam",
+    "done": "{{count}} entradas processadas",
+    "unavailable": "Não se aplica a todas as linhas selecionadas",
+    "rows": "{{count}} entradas"
   }
 }

--- a/client/src/app/features/plugin-view/plugin-view.html
+++ b/client/src/app/features/plugin-view/plugin-view.html
@@ -52,6 +52,7 @@
         [listUrl]="resourceUrl(view.list)"
         [columns]="view.columns"
         [filters]="view.filters ?? []"
+        [bulkSelect]="view.bulkSelect ?? false"
         [rowActions]="tableRowActions(view)"
         [listActions]="tableListActions(view)"
         [defaultSortKey]="view.defaultSortKey ?? null"

--- a/client/src/app/shared/components/data-table/data-table.html
+++ b/client/src/app/shared/components/data-table/data-table.html
@@ -36,35 +36,70 @@
     </div>
   </div>
 
-  @if (filters().length) {
-    <div class="flex flex-wrap items-center gap-2">
-      @for (filter of filters(); track filter.key) {
-        @switch (filter.kind) {
-          @case ('search') {
-            <input
-              type="search"
-              class="input input-bordered input-sm w-full max-w-xs"
-              [placeholder]="filter.placeholderKey | translate"
-              [value]="filterValue(filter.key)"
-              (input)="onSearchInput(filter.key, $event)"
-            />
-          }
-          @case ('select') {
-            <select
-    appTvSelect
-              class="select select-bordered select-sm"
-              [attr.aria-label]="filter.labelKey | translate"
-              (change)="onSelectChange(filter.key, $event)"
+  <!-- One bar for both states: a selection swaps its content instead of adding a row, so the
+       table never shifts. It also stays put on a page that declares no filter at all. -->
+  @if (filters().length || (bulkSelect() && rows().length > 0)) {
+    <div
+      class="flex flex-wrap items-center gap-2 rounded-lg border border-base-200 bg-base-200/40 px-3 py-2"
+    >
+      @if (bulkSelect() && selectedRows().length > 0) {
+        <span class="text-sm font-medium">
+          {{ 'bulk.selected' | translate: { count: selectedRows().length } }}
+        </span>
+        <div class="flex flex-wrap gap-2 ms-auto">
+          @for (item of batchActions(); track item.action.labelKey) {
+            <button
+              type="button"
+              class="btn btn-outline btn-sm"
+              [class.btn-error]="item.action.tone === 'danger'"
+              [disabled]="bulkBusy() || !item.enabled"
+              [attr.title]="item.enabled ? null : ('bulk.unavailable' | translate)"
+              (click)="runBatch(item.action)"
             >
-              @for (option of filter.options; track option.value) {
-                <option
-                  [value]="option.value"
-                  [selected]="filterValue(filter.key) === option.value"
-                >
-                  {{ option.labelKey | translate }}
-                </option>
+              @if (bulkBusy()) {
+                <span class="loading loading-spinner loading-xs"></span>
               }
-            </select>
+              {{ item.action.labelKey | translate }}
+            </button>
+          }
+          <button type="button" class="btn btn-ghost btn-sm" [disabled]="bulkBusy()" (click)="clearSelection()">
+            {{ 'bulk.clear' | translate }}
+          </button>
+        </div>
+      } @else {
+        @if (!filters().length) {
+          <span class="text-sm text-base-content/60">
+            {{ 'bulk.rows' | translate: { count: paged() ? total() : rows().length } }}
+          </span>
+        }
+        @for (filter of filters(); track filter.key) {
+          @switch (filter.kind) {
+            @case ('search') {
+              <input
+                type="search"
+                class="input input-bordered input-sm w-full max-w-xs"
+                [placeholder]="filter.placeholderKey | translate"
+                [value]="filterValue(filter.key)"
+                (input)="onSearchInput(filter.key, $event)"
+              />
+            }
+            @case ('select') {
+              <select
+      appTvSelect
+                class="select select-bordered select-sm"
+                [attr.aria-label]="filter.labelKey | translate"
+                (change)="onSelectChange(filter.key, $event)"
+              >
+                @for (option of filter.options; track option.value) {
+                  <option
+                    [value]="option.value"
+                    [selected]="filterValue(filter.key) === option.value"
+                  >
+                    {{ option.labelKey | translate }}
+                  </option>
+                }
+              </select>
+            }
           }
         }
       }
@@ -84,6 +119,18 @@
       <table class="table table-zebra">
         <thead>
           <tr>
+            @if (bulkSelect()) {
+              <th class="w-10">
+                <input
+                  type="checkbox"
+                  class="checkbox checkbox-sm"
+                  [checked]="allSelected()"
+                  [indeterminate]="selectedRows().length > 0 && !allSelected()"
+                  [attr.aria-label]="'bulk.select_all' | translate"
+                  (change)="toggleAllSelected()"
+                />
+              </th>
+            }
             @for (col of columns(); track col.key) {
               <th>{{ col.labelKey | translate }}</th>
             }
@@ -95,6 +142,17 @@
         <tbody>
           @for (row of rows(); track $index) {
             <tr>
+              @if (bulkSelect()) {
+                <td>
+                  <input
+                    type="checkbox"
+                    class="checkbox checkbox-sm"
+                    [checked]="isSelected(row.id)"
+                    [attr.aria-label]="'bulk.select_row' | translate: { name: rowSelectLabel(row) }"
+                    (change)="toggleSelected(row.id)"
+                  />
+                </td>
+              }
               @for (col of columns(); track col.key) {
                 <td [class.whitespace-nowrap]="cellNowrap(col)">
                   @switch (col.format) {

--- a/client/src/app/shared/components/data-table/data-table.spec.ts
+++ b/client/src/app/shared/components/data-table/data-table.spec.ts
@@ -3,11 +3,14 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { TranslateLoader, TranslateService, provideTranslateService } from '@ngx-translate/core';
-import { Subject, of } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
 import { vi } from 'vitest';
 import { DataTableComponent } from './data-table';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
 import { SseService } from '../../../core/services/sse.service';
+import { ToastService } from '../../../core/services/toast.service';
+import { SKIP_ERROR_TOAST } from '../../../core/interceptors/error.interceptor';
+import { HttpContext } from '@angular/common/http';
 import { ListAction, RowAction, TableColumn, TableFilter, TableRow } from './data-table.types';
 
 const COLUMNS: TableColumn[] = [{ key: 'name', labelKey: 'x.name' }];
@@ -49,6 +52,9 @@ async function createComponent(opts: {
   refreshOn?: string[];
   sseEvent?: WritableSignal<{ type: string } | null>;
   confirmation?: unknown;
+  bulkSelect?: boolean;
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  toast?: { success: (...a: any[]) => void; error: (...a: any[]) => void };
 }) {
   TestBed.configureTestingModule({
     providers: [
@@ -70,6 +76,7 @@ async function createComponent(opts: {
         provide: SseService,
         useValue: { lastEvent: opts.sseEvent ?? signal(null) } as unknown as SseService,
       },
+      { provide: ToastService, useValue: opts.toast ?? { success: () => {}, error: () => {} } },
     ],
   });
   const fixture = TestBed.createComponent(DataTableComponent);
@@ -85,6 +92,7 @@ async function createComponent(opts: {
   if (opts.pageSize) fixture.componentRef.setInput('pageSize', opts.pageSize);
   if (opts.refreshMs) fixture.componentRef.setInput('refreshMs', opts.refreshMs);
   if (opts.refreshOn) fixture.componentRef.setInput('refreshOn', opts.refreshOn);
+  if (opts.bulkSelect) fixture.componentRef.setInput('bulkSelect', opts.bulkSelect);
   fixture.detectChanges();
   await fixture.whenStable();
   await new Promise((r) => setTimeout(r, 0));
@@ -903,5 +911,223 @@ describe('DataTableComponent — a plugin message that is an i18n key', () => {
     const row = { id: 1, status: 'failed', statusMessage: '' };
     const fixture = await withTranslation(row);
     expect(fixture.componentInstance.detailText(COL, row)).toBe('');
+  });
+});
+
+describe('DataTableComponent: bulk selection', () => {
+  const ROWS = [
+    { id: 1, name: 'A', state: 'active' },
+    { id: 2, name: 'B', state: 'active' },
+    { id: 3, name: 'C', state: 'paused' },
+  ];
+
+  const REMOVE: RowAction = { kind: 'proxy', labelKey: 'x.rm', method: 'DELETE', path: '/api/x/:id' };
+
+  it('selects, deselects and covers every loaded row from the header box', async () => {
+    const fixture = await createComponent({ http: { get: () => of(ROWS) }, bulkSelect: true });
+    const c = fixture.componentInstance;
+
+    c.toggleSelected(1);
+    expect([...c.selectedIds()]).toEqual([1]);
+    expect(c.allSelected()).toBe(false);
+    c.toggleSelected(1);
+    expect(c.selectedIds().size).toBe(0);
+
+    c.toggleAllSelected();
+    expect(c.allSelected()).toBe(true);
+    expect(c.selectedRows()).toHaveLength(3);
+    c.toggleAllSelected();
+    expect(c.selectedIds().size).toBe(0);
+  });
+
+  it('VERDICT: the header box is indeterminate on a partial selection and checked once every row is ticked', async () => {
+    const fixture = await createComponent({ http: { get: () => of(ROWS) }, bulkSelect: true });
+    const c = fixture.componentInstance;
+    const header = () =>
+      fixture.nativeElement.querySelector('thead input[type="checkbox"]') as HTMLInputElement;
+
+    c.toggleSelected(1);
+    fixture.detectChanges();
+    expect(header().indeterminate).toBe(true);
+    expect(header().checked).toBe(false);
+
+    c.toggleAllSelected();
+    fixture.detectChanges();
+    expect(header().indeterminate).toBe(false);
+    expect(header().checked).toBe(true);
+  });
+
+  it('no selection column at all on a table that did not opt into it', async () => {
+    const fixture = await createComponent({ http: { get: () => of(ROWS) } });
+    expect(fixture.nativeElement.querySelectorAll('input[type="checkbox"]')).toHaveLength(0);
+  });
+
+  it('VERDICT: one bar, whose content swaps on selection, so the table never shifts down', async () => {
+    const SEARCH: TableFilter = { kind: 'search', key: 'q', placeholderKey: 'x.search' };
+    const fixture = await createComponent({
+      http: { get: () => of(ROWS) },
+      bulkSelect: true,
+      filters: [SEARCH],
+      rowActions: [REMOVE],
+    });
+    const c = fixture.componentInstance;
+    const bars = () => fixture.nativeElement.querySelectorAll('.bg-base-200\\/40').length;
+    const searchBox = () => fixture.nativeElement.querySelector('input[type="search"]');
+    const rmButton = () =>
+      Array.from(fixture.nativeElement.querySelectorAll('button')).find((b) =>
+        (b as HTMLButtonElement).textContent?.includes('x.rm'),
+      );
+
+    expect(bars()).toBe(1);
+    expect(searchBox()).not.toBeNull();
+    expect(rmButton()).toBeUndefined();
+
+    c.toggleSelected(1);
+    fixture.detectChanges();
+    // The batch bar replaces the filters row rather than stacking above it.
+    expect(bars()).toBe(1);
+    expect(searchBox()).toBeNull();
+    expect(rmButton()).toBeDefined();
+
+    c.clearSelection();
+    fixture.detectChanges();
+    expect(bars()).toBe(1);
+    expect(searchBox()).not.toBeNull();
+  });
+
+  it('VERDICT: holds the bar from the start even with no declared filter, so selecting shifts nothing', async () => {
+    const fixture = await createComponent({ http: { get: () => of(ROWS) }, bulkSelect: true });
+    const bars = () => fixture.nativeElement.querySelectorAll('.bg-base-200\\/40').length;
+    expect(bars()).toBe(1);
+
+    fixture.componentInstance.toggleSelected(1);
+    fixture.detectChanges();
+    expect(bars()).toBe(1);
+  });
+
+  it('VERDICT: a batch delete confirms once and issues one request per selected row, each skipping the error toast', async () => {
+    const del = vi.fn((_url: unknown, _opts?: unknown) => of({}));
+    const confirm = vi.fn(() => Promise.resolve(true));
+    const toast = { success: vi.fn(), error: vi.fn() };
+    const fixture = await createComponent({
+      http: { get: () => of(ROWS), delete: del },
+      bulkSelect: true,
+      toast,
+      rowActions: [{ ...REMOVE, confirmKey: 'x.confirm_rm' }],
+      confirmation: { confirm, confirmWithToggle: () => Promise.resolve({ ok: true, toggle: true }) },
+    });
+    const c = fixture.componentInstance;
+    c.toggleAllSelected();
+    await c.runBatch(c.batchActions()[0]!.action);
+
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(del).toHaveBeenCalledTimes(3);
+    expect(del.mock.calls.map((call) => call[0])).toEqual(['/api/x/1', '/api/x/2', '/api/x/3']);
+    const ctx = (del.mock.calls[0]![1] as { context: HttpContext }).context;
+    expect(ctx.get(SKIP_ERROR_TOAST)).toBe(true);
+    expect(toast.success).toHaveBeenCalledTimes(1);
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(c.selectedIds().size).toBe(0);
+  });
+
+  it('VERDICT: a partial batch failure reports once and keeps the selection', async () => {
+    const failing = vi.fn((url: unknown) =>
+      String(url).endsWith('/2') ? throwError(() => new Error('nope')) : of({}),
+    );
+    const toast = { success: vi.fn(), error: vi.fn() };
+    const fixture = await createComponent({
+      http: { get: () => of(ROWS), delete: failing },
+      bulkSelect: true,
+      toast,
+      rowActions: [REMOVE],
+    });
+    const c = fixture.componentInstance;
+    c.toggleAllSelected();
+    await c.runBatch(c.batchActions()[0]!.action);
+
+    expect(failing).toHaveBeenCalledTimes(3);
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(c.selectedIds().size).toBe(3);
+  });
+
+  it('does nothing when the single batch confirmation is declined', async () => {
+    const del = vi.fn(() => of({}));
+    const fixture = await createComponent({
+      http: { get: () => of(ROWS), delete: del },
+      bulkSelect: true,
+      rowActions: [{ ...REMOVE, confirmKey: 'x.confirm_rm' }],
+      confirmation: {
+        confirm: () => Promise.resolve(false),
+        confirmWithToggle: () => Promise.resolve({ ok: true, toggle: true }),
+      },
+    });
+    const c = fixture.componentInstance;
+    c.toggleAllSelected();
+    await c.runBatch(c.batchActions()[0]!.action);
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it('VERDICT: an action whose visibleWhen excludes one selected row renders disabled for the whole selection', async () => {
+    const PAUSE: RowAction = {
+      kind: 'proxy',
+      labelKey: 'x.pause',
+      method: 'POST',
+      path: '/api/x/:id/pause',
+      visibleWhen: { key: 'state', in: ['active'] },
+    };
+    const fixture = await createComponent({
+      http: { get: () => of(ROWS) },
+      bulkSelect: true,
+      rowActions: [PAUSE],
+    });
+    const c = fixture.componentInstance;
+
+    c.toggleSelected(1); // active: still allowed alone
+    expect(c.batchActions()[0]!.enabled).toBe(true);
+    c.toggleSelected(3); // paused: excluded by visibleWhen
+    expect(c.batchActions()[0]!.enabled).toBe(false);
+
+    fixture.detectChanges();
+    const button = Array.from(fixture.nativeElement.querySelectorAll('button')).find((b) =>
+      (b as HTMLButtonElement).textContent?.includes('x.pause'),
+    ) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.title).toBe('bulk.unavailable');
+  });
+
+  it('VERDICT: survives a silent reload, but is cleared by a page change and by a filter change', async () => {
+    const STATUS: TableFilter = {
+      kind: 'select',
+      key: 'status',
+      labelKey: 'x.status',
+      options: [{ value: '', labelKey: 'x.all' }, { value: 'failed', labelKey: 'x.failed' }],
+    };
+    const get = vi.fn(() => of({ data: ROWS, total: 40, page: 1, pageSize: 20 }));
+    const fixture = await createComponent({
+      http: { get },
+      bulkSelect: true,
+      paged: true,
+      filters: [STATUS],
+    });
+    const c = fixture.componentInstance;
+
+    c.toggleSelected(1);
+    expect(c.selectedIds().size).toBe(1);
+
+    // A refreshMs poll must not wipe a selection under the user's hands.
+    await c.loadRows({ silent: true });
+    expect(c.selectedIds().size).toBe(1);
+
+    await c.goToPage(2);
+    expect(c.selectedIds().size).toBe(0);
+
+    c.toggleSelected(2);
+    expect(c.selectedIds().size).toBe(1);
+    const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+    select.value = 'failed';
+    select.dispatchEvent(new Event('change'));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(c.selectedIds().size).toBe(0);
   });
 });

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -12,7 +12,7 @@ import {
   viewChild,
   ElementRef,
 } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpContext, HttpParams } from '@angular/common/http';
 import { LucideEllipsisVertical } from '@lucide/angular';
 import { TvSelectDirective } from '../../directives/tv-select.directive';
 import { Router } from '@angular/router';
@@ -22,6 +22,8 @@ import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
 import { formatBytes, formatSpeed } from '../../utils/download-format';
 import { safeExternalUrl } from '../../utils/safe-url';
 import { ConfirmationService } from '../../../core/services/confirmation.service';
+import { SKIP_ERROR_TOAST } from '../../../core/interceptors/error.interceptor';
+import { ToastService } from '../../../core/services/toast.service';
 import { SseService } from '../../../core/services/sse.service';
 import { PaginationComponent } from '../pagination/pagination';
 import { ProgressBadgeComponent } from '../progress-badge/progress-badge.component';
@@ -90,6 +92,7 @@ export class DataTableComponent implements OnInit {
   private readonly translate = inject(TranslateService);
   private readonly confirmation = inject(ConfirmationService);
   private readonly localeDate = inject(LocaleDatePipe);
+  private readonly toast = inject(ToastService);
 
   /** Empty renders no heading — an embedded table (a row action's result) carries its own. */
   readonly titleKey = input('');
@@ -111,6 +114,9 @@ export class DataTableComponent implements OnInit {
   readonly pageSize = input(20);
   /** Declared `search`/`select` filters, rendered above the table. */
   readonly filters = input<readonly TableFilter[]>([]);
+  /** Adds a selection column and turns the declared `proxy` row actions into batch actions.
+   *  Opt-in: a table read one row at a time should not grow a column asking to be ticked. */
+  readonly bulkSelect = input(false);
   /** Poll the list this often while the page is on screen; 0 disables it. */
   readonly refreshMs = input(0);
   /** SSE event types that reload the list as they arrive. */
@@ -121,6 +127,12 @@ export class DataTableComponent implements OnInit {
   readonly listError = signal('');
   readonly busy = signal<string | null>(null);
   readonly listActionBusy = signal<string | null>(null);
+
+  /** Ids ticked in the selection column. Not pruned on reload (unlike provider-list): `refreshMs`
+   *  polling reloads this table every couple of seconds and must not wipe a selection under the
+   *  user's hands, so a stale id just falls out of `selectedRows` until its row reappears. */
+  readonly selectedIds = signal<ReadonlySet<TableRow['id']>>(new Set());
+  readonly bulkBusy = signal(false);
 
   /** Both dialogs stay mounted and are driven by `showModal()`/`close()`: an `@if` around the
    *  element unmounts it on close, and daisyUI animates the exit on the element that remains. */
@@ -261,12 +273,14 @@ export class DataTableComponent implements OnInit {
     // Disarms a still-pending debounce so an immediate caller (e.g. a select) can't double-fire it.
     if (this.searchDebounce) clearTimeout(this.searchDebounce);
     this.page.set(1);
+    this.clearSelection();
     await this.loadRows();
   }
 
   async goToPage(page: number): Promise<void> {
     if (page < 1 || page > this.totalPages()) return;
     this.page.set(page);
+    this.clearSelection();
     await this.loadRows();
   }
 
@@ -539,5 +553,143 @@ export class DataTableComponent implements OnInit {
     }
     await firstValueFrom(method === 'POST' ? this.http.post(url, {}) : this.http.delete(url));
     return true;
+  }
+
+  /** One confirmation for a whole batch rather than one per row, mirroring `runHttpAction`'s own
+   *  confirm+toggle contract. Kept separate (not shared code) so a single row's action keeps
+   *  firing its request in the same microtask as a declined-confirm-free click always has. */
+  private async confirmBatch(
+    confirmKey?: string,
+    toggle?: { labelKey: string; param: string; hintKey?: string },
+  ): Promise<{ ok: boolean; toggleSuffix: string }> {
+    if (!confirmKey) return { ok: true, toggleSuffix: '' };
+    if (toggle) {
+      const { ok, toggle: checked } = await this.confirmation.confirmWithToggle({
+        title: this.translate.instant('common.confirm'),
+        message: this.translate.instant(confirmKey),
+        variant: 'danger',
+        toggleLabel: this.translate.instant(toggle.labelKey),
+        ...(toggle.hintKey ? { toggleHint: this.translate.instant(toggle.hintKey) } : {}),
+      });
+      return { ok, toggleSuffix: ok ? `${toggle.param}=${checked}` : '' };
+    }
+    const ok = await this.confirmation.confirm({
+      title: this.translate.instant('common.confirm'),
+      message: this.translate.instant(confirmKey),
+      variant: 'danger',
+    });
+    return { ok, toggleSuffix: '' };
+  }
+
+  isSelected(id: TableRow['id']): boolean {
+    return this.selectedIds().has(id);
+  }
+
+  toggleSelected(id: TableRow['id']): void {
+    this.selectedIds.update((ids) => {
+      const next = new Set(ids);
+      if (!next.delete(id)) next.add(id);
+      return next;
+    });
+  }
+
+  /** The header box: ticks or unticks the rows currently loaded, the one page of a paged list,
+   *  or the one filtered response of an unpaged one. */
+  toggleAllSelected(): void {
+    const loaded = this.rows().map((r) => r.id);
+    const all = this.allSelected();
+    this.selectedIds.update((ids) => {
+      const next = new Set(ids);
+      for (const id of loaded) {
+        if (all) next.delete(id);
+        else next.add(id);
+      }
+      return next;
+    });
+  }
+
+  clearSelection(): void {
+    this.selectedIds.set(new Set());
+  }
+
+  readonly allSelected = computed(() => {
+    const rows = this.rows();
+    const ids = this.selectedIds();
+    return rows.length > 0 && rows.every((r) => ids.has(r.id));
+  });
+
+  /** Selected ids narrowed to the rows actually on screen: a stale id from before a reload
+   *  simply drops out here rather than being acted on or miscounted. */
+  readonly selectedRows = computed(() => {
+    const ids = this.selectedIds();
+    return this.rows().filter((r) => ids.has(r.id));
+  });
+
+  /** No page declares a canonical "name" field on a `TableRow`; the first column is what the
+   *  row already reads as to the person ticking it. */
+  rowSelectLabel(row: TableRow): string {
+    const col = this.columns()[0];
+    return col ? this.cellLabel(col, row[col.key]) : String(row.id);
+  }
+
+  /** `proxy` actions only: `route`/`action`/`detail` have no batch meaning against a selection.
+   *  One not allowed by every selected row's `visibleWhen` still renders, disabled, rather than
+   *  disappearing: the button's absence would be read as "not offered" instead of "not now". */
+  readonly batchActions = computed(() => {
+    const rows = this.selectedRows();
+    return this.rowActions()
+      .filter((a): a is Extract<RowAction, { kind: 'proxy' }> => a.kind === 'proxy')
+      .map((action) => ({
+        action,
+        enabled: rows.length > 0 && rows.every((r) => this.rowAllows(action.visibleWhen, r)),
+      }));
+  });
+
+  /** Bulk writes report as one batch, so their failures must not each raise their own toast. */
+  private silent(): { context: HttpContext } {
+    return { context: new HttpContext().set(SKIP_ERROR_TOAST, true) };
+  }
+
+  /**
+   * Runs one request per selected row, sequentially, and reports once. Sequential on purpose: a
+   * burst of parallel writes against a plugin's own database buys nothing and turns one slow row
+   * into a spike the far end may rate-limit. The confirmation (and its toggle) is asked once for
+   * the whole batch, never once per row, and the loop never stops early: every row that can be
+   * written is written.
+   */
+  async runBatch(action: Extract<RowAction, { kind: 'proxy' }>): Promise<void> {
+    const rows = this.selectedRows();
+    if (rows.length === 0) return;
+    const { ok, toggleSuffix } = await this.confirmBatch(action.confirmKey, action.confirmToggle);
+    if (!ok) return;
+
+    this.bulkBusy.set(true);
+    let failed = 0;
+    try {
+      for (const row of rows) {
+        const path = this.rowPath(action.path, row);
+        const url = toggleSuffix ? `${path}${path.includes('?') ? '&' : '?'}${toggleSuffix}` : path;
+        try {
+          await firstValueFrom(
+            action.method === 'POST'
+              ? this.http.post(url, {}, this.silent())
+              : this.http.delete(url, this.silent()),
+          );
+        } catch {
+          failed++;
+        }
+      }
+      await this.loadRows();
+      if (failed === 0) {
+        this.toast.success(this.translate.instant('bulk.done', { count: rows.length }));
+        this.clearSelection();
+      } else {
+        this.toast.error(
+          this.translate.instant('bulk.partial', { done: rows.length - failed, failed }),
+        );
+      }
+    } finally {
+      this.bulkBusy.set(false);
+    }
   }
 }

--- a/client/src/app/shared/components/provider-list/provider-list.html
+++ b/client/src/app/shared/components/provider-list/provider-list.html
@@ -60,7 +60,7 @@
         </label>
       } @else {
       <span class="text-sm font-medium">
-        {{ 'provider_list.bulk_selected' | translate: { count: selectedIds().size } }}
+        {{ 'bulk.selected' | translate: { count: selectedIds().size } }}
       </span>
       <div class="flex flex-wrap gap-2 ms-auto">
         <button
@@ -90,7 +90,7 @@
           {{ 'provider_list.bulk_delete' | translate }}
         </button>
         <button type="button" class="btn btn-ghost btn-sm" [disabled]="bulkBusy()" (click)="clearSelection()">
-          {{ 'provider_list.bulk_clear' | translate }}
+          {{ 'bulk.clear' | translate }}
         </button>
       </div>
       }
@@ -119,7 +119,7 @@
                   class="checkbox checkbox-sm"
                   [checked]="allSelected()"
                   [indeterminate]="selectedIds().size > 0 && !allSelected()"
-                  [attr.aria-label]="'provider_list.bulk_select_all' | translate"
+                  [attr.aria-label]="'bulk.select_all' | translate"
                   (change)="toggleAllSelected()"
                 />
               </th>
@@ -150,7 +150,7 @@
                     type="checkbox"
                     class="checkbox checkbox-sm"
                     [checked]="isSelected(row.id)"
-                    [attr.aria-label]="'provider_list.bulk_select_row' | translate: { name: row.name }"
+                    [attr.aria-label]="'bulk.select_row' | translate: { name: row.name }"
                     (change)="toggleSelected(row.id)"
                   />
                 </td>

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -589,7 +589,7 @@ export class ProviderListComponent implements OnInit {
         this.clearSelection();
       } else {
         this.toast.error(
-          this.translate.instant('provider_list.bulk_partial', {
+          this.translate.instant('bulk.partial', {
             done: rows.length - failed,
             failed,
           }),
@@ -690,7 +690,7 @@ export class ProviderListComponent implements OnInit {
             this.silent(),
           ),
         ),
-      'provider_list.bulk_edited_done',
+      'bulk.done',
     );
   }
 


### PR DESCRIPTION
## Why

The same selection the providers list got, for a plugin's declarative `table` page. The immediate consumer is the download history, where cleaning up several rows is the normal thing to do and the page already has the filters to narrow down which.

## What

`TableConfigPage.bulkSelect` (additive, optional; `bulkSelect` input on `app-data-table`, off by default) adds a selection column with a tri-state header box, and turns the declared `proxy` row actions into batch actions.

- **Batchable = a `proxy` action whose `visibleWhen` holds for every selected row.** One that does not still renders, disabled, with a hint: a missing button reads as "not offered" rather than "not for this selection". Reuses the existing `rowAllows`.
- The action's declared `confirmKey` is asked **once for the batch**, never once per row, and its `confirmToggle` likewise.
- Then one request per row, sequentially, each with `SKIP_ERROR_TOAST`, never stopping on a failure, then a reload and one summary: `bulk.done` on a clean run (clearing the selection), `bulk.partial` otherwise (keeping it).
- **One bar, two contents.** The filters row and the batch bar are the same container, so a selection swaps its content instead of pushing the table down. It also renders from the start on a page that declares no filters, showing the row count, for the same reason: this jump was a bug report on the other component, and "exactly one bar in both states" is pinned by a spec.
- **The selection is never cleared by a reload**, because `refreshMs` polling reloads this table every couple of seconds and would wipe it under the user's hands. A page change or a filter change does clear it, both being explicit gestures. A stale id simply falls out of `selectedRows`, so nothing is acted on or miscounted after a poll.
- The generic selection strings moved to a shared `bulk.*` namespace in all six locales, used by both components, instead of being duplicated. Each page's own action labels stay where they belong.

`plugin-view` passes the flag through, the same way it already does for a `providers` page.

## Test

757 pass across 79 files (up from 747), `tsc -p client/tsconfig.app.json --noEmit` clean. 10 new specs: selection maths and the tri-state box, one bar in both states (with and without declared filters), a batch delete with exactly one confirmation and the skip-toast context per request, a partial failure reported once with the selection kept, a `visibleWhen`-excluded action rendering disabled, and the selection surviving a silent reload while a page or filter change clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)