### PR TITLE
feat(data-table): let a table page report on its whole list

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -427,7 +427,9 @@ export interface TableConfigPage extends ConfigPageBase {
   )[];
   defaultSortKey?: string;
   /** `list` answers `{data,total,page,pageSize}` rather than a bare array — a
-   *  paged resource renders empty against an array-only reader. */
+   *  paged resource renders empty against an array-only reader. That response may also carry
+   *  `notice: {messageKey, tone: 'info'|'warning'|'error', detail?, count?}` beside `data`,
+   *  rendered as a list-wide alert; a bare-array `list` has nowhere to carry one. */
   paged?: boolean;
   pageSize?: number;
   /** Re-fetch this often while the page is on screen, for a list whose values move on

--- a/client/src/app/shared/components/data-table/data-table.html
+++ b/client/src/app/shared/components/data-table/data-table.html
@@ -36,6 +36,12 @@
     </div>
   </div>
 
+  @if (notice(); as n) {
+    <div role="status" class="alert py-2 text-sm" [class]="noticeClass(n.tone)">
+      {{ n.messageKey | translate: { detail: n.detail, count: n.count } }}
+    </div>
+  }
+
   <!-- One bar for both states: a selection swaps its content instead of adding a row, so the
        table never shifts. It also stays put on a page that declares no filter at all. -->
   @if (filters().length || (bulkSelect() && rows().length > 0)) {

--- a/client/src/app/shared/components/data-table/data-table.spec.ts
+++ b/client/src/app/shared/components/data-table/data-table.spec.ts
@@ -1131,3 +1131,62 @@ describe('DataTableComponent: bulk selection', () => {
     expect(c.selectedIds().size).toBe(0);
   });
 });
+
+describe('DataTableComponent: the list-wide notice', () => {
+  const notice = { messageKey: 'x.hidden', tone: 'warning' as const, count: 2 };
+  const pagedWith = (extra: Record<string, unknown>) => ({
+    data: [{ id: 1, name: 'A' }],
+    total: 1,
+    page: 1,
+    pageSize: 20,
+    ...extra,
+  });
+
+  function alert(fixture: { nativeElement: HTMLElement }): HTMLElement | null {
+    return fixture.nativeElement.querySelector('[role="status"]');
+  }
+
+  it('VERDICT: renders what the response reports about the whole list, with its tone', async () => {
+    const fixture = await createComponent({ http: { get: () => of(pagedWith({ notice })) }, paged: true });
+    const el = alert(fixture);
+    expect(el).not.toBeNull();
+    expect(el!.className).toContain('alert-warning');
+    // The test loader resolves no strings, so the key itself is what lands in the DOM.
+    expect(el!.textContent).toContain('x.hidden');
+  });
+
+  it('renders none when the response carries none', async () => {
+    const fixture = await createComponent({ http: { get: () => of(pagedWith({})) }, paged: true });
+    expect(alert(fixture)).toBeNull();
+    expect(fixture.componentInstance.notice()).toBeNull();
+  });
+
+  it('VERDICT: a notice does not outlive the load that raised it', async () => {
+    let body: Record<string, unknown> = pagedWith({ notice });
+    const fixture = await createComponent({ http: { get: () => of(body) }, paged: true });
+    expect(alert(fixture)).not.toBeNull();
+
+    body = pagedWith({});
+    await fixture.componentInstance.loadRows();
+    fixture.detectChanges();
+    expect(alert(fixture)).toBeNull();
+  });
+
+  it('falls back to info on a tone it does not know, rather than putting it in the DOM', async () => {
+    const fixture = await createComponent({
+      http: { get: () => of(pagedWith({ notice: { messageKey: 'x.hidden', tone: 'catastrophe' } })) },
+      paged: true,
+    });
+    expect(alert(fixture)!.className).toContain('alert-info');
+    expect(alert(fixture)!.className).not.toContain('catastrophe');
+  });
+
+  it('shows alongside an empty list, since it is the only thing that can explain it', async () => {
+    const fixture = await createComponent({
+      http: { get: () => of({ data: [], total: 0, page: 1, pageSize: 20, notice }) },
+      paged: true,
+    });
+    expect(alert(fixture)).not.toBeNull();
+    expect(fixture.nativeElement.textContent).toContain('data_table.empty');
+  });
+});

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -30,6 +30,8 @@ import { ProgressBadgeComponent } from '../progress-badge/progress-badge.compone
 import {
   BadgeTone,
   CellValue,
+  NoticeTone,
+  TableNotice,
   ListAction,
   PagedResult,
   RowAction,
@@ -63,6 +65,14 @@ const BADGE_CLASSES: Readonly<Record<BadgeTone, string>> = {
   warning: 'badge-warning',
   error: 'badge-error',
   ghost: 'badge-ghost',
+};
+
+/** The only classes a declared notice tone can resolve to; an unknown tone reads as `info`
+ *  rather than reaching the DOM, the same rule as `BADGE_CLASSES`. */
+const NOTICE_CLASSES: Readonly<Record<NoticeTone, string>> = {
+  info: 'alert-info',
+  warning: 'alert-warning',
+  error: 'alert-error',
 };
 
 /**
@@ -123,6 +133,9 @@ export class DataTableComponent implements OnInit {
   readonly refreshOn = input<readonly string[]>([]);
 
   readonly rows = signal<TableRow[]>([]);
+  /** What the list as a whole reports, from the paged response. Replaced on every load, so a
+   *  warning never outlives the state that raised it. */
+  readonly notice = signal<TableNotice | null>(null);
   readonly loading = signal(true);
   readonly listError = signal('');
   readonly busy = signal<string | null>(null);
