### PR TITLE
feat(horizontal-scroller): hold the rail offset across a return

### DIFF
--- a/client/src/app/core/services/navbar.service.ts
+++ b/client/src/app/core/services/navbar.service.ts
@@ -79,14 +79,14 @@ export class NavbarService {
     let lastUrl = '';
     this.router.events.subscribe((e) => {
       if (e instanceof NavigationStart) {
-        // A page returned to must look exactly as it was left, and the artwork
-        // reveal replays whenever a cached subtree is re-inserted. Not
-        // `isPoppingBack`: the top-level nav entries set that too, and opening
-        // a screen from the sidebar still earns its reveal.
-        document.documentElement.classList.toggle(
-          'nav-back',
-          e.navigationTrigger === 'popstate' || this.lastWasBack(),
-        );
+        // A page returned to must look exactly as it was left, where a page
+        // opened is a fresh screen. Not `isPoppingBack`: the top-level nav
+        // entries set that too, and opening a screen from the sidebar is not a
+        // return. The class drives the CSS side of that (the artwork reveal
+        // replays whenever a cached subtree is re-inserted).
+        const back = e.navigationTrigger === 'popstate' || this.lastWasBack();
+        this.navigatedBack.set(back);
+        document.documentElement.classList.toggle('nav-back', back);
       }
       // Browser back/forward: mirror the pop on our internal stack so the
       // next in-app back button doesn't re-push the URL we just left (which
@@ -177,6 +177,12 @@ export class NavbarService {
   /** Set when goBack() is currently navigating; consumed by the destination
    *  page's ngOnInit to decide between restoring focus vs. landing default. */
   readonly lastWasBack = signal(false);
+
+  /** Whether the navigation in flight is a return, held until the next one so
+   *  a page restored from the reuse cache can tell which it is. Wider than
+   *  {@link lastWasBack}: the browser and gesture back never go through
+   *  goBack(). */
+  readonly navigatedBack = signal(false);
 
   goBack(fallback?: readonly (string | number)[]): void {
     const prev = this.history.pop();

--- a/client/src/app/shared/components/horizontal-scroller.spec.ts
+++ b/client/src/app/shared/components/horizontal-scroller.spec.ts
@@ -1,0 +1,68 @@
+import { Component, provideZonelessChangeDetection, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, DetachedRouteHandle, Route } from '@angular/router';
+import { vi } from 'vitest';
+import { HorizontalScrollerComponent } from './horizontal-scroller';
+import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
+import { NavbarService } from '../../core/services/navbar.service';
+import { TvService } from '../../core/services/tv.service';
+
+@Component({
+  imports: [HorizontalScrollerComponent],
+  template: '<app-horizontal-scroller title="Row"><div>card</div></app-horizontal-scroller>',
+})
+class HostStub {}
+
+/** A detached subtree loses its scroll offset and the reattach runs no lifecycle
+ *  hook, so the row came back at zero on every return. */
+describe('HorizontalScrollerComponent', () => {
+  beforeAll(() => {
+    // jsdom ships no ResizeObserver, and ngAfterViewInit observes the rail.
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe() {}
+      disconnect() {}
+    };
+  });
+
+  /** Returns the rail's stubbed scrollTo after parking an offset on it and
+   *  driving one detach / reattach cycle through the reuse cache. */
+  function reattachWith(navigatedBack: boolean) {
+    const back = signal(navigatedBack);
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: TvService, useValue: { isTv: () => false } as unknown as TvService },
+        { provide: NavbarService, useValue: { navigatedBack: back } as unknown as NavbarService },
+      ],
+    });
+    const fixture = TestBed.createComponent(HostStub);
+    fixture.detectChanges();
+
+    const rail = fixture.nativeElement.querySelector('[data-scroller]') as HTMLElement;
+    const scrollTo = vi.fn();
+    rail.scrollTo = scrollTo as unknown as HTMLElement['scrollTo'];
+    // jsdom has no layout, so the offset the user left behind is faked onto the
+    // element and picked up by the (scroll) handler.
+    Object.defineProperty(rail, 'scrollLeft', { value: 640, configurable: true });
+    rail.dispatchEvent(new Event('scroll'));
+
+    const reuse = TestBed.inject(CachingReuseStrategy);
+    const route: Route = { path: '', data: { reuse: true } };
+    const snapshot = { routeConfig: route, params: {} } as unknown as ActivatedRouteSnapshot;
+    reuse.store(snapshot, { componentRef: { destroy: () => {} } } as unknown as DetachedRouteHandle);
+    reuse.retrieve(snapshot);
+
+    // attached$ is emitted from a microtask inside retrieve().
+    return Promise.resolve().then(() => scrollTo);
+  }
+
+  it('VERDICT: restores the parked offset on a return, without smooth scroll', async () => {
+    expect(await reattachWith(true)).toHaveBeenCalledWith({ left: 640, behavior: 'instant' });
+  });
+
+  /** Opening the page is a fresh screen, so the rail stays where the reattach
+   *  left it rather than replaying wherever the user was last time. */
+  it('VERDICT: leaves the rail alone when the page is navigated to, not returned to', async () => {
+    expect(await reattachWith(false)).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/app/shared/components/horizontal-scroller.ts
+++ b/client/src/app/shared/components/horizontal-scroller.ts
@@ -16,6 +16,7 @@ import { LucideChevronLeft, LucideChevronRight } from '@lucide/angular';
 import { TvRowDirective } from '../directives/tv-row.directive';
 import { TvService } from '../../core/services/tv.service';
 import { CachingReuseStrategy } from '../../core/services/route-reuse.strategy';
+import { NavbarService } from '../../core/services/navbar.service';
 import { rowTopOffset, snapRowOnFocus } from '../../core/utils/focus-snap.util';
 
 @Component({
@@ -29,6 +30,7 @@ export class HorizontalScrollerComponent implements AfterViewInit, OnDestroy {
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly tv = inject(TvService);
   private readonly reuse = inject(CachingReuseStrategy);
+  private readonly navbar = inject(NavbarService);
   private readonly destroyRef = inject(DestroyRef);
   readonly title = input('');
   readonly atStart = signal(true);
@@ -42,6 +44,9 @@ export class HorizontalScrollerComponent implements AfterViewInit, OnDestroy {
 
   private readonly scrollerEl = viewChild<ElementRef<HTMLElement>>('scroller');
   private resizeObserver?: ResizeObserver;
+  /** Last offset the row was left at. A detached subtree loses its scroll, and
+   *  the instance outlives the detach, so the field is the whole store. */
+  private parkedScrollLeft = 0;
 
   @HostListener('focusin', ['$event'])
   protected onFocusIn(event: FocusEvent): void {
@@ -67,7 +72,15 @@ export class HorizontalScrollerComponent implements AfterViewInit, OnDestroy {
         // stale proximity state, then recompute the scroll extents.
         this.showLeft.set(false);
         this.showRight.set(false);
-        requestAnimationFrame(() => this.updateArrows());
+        // Synchronously, before the frame that would dispatch the reset's own
+        // scroll event and overwrite the parked offset.
+        this.restoreScroll();
+        requestAnimationFrame(() => {
+          // Again once laid out: a rail whose extents weren't known yet clamped
+          // the first attempt.
+          this.restoreScroll();
+          this.updateArrows();
+        });
       });
   }
 
@@ -80,8 +93,23 @@ export class HorizontalScrollerComponent implements AfterViewInit, OnDestroy {
     // attached$ is not route-scoped, so rails of pages still held by the reuse
     // cache get here too — reading their extents is a forced layout for nothing.
     if (!el || !el.isConnected) return;
+    this.parkedScrollLeft = el.scrollLeft;
     this.atStart.set(el.scrollLeft <= 0);
     this.atEnd.set(el.scrollLeft + el.clientWidth >= el.scrollWidth - 1);
+  }
+
+  /** `scrollTo`, not the property: the rail carries `scroll-behavior: smooth`,
+   *  which would turn a restore into a visible glide.
+   *
+   *  Only on a return. Opening the page is a fresh screen, and the reattach
+   *  already left the rail at zero — the parked offset is then overwritten by
+   *  the `updateArrows()` that follows, so the next return restores what the
+   *  user actually left. */
+  private restoreScroll() {
+    const el = this.scrollerEl()?.nativeElement;
+    if (!el || !el.isConnected || !this.parkedScrollLeft) return;
+    if (!this.navbar.navigatedBack()) return;
+    el.scrollTo({ left: this.parkedScrollLeft, behavior: 'instant' });
   }
 
   scrollLeft() {


### PR DESCRIPTION
## Why

A route flagged `reuse: true` is detached rather than destroyed, and a detached subtree loses the `scrollLeft` of every element in it. The reattach runs no lifecycle hook to put it back, so returning to home from a title reset every rail to its first card.

The component already knew: the comment on its `attached$` subscription says "The reattach can reset the rail's scrollLeft", and it only used that to recompute the arrow state.

## What

- The offset is parked from the `(scroll)` handler already wired for the arrows, into a plain field - the component instance outlives the detach, so there is nothing to key or evict.
- Re-applied on `attached$`, twice: synchronously, ahead of the frame that would dispatch the reset's own scroll event and overwrite the parked value, then once more inside the `requestAnimationFrame` that was already there, for a rail whose extents were not known yet and clamped the first attempt.
- `scrollTo({ behavior: 'instant' })`, not the property: the rail carries `scroll-behavior: smooth`, so an assignment would animate the restore into a visible glide. Same trap `ScrollMemoryService` documents for the vertical case.

## Only on a return

Opening the page is a fresh screen and starts at the first card; returning to it restores what was left. Same rule as the artwork reveal in #1201, off the same signal, now exposed as `NavbarService.navigatedBack` (popstate, or `goBack()`, which the hardware back, Escape and the navbar arrow all route through) with the `nav-back` class derived from it.

Nothing extra is needed to keep the two directions from leaking into each other: on a forward attach the rail is left at the reattach's zero, and the `updateArrows()` that follows parks that zero, so a later return restores where the user actually was rather than where they were two visits ago.

## Test

New spec, both directions: the rail is restored to the parked offset on a return and left alone when the page is navigated to. Checked that it is not vacuous - neutering the restore drops the suite to 79/80.

Full suite 80/80, `tsc -p tsconfig.app.json --noEmit` clean.

Vertical page scroll is untouched: home already passes a `scrollKey` to `keepRouteFresh`, and `ScrollMemoryService.restoreSticky` handles it.
