### PR TITLE
style(media-detail): widen the episode still in the header

### DIFF
--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -188,7 +188,8 @@
          [class.lg:w-[200px]]="posterMode() === 'poster'"
          [class.xl:w-[220px]]="posterMode() === 'poster'"
          [class.2xl:w-[280px]]="posterMode() === 'poster'"
-         [class.w-[20%]]="posterMode() === 'still'">
+         [class.w-[28%]]="posterMode() === 'still'"
+         [class.3xl:w-[22%]]="posterMode() === 'still'">
       @if (posterUrl()) {
         <img
           appImgFadeIn


### PR DESCRIPTION
The still sat at a fifth of the header width, small next to the block of text beside it. It takes 28% now, easing back to 22% from `3xl` up (120rem), where the same share would grow past what the column beside it needs.

Episode pages only — `posterMode() === 'still'`; the portrait poster keeps its fixed widths.

## Test

`ng build` clean, and both utilities are emitted (`width:28%`, `width:22%` under the 3xl query) — an arbitrary value inside an Angular class binding is easy to leave unscanned.