### PR TITLE
fix(client): keep card badges and page chrome correct across navigations

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -379,7 +379,6 @@
     "title": "Verlauf",
     "empty": "Kein Wiedergabeverlauf.",
     "completed": "Abgeschlossen",
-    "resume": "Fortsetzen",
     "remove": "Aus dem Verlauf entfernen",
     "mark_watched": "Als gesehen markieren"
   },

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -384,7 +384,6 @@
     "title": "History",
     "empty": "No playback history.",
     "completed": "Completed",
-    "resume": "Resume",
     "remove": "Remove from history",
     "mark_watched": "Mark as watched"
   },

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -379,7 +379,6 @@
     "title": "Historial",
     "empty": "No hay historial de reproducción.",
     "completed": "Terminado",
-    "resume": "Reanudar",
     "remove": "Eliminar del historial",
     "mark_watched": "Marcar como visto"
   },

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -384,7 +384,6 @@
     "title": "Historique",
     "empty": "Aucun historique de lecture.",
     "completed": "Terminé",
-    "resume": "Reprendre",
     "remove": "Supprimer de l'historique",
     "mark_watched": "Marquer comme vu"
   },

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -379,7 +379,6 @@
     "title": "Cronologia",
     "empty": "Nessuna cronologia di riproduzione.",
     "completed": "Completato",
-    "resume": "Riprendi",
     "remove": "Rimuovi dalla cronologia",
     "mark_watched": "Segna come visto"
   },

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -379,7 +379,6 @@
     "title": "Histórico",
     "empty": "Nenhum histórico de reprodução.",
     "completed": "Concluído",
-    "resume": "Retomar",
     "remove": "Remover do histórico",
     "mark_watched": "Marcar como visto"
   },

--- a/client/src/app/core/services/keep-route-fresh.spec.ts
+++ b/client/src/app/core/services/keep-route-fresh.spec.ts
@@ -55,6 +55,24 @@ describe('keepRouteFresh', () => {
     expect(calls).toEqual(['activate:home', 'refresh', 'restore:home']);
   });
 
+  it('follows its own key across a param change', () => {
+    // media-detail keeps its instance when only the episode param moves, and is
+    // then cached under the episode it last showed. A latched key left the hero
+    // navbar (and its series logo) behind on the page navigated to.
+    const reuse = TestBed.inject(CachingReuseStrategy) as unknown as {
+      keyFor: () => string;
+    };
+    let key = OWN_KEY;
+    reuse.keyFor = () => key;
+    bind({ onDetach: () => calls.push('detach'), onAttach: () => calls.push('attach') });
+
+    key = 'route-7::id=1&episodeId=5';
+    detached$.next(key);
+    attached$.next(key);
+
+    expect(calls).toEqual(['detach', 'attach']);
+  });
+
   it('ignores another route reattaching', () => {
     bind({ refresh: () => calls.push('refresh'), scrollKey: 'home' });
 

--- a/client/src/app/core/services/keep-route-fresh.ts
+++ b/client/src/app/core/services/keep-route-fresh.ts
@@ -51,14 +51,18 @@ export function keepRouteFresh(
   const destroyRef = inject(DestroyRef);
 
   const detached = signal(false);
-  const ownKey = reuse.keyFor(route.snapshot);
+  // Read per event, never latched: a page that keeps its instance across a
+  // param change (`reuseOnParamChange`) is filed under the params it last
+  // showed, so a key captured on the first snapshot stops matching and the
+  // page never learns it was detached.
+  const ownKey = () => reuse.keyFor(route.snapshot);
   const scrollKey = (): string | null =>
     typeof opts.scrollKey === 'function'
       ? opts.scrollKey()
       : (opts.scrollKey ?? null);
 
   reuse.attached$.pipe(takeUntilDestroyed(destroyRef)).subscribe((key) => {
-    if (key !== ownKey) return;
+    if (key !== ownKey()) return;
     detached.set(false);
     const sk = scrollKey();
     if (sk) scrollMemory.activate(sk);
@@ -68,7 +72,7 @@ export function keepRouteFresh(
   });
 
   reuse.detached$.pipe(takeUntilDestroyed(destroyRef)).subscribe((key) => {
-    if (key !== ownKey) return;
+    if (key !== ownKey()) return;
     detached.set(true);
     const sk = scrollKey();
     if (sk) scrollMemory.deactivateIf(sk);

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -243,6 +243,7 @@
                 class="sm:row-span-2"
                 widthClass="shrink-0 w-28 sm:w-48 lg:w-56"
                 [id]="'episode-row-' + ep.id"
+                [posterMorph]="false"
                 [imageUrl]="ep.stillUrl ?? null"
                 [title]="episodeTitle(ep)"
                 [subtitle]="episodeCardSubtitle((ep.airDate | localeDate), ep.runtime)"
@@ -304,6 +305,7 @@
         @for (ep of filteredEpisodes(); track ep.id) {
           <app-media-card [aspect]="'landscape'"
             [id]="'episode-' + ep.id"
+            [posterMorph]="false"
             [imageUrl]="ep.stillUrl ?? null"
             [title]="episodeTitle(ep)"
             [subtitle]="episodeCardSubtitle((ep.airDate | localeDate), ep.runtime)"

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -125,6 +125,7 @@
                   [subtitle]="other.episodes.length + ' ' + ('media_detail.episodes' | translate)"
                   [link]="seasonLink(m, other)"
                   [replaceUrl]="true"
+                  [posterMorph]="false"
                   [interactiveWatched]="true"
                   [status]="seasonFullyWatched(other) ? 'watched' : null"
                   [highlighted]="other.id === focusedSeason()?.id"

--- a/client/src/app/features/watch-history/watch-history.html
+++ b/client/src/app/features/watch-history/watch-history.html
@@ -47,15 +47,13 @@
               <div
                 class="pointer-events-none absolute inset-0 z-1 flex cursor-pointer items-center justify-center bg-black/35 opacity-0 transition-opacity duration-200 ease-out group-hover/thumb:pointer-events-auto group-hover/thumb:opacity-100"
               >
-                <span class="tooltip tooltip-top z-20" [attr.data-tip]="'history.resume' | translate">
-                  <button
-                    type="button"
-                    class="btn btn-circle btn-md z-10 min-h-0 h-11 w-11 border-0 bg-black/55 text-white transition-colors duration-200 ease-out hover:bg-black/70"
-                    (click)="play(item); $event.stopPropagation()"
-                  >
-                    <svg lucidePlay class="h-6 w-6" [strokeWidth]="2"></svg>
-                  </button>
-                </span>
+                <button
+                  type="button"
+                  class="btn btn-circle btn-md z-10 min-h-0 h-11 w-11 border-0 bg-black/50 text-white transition-colors hover:bg-neutral-500/50"
+                  (click)="play(item); $event.stopPropagation()"
+                >
+                  <svg lucidePlay class="h-6 w-6" [strokeWidth]="2"></svg>
+                </button>
               </div>
             }
 
@@ -67,9 +65,9 @@
               <p class="text-sm sm:text-lg font-semibold leading-tight line-clamp-2 group-hover:underline">{{ item.mediaTitle }}</p>
             </button>
             @if (item.episodeLabel) {
-              <p class="text-xs text-base-content/65 line-clamp-2">{{ item.episodeLabel }}</p>
+              <p class="text-xs sm:text-base text-base-content/65 line-clamp-2">{{ item.episodeLabel }}</p>
             }
-            <p class="text-[11px] text-base-content/45 leading-tight">{{ formatDate(item.lastPlayedAt) }}</p>
+            <p class="text-[11px] sm:text-sm text-base-content/45 leading-tight">{{ formatDate(item.lastPlayedAt) }}</p>
 
           </div>
 

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -54,6 +54,11 @@
       </div>
     }
 
+    <!-- Badges, progress and hover affordances. Grouped so a single
+         view-transition-name lifts them above the poster that morphs onto
+         this card, which would otherwise hide them for the whole animation. -->
+    <div #cardOverlay data-card-overlay class="absolute inset-0 pointer-events-none">
+
     <!-- Rating badge (bottom-left, portrait only) -->
     @if (_rating() > 0 && aspect() === 'portrait') {
       <div class="absolute bottom-1.5 left-1.5 z-10 flex items-center gap-0.5 bg-black/60 rounded-md px-1.5 py-0.5">
@@ -105,7 +110,7 @@
     } @else if (interactiveWatched()) {
       <button
         type="button"
-        class="absolute top-1.5 right-1.5 z-10 w-5 h-5 rounded-full flex items-center justify-center shadow transition-colors cursor-pointer"
+        class="absolute top-1.5 right-1.5 z-10 w-5 h-5 rounded-full flex items-center justify-center shadow transition-colors cursor-pointer pointer-events-auto"
         [class.bg-success]="status() === 'watched'"
         [class.hover:bg-success/90]="status() === 'watched'"
         [class.bg-black/50]="status() !== 'watched'"
@@ -153,13 +158,14 @@
     @if (showHoverOverlay() && cardActions().length) {
       <button
         type="button"
-        class="absolute top-2 right-2 z-10 btn btn-circle btn-sm border-0 bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-neutral-500/50"
+        class="absolute top-2 right-2 z-10 btn btn-circle btn-sm border-0 bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-neutral-500/50 pointer-events-auto"
         (click)="openActions($event)"
         [attr.aria-label]="'media_card.actions' | translate"
       >
         <svg lucideEllipsisVertical class="h-4 w-4" [strokeWidth]="2"></svg>
       </button>
     }
+    </div>
   </figure>
 
   <!-- Title below -->

--- a/client/src/app/shared/components/media-card/media-card.spec.ts
+++ b/client/src/app/shared/components/media-card/media-card.spec.ts
@@ -629,3 +629,30 @@ describe('media-card artwork placeholder', () => {
     expect(placeholder(h)).toBeTruthy();
   });
 });
+
+describe('media-card poster morph opt-out', () => {
+  it('clears a stale stamp instead of naming a card that returns to its own page', async () => {
+    // The guard is skipped where the engine has no View Transitions.
+    (document as unknown as { startViewTransition: unknown }).startViewTransition = () => ({
+      finished: Promise.resolve(),
+    });
+    const stale = document.createElement('img');
+    stale.style.viewTransitionName = 'media-poster-3';
+    document.body.appendChild(stale);
+
+    const h = await createFixture(FULL_MEMBER, {
+      media: makeMedia({ posterUrl: '/api/images/poster.jpg' }),
+      posterMorph: false,
+    });
+    (h.fixture.componentInstance as unknown as { flagPosterForTransition(): void })
+      .flagPosterForTransition();
+
+    // A name still on the card would pair with this page's own hero and abort
+    // the transition on a duplicate.
+    expect(h.fixture.nativeElement.querySelector('img').style.viewTransitionName).toBe('');
+    expect(stale.style.viewTransitionName).toBe('');
+
+    stale.remove();
+    delete (document as unknown as { startViewTransition?: unknown }).startViewTransition;
+  });
+});

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -252,6 +252,12 @@ export class MediaCardComponent {
    * time means only the clicked card carries the name during the snapshot.
    */
   private readonly imgRef = viewChild<ElementRef<HTMLImageElement>>('cardImg');
+  private readonly overlayRef = viewChild<ElementRef<HTMLElement>>('cardOverlay');
+
+  /** Off for a card whose destination is the page it already sits on: the
+   *  hero there ends up with the name this card stamped, and a duplicate name
+   *  aborts the whole transition ("Transition was skipped"). */
+  readonly posterMorph = input(true);
 
   /**
    * Desktop affordance — opens the same contextual panel that TV's menu key
@@ -336,10 +342,16 @@ export class MediaCardComponent {
     // Pointless where the engine has no View Transitions (Chromium <111, Tizen 5.5
     // WebKit, webOS 5), and it costs a querySelectorAll per click.
     if (!('startViewTransition' in document)) return;
+    if (!this.posterMorph()) {
+      // A stamp left by an earlier click would pair with this navigation's hero
+      // and morph the wrong image.
+      clearPosterStamps();
+      return;
+    }
     const id = this.resolveMediaId();
     const img = this.imgRef()?.nativeElement;
     if (id == null || !img) return;
-    stampPoster(img, id, this.episodeIdFromLink());
+    stampPoster(img, id, this.episodeIdFromLink(), this.overlayRef()?.nativeElement);
   }
   protected readonly _playable = computed(() => {
     if (this.playable()) return true;

--- a/client/src/app/shared/directives/default-focus.directive.ts
+++ b/client/src/app/shared/directives/default-focus.directive.ts
@@ -51,10 +51,11 @@ export class DefaultFocusDirective implements OnInit, OnDestroy {
   ngOnInit(): void {
     // Let spatial-nav land here when nothing is focused (cold-load + first key).
     this.svc.register(this.targetGetter);
-    const ownKey = this.reuseStrategy.keyFor(this.route.snapshot);
     this.subs.add(
       this.reuseStrategy.attached$
-        .pipe(filter((key) => key === ownKey))
+        // Resolved per event: a page reused across a param change is cached
+        // under the params it last showed, not the ones it started on.
+        .pipe(filter((key) => key === this.reuseStrategy.keyFor(this.route.snapshot)))
         .subscribe(() => this.svc.applyOnArrival(this.target())),
     );
     // Capture the focused item the instant a navigation starts (host still in

--- a/client/src/app/shared/utils/view-transition.spec.ts
+++ b/client/src/app/shared/utils/view-transition.spec.ts
@@ -34,6 +34,21 @@ describe('view-transition poster stamps', () => {
     expect(first.style.viewTransitionName).toBe('');
   });
 
+  it('lifts the clicked card\'s badges with its poster', () => {
+    const card = img();
+    const overlay = document.createElement('div');
+    overlay.setAttribute('data-card-overlay', '');
+    document.body.appendChild(overlay);
+
+    stampPoster(card, 7, null, overlay);
+    expect(overlay.style.viewTransitionName).toBe('media-card-overlay');
+
+    // A second card must not leave two overlays named: a duplicate aborts the
+    // whole transition.
+    stampPoster(img(), 9);
+    expect(overlay.style.viewTransitionName).toBe('');
+  });
+
   it('names an episode target on the episode id, not the series', () => {
     const card = img();
 

--- a/client/src/app/shared/utils/view-transition.ts
+++ b/client/src/app/shared/utils/view-transition.ts
@@ -6,11 +6,16 @@
  * timer, only replaced. That makes a stale stamp the hazard, and the router's
  * transition hook drops it once neither side of a navigation has a poster.
  */
-export function clearPosterStamps(except?: HTMLElement): void {
+/** The clicked card's badges and progress bar, captured as one layer. */
+export const CARD_OVERLAY_NAME = 'media-card-overlay';
+
+export function clearPosterStamps(): void {
   document
-    .querySelectorAll<HTMLElement>('img[style*="view-transition-name"]')
+    .querySelectorAll<HTMLElement>(
+      'img[style*="view-transition-name"], [data-card-overlay][style*="view-transition-name"]',
+    )
     .forEach((el) => {
-      if (el !== except) el.style.viewTransitionName = '';
+      el.style.viewTransitionName = '';
     });
 }
 
@@ -18,13 +23,17 @@ export function stampPoster(
   img: HTMLElement,
   mediaId: number,
   episodeId?: number | null,
+  overlay?: HTMLElement | null,
 ): void {
-  clearPosterStamps(img);
+  clearPosterStamps();
   // An episode page shows a still, not the series poster, so it pairs on its
   // own name: the series name would morph the card into the wrong image.
   img.style.viewTransitionName = episodeId
     ? `media-poster-ep-${episodeId}`
     : `media-poster-${mediaId}`;
+  // The morphing poster is painted above the page snapshot, so the card's own
+  // badges only reappear when the animation ends unless they are lifted too.
+  if (overlay) overlay.style.viewTransitionName = CARD_OVERLAY_NAME;
 }
 
 interface RouteNode {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1191,6 +1191,25 @@ body.tablet [data-touch-only] {
   z-index: 0;
 }
 
+/* The card's own badges and progress bar ride above the poster that morphs
+   onto them (z-index 1): captured inside the root snapshot they stayed hidden
+   under it for the whole animation. Nothing pairs with them on the detail side,
+   so the arriving copy skips the entry fade and the leaving one is quick. */
+::view-transition-group(media-card-overlay) {
+  z-index: 2;
+}
+::view-transition-new(media-card-overlay) {
+  animation: none;
+}
+::view-transition-old(media-card-overlay) {
+  animation: card-overlay-out 120ms linear both;
+}
+@keyframes card-overlay-out {
+  to {
+    opacity: 0;
+  }
+}
+
 /* Closing the player: the only navigation that opts the root pair back in.
    The old snapshot IS the player, so it shrinks and fades above the page it
    returns to, mirroring the open animation in `player.ts`. */


### PR DESCRIPTION
Three navigation-related fixes found while going back and forth between the home rows and a media
page, plus a small polish pass on the history page.

## 1. A card's badges disappeared under the poster morph

Returning to "Reprendre la lecture" from a media page showed the card with no progress bar and no
watched dot until the animation ended.

An element carrying a `view-transition-name` is captured out of the page snapshot and painted
above it (`::view-transition-group(*)` sits at `z-index: 1`, root at `0`). The card's `<img>` is
that element, so the poster morphing onto the card covered the card's own overlays — which live
in the root snapshot — for the whole transition. Not a data problem: the row is a reused route and
the values were already in the DOM.

Every overlay (badges, progress bar, rating, hover affordances) is now grouped in one wrapper that
is stamped alongside the poster and painted above it: opaque from the first frame on the way in,
faded out in 120ms on the way out so the forward navigation drags no ghost over the detail page.

## 2. Episode cards aborted the transition and poisoned the next one

Clicking an episode inside "Plus de saison" logged `AbortError: Transition was skipped`, and a
later back navigation sometimes morphed the hero into a still from that row.

Those cards stamped `media-poster-ep-<id>`, which is exactly the name the destination hero ends up
with on the same page instance — a duplicate name, and the browser skips the transition. The stamp
then outlives its navigation (by design, the back morph reads it again), so it stayed on the card
and paired with the hero on a later return.

New `posterMorph` input, off for every card whose destination is the page it already sits on (the
"Plus de saison" scroller, the season panel tiles, the "Autres saisons" row). When off the card
clears any leftover stamp instead of setting one.

Note the same `AbortError` still shows for an episode → episode navigation: that one is our own
deliberate `transition.skipTransition()` in `app.config.ts`, which Angular logs under `ngDevMode`
only. Nothing to fix there.

## 3. The series logo stayed on the page you navigated to

Open an episode, switch to another episode from the list, then go Home: the series logo stayed in
the navbar.

`media-detail` is `reuse: true` + `reuseOnParamChange: true`, so switching episode keeps the
instance but the route is cached under the params it last showed. `keepRouteFresh` latched
`keyFor(route.snapshot)` at construction, so the detach arrived under a key that no longer matched
and `onDetach` never ran — `leaveHeroPage()` with it. The key is now resolved per event.
`DefaultFocusDirective` had the same latched key, so TV focus restore on return was dead for that
page too.

## 4. History page polish

The resume button uses the media card's hover (`bg-black/50` → `hover:bg-neutral-500/50`) and drops
the "Reprendre" tooltip; its now-unused i18n key is removed from all six locales. The episode label
and the date keep their phone sizes and step up from `sm`.

## Test

- `tsc`, `ng build` clean.
- `view-transition.spec.ts` (7), `media-card.spec.ts` (36), `keep-route-fresh.spec.ts` (7) and
  media-detail's 6 spec files (33) pass. New cases: the overlay stamp and its duplicate-name guard,
  the morph opt-out clearing a stale stamp, and a detach arriving under a post-param-change key.
- Manual: back from a media page to "Reprendre la lecture", episode switching inside "Plus de
  saison", then Home.
