### PR TITLE
feat(view-transition): morph the poster between a card and a media page

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -43,6 +43,8 @@ import { PluginI18nService } from './core/plugin-ui/plugin-i18n.service';
 import { ImageCacheService } from './core/services/image-cache.service';
 import {
   clearStalePosterStamps,
+  enteringPosterPage,
+  leavingPosterPage,
   leafRoutePath,
   markViewTransition,
 } from './shared/utils/view-transition';
@@ -70,6 +72,8 @@ export function loadPersistedState(): Promise<unknown> {
 const EPISODE_PATH = 'series/:id/episode/:episodeId';
 const WATCH_PATH = 'watch/:mediaFileId';
 const PLAYER_CLOSE_CLASS = 'vt-player-close';
+const POSTER_IN_CLASS = 'vt-poster-in';
+const POSTER_OUT_CLASS = 'vt-poster-out';
 const NATIVE_PLAYER_CLASS = 'native-player-active';
 const IS_TV = detectDevice().formFactor === 'tv';
 
@@ -131,6 +135,17 @@ export const appConfig: ApplicationConfig = {
                   const root = document.documentElement;
                   root.classList.add(PLAYER_CLOSE_CLASS);
                   const done = () => root.classList.remove(PLAYER_CLOSE_CLASS);
+                  void transition.finished.then(done, done);
+                }
+                // The morph is tuned per direction: the box grows into a
+                // poster one way and collapses onto a card the other.
+                const posterTrip =
+                  (leavingPosterPage(from, to) && POSTER_OUT_CLASS) ||
+                  (enteringPosterPage(from, to) && POSTER_IN_CLASS);
+                if (posterTrip) {
+                  const root = document.documentElement;
+                  root.classList.add(posterTrip);
+                  const done = () => root.classList.remove(posterTrip);
                   void transition.finished.then(done, done);
                 }
                 markViewTransition(transition);

--- a/client/src/app/shared/utils/view-transition.spec.ts
+++ b/client/src/app/shared/utils/view-transition.spec.ts
@@ -1,6 +1,8 @@
 import {
   clearPosterStamps,
   clearStalePosterStamps,
+  enteringPosterPage,
+  leavingPosterPage,
   markViewTransition,
   stampPoster,
   viewTransitionRunning,
@@ -66,6 +68,27 @@ describe('view-transition poster stamps', () => {
     clearPosterStamps();
 
     expect(card.style.viewTransitionName).toBe('');
+  });
+
+  describe('enteringPosterPage', () => {
+    function route(path: string) {
+      return { routeConfig: null, firstChild: { routeConfig: { path }, firstChild: null } };
+    }
+
+    it('marks the way back for its own animation', () => {
+      expect(leavingPosterPage(route('movies/:id'), route(''))).toBe(true);
+      expect(leavingPosterPage(route(''), route('movies/:id'))).toBe(false);
+      // Detail to detail stays on a poster on both sides.
+      expect(leavingPosterPage(route('movies/:id'), route('series/:id'))).toBe(false);
+    });
+
+    it('holds on the way in and not on the way back', () => {
+      // The tuned crop and easing only suit the card growing into the poster.
+      expect(enteringPosterPage(route(''), route('movies/:id'))).toBe(true);
+      expect(enteringPosterPage(route('movies/:id'), route(''))).toBe(false);
+      // Detail to detail keeps both sides on a poster: nothing to reshape.
+      expect(enteringPosterPage(route('movies/:id'), route('series/:id'))).toBe(false);
+    });
   });
 
   describe('clearStalePosterStamps', () => {

--- a/client/src/app/shared/utils/view-transition.ts
+++ b/client/src/app/shared/utils/view-transition.ts
@@ -55,6 +55,16 @@ export function leafRoutePath(root: RouteNode): string | undefined {
   return leaf.routeConfig?.path;
 }
 
+/** A card opening the page that carries the other half of its morph. */
+export function enteringPosterPage(from: RouteNode, to: RouteNode): boolean {
+  return POSTER_ROUTES.has(leafRoutePath(to)) && !POSTER_ROUTES.has(leafRoutePath(from));
+}
+
+/** The way back: the page that owns the hero returns to a list of cards. */
+export function leavingPosterPage(from: RouteNode, to: RouteNode): boolean {
+  return POSTER_ROUTES.has(leafRoutePath(from)) && !POSTER_ROUTES.has(leafRoutePath(to));
+}
+
 /**
  * Drop a stamp left over from an earlier card click when neither side of the
  * navigation has a poster to pair with: the lone img would be snapshotted out of

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1179,6 +1179,55 @@ body.tablet [data-touch-only] {
   animation: none;
 }
 
+/* Only the two halves of the poster morph take part in the flip below. The
+   class rides along with the name (it means nothing without one), so the card's
+   badges and the page-wide snapshot keep their own animations — a `*` selector
+   outranked them and flipped the progress bar with the artwork. */
+app-media-card img,
+app-media-info-header img {
+  view-transition-class: poster;
+}
+
+/* A card and a media page hold different pictures in different aspects — a
+   16:9 still against a 2:3 poster. The travelling box carries the whole change:
+   it interpolates from one rect to the other while the picture fills it,
+   cropping as the shape turns. Neither picture carries a transform of its own:
+   two of them on their own curves is what showed as a double image. */
+html.vt-poster-in::view-transition-group(.poster),
+html.vt-poster-out::view-transition-group(.poster) {
+  animation-duration: 300ms;
+  animation-timing-function: cubic-bezier(0.2, 0, 0, 1);
+}
+/* Coming back, the box lands on the card first. Held to the poster's size any
+   longer, the still shows larger than the card it is landing on. */
+html.vt-poster-out::view-transition-group(.poster) {
+  animation-duration: 180ms;
+  animation-timing-function: cubic-bezier(0, 0.8, 0.2, 1);
+}
+/* Rounded to whatever it is landing on — the card's `rounded-lg` on the way
+   back, the page poster's `rounded-xl` on the way in — or the square corners of
+   the picture show past the destination's own. */
+html.vt-poster-out::view-transition-group(.poster),
+html.vt-poster-out::view-transition-image-pair(.poster) {
+  clip-path: inset(0 round 0.5rem);
+}
+html.vt-poster-in::view-transition-group(.poster),
+html.vt-poster-in::view-transition-image-pair(.poster) {
+  clip-path: inset(0 round 0.75rem);
+}
+/* Both pictures fill that same box and neither carries a transform of its own,
+   so they hold the same position and shape from the first frame to the last and
+   change shape together — a dissolve between two croppings of the same frame,
+   not two pictures sliding past each other. The UA's additive cross-fade is
+   kept: it is the one that never dips in the middle. */
+html.vt-poster-in::view-transition-old(.poster),
+html.vt-poster-in::view-transition-new(.poster),
+html.vt-poster-out::view-transition-old(.poster),
+html.vt-poster-out::view-transition-new(.poster) {
+  /* Crop rather than the UA's fill: the picture does not fit both boxes. */
+  object-fit: cover;
+}
+
 /* Force the hero (poster) morph above root. The default pseudo-tree order
    should put named groups above root, but with `animation: none` on root
    the old/new pair stays fully opaque for the whole transition and on some
@@ -1194,20 +1243,20 @@ body.tablet [data-touch-only] {
 /* The card's own badges and progress bar ride above the poster that morphs
    onto them (z-index 1): captured inside the root snapshot they stayed hidden
    under it for the whole animation. Nothing pairs with them on the detail side,
-   so the arriving copy skips the entry fade and the leaving one is quick. */
+   so the arriving copy is there from the first frame, and the leaving one goes
+   with the card it belongs to rather than hanging over the page. */
 ::view-transition-group(media-card-overlay) {
   z-index: 2;
+  /* Captured out of the figure that rounds it, so the progress bar arrives with
+     square ends unless the snapshot carries the card's own radius. */
+  clip-path: inset(0 round 0.5rem);
 }
 ::view-transition-new(media-card-overlay) {
   animation: none;
 }
 ::view-transition-old(media-card-overlay) {
-  animation: card-overlay-out 120ms linear both;
-}
-@keyframes card-overlay-out {
-  to {
-    opacity: 0;
-  }
+  animation: none;
+  opacity: 0;
 }
 
 /* Closing the player: the only navigation that opts the root pair back in.


### PR DESCRIPTION
## Why

A "Reprendre la lecture" card holds a 16:9 still; the page it opens holds a 2:3 poster. The UA
fills a snapshot into the box it animates, so the still stretched into the poster's shape on the
way in, and on the way back the poster kept its own proportions the whole trip and hung well below
the card it was landing on.

## What

The travelling box carries the change; the pictures only fill it.

- **Both snapshots share that box, with no transform of their own**, so they hold the same
  position and shape from the first frame to the last and change together. Per-picture curves were
  tried and dropped: two pictures on their own scales read as a double image, and the scales either
  spilled past the card or left a hole in the middle of the animation. `object-fit: cover` so the
  crop turns without distorting, and the UA's additive cross-fade is kept — it is the blend that
  does not dip halfway.
- **Clipped to the destination's radius** (`rounded-lg` back to a card, `rounded-xl` into the page
  poster), or the square corners of the snapshot show past the destination's own.
- **The two directions are tuned apart**, since only one of them can overshoot: 300ms decelerating
  into a page, 180ms collapsing onto a card so the still is never drawn larger than the card
  receiving it.
- **The card's badges** are captured out of the figure that rounds them, so their snapshot now
  carries the card's radius too — the progress bar spans the full width, so its square ends were
  the visible part — and the leaving copy no longer lingers over the page.

Scoped with `view-transition-class: poster` on the card and hero images: a `*` selector outranked
the badges' own rules and animated the progress bar along with the artwork. Two direction classes
(`vt-poster-in` / `vt-poster-out`) are set for the transition's lifetime, the same pattern as
`vt-player-close`.

`view-transition-class` is Chromium 125+. Older engines match none of it and get the plain morph;
the TV builds have view transitions off entirely.

## Test

- `tsc`, `ng build` clean, `view-transition.spec.ts` 9 pass (2 new: the direction predicates).
- Manual, both directions: a movie from "Reprendre la lecture", a poster card from a library grid
  (same shape on both sides), and an episode card, whose page hero is a still.
