### PR TITLE
fix(media-detail): keep the page instance when switching episode

### DIFF
--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -225,7 +225,10 @@ export const routes: Routes = [
           import('./features/media-detail/media-detail').then(
             (m) => m.MediaDetailComponent,
           ),
-        data: { kind: 'series', reuse: true },
+        // Switching episodes only moves a param on a page that already holds
+        // the season rails, the subtitle list and the poster, and the component
+        // reads the params itself, so it keeps its instance.
+        data: { kind: 'series', reuse: true, reuseOnParamChange: true },
       },
       {
         path: 'requests',

--- a/client/src/app/core/services/route-reuse.strategy.spec.ts
+++ b/client/src/app/core/services/route-reuse.strategy.spec.ts
@@ -25,6 +25,28 @@ describe('CachingReuseStrategy', () => {
     return TestBed.inject(CachingReuseStrategy);
   }
 
+  it('VERDICT: reuseOnParamChange keeps the instance across params, plain reuse does not', () => {
+    const strategy = setup();
+    const episode: Route = {
+      path: 'series/:id/episode/:episodeId',
+      data: { reuse: true, reuseOnParamChange: true },
+    };
+    const library: Route = { path: 'libraries/:libraryName', data: { reuse: true } };
+
+    expect(
+      strategy.shouldReuseRoute(
+        snapshotFor(episode, { id: '1', episodeId: '8' }),
+        snapshotFor(episode, { id: '1', episodeId: '9' }),
+      ),
+    ).toBe(true);
+    expect(
+      strategy.shouldReuseRoute(
+        snapshotFor(library, { libraryName: 'Movies' }),
+        snapshotFor(library, { libraryName: 'Series' }),
+      ),
+    ).toBe(false);
+  });
+
   it('VERDICT: clear() destroys every cached handle, not just the map entries', () => {
     const strategy = setup();
     const route: Route = { path: 'libraries/:libraryName' };

--- a/client/src/app/core/services/route-reuse.strategy.ts
+++ b/client/src/app/core/services/route-reuse.strategy.ts
@@ -121,6 +121,9 @@ export class CachingReuseStrategy implements RouteReuseStrategy {
 
   shouldReuseRoute(future: ActivatedRouteSnapshot, current: ActivatedRouteSnapshot): boolean {
     if (future.routeConfig !== current.routeConfig) return false;
+    // A page that drives itself off the route params keeps its instance across
+    // them, so nothing under it is rebuilt when only a param moves.
+    if (future.routeConfig?.data?.['reuseOnParamChange']) return true;
     // For routes flagged `reuse: true` we need stricter behavior: two distinct
     // param values (e.g. /libraries/Movies vs /libraries/Series) must each
     // detach so their state lands in its own cache slot. Without this guard

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -303,9 +303,8 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Angular reuses this component between two `movies/:id` URLs — the similar
-   * -movies rail links to one — so the load is driven by the route param
-   * instead of ngOnInit, which would only ever run for the first title.
+   * Driven by the route param rather than ngOnInit: switching episodes reuses
+   * this instance, and the series it already holds must not be refetched.
    */
   private readonly routeMediaEffect = effect(() => {
     const params = this.routeParams();


### PR DESCRIPTION
## Why

Switching episode from the `Plus de saison X` or `Autre saison` rails rebuilt the whole detail page, so those cards were destroyed and recreated: `imgLoaded` (a `linkedSignal` sourced on the image url) reset to `false`, the placeholder showed, and `card-img-reveal` replayed on artwork that had not changed. The subtitle list was refetched too.

None of that is by design. `MediaDetailComponent` is written to be reused across these URLs and says so:

- `routeParams = toSignal(this.route.paramMap)` - "a plain snapshot read in ngOnInit would miss subsequent param changes"
- `routeMediaEffect` returns early on `id === this.loadedId`, so the series is not refetched
- `episodeFocusEffect` recomputes `focusedSeason` / `focusedEpisode` / `notFound` / the navbar title on every param move

What defeated it is in the reuse strategy:

```ts
if (future.routeConfig?.data?.['reuse']) {
  return this.keyFor(future) === this.keyFor(current);   // episodeId differs -> false
}
```

That rule exists so `/libraries/Movies` and `/libraries/Series` each detach into their own cache slot. It applied to every `reuse: true` route, the episode page included, so a param move was treated as a route change.

## What

`reuseOnParamChange` on the episode route lets a page that drives itself off the params opt out of the strict rule. Everything else keeps the per-value slots.

The rails then behave correctly on their own: `seasonsRow()` does not change, so `@for ... track other.id` keeps the same card instances; `currentSeasonEpisodes()` only changes when the new episode is in another season, and there new cards are legitimate.

Nothing needs refetching either - subtitles load per series (`loadEffect` on `mediaId()`) and are filtered per episode by the `episodeId` input, so a switch within a series is pure signal propagation.

## Episode-scoped state, audited

Each one either resets in `applyEpisodeFocus` or is a computed off `focusedEpisode()`:

| state | how it follows the param |
|---|---|
| `episodeMode`, `focusedSeason`, `focusedEpisode`, `notFound`, navbar title | set in `applyEpisodeFocus` |
| `selectedFileId` | `episodeActiveFileId()` falls back to `files[0]` when the held id is not in the new episode's files |
| subtitles | `episodeSubtitles()` filters on the `episodeId` input |
| page backdrop | `backgroundEffect` keys on `media()`, unchanged across episodes, so it does not re-randomise |
| scroll | `scrollPositionRestoration: 'top'` fires on navigation, reuse or not |
| episode drawer, per-episode release search | set when the drawer opens |

One residue: `episodeSeed` (the card's handoff stub) is only refreshed inside `loadMedia`, which a same-series switch skips, so it keeps the previous episode's value. It is read only as `episodeLabel() ?? episodeSeed()?.label`, and `episodeLabel()` is always populated on this path because `applyEpisodeFocus` runs in the same change-detection pass, so the stale value is unreachable. Left alone rather than cleared for a branch nothing takes.

## Trade-off

Episodes no longer get one cache slot each. Going back to an episode seen a moment ago now recomputes the focus on the live instance instead of re-attaching its detached DOM. Since the rails, the poster and the subtitle list are all already in memory, that is the cheaper path, and `scrollPositionRestoration: 'top'` sent an episode switch to the top either way.

## Test

- Full client suite: 79/79 files, 748 tests. `layout.spec.ts` flakes on a `vi.mock('@capacitor/core')` hoisting patch unrelated to this change (green on re-runs, and green before it).
- New spec: `reuseOnParamChange` keeps the instance across two episode ids while `libraries/:libraryName` still returns false.
- `tsc -p tsconfig.app.json --noEmit` clean.

Not verified at runtime - the test device came off USB before I could build to it. Worth clicking through: episode to episode in the same season, episode to another season, browser back across episodes, and the player round trip from an episode page.
