### PR TITLE
fix(subtitles): scale cue text with the surface instead of a fixed sp size

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/CastPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/CastPlugin.java
@@ -468,11 +468,13 @@ public class CastPlugin extends Plugin {
         return style;
     }
 
+    /** Mirrors CAST_SUBTITLE_SIZE_SCALE (subtitle-presets.ts). */
     private static float mapSize(String name) {
         switch (name) {
-            case "small": return 0.7f;
-            case "large": return 1.1f;
-            case "xlarge": return 1.4f;
+            case "xsmall": return 0.7f;
+            case "small": return 0.775f;
+            case "large": return 0.975f;
+            case "xlarge": return 1.1f;
             default: return 0.85f;
         }
     }

--- a/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
@@ -645,10 +645,7 @@ public class NativePlayerPlugin extends Plugin {
                     Color.BLACK,                     // edge color
                     null);                           // typeface (null = default)
 
-            // Bottom margin via padding
-            int screenH = getActivity().getWindow().getDecorView().getHeight();
-            int paddingBottom = (int) (screenH * bottomMargin / 100f);
-            subtitles.applyStyle(style, fontScale, paddingBottom);
+            subtitles.applyStyle(style, fontScale, bottomMargin / 100f);
 
             call.resolve();
         });

--- a/client/android/app/src/main/java/media/fliks/app/SubtitleOverlay.java
+++ b/client/android/app/src/main/java/media/fliks/app/SubtitleOverlay.java
@@ -39,6 +39,7 @@ class SubtitleOverlay {
     private SubtitleView subtitleView;
     private ImageView imageView;
     private final SurfaceView surfaceView;
+    private float bottomMargin;
 
     SubtitleOverlay(Context ctx, ViewGroup webViewParent, FrameLayout wrapper, SurfaceView surfaceView) {
         this.surfaceView = surfaceView;
@@ -48,6 +49,8 @@ class SubtitleOverlay {
         webViewParent.addView(subtitleView, 1, new FrameLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT));
+        subtitleView.addOnLayoutChangeListener(
+                (v, l, t, r, b, ol, ot, or_, ob) -> applyBottomMargin());
 
         // Added to `wrapper` (a FrameLayout we own) so the gravity-bearing
         // FrameLayout.LayoutParams cast stays valid regardless of the host
@@ -77,11 +80,24 @@ class SubtitleOverlay {
         renderImageCue(null);
     }
 
-    void applyStyle(CaptionStyleCompat style, float fontScale, int paddingBottom) {
+    /** Text height as a fraction of the view, matching the iOS overlay and the
+     *  browser's `vh` cues: a fixed sp size reads half as tall on a tablet. */
+    private static final float TEXT_SIZE_FRACTION = 0.035f;
+
+    /** The lift translates the whole view instead of padding it: padding shrinks
+     *  the canvas the fractional text size is measured against, so the cues used
+     *  to shrink whenever the controls raised them. */
+    void applyStyle(CaptionStyleCompat style, float fontScale, float bottomMarginFraction) {
         if (subtitleView == null) return;
         subtitleView.setStyle(style);
-        subtitleView.setFixedTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 18f * fontScale);
-        subtitleView.setPadding(0, 0, 0, paddingBottom);
+        subtitleView.setFractionalTextSize(TEXT_SIZE_FRACTION * fontScale, true);
+        bottomMargin = bottomMarginFraction;
+        applyBottomMargin();
+    }
+
+    private void applyBottomMargin() {
+        if (subtitleView == null || subtitleView.getHeight() <= 0) return;
+        subtitleView.setTranslationY(-subtitleView.getHeight() * bottomMargin);
     }
 
     /** Dim text cues when the screen is at max brightness (HDR mode). */

--- a/client/ios/App/App/CastPlugin.swift
+++ b/client/ios/App/App/CastPlugin.swift
@@ -463,11 +463,13 @@ public class CastPlugin: CAPPlugin, CAPBridgedPlugin, GCKSessionManagerListener,
         return style
     }
 
+    /// Mirrors CAST_SUBTITLE_SIZE_SCALE (subtitle-presets.ts).
     private func mapSize(_ name: String) -> CGFloat {
         switch name {
-        case "small": return 0.7
-        case "large": return 1.1
-        case "xlarge": return 1.4
+        case "xsmall": return 0.7
+        case "small": return 0.775
+        case "large": return 0.975
+        case "xlarge": return 1.1
         default: return 0.85
         }
     }

--- a/client/ios/App/App/SubtitleOverlayView.swift
+++ b/client/ios/App/App/SubtitleOverlayView.swift
@@ -146,7 +146,7 @@ final class SubtitleOverlayView: UIView {
         // portrait and landscape (the short side is orientation-invariant),
         // rather than the full height (oversized in portrait) or the
         // letterboxed video band (undersized in portrait).
-        let pointSize = max(8, min(bounds.width, bounds.height) * 0.05 * style.fontScale)
+        let pointSize = max(8, min(bounds.width, bounds.height) * 0.035 * style.fontScale)
         let base = UIFont.systemFont(ofSize: pointSize, weight: .semibold)
         let out = NSMutableAttributedString()
         for (lineIdx, runs) in lines.enumerated() {

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -455,6 +455,7 @@
     "sub_color": "Textfarbe",
     "sub_shadow": "Schlagschatten",
     "sub_bg": "Hintergrundfarbe",
+    "sub_size_xsmall": "Sehr klein",
     "sub_size_small": "Klein",
     "sub_size_normal": "Normal",
     "sub_size_large": "Groß",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -460,6 +460,7 @@
     "sub_color": "Text color",
     "sub_shadow": "Drop shadow",
     "sub_bg": "Background color",
+    "sub_size_xsmall": "Very small",
     "sub_size_small": "Small",
     "sub_size_normal": "Normal",
     "sub_size_large": "Large",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -455,6 +455,7 @@
     "sub_color": "Color del texto",
     "sub_shadow": "Sombra proyectada",
     "sub_bg": "Color del fondo",
+    "sub_size_xsmall": "Muy pequeño",
     "sub_size_small": "Pequeño",
     "sub_size_normal": "Normal",
     "sub_size_large": "Grande",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -460,6 +460,7 @@
     "sub_color": "Couleur du texte",
     "sub_shadow": "Ombre portée",
     "sub_bg": "Couleur du fond",
+    "sub_size_xsmall": "Très petit",
     "sub_size_small": "Petit",
     "sub_size_normal": "Normal",
     "sub_size_large": "Grand",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -455,6 +455,7 @@
     "sub_color": "Colore del testo",
     "sub_shadow": "Ombreggiatura",
     "sub_bg": "Colore dello sfondo",
+    "sub_size_xsmall": "Molto piccolo",
     "sub_size_small": "Piccolo",
     "sub_size_normal": "Normale",
     "sub_size_large": "Grande",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -455,6 +455,7 @@
     "sub_color": "Cor do texto",
     "sub_shadow": "Sombra",
     "sub_bg": "Cor do fundo",
+    "sub_size_xsmall": "Muito pequeno",
     "sub_size_small": "Pequeno",
     "sub_size_normal": "Normal",
     "sub_size_large": "Grande",

--- a/client/src/app/core/services/cast-settings.service.ts
+++ b/client/src/app/core/services/cast-settings.service.ts
@@ -8,7 +8,7 @@ import { Injectable, signal } from '@angular/core';
  *  one shared UI between local and Cast and matches user expectations
  *  ("Normal / Grand", "Blanc / Jaune") rather than raw values. */
 export interface CastSubtitleStyle {
-  size: string;        // 'small' | 'normal' | 'large' | 'xlarge'
+  size: string;        // 'xsmall' | 'small' | 'normal' | 'large' | 'xlarge'
   color: string;       // 'white' | 'yellow' | 'green' | 'cyan'
   shadow: string;      // 'none' | 'drop' | 'outline' | 'raised'
   background: string;  // 'transparent' | 'semi' | 'black'

--- a/client/src/app/core/services/player-settings.service.ts
+++ b/client/src/app/core/services/player-settings.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { DeviceService } from './device.service';
+import {
+  DOM_SUBTITLE_HEIGHT_FRACTION,
+  NATIVE_SUBTITLE_SIZE_SCALE,
+} from '../utils/subtitle-presets';
 
 
 export interface PlayerSettings {
@@ -76,9 +80,14 @@ export function normalizeLang(code: string | undefined): string {
 
 // ── Subtitle appearance maps ──
 
-export const SUBTITLE_SIZE_MAP: Record<string, string> = {
-  small: '2.2vh', normal: '3vh', large: '3.5vh', xlarge: '4.5vh',
-};
+/** The DOM cue sizes are the native ladder in `vh`, so a preset keeps the same
+ *  proportions on every surface. */
+export const SUBTITLE_SIZE_MAP: Record<string, string> = Object.fromEntries(
+  Object.entries(NATIVE_SUBTITLE_SIZE_SCALE).map(([size, scale]) => [
+    size,
+    `${+(scale * DOM_SUBTITLE_HEIGHT_FRACTION * 100).toFixed(2)}vh`,
+  ]),
+);
 
 export const SUBTITLE_COLOR_MAP: Record<string, string> = {
   white: '#ffffff', yellow: '#ffff00', green: '#00ff00', cyan: '#00ffff',
@@ -106,7 +115,7 @@ export class PlayerSettingsService {
     // 10-foot UI: default to large subtitles on every TV form factor
     // (AndroidTV / Tizen / webOS — still overridable by the user).
     const defaults: PlayerSettings = this.device.isTv()
-      ? { ...DEFAULTS, subtitleSize: 'large' }
+      ? { ...DEFAULTS, subtitleSize: 'xlarge' }
       : { ...DEFAULTS };
     try {
       const raw = localStorage.getItem(SETTINGS_KEY);

--- a/client/src/app/core/utils/subtitle-presets.ts
+++ b/client/src/app/core/utils/subtitle-presets.ts
@@ -1,7 +1,7 @@
 /** Subtitle appearance presets, shared between NativeEngine and Cast.
  *
- *  Each table maps the same user-facing preset keys (`'small'` / `'normal'`
- *  / `'large'` / `'xlarge'`) to a platform-calibrated value:
+ *  Each table maps the same user-facing preset keys (`'xsmall'` / `'small'` /
+ *  `'normal'` / `'large'` / `'xlarge'`) to a platform-calibrated value:
  *
  *  - **Native** runs on ExoPlayer's `CaptionStyleCompat` and iOS
  *    `AVTextStyleRule`. Both define `1.0` as the platform's default
@@ -15,18 +15,32 @@
  *  The divergence is intentional. If a sender ever sees subtitles that
  *  look bigger on Cast than on the same device's local playback, the
  *  Cast scale is the lever to retune — not the Native one. */
+
+/** Text height at scale 1.0, as a fraction of the surface height, for the
+ *  engines that own their renderer. The ExoPlayer and AVPlayer overlays
+ *  hardcode the same value (SubtitleOverlay.java, SubtitleOverlayView.swift) —
+ *  retune the three together. */
+export const SUBTITLE_HEIGHT_FRACTION = 0.035;
+
+/** Same ladder for DOM cues, one notch lower: the browser path is mostly read
+ *  on a desktop monitor, further away than a held device. TVs sit on this path
+ *  too but default to the `large` preset. */
+export const DOM_SUBTITLE_HEIGHT_FRACTION = 0.03;
+
 export const NATIVE_SUBTITLE_SIZE_SCALE: Record<string, number> = {
-  small: 0.7,
+  xsmall: 0.7,
+  small: 0.85,
   normal: 1.0,
-  large: 1.3,
-  xlarge: 1.6,
+  large: 1.15,
+  xlarge: 1.3,
 };
 
 export const CAST_SUBTITLE_SIZE_SCALE: Record<string, number> = {
-  small: 0.7,
+  xsmall: 0.7,
+  small: 0.775,
   normal: 0.85,
-  large: 1.1,
-  xlarge: 1.4,
+  large: 0.975,
+  xlarge: 1.1,
 };
 
 /** Foreground colour in `#RRGGBB` (Android / iOS native renderers want

--- a/client/src/app/features/playback-settings/playback-options.ts
+++ b/client/src/app/features/playback-settings/playback-options.ts
@@ -28,6 +28,7 @@ export const SUBTITLE_MODE_OPTIONS = [
 ];
 
 export const SIZE_OPTIONS = [
+  { value: 'xsmall', labelKey: 'playback_settings.sub_size_xsmall' },
   { value: 'small', labelKey: 'playback_settings.sub_size_small' },
   { value: 'normal', labelKey: 'playback_settings.sub_size_normal' },
   { value: 'large', labelKey: 'playback_settings.sub_size_large' },

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -4822,7 +4822,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         <style> that targets video::cue. */
   private applySubtitleStyle() {
     const s = this.playerSettings.get();
-    const fontSize = SUBTITLE_SIZE_MAP[s.subtitleSize] ?? '0.7em';
+    const fontSize = SUBTITLE_SIZE_MAP[s.subtitleSize] ?? SUBTITLE_SIZE_MAP['normal'];
     const color = SUBTITLE_COLOR_MAP[s.subtitleColor] ?? '#ffffff';
     const shadow = SUBTITLE_SHADOW_MAP[s.subtitleShadow] ?? 'none';
     const bg = SUBTITLE_BG_MAP[s.subtitleBackground] ?? 'transparent';


### PR DESCRIPTION
## Why

On a Galaxy Tab S5e in landscape, `normal` subtitles read far smaller in the app than on a phone,
and smaller than the browser on that same tablet.

Cause: Android sized cues with `setFixedTextSize(COMPLEX_UNIT_SP, 18f * fontScale)`. An absolute sp
value keeps no relation to the screen, so its share of the height collapses on a large,
low-density panel:

| Surface, `normal`, landscape | View height | Text | % of height |
|---|---|---|---|
| Phone native (1080x2400, dp 3.0) | 360dp | 18dp | 5.0% |
| Tab S5e native (2560x1600, dp 2.0) | 800dp | 18dp | **2.25%** |
| Tab S5e browser (`3vh`) | 800px | 24px | 3.0% |
| iOS native (`min(w,h) * 0.05`) | - | - | 5.0% |

The iOS overlay and the DOM cues were already proportional to their surface. Android was the
outlier.

## What

**One calibration constant per rendering family.** `SUBTITLE_HEIGHT_FRACTION = 0.035` for the
engines that own their renderer (ExoPlayer, AVPlayer), `DOM_SUBTITLE_HEIGHT_FRACTION = 0.03` for
DOM cues — a notch lower because that path is mostly read at desk distance on a monitor, while the
TV overlay on the same path defaults to a larger preset. Android now calls
`setFractionalTextSize`, which also follows a rotation on its own, and `SUBTITLE_SIZE_MAP` is
derived from the native ladder instead of being hand-written a second time.

**The controls lift no longer resizes the text.** It used to be `setPadding(bottom)`, and media3
resolves fractional text against the canvas that remains after padding, so the +10% bump the
controls apply cut about a tenth off the size. The lift is now a `translationY` on the
`SubtitleView`, re-applied on layout so a rotation keeps it. `setBottomPaddingFraction()` looks
like the right API but is not: `SubtitlePainter` honours it only for cues whose `line` is unset,
which left the cues pinned to the bottom.

**Two intermediate size steps.** The four-step ladder jumped too far between rungs:

| Option | Was | Now | Browser | Native |
|---|---|---|---|---|
| Très petit (new) | - | 0.7 | 2.1vh | 2.45% |
| Petit | 0.7 | 0.85 | 2.55vh | 2.98% |
| Normal | 1.0 | 1.0 | 3vh | 3.5% |
| Grand | 1.3 | 1.15 | 3.45vh | 4.02% |
| Très grand | 1.6 (dropped) | 1.3 | 3.9vh | 4.55% |

`normal` is unchanged, TVs default to `xlarge` so they keep the exact size they had, and every
stored value stays valid. Cast mirrors the same shift, including the two hardcoded native tables
(`CastPlugin.java`, `CastPlugin.swift`).

## Test

- `tsc`, `ng build`, `playback-options.spec.ts` (every offered preset resolves in its style map)
  and `:app:compileDebugJavaWithJavac` all pass.
- Validated on the Tab S5e: size at `normal`, the position setting, and the controls open/close.

## Notes

`client/android/app/src/main/assets/public/*.js` still carries the previous ladder; it is committed
`cap sync` output and refreshes on the next Android build. iOS is untested on a device — the change
there is the `0.05 -> 0.035` constant and the Cast table.
