### PR TITLE
feat(player): add a display option to sort track pickers by language

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -218,6 +218,8 @@
     "home_background_hint": "Zeigt ein Poster im Vollbild hinter den Bereichen der Startseite an.",
     "gray_unreleased": "Unveröffentlichte Folgen ausgrauen",
     "gray_unreleased_hint": "Zeigt das Standbild in Schwarz-Weiß, bis die Folge ausgestrahlt wird.",
+    "sort_tracks_by_language": "Spuren nach Sprache sortieren",
+    "sort_tracks_by_language_hint": "Sortiert die Audio- und Untertitelauswahl alphabetisch nach Sprache; Spuren ohne erkannte Sprache bleiben am Ende.",
     "language": "App-Sprache",
     "language_auto": "System",
     "language_hint": "Sprache der Oberfläche. Standardmäßig die deines Browsers oder Systems."

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -223,6 +223,8 @@
     "home_background_hint": "Shows a full-screen poster behind the home sections.",
     "gray_unreleased": "Grey out unreleased episodes",
     "gray_unreleased_hint": "Shows the still in black and white until the episode airs.",
+    "sort_tracks_by_language": "Sort tracks by language",
+    "sort_tracks_by_language_hint": "Orders the audio and subtitle pickers alphabetically by language; tracks with no known language stay at the end.",
     "language": "Application language",
     "language_auto": "System",
     "language_hint": "Interface language. Defaults to your browser or system language."

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -218,6 +218,8 @@
     "home_background_hint": "Muestra un póster a pantalla completa detrás de las secciones del inicio.",
     "gray_unreleased": "Episodios no estrenados en blanco y negro",
     "gray_unreleased_hint": "Muestra la imagen en blanco y negro hasta que se emita el episodio.",
+    "sort_tracks_by_language": "Ordenar las pistas por idioma",
+    "sort_tracks_by_language_hint": "Ordena los selectores de audio y subtítulos alfabéticamente por idioma; las pistas sin idioma identificado quedan al final.",
     "language": "Idioma de la aplicación",
     "language_auto": "Sistema",
     "language_hint": "Idioma de la interfaz. Por defecto, el de tu navegador o sistema."

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -223,6 +223,8 @@
     "home_background_hint": "Affiche une affiche en plein écran derrière les sections de l'accueil.",
     "gray_unreleased": "Épisodes non sortis en noir et blanc",
     "gray_unreleased_hint": "Affiche l'image en noir et blanc tant que l'épisode n'est pas diffusé.",
+    "sort_tracks_by_language": "Trier les pistes par langue",
+    "sort_tracks_by_language_hint": "Classe les sélecteurs audio et sous-titres par ordre alphabétique de langue ; les pistes sans langue identifiée restent à la fin.",
     "language": "Langue de l'application",
     "language_auto": "Système",
     "language_hint": "Langue de l'interface. Par défaut, celle de votre navigateur ou de votre système."

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -218,6 +218,8 @@
     "home_background_hint": "Mostra un poster a schermo intero dietro le sezioni della home.",
     "gray_unreleased": "Episodi non ancora usciti in bianco e nero",
     "gray_unreleased_hint": "Mostra l'immagine in bianco e nero finché l'episodio non va in onda.",
+    "sort_tracks_by_language": "Ordina le tracce per lingua",
+    "sort_tracks_by_language_hint": "Ordina i selettori audio e sottotitoli in ordine alfabetico di lingua; le tracce senza lingua riconosciuta restano in fondo.",
     "language": "Lingua dell'app",
     "language_auto": "Sistema",
     "language_hint": "Lingua dell'interfaccia. Per impostazione predefinita, quella del browser o del sistema."

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -218,6 +218,8 @@
     "home_background_hint": "Mostra um poster em ecrã inteiro atrás das secções do início.",
     "gray_unreleased": "Episódios por estrear a preto e branco",
     "gray_unreleased_hint": "Mostra a imagem a preto e branco até o episódio ser emitido.",
+    "sort_tracks_by_language": "Ordenar as faixas por idioma",
+    "sort_tracks_by_language_hint": "Ordena os seletores de áudio e legendas por ordem alfabética de idioma; as faixas sem idioma identificado ficam no fim.",
     "language": "Idioma da aplicação",
     "language_auto": "Sistema",
     "language_hint": "Idioma da interface. Por predefinição, o do seu navegador ou sistema."

