### PR TITLE
fix(media-card): keep the resting artwork radius for the poster morph

### DIFF
--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -23,17 +23,21 @@
     (keydown.space)="onCardClick(); $event.preventDefault()"
   >
     @if (_img() && !imgFailed()) {
-      <!-- rounded-md, not -lg: the figure's clip loses the border width when the
-           card is highlighted, and a wider radius here cuts the corners inside it. -->
+      <!-- Concentric with the figure's clip, which loses the border width when the
+           card is highlighted. Bound rather than fixed at the smaller value: a
+           view transition snapshots this img out of that clip, so its own radius
+           is the only one the poster morph has. -->
       <img
         #cardImg
         [cachedSrc]="_img()! | resolveUrl:'thumb'"
         [alt]="_title()"
-        class="w-full h-full object-cover select-none rounded-md"
+        class="w-full h-full object-cover select-none"
         style="-webkit-user-drag: none; user-drag: none;"
         draggable="false"
         [appSpoiler]="spoiler()"
         #spoilerImg="spoiler"
+        [class.rounded-lg]="!highlighted()"
+        [class.rounded-md]="highlighted()"
         [class.scale-110]="spoilerImg.masked()"
         [class.grayscale]="grayscale()"
         [class.opacity-0]="!imgLoaded()"

--- a/client/src/app/shared/components/media-card/media-card.spec.ts
+++ b/client/src/app/shared/components/media-card/media-card.spec.ts
@@ -567,6 +567,27 @@ describe('MediaCardComponent — card.actions merges with plugin contributions',
  * start; a poster URL that outlived its file never paints at all. Both must
  * show the film glyph rather than the WebView's broken-image icon.
  */
+/** The figure clips with `overflow-hidden`, and that clip loses the border width
+ *  when the card is highlighted, so the art has to follow. It cannot just sit at
+ *  the smaller value either: a view transition snapshots the img out of the
+ *  figure, and its own radius is the only one the poster morph has. */
+describe('media-card artwork radius', () => {
+  const img = (h: Harness): HTMLImageElement | null =>
+    h.fixture.nativeElement.querySelector('img');
+
+  it('VERDICT: matches the figure clip, so the poster morph keeps the resting radius', async () => {
+    const art = { posterUrl: '/api/images/poster.jpg' };
+    const resting = await createFixture(FULL_MEMBER, { media: makeMedia(art) });
+    expect(img(resting)!.classList.contains('rounded-lg')).toBe(true);
+    expect(img(resting)!.classList.contains('rounded-md')).toBe(false);
+
+    const active = await createFixture(FULL_MEMBER, { media: makeMedia(art), highlighted: true });
+    expect(active.fixture.nativeElement.querySelector('figure')!.classList).toContain('border-2');
+    expect(img(active)!.classList.contains('rounded-md')).toBe(true);
+    expect(img(active)!.classList.contains('rounded-lg')).toBe(false);
+  });
+});
+
 describe('media-card artwork placeholder', () => {
   const placeholder = (h: Harness) =>
     h.fixture.nativeElement.querySelector('svg.lucide-film');


### PR DESCRIPTION
## Why

#1200 pinned the card artwork at `rounded-md` to sit concentric inside the highlighted card's `border-2`. That was right for the card and wrong for the poster morph.

A view transition snapshots the named element **out of its ancestors** - `view-transition.ts` says so itself: "the lone img would be snapshotted out of the figure that rounds it". So the two states read the radius from different places:

| | what rounds the art |
|---|---|
| in the card, at rest | the figure's `overflow-hidden` clip, 8px |
| in the card, highlighted | the same clip, 6px once `border-2` is on |
| during the poster morph | the img's own `border-radius`, and nothing else |

Pinned at 6px, the morph flew a 6px poster away from the 8px corner the user was looking at, into the hero's `rounded-xl`.

That is also why the headless render behind #1200 said one value was enough: it measured the static card, where the img's own radius is genuinely inert, and not the snapshot, where it is everything.

## What

The radius follows the state, which is correct in all three rows of that table: `rounded-lg` at rest (the clip and the morph agree at 8px), `rounded-md` while highlighted (the clip is 6px, and a morph from that card starts where it visually sits).

## Test

New spec asserting both states on the rendered img, next to the `border-2` it has to stay concentric with. Full suite 79/79, `tsc` clean.
