### PR TITLE
fix(navigation): re-enable view transitions on capacitor

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -82,12 +82,17 @@ export const appConfig: ApplicationConfig = {
     provideRouter(
       routes,
       withInMemoryScrolling({ scrollPositionRestoration: 'top' }),
-      // Poster→hero morph. Gated by `viewTransitionsEnabled()`; on TV the root
-      // snapshot costs ~400 ms on a Tizen 9 panel, so only the player close earns one.
+      // Poster→hero morph. On TV the root snapshot costs ~400 ms on a Tizen 9
+      // panel, so only the player close earns one.
       ...(!viewTransitionsEnabled()
         ? []
         : [
             withViewTransitions({
+              // The launch navigation has no previous page to morph from, and its
+              // snapshot capture never completes under Capacitor's splash: `ready`
+              // rejects on Chromium's 4 s timeout, and the splash only hides once
+              // the navigation does.
+              skipInitialTransition: true,
               // Episode → episode: the cross-fade keeps the old page (and its scroll
               // offset) on screen, so the jump to top only lands once it ends.
               onViewTransitionCreated: ({ transition, from, to }) => {

--- a/client/src/app/core/services/device.service.ts
+++ b/client/src/app/core/services/device.service.ts
@@ -107,16 +107,9 @@ export function detectDevice(): DetectResult {
 /**
  * Whether router view transitions are registered, and so whether the player's
  * closing animation is theirs to run rather than the player's own.
- *
- * Off on Capacitor: its WebView never completes a snapshot capture for a
- * launch-created document, so every navigation waits Chrome's 4s timeout. TV is
- * the exception — closing the player is the one navigation that needs the
- * destination painted under the shrinking player, and it is the only one the
- * transition is allowed to run for (see `app.config.ts`).
  */
 export function viewTransitionsEnabled(): boolean {
-  if (typeof document === 'undefined' || !document.startViewTransition) return false;
-  return !Capacitor.isNativePlatform() || detectDevice().formFactor === 'tv';
+  return typeof document !== 'undefined' && !!document.startViewTransition;
 }
 
 interface DetectResult {

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -5,7 +5,6 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { LucideFilm, LucidePlay, LucideStar, LucideCheck, LucideClock, LucideEllipsisVertical, LucideCircleX } from '@lucide/angular';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import { Media } from '../../../core/services/api/media.service';
-import { Capacitor } from '@capacitor/core';
 import { computeMediaBarStatus, computeMediaBarPercent } from '../../utils/media-status.util';
 import { MediaService } from '../../../core/services/api/media.service';
 import { ToastService } from '../../../core/services/toast.service';
@@ -68,7 +67,6 @@ export class MediaCardComponent {
   private readonly navbar = inject(NavbarService);
   private readonly pluginUi = inject(PluginUiRegistryService);
   protected readonly device = inject(DeviceService);
-  protected readonly isNative = Capacitor.isNativePlatform();
   /** Hover overlay (play button) only makes sense on a real pointer device. */
   protected readonly showHoverOverlay = computed(() => this.device.input() === 'mouse');
   /**
@@ -335,9 +333,9 @@ export class MediaCardComponent {
   }
 
   protected flagPosterForTransition() {
-    // Pointless where the router runs no transition (Capacitor) or the engine has
-    // none (Chromium <111, Tizen 5.5 WebKit, webOS 5) — and it costs a querySelectorAll per click.
-    if (this.isNative || !('startViewTransition' in document)) return;
+    // Pointless where the engine has no View Transitions (Chromium <111, Tizen 5.5
+    // WebKit, webOS 5), and it costs a querySelectorAll per click.
+    if (!('startViewTransition' in document)) return;
     const id = this.resolveMediaId();
     const img = this.imgRef()?.nativeElement;
     if (id == null || !img) return;

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1210,6 +1210,12 @@ html.vt-player-close::view-transition-old(root) {
 html.vt-player-close::view-transition-group(root) {
   z-index: 2;
 }
+/* Which also hid the destination's own poster until the transition ended, while
+   every unnamed image beside it painted at once. Nothing pairs with it on a
+   close, so keep it out of the capture and let it paint with the page. */
+html.vt-player-close app-media-info-header img {
+  view-transition-name: none !important;
+}
 @keyframes player-close {
   to {
     opacity: 0;


### PR DESCRIPTION
## Why

#1018 turned view transitions off on Capacitor because "every navigation waits Chrome's 4s timeout". That diagnosis was one navigation too broad: only the **launch** navigation ever hung.

Measured over CDP against the running app on a OnePlus 9 (Android 14, WebView 151):

| navigation | `updateCallbackDone` | `ready` | `finished` |
|---|---|---|---|
| initial (root → home) | 97 ms | **rejects, TimeoutError @ 4010 ms** | 4010 ms |
| home → `movies/:id` | 98 ms | 117 ms | 442 ms |
| back to home | 60 ms | 83 ms | 365 ms |
| `series/:id` → `episode/:episodeId` | 174 ms | 174 ms | 443 ms |
| `movies/:id` → `watch/:mediaFileId` | 84 ms | 93 ms | 380 ms |

Angular's render promise resolves fine (97 ms). What never completes is the capture of the **new** state for a document that has not painted yet, so Chromium falls back to its 4 s timeout. For those 4 s the document is frozen on the pre-Angular snapshot, and `SplashScreen.hide()` runs from the `requestAnimationFrame` after the first `NavigationEnd` - a frame the pending transition starves. Cold start therefore sat on a dead splash.

A/B on device, same APK with the flag flipped:

- flag off: splash unchanged at 900 / 1400 / 1900 / 2600 / 4000 / **5000 ms** (byte-identical frames)
- flag on: home painted by **1900 ms**

## What

- `skipInitialTransition: true`. The launch navigation has no previous page and no named pair, and `::view-transition-old(root)` already carries `animation: none`, so this drops a no-op, not an animation - on every platform.
- `viewTransitionsEnabled()` is feature detection again. The TV carve-out it grew is unnecessary: `app.config.ts` already skips every TV navigation except the player close.
- The poster stamp in `media-card` no longer bails out on native, so the card → hero morph is back on phone and tablet.

The `native-player-active` guard still skips the player close where the video renders on a native surface, verified on device: opening the player transitions (`ready` 93 ms), closing it runs no transition and the class is cleared on arrival.

## Test

- Full client suite: 79/79 files pass.
- `tsc -p tsconfig.app.json --noEmit` clean.
- On device (OnePlus 9, debug APK): cold start, home ↔ movie, home ↔ series, series ↔ episode, episode → episode, browser back, player open/close. No timeout on any of them.

Not covered: iOS (WKWebView has no View Transitions, so it keeps the no-op path) and a real TV panel, whose behaviour this does not change.