### PR TITLE
fix(media-card): replay the artwork reveal on a route restored from cache

### DIFF
--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -27,7 +27,7 @@
         #cardImg
         [cachedSrc]="_img()! | resolveUrl:'thumb'"
         [alt]="_title()"
-        class="w-full h-full object-cover select-none rounded-lg transition-opacity duration-200"
+        class="w-full h-full object-cover select-none rounded-lg"
         style="-webkit-user-drag: none; user-drag: none;"
         draggable="false"
         [appSpoiler]="spoiler()"
@@ -35,6 +35,7 @@
         [class.scale-110]="spoilerImg.masked()"
         [class.grayscale]="grayscale()"
         [class.opacity-0]="!imgLoaded()"
+        [class.card-img-reveal]="imgLoaded()"
         loading="lazy"
         decoding="async"
         (load)="imgLoaded.set(true)"

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -776,11 +776,29 @@ body.tv .mosaic-art > * > img:nth-child(3) {
 body.tv .mosaic-art > * > img:nth-child(4) {
   border-bottom-right-radius: inherit;
 }
+/* An animation rather than a transition on the artwork reveal: a route restored
+   from the reuse cache re-inserts the subtree, which replays animations but
+   leaves an already-settled transition alone — the grid came back bare. */
+@keyframes card-img-reveal {
+  from {
+    opacity: 0;
+  }
+}
+.card-img-reveal {
+  animation: card-img-reveal 200ms ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .card-img-reveal {
+    animation: none;
+  }
+}
+
 /* One promotion source fewer, and the reveal stays (the art is still hidden
    until it has decoded — only the 200 ms tween goes). */
 body.tv app-media-card figure img,
 body.tv .mosaic-art img {
   transition: none !important;
+  animation: none !important;
 }
 
 /* Resting cards carry shadow-md (a blurred shadow) re-rasterised for every


### PR DESCRIPTION
Reopening a library showed its artwork with no fade, while switching tabs on the same page still animated.

### Cause

`libraries/:libraryName` is `reuse: true`, and the reuse key includes the route params, so each library keeps its own cache slot. From the second visit on, Angular re-attaches the detached subtree with component state intact: `imgLoaded` is already true and the artwork already at full opacity. The reveal was a `transition`, which needs a property change to run, and there is none — nothing moves, so nothing animates. Switching tabs kept working because it builds fresh cards through `@for`, with `imgLoaded` back to false.

The image cache is not involved: a newly created element still fires `load` for a memory-cached response.

### Fix

The reveal moves from a transition to a keyframe animation. An animation restarts when its subtree is re-inserted into the document, which a settled transition does not, so a restored grid reveals its cards the way a fresh one does. The `prefers-reduced-motion` guard matches the rest of the file.

The TV suppression at the bottom of the artwork rules named only `transition`, so it now covers `animation` too — otherwise this change would have quietly reintroduced on TV the layer promotion that rule exists to avoid.

### Testing

`tsc` clean, 34 media-card specs pass.

Worth a look on merge: the reveal now replays on every page restored from the reuse cache, not only the library — home and the detail rows included. That is the intended behaviour here, but it does mean pages that used to come back instantly now animate their artwork.
