### PR TITLE
fix(media-card): size the artwork radius for a highlighted border

### DIFF
--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -27,7 +27,7 @@
         #cardImg
         [cachedSrc]="_img()! | resolveUrl:'thumb'"
         [alt]="_title()"
-        class="w-full h-full object-cover select-none rounded-lg"
+        class="w-full h-full object-cover select-none"
         style="-webkit-user-drag: none; user-drag: none;"
         draggable="false"
         [appSpoiler]="spoiler()"

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -23,11 +23,13 @@
     (keydown.space)="onCardClick(); $event.preventDefault()"
   >
     @if (_img() && !imgFailed()) {
+      <!-- rounded-md, not -lg: the figure's clip loses the border width when the
+           card is highlighted, and a wider radius here cuts the corners inside it. -->
       <img
         #cardImg
         [cachedSrc]="_img()! | resolveUrl:'thumb'"
         [alt]="_title()"
-        class="w-full h-full object-cover select-none"
+        class="w-full h-full object-cover select-none rounded-md"
         style="-webkit-user-drag: none; user-drag: none;"
         draggable="false"
         [appSpoiler]="spoiler()"


### PR DESCRIPTION
## Why

The active episode's card is the only one that gets `border-2 border-primary`, and its artwork corners came away from that border.

An element's `overflow: hidden` clip follows the padding box: its corner radius is the border radius **minus the border width**. So the figure, `rounded-lg overflow-hidden`, clips at 8px normally and at 6px once the 2px border is on. The image carried `rounded-lg`, 8px, and kept curving at 8px inside a 6px clip: the corners cut in past the border and the figure's `bg-base-300` showed through the crescent between the two arcs.

## What

`rounded-md` (6px) on the image, matching the clip under a 2px border.

Verified by rendering the three cases headless at high zoom: 8px inside the border leaves the visible gap, 6px and 0 both sit flush. And on a figure with no border the image's own radius makes no difference at all - even at 0 the figure's clip is what rounds the art, so one unconditional value covers both states rather than a binding per state.

## The rule

A radius on a child under a clipping, bordered parent has to be the parent's radius minus the border width. Larger and the child cuts inside the clip, which is what this was; smaller and the clip just wins.