@@ -234,6 +247,7 @@ export class DataTableComponent implements OnInit {
         if (seq !== this.loadSeq) return;
         this.rows.set(this.applyDefaultSort(Array.isArray(res?.data) ? res.data : []));
         this.total.set(res?.total ?? 0);
+        this.notice.set(res?.notice?.messageKey ? res.notice : null);
       } else {
         const data = await firstValueFrom(this.http.get<TableRow[]>(this.listUrl(), { params }));
         if (seq !== this.loadSeq) return;
@@ -282,6 +296,10 @@ export class DataTableComponent implements OnInit {
     this.page.set(page);
     this.clearSelection();
     await this.loadRows();
+  }
+
+  noticeClass(tone: NoticeTone): string {
+    return NOTICE_CLASSES[tone] ?? NOTICE_CLASSES.info;
   }
 
   /** `LocaleDatePipe` doesn't accept a boolean — no declared column is ever meant to be one. */

--- a/client/src/app/shared/components/data-table/data-table.types.ts
+++ b/client/src/app/shared/components/data-table/data-table.types.ts
@@ -72,12 +72,26 @@ export interface TableRow {
   [key: string]: CellValue;
 }
 
+/** Tone of a `PagedResult.notice`; an unknown value renders as `info` in `data-table`. */
+export type NoticeTone = 'info' | 'warning' | 'error';
+
+/** A list-wide notice, say rows missing because a source did not answer: a fact no single row
+ *  can carry. `detail` and `count` are interpolation params for `messageKey`. */
+export interface TableNotice {
+  messageKey: string;
+  tone: NoticeTone;
+  detail?: string;
+  count?: number;
+}
+
 /** `list` answering `{data,total,page,pageSize}` instead of a bare array. */
 export interface PagedResult<T> {
   data: T[];
   total: number;
   page: number;
   pageSize: number;
+  /** Only a paged response can carry one: a bare-array `list` has nowhere to put it. */
+  notice?: TableNotice;
 }
 
 /**


### PR DESCRIPTION
## Why

A declarative `table` page could say nothing about its list as a whole. The case that exposed it: the download queue is a projection of what the download clients report, so a client that is disabled or does not answer makes rows vanish and nothing on screen says the list is incomplete. The plugin already computes that fact and puts `clientsUnreachable` in its response, where nobody reads it.

## What

A **paged** response may carry a notice beside its rows:

```ts
notice?: { messageKey: string; tone: 'info' | 'warning' | 'error'; detail?: string; count?: number }
```

`messageKey` is one of the plugin's own i18n keys (its dictionary is merged into the active language at boot), `detail` and `count` are its interpolation parameters. Rendered as an alert above the table.

- The tone resolves through a closed lookup, so an unknown one reads as `info` instead of reaching the DOM: the same rule `BADGE_CLASSES` already applies to declared badges.
- Replaced on every load, including a silent `refreshMs` poll, so a warning never outlives the state that raised it.
- Renders alongside an empty list, which is exactly when it is the only thing that can explain what is on screen, and it never replaces the empty or the error state.
- Only the paged shape can carry one; a bare-array `list` has nowhere to put it, and the contract says so where plugin authors read it.

## Test

762 pass across 79 files (up from 757), `tsc -p client/tsconfig.app.json --noEmit` clean. Five new specs: the notice renders with its tone and its key, none renders no alert, a notice is gone after a load without one, an unknown tone falls back to info without leaking the value into the class list, and it shows alongside an empty list.

The consumer is a plugin change that lands next: the queue stops listing rows it cannot verify and explains the gap here instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)