### PR TITLE
fix(media-detail): re-read the resume position when the cached page returns

### DIFF
--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -848,6 +848,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   readonly profilesModal = viewChild(MediaDetailProfilesModalComponent);
   readonly libraryModal = viewChild(MediaDetailLibraryModalComponent);
   readonly subtitleSection = viewChild(SubtitlesModalComponent);
+  private readonly infoHeader = viewChild(MediaInfoHeaderComponent);
 
   openTracking(scope: TrackingScope): void {
     const id = this.media()?.id;
@@ -1071,6 +1072,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     const m = this.media();
     if (!m) return;
     void this.loadPlaybackState(m);
+    this.infoHeader()?.reloadPlaybackState();
     void this.mediaService
       .getOne(m.id, { force: true })
       .then((fresh) => {

--- a/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.spec.ts
@@ -728,6 +728,23 @@ describe('MediaInfoHeaderComponent — resume state across an episode switch', (
 
     expect(fixture.componentInstance.resumePositionSeconds()).toBe(1992);
   });
+
+  /** A cached detail page comes back from the player with the same inputs, so
+   *  the effect never re-fires and the bar kept the position from before. */
+  it('re-reads the resume position on demand with unchanged inputs', async () => {
+    const states = {
+      3: { positionSeconds: 1992, durationSeconds: 3660, completed: false, mediaFileId: 30 },
+    };
+    const fixture = await createFixture(OWNER, { ...SERIES_EPISODE, playbackStates: states });
+    expect(fixture.componentInstance.resumePositionSeconds()).toBe(1992);
+
+    states[3].positionSeconds = 2500;
+    fixture.componentInstance.reloadPlaybackState();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.resumePositionSeconds()).toBe(2500);
+  });
 });
 
 /**

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -332,7 +332,11 @@ export class MediaInfoHeaderComponent {
    *  be tracked to drop the previous episode's resume state. */
   private lastPlaybackKey: string | null = null;
 
-  private readonly loadPlaybackEffect = effect(() => {
+  private readonly loadPlaybackEffect = effect(() => this.reloadPlaybackState());
+
+  /** Re-read the server's resume position. Cached pages come back with the same
+   *  inputs, so the effect alone never fires again after a playback session. */
+  reloadPlaybackState(): void {
     const mediaId = this.mediaId();
     // A series page has no episode context of its own, but it does know which
     // episode its resume button targets. Without this fallback it asked for the
@@ -385,7 +389,7 @@ export class MediaInfoHeaderComponent {
       }
       this.applyResume(queued, ps);
     });
-  });
+  }
 
   /** Show the server's position, unless one queued while the server was out of
    *  reach is still waiting to reach it — that one is newer by construction. */


### PR DESCRIPTION
## Problem

Seek in the player, close it, and the detail page came back showing the progress bar from before the
session. Same from the other direction: opening a media page from a continue-watching card showed a
stale position until a full page reload.

## Cause

`MediaInfoHeaderComponent` loads its resume position in an effect keyed on `mediaId` / `episodeId` /
`resumeEpisodeId`. Those routes are flagged `reuse: true`, so the page instance is parked in the
route cache and comes back with the exact same inputs — the effect never fires again. The page's own
`refreshOnReturn()` hook did re-read `resumeInfo` and the per-episode progress, but the header holds
its own separate copy fetched from `getPlaybackState`, and nothing ever refreshed it.

## Fix

The effect body becomes a public `reloadPlaybackState()`, and `refreshOnReturn()` calls it alongside
the state it already refreshes. One extra call on the path that was built for exactly this.

## Test

`media-info-header.spec.ts` covers the reload with unchanged inputs: the served position changes and
the header picks it up. Full spec files for the header and media-detail pass.