--- a/client/src/app/core/services/app-settings.service.ts
+++ b/client/src/app/core/services/app-settings.service.ts
@@ -1,5 +1,8 @@
 import { Injectable, computed, inject } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { PlayerSettingsService } from './player-settings.service';
+import { DisplaySettingsService } from './display-settings.service';
+import { sortByLanguageName } from '../utils/language.utils';
 
 /**
  * Read access to the client-local player preferences that surfaces needing a
@@ -8,6 +11,8 @@ import { PlayerSettingsService } from './player-settings.service';
 @Injectable({ providedIn: 'root' })
 export class AppSettingsService {
   private readonly playerSettings = inject(PlayerSettingsService);
+  private readonly displaySettings = inject(DisplaySettingsService);
+  private readonly translate = inject(TranslateService);
 
   /**
    * Hide image-based (PGS/VOBSUB) subtitles from the pickers and native player.
@@ -22,4 +27,17 @@ export class AppSettingsService {
   readonly showSubtitleFormat = computed(
     () => this.playerSettings.settings().showSubtitleFormat,
   );
+
+  /** Order the pickers by language name rather than by stream order. */
+  readonly sortTracksByLanguage = computed(
+    () => this.displaySettings.settings().sortTracksByLanguage,
+  );
+
+  /** A picker's rows in the order the viewer asked for. Call it from a
+   *  computed: it reads the setting, so the list follows a toggle. */
+  sortTracks<T extends { language?: string }>(items: readonly T[]): T[] {
+    return this.sortTracksByLanguage()
+      ? sortByLanguageName(items, this.translate)
+      : [...items];
+  }
 }

--- a/client/src/app/core/services/display-settings.service.ts
+++ b/client/src/app/core/services/display-settings.service.ts
@@ -9,6 +9,9 @@ export interface DisplaySettings {
   language: string;
   /** Desaturate the still of an episode that hasn't aired yet. */
   grayUnreleased: boolean;
+  /** Order the audio and subtitle pickers by language name instead of the
+   *  file's stream order. Unnamed tracks stay at the end. */
+  sortTracksByLanguage: boolean;
 }
 
 const STORAGE_KEY = 'display.settings';
@@ -18,6 +21,7 @@ const DEFAULTS: DisplaySettings = {
   onlyMyRequests: false,
   language: '',
   grayUnreleased: true,
+  sortTracksByLanguage: false,
 };
 
 @Injectable({ providedIn: 'root' })

