### PR TITLE
fix(media-info-header): reserve the height of the stream info row

### DIFF
--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -419,7 +419,9 @@
      when iterating on the layout. -->
 <ng-template #streamInfoBlock>
   @if (selectedFileId() && (mediaType() !== 'series' || episodeId())) {
-    <div appTvRow class="flex flex-wrap items-center gap-x-4 gap-y-1.5 mt-5">
+    <!-- min-h reserves the tallest child (a `select-sm`): the subtitle dropdown
+         arrives after the video/audio labels, which are plain text. -->
+    <div appTvRow class="flex flex-wrap items-center gap-x-4 gap-y-1.5 mt-5 min-h-8">
       <div class="flex items-center gap-2">
         <span class="text-base-content/50">{{ 'media_info.video' | translate }}</span>
         @if (multipleFiles()) {


### PR DESCRIPTION
## Why

Opening an episode that is not in the route cache (from the `Plus de saison X` rail) reflowed the Video / Audio / Subtitles row: it laid out one height, then grew, shifting everything below it.

The three cells do not arrive together. `videoLabel` and `audioTracks` both derive from `selectedFile()`, so they render as soon as the file is known. `subtitles` comes from `subtitleSection()?.headerSubtitles()` - a `viewChild` that resolves on a later pass, over a list that is fetched separately. And the subtitle cell is the only one that always renders a `select-sm` trigger (2rem); a plain video or single-track audio label is 1.5rem.

Measured on device: children at 24 / 24 / 32 px, row settling at 32 px. So the row lays out at 24 px and jumps to 32 px when the subtitles land.

## What

`min-h-8` (2rem, the `select-sm` height) on the row, in the `streamInfoBlock` template shared by the mobile and desktop layouts. The row now holds its final height from its first paint, whichever cells have arrived. Where the row wraps on a narrow viewport it is already taller, so the min-height is inert there.

Not reserved: the row's own appearance. It is gated on `selectedFileId()`, and an episode with no file must not leave a 52 px hole.