### PR TITLE
fix(media-card): don't replay the artwork reveal on a back navigation

### DIFF
--- a/client/src/app/core/services/navbar.service.spec.ts
+++ b/client/src/app/core/services/navbar.service.spec.ts
@@ -57,6 +57,34 @@ describe('NavbarService', () => {
     expect(navbar.canGoBack()).toBe(false);
   });
 
+  /** The artwork reveal replays whenever a cached subtree is re-inserted, so a
+   *  page returned to would re-announce art the user was already looking at. */
+  it('flags the document on a back navigation and clears it on a forward one', async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          { path: '', component: PageStub },
+          { path: 'library', component: PageStub },
+        ]),
+      ],
+    });
+
+    const navbar = TestBed.inject(NavbarService);
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl('/');
+    await router.navigateByUrl('/library');
+    expect(document.documentElement.classList.contains('nav-back')).toBe(false);
+
+    navbar.goBack();
+    // goBack() releases `lastWasBack` a macrotask after its navigation settles,
+    // so the forward hop below has to come after that, not inside the same tick.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(document.documentElement.classList.contains('nav-back')).toBe(true);
+
+    await router.navigateByUrl('/library');
+    expect(document.documentElement.classList.contains('nav-back')).toBe(false);
+  });
+
   it('records a back entry once a real in-app navigation happens', async () => {
     TestBed.configureTestingModule({
       providers: [

--- a/client/src/app/core/services/navbar.service.ts
+++ b/client/src/app/core/services/navbar.service.ts
@@ -78,6 +78,16 @@ export class NavbarService {
     // the first hardware-back press on the entry screen a no-op redirect.
     let lastUrl = '';
     this.router.events.subscribe((e) => {
+      if (e instanceof NavigationStart) {
+        // A page returned to must look exactly as it was left, and the artwork
+        // reveal replays whenever a cached subtree is re-inserted. Not
+        // `isPoppingBack`: the top-level nav entries set that too, and opening
+        // a screen from the sidebar still earns its reveal.
+        document.documentElement.classList.toggle(
+          'nav-back',
+          e.navigationTrigger === 'popstate' || this.lastWasBack(),
+        );
+      }
       // Browser back/forward: mirror the pop on our internal stack so the
       // next in-app back button doesn't re-push the URL we just left (which
       // would let goBack() walk *forward* into the page the user came back

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -792,6 +792,11 @@ body.tv .mosaic-art > * > img:nth-child(4) {
     animation: none;
   }
 }
+/* Held until the next navigation, so art that lands from the revalidation
+   behind a restored page stays as quiet as the art already on it. */
+html.nav-back .card-img-reveal {
+  animation: none;
+}
 
 /* One promotion source fewer, and the reveal stays (the art is still hidden
    until it has decoded — only the 200 ms tween goes). */


### PR DESCRIPTION
## What caused it

Nothing reloaded. The images are cached at every link in the chain, and the fade was an animation replaying.

| link | state on return to home |
|---|---|
| route `''` | `reuse: true`, so the subtree is detached and re-attached, never rebuilt |
| `imgLoaded` | stays `true` - the card component is never recreated |
| the `<img>` elements | the same nodes, image data already decoded |
| `cachedSrc` | an `effect` over the url string, which does not change, so `src` is never rewritten |
| `keepRouteFresh` revalidation | every home rail tracks a stable id (`m.id`, `p.id`, `rec.media.id`, …), so items update inputs instead of recreating cards |

What was left is `card-img-reveal`. #1196 made the reveal a keyframe animation precisely because **re-inserting a subtree into the document restarts CSS animations** while an already-settled transition stays inert - that is what brought the fade back when a cached library grid was reopened.

## The rule

That replay is right when a screen is opened and wrong when one is returned to. A page returned to should look exactly as it was left, and re-announcing art the user was already looking at is the opposite.

So: reveal on a forward navigation, none on a back. Both of the reports this reconciles hold - reopening a library from the sidebar still animates, going back to home does not.

## What

`nav-back` on the document element, set at `NavigationStart` when the navigation in flight is a back: either `navigationTrigger === 'popstate'` (browser and gesture back) or `lastWasBack()`, which `goBack()` raises and which the Android hardware back, Escape and the navbar arrow all route through.

Deliberately **not** `isPoppingBack`. That flag means "do not push onto the back stack", and `resetNavHistory()` raises it for every top-level nav entry, the sidebar library links included - so it would have suppressed exactly the case #1196 fixed.

The flag is held until the next `NavigationStart` rather than cleared when the navigation ends. That is on purpose: art that arrives from the revalidation running behind a restored page then stays as quiet as the art already on screen, and it avoids racing the frame in which the animation would otherwise be created.

## Test

- New spec: the flag is absent on a forward navigation, present after `goBack()`, and cleared by the next forward hop. It documents one timing detail found while writing it - `goBack()` releases `lastWasBack` a macrotask after its navigation settles, so a forward navigation issued inside that same tick still reads as a back. Unreachable by hand, but the test has to wait it out.
- Full client suite: 79/79 files.
- `tsc -p tsconfig.app.json --noEmit` clean.