--- a/client/src/app/core/services/playback-target.ts
+++ b/client/src/app/core/services/playback-target.ts
@@ -5,6 +5,8 @@ import { SpriteMetadata } from '../utils/player.utils';
 export interface PlaybackOption {
   id: string;
   label: string;
+  /** Source language code, used to order the pickers. */
+  language?: string;
   /** Two-line row: language above, codec and channels below. Falls back to
    *  `label` on a source that cannot split it. */
   head?: string;

--- a/client/src/app/core/services/remote-playback-target.ts
+++ b/client/src/app/core/services/remote-playback-target.ts
@@ -258,6 +258,7 @@ export class RemotePlaybackTarget implements PlaybackTarget {
         subs.map((o) => ({
           id: o.id,
           label: o.label,
+          language: o.language,
           head: o.menuHead,
           sub: o.menuSub,
         })),

--- a/client/src/app/core/utils/language-utils.spec.ts
+++ b/client/src/app/core/utils/language-utils.spec.ts
@@ -1,0 +1,55 @@
+import { localizeLanguage, sortByLanguageName } from './language.utils';
+import { TranslateService } from '@ngx-translate/core';
+
+const NAMES: Record<string, string> = {
+  'language.fr': 'Français',
+  'language.en': 'Anglais',
+  'language.de': 'Allemand',
+};
+const translate = { instant: (key: string) => NAMES[key] ?? key } as TranslateService;
+
+describe('sortByLanguageName', () => {
+  it('sorts by name and pushes unnamed tracks last', () => {
+    const sorted = sortByLanguageName(
+      [
+        { id: 'a', language: 'und' },
+        { id: 'b', language: 'fre' },
+        { id: 'c', language: 'qaa' },
+        { id: 'd', language: 'deu' },
+        { id: 'e', language: 'eng' },
+      ],
+      translate,
+    );
+    expect(sorted.map((t) => t.id)).toEqual(['d', 'e', 'b', 'a', 'c']);
+  });
+
+  it('keeps same-language renditions in source order', () => {
+    const sorted = sortByLanguageName(
+      [{ id: '5.1', language: 'fr' }, { id: 'stereo', language: 'fr' }],
+      translate,
+    );
+    expect(sorted.map((t) => t.id)).toEqual(['5.1', 'stereo']);
+  });
+});
+
+describe('localizeLanguage', () => {
+  it('names a code the app carries no translation for', () => {
+    const bare = { instant: (key: string) => key, currentLang: 'fr' } as TranslateService;
+    expect(localizeLanguage('est', bare)).toBe('Estonien');
+    expect(localizeLanguage('tam', bare)).toBe('Tamoul');
+  });
+
+  it('keeps the raw code for a private-use tag', () => {
+    const bare = { instant: (key: string) => key, currentLang: 'en' } as TranslateService;
+    expect(localizeLanguage('qaa', bare)).toBe('qaa');
+    expect(localizeLanguage(undefined, bare)).toBe('und');
+  });
+
+  it('prefers our own translation over the platform name', () => {
+    const translate = {
+      instant: (key: string) => (key === 'language.fr' ? 'Français' : key),
+      currentLang: 'en',
+    } as TranslateService;
+    expect(localizeLanguage('fre', translate)).toBe('Français');
+  });
+});

--- a/client/src/app/core/utils/language.utils.ts
+++ b/client/src/app/core/utils/language.utils.ts
@@ -87,5 +87,53 @@ export function localizeLanguage(
   if (norm === 'und' || norm === 'xx') return norm;
   const key = `language.${norm}`;
   const t = translate.instant(key);
-  return typeof t === 'string' && t !== key ? t : norm;
+  if (typeof t === 'string' && t !== key) return t;
+  const locale = translate.currentLang || translate.defaultLang || 'en';
+  return nativeLanguageName(norm, locale) ?? norm;
+}
+
+const displayNames = new Map<string, Intl.DisplayNames | null>();
+
+/**
+ * The platform's own name for a language code we carry no translation for
+ * (`est`, `tam`, …), in the UI locale. Null when the runtime has no
+ * `Intl.DisplayNames` (Chromium < 81, i.e. the TV builds) or the code is
+ * unknown to it — the caller then shows the raw code.
+ */
+function nativeLanguageName(code: string, locale: string): string | null {
+  if (typeof Intl.DisplayNames !== 'function') return null;
+  if (!displayNames.has(locale)) {
+    try {
+      displayNames.set(locale, new Intl.DisplayNames([locale], { type: 'language' }));
+    } catch {
+      displayNames.set(locale, null);
+    }
+  }
+  let name: string | undefined;
+  try {
+    name = displayNames.get(locale)?.of(code);
+  } catch {
+    return null;
+  }
+  if (!name || name === code) return null;
+  // Our own names are capitalised; several locales render theirs lowercase.
+  return name.charAt(0).toLocaleUpperCase(locale) + name.slice(1);
+}
+
+/**
+ * Track lists ordered by their displayed language name. Entries whose code has
+ * no known name (`und`, `xx`, an untranslated code) go last, in source order;
+ * the sort is stable, so same-language renditions keep their source order too.
+ */
+export function sortByLanguageName<T extends { language?: string }>(
+  items: readonly T[],
+  translate: TranslateService,
+): T[] {
+  const name = (i: T) => localizeLanguage(i.language, translate);
+  const unnamed = (i: T) => (name(i) === normalizeLangCode(i.language) ? 1 : 0);
+  return [...items].sort(
+    (a, b) =>
+      unnamed(a) - unnamed(b) ||
+      (unnamed(a) ? 0 : name(a).localeCompare(name(b))),
+  );
 }

--- a/client/src/app/features/app-settings/display-settings/display-settings.html
+++ b/client/src/app/features/app-settings/display-settings/display-settings.html
@@ -30,5 +30,12 @@
       [label]="'display_settings.gray_unreleased' | translate"
       [hint]="'display_settings.gray_unreleased_hint' | translate"
     />
+
+    <app-toggle-field
+      [value]="sortTracksByLanguage()"
+      (valueChange)="onSortTracksByLanguageChange($event)"
+      [label]="'display_settings.sort_tracks_by_language' | translate"
+      [hint]="'display_settings.sort_tracks_by_language_hint' | translate"
+    />
   </div>
 </div>

--- a/client/src/app/features/app-settings/display-settings/display-settings.ts
+++ b/client/src/app/features/app-settings/display-settings/display-settings.ts
@@ -18,6 +18,7 @@ export class DisplaySettingsPageComponent implements OnInit {
 
   readonly homeBackground = signal(true);
   readonly grayUnreleased = signal(true);
+  readonly sortTracksByLanguage = signal(false);
   readonly languageOptions = SUPPORTED_LOCALES;
   /** '' = follow the browser/OS language. */
   readonly language = signal('');
@@ -26,6 +27,7 @@ export class DisplaySettingsPageComponent implements OnInit {
     const s = this.displaySettings.get();
     this.homeBackground.set(s.homeBackground);
     this.grayUnreleased.set(s.grayUnreleased);
+    this.sortTracksByLanguage.set(s.sortTracksByLanguage);
     this.language.set(s.language);
   }
 
@@ -37,6 +39,11 @@ export class DisplaySettingsPageComponent implements OnInit {
   onGrayUnreleasedChange(value: boolean) {
     this.grayUnreleased.set(value);
     this.displaySettings.save({ grayUnreleased: value });
+  }
+
+  onSortTracksByLanguageChange(value: boolean) {
+    this.sortTracksByLanguage.set(value);
+    this.displaySettings.save({ sortTracksByLanguage: value });
   }
 
   onLanguageChange(value: string) {

--- a/client/src/app/features/player/controls/player-controls.html
+++ b/client/src/app/features/player/controls/player-controls.html
@@ -573,7 +573,7 @@
       <span class="flex-1 text-left">{{ 'player.off' | translate }}</span>
       @if (!activeSubtitleId()) { <svg lucideCheck class="h-5 w-5 text-white shrink-0"></svg> }
     </button>
-    @for (sub of availableSubtitles(); track sub.id) {
+    @for (sub of sortedSubtitles(); track sub.id) {
       <button
         type="button"
         class="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-white hover:bg-white/10 active:bg-white/10"
@@ -624,7 +624,7 @@
   <div class="text-center text-white/60 text-xs font-medium mb-3">{{ 'player.audio_track' | translate }}</div>
   <!-- Only the options scroll; the title above stays visible. -->
   <div class="max-h-[40vh] overflow-y-auto scroll-ring-safe">
-  @for (track of availableAudioTracks(); track track.id) {
+  @for (track of sortedAudioTracks(); track track.id) {
     <button
       type="button"
       class="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-white hover:bg-white/10 active:bg-white/10"

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -32,6 +32,7 @@ import { QueueItem } from '../../../core/services/playback-queue.service';
 import { NgTemplateOutlet } from '@angular/common';
 import { BottomSheetComponent } from '../../../shared/components/bottom-sheet';
 import { TranslateModule } from '@ngx-translate/core';
+import { AppSettingsService } from '../../../core/services/app-settings.service';
 import { formatTime, SpriteMetadata } from '../../../core/utils/player.utils';
 import { initialOverlayFocus } from '../../../core/services/focusable.constants';
 import { SeekbarComponent } from '../../../shared/components/seekbar/seekbar';
@@ -127,6 +128,7 @@ export class PlayerControlsComponent {
   private readonly dismissStack = inject(DismissableStackService);
   private readonly playerSettings = inject(PlayerSettingsService);
   private readonly tv = inject(TvService);
+  private readonly appSettings = inject(AppSettingsService);
   /** True on Android TV — drives 10-foot UI choices in the template. */
   readonly isTv = this.device.isTv;
   /** Show a leaf next to the quality value when the active rung is a
@@ -296,11 +298,17 @@ export class PlayerControlsComponent {
   /** Desktop (Electron) — native engine but mouse-driven; keeps the fullscreen
    *  button which is otherwise hidden for native (mobile/TV) engines. */
   readonly isDesktop = input(false);
-  readonly availableSubtitles = input<{ id: string; label: string; menuHead?: string; menuSub?: string; burnIn?: boolean; isImage?: boolean }[]>([]);
+  readonly availableSubtitles = input<{ id: string; label: string; language?: string; menuHead?: string; menuSub?: string; burnIn?: boolean; isImage?: boolean }[]>([]);
   readonly availableQualities = input<{ id: string; label: string; lowBandwidth?: boolean }[]>([]);
   readonly activeSubtitleId = input<string | null>(null);
   readonly activeQualityId = input('auto');
-  readonly availableAudioTracks = input<{ id: string; label: string; menuHead?: string; menuSub?: string }[]>([]);
+  readonly availableAudioTracks = input<{ id: string; label: string; language?: string; menuHead?: string; menuSub?: string }[]>([]);
+  readonly sortedSubtitles = computed(() =>
+    this.appSettings.sortTracks(this.availableSubtitles()),
+  );
+  readonly sortedAudioTracks = computed(() =>
+    this.appSettings.sortTracks(this.availableAudioTracks()),
+  );
   readonly activeAudioTrackId = input<string | null>(null);
   readonly pipAvailable = input(true);
   readonly canLockOrientation = input(false);

--- a/client/src/app/features/player/remote/cast-remote.html
+++ b/client/src/app/features/player/remote/cast-remote.html
@@ -38,7 +38,7 @@
             <span class="flex-1 text-left">Désactivé</span>
             @if (!activeSubId()) { <svg lucideCheck class="h-4 w-4 text-white shrink-0"></svg> }
           </button>
-          @for (sub of availableSubtitles(); track sub.id) {
+          @for (sub of sortedSubtitles(); track sub.id) {
             <button class="dropdown-item text-white" (click)="selectSubtitle(sub)">
               <svg lucideCaptions class="h-4 w-4 text-white/50 shrink-0"></svg>
               <span class="flex-1 text-left">{{ sub.label }}@if (sub.burnIn) { <span class="text-warning/70 text-[10px] ml-1">gravé</span> }</span>
@@ -55,7 +55,7 @@
             <svg lucideHeadphones class="h-4 w-4"></svg>
             Audio
           </button>
-          @for (track of availableAudioTracks(); track track.id) {
+          @for (track of sortedAudioTracks(); track track.id) {
             <button class="dropdown-item text-white" (click)="selectAudio(track)">
               <svg lucideHeadphones class="h-4 w-4 text-white/50 shrink-0"></svg>
               <span class="flex-1 text-left">{{ track.label }}</span>

--- a/client/src/app/features/player/remote/cast-remote.ts
+++ b/client/src/app/features/player/remote/cast-remote.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   effect,
   inject,
   input,
@@ -8,6 +9,7 @@ import {
   signal,
 } from '@angular/core';
 import { CastService } from '../../../core/services/cast.service';
+import { AppSettingsService } from '../../../core/services/app-settings.service';
 import { DropdownMenuComponent } from '../../../shared/components/dropdown-menu';
 import { TranslateModule } from '@ngx-translate/core';
 import {
@@ -69,6 +71,14 @@ export interface CastQualityOption {
 })
 export class CastRemoteComponent {
   readonly cast = inject(CastService);
+  private readonly appSettings = inject(AppSettingsService);
+
+  readonly sortedSubtitles = computed(() =>
+    this.appSettings.sortTracks(this.availableSubtitles()),
+  );
+  readonly sortedAudioTracks = computed(() =>
+    this.appSettings.sortTracks(this.availableAudioTracks()),
+  );
 
   readonly mediaTitle = input('');
   readonly episodeTitle = input('');

--- a/client/src/app/shared/cast-overlay/cast-overlay.ts
+++ b/client/src/app/shared/cast-overlay/cast-overlay.ts
@@ -10,6 +10,7 @@ import { RemoteService } from '../../core/services/remote.service';
 import { CastPlaybackTarget } from '../../core/services/cast-playback-target';
 import { RemotePlaybackTarget } from '../../core/services/remote-playback-target';
 import { PlaybackOption } from '../../core/services/playback-target';
+import { AppSettingsService } from '../../core/services/app-settings.service';
 import { SeekbarComponent } from '../components/seekbar/seekbar';
 import { CachedSrcDirective } from '../directives/cached-src.directive';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
@@ -62,6 +63,7 @@ interface PickerRow {
 })
 export class CastOverlayComponent {
   private readonly remote = inject(RemoteService);
+  private readonly appSettings = inject(AppSettingsService);
   private readonly castTarget = inject(CastPlaybackTarget);
   private readonly remoteTarget = inject(RemotePlaybackTarget);
 
@@ -112,7 +114,7 @@ export class CastOverlayComponent {
         kind: 'audio',
         labelKey: 'player.audio',
         active: this.activeAudioLabel(),
-        options: t.availableAudioTracks(),
+        options: this.appSettings.sortTracks(t.availableAudioTracks()),
         activeId: t.activeAudioTrackId(),
         offRow: false,
       });
@@ -122,7 +124,7 @@ export class CastOverlayComponent {
         kind: 'subtitle',
         labelKey: 'player.subtitles',
         active: this.activeSubtitleLabel(),
-        options: t.availableSubtitles(),
+        options: this.appSettings.sortTracks(t.availableSubtitles()),
         activeId: t.activeSubtitleId(),
         offRow: true,
       });

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -468,7 +468,7 @@
               [selected]="!selectedSubtitleId()"
               (click)="onSubtitleChange(null)"
             />
-            @for (s of subtitles(); track s.id) {
+            @for (s of sortedSubtitles(); track s.id) {
               <app-dropdown-option
                 [head]="s.head || s.label"
                 [sub]="s.sub"

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -56,6 +56,7 @@ import {
   CardActionsService,
   type CardAction,
 } from '../../../core/services/card-actions.service';
+import { AppSettingsService } from '../../../core/services/app-settings.service';
 import { PluginUiRegistryService } from '../../../core/plugin-ui/plugin-ui-registry.service';
 import { evaluateWhen, type WhenContext } from '../../../core/plugin-ui/when-evaluator';
 import type { MediaType } from '../../../core/enums/media-type.enum';
@@ -143,6 +144,7 @@ export class MediaInfoHeaderComponent {
   private readonly router = inject(Router);
   private readonly playerSettings = inject(PlayerSettingsService);
   private readonly trackManager = inject(TrackManagerService);
+  private readonly appSettings = inject(AppSettingsService);
   readonly navbar = inject(NavbarService);
   readonly tv = inject(TvService);
   private readonly device = inject(DeviceService);
@@ -408,7 +410,7 @@ export class MediaInfoHeaderComponent {
     const file = this.selectedFile();
     const audio = file?.streamInfo?.audio as any[] | undefined;
     if (!audio?.length) return [];
-    return audio.map((a: any, i: number) => {
+    const tracks = audio.map((a: any, i: number) => {
       const parts = formatAudioParts(a, this.translate, i + 1);
       return {
         index: i,
@@ -418,7 +420,12 @@ export class MediaInfoHeaderComponent {
         language: a.language ?? 'und',
       };
     });
+    return this.appSettings.sortTracks(tracks);
   });
+
+  readonly sortedSubtitles = computed(() =>
+    this.appSettings.sortTracks(this.subtitles()),
+  );
   readonly selectedAudio = computed(
     () => this.audioTracks().find((t) => t.index === this.selectedAudioIndex()) ?? null,
   );


### PR DESCRIPTION
## Why

Track pickers followed the file's stream order. On a release carrying a dozen audio or subtitle
tracks, finding a language meant scanning the whole list.

A second, unrelated symptom showed up in the same lists: language codes outside our 37-language
i18n table (`est`, `lav`, `lit`, `tam`, `tel`, …) were displayed raw.

## What

**Opt-in alphabetical ordering.** New `sortTracksByLanguage` display setting (off by default),
in app-settings > Display next to the other viewing preferences. `AppSettingsService.sortTracks()`
is the single read surface, so every picker follows the toggle at once and live:

- media-detail header (audio + subtitles)
- player menus
- cast overlay
- cast remote

Ordering rules: alphabetical by the localized language name; tracks with no nameable language
(`und`, `xx`, private-use tags) go last in stream order. The sort is stable, so same-language
renditions keep their source order — the ordinal `saveAudioSelection` stores to tell 5.1 from
stereo still resolves to the same track. `availableAudioTracks()` itself is untouched: its index
is the backend audio-stream index.

`PlaybackOption` gained `language?`, and the remote target now forwards it — without it the
remote's subtitle rows had nothing to sort on.

**Language names.** `localizeLanguage()` falls back to `Intl.DisplayNames` in the UI locale when
no translation of ours matches, which covers every ISO 639-1/2 code in all six locales with no
table to maintain. Our own names still win (`fre` stays "Français"); `und`/`xx` and unknown tags
still return the raw code, so they keep sorting last. Guarded on the constructor: Chromium < 81
(the Tizen/webOS builds) degrades to today's raw code.

## Notes

The backend's `normalizeLanguageCode` still only knows the 37-language table, so HLS `LANGUAGE`
attributes carry the raw 3-letter tag for these languages. Harmless for display, out of scope here.

## Test

- `npx tsc -p tsconfig.app.json --noEmit` and `ng build` clean.
- New `language-utils.spec.ts` (5 tests): ordering, unnamed-last, stable same-language order, the
  `Intl.DisplayNames` fallback and the private-use passthrough.
- Manual: pickers on media-detail and in the player, toggle on and off.
