### PR TITLE
fix(player,subtitles): four Android playback and navigation regressions

### DIFF
--- a/backend/src/modules/streaming/playback.service.ts
+++ b/backend/src/modules/streaming/playback.service.ts
@@ -67,8 +67,8 @@ const RESUME_FROM_START_UNDER_SECONDS = 10;
 
 /**
  * Minimum watched position before a media enters the watch history
- * (`playedAt` stamp). Keeps an accidental click that's closed within a few
- * seconds out of the history — only a real watch (≥ 5 s) records.
+ * (`playedAt` stamp) or continue-watching. Keeps an accidental click that's
+ * closed within a few seconds out of both — only a real watch (≥ 5 s) records.
  */
 const HISTORY_MIN_WATCH_SECONDS = 5;
 
@@ -340,7 +340,7 @@ export class PlaybackService {
        WHERE ps."userId" = $1
          AND ps.completed = false
          AND ps."hiddenFromContinueWatching" = false
-         AND ps."positionSeconds" > 0
+         AND ps."positionSeconds" >= ${HISTORY_MIN_WATCH_SECONDS}
          AND m.type = 'movie'${libFilter}
        ORDER BY ps."lastPlayedAt" DESC`,
       params,
@@ -386,7 +386,8 @@ export class PlaybackService {
                ps."positionSeconds", ps."durationSeconds"
         FROM playback_states ps
         WHERE ps."userId" = $1
-          AND ps.completed = false AND ps."positionSeconds" > 0 AND ps."episodeId" IS NOT NULL
+          AND ps.completed = false AND ps."positionSeconds" >= ${HISTORY_MIN_WATCH_SECONDS}
+          AND ps."episodeId" IS NOT NULL
         ORDER BY ps."mediaId", ps."lastPlayedAt" DESC
       ),
       next_ep AS (

--- a/client/android/app/src/main/java/media/fliks/app/SubtitleOverlay.java
+++ b/client/android/app/src/main/java/media/fliks/app/SubtitleOverlay.java
@@ -2,6 +2,7 @@ package media.fliks.app;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.SurfaceView;
 import android.view.View;
@@ -49,8 +50,16 @@ class SubtitleOverlay {
         webViewParent.addView(subtitleView, 1, new FrameLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT));
-        subtitleView.addOnLayoutChangeListener(
-                (v, l, t, r, b, ol, ot, or_, ob) -> applyBottomMargin());
+        subtitleView.addOnLayoutChangeListener((v, l, t, r, b, ol, ot, or_, ob) -> {
+            applyTextSize();
+            applyBottomMargin();
+        });
+        // The picture only gets its height once the video's aspect is known, and
+        // it changes again on rotation — the cue size follows it.
+        if (surfaceView != null) {
+            surfaceView.addOnLayoutChangeListener(
+                    (v, l, t, r, b, ol, ot, or_, ob) -> applyTextSize());
+        }
 
         // Added to `wrapper` (a FrameLayout we own) so the gravity-bearing
         // FrameLayout.LayoutParams cast stays valid regardless of the host
@@ -80,19 +89,35 @@ class SubtitleOverlay {
         renderImageCue(null);
     }
 
-    /** Text height as a fraction of the view, matching the iOS overlay and the
-     *  browser's `vh` cues: a fixed sp size reads half as tall on a tablet. */
+    /** Text height as a fraction of the video, not of the view: the view spans the
+     *  whole screen, which in portrait is mostly letterbox. */
     private static final float TEXT_SIZE_FRACTION = 0.035f;
 
-    /** The lift translates the whole view instead of padding it: padding shrinks
-     *  the canvas the fractional text size is measured against, so the cues used
-     *  to shrink whenever the controls raised them. */
+    /** Floor under the fraction: a phone's picture is ~200dp tall in portrait and
+     *  ~360dp in landscape, too short for the fraction alone to stay readable. */
+    private static final float MIN_TEXT_SIZE_SP = 18f;
+
+    private float fontScale = 1f;
+
+    /** The lift translates the whole view rather than padding it, so the cue
+     *  layout is untouched and only its position moves. */
     void applyStyle(CaptionStyleCompat style, float fontScale, float bottomMarginFraction) {
         if (subtitleView == null) return;
         subtitleView.setStyle(style);
-        subtitleView.setFractionalTextSize(TEXT_SIZE_FRACTION * fontScale, true);
+        this.fontScale = fontScale;
         bottomMargin = bottomMarginFraction;
+        applyTextSize();
         applyBottomMargin();
+    }
+
+    private void applyTextSize() {
+        if (subtitleView == null) return;
+        float minPx = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_SP, MIN_TEXT_SIZE_SP * fontScale,
+                subtitleView.getResources().getDisplayMetrics());
+        int videoH = surfaceView != null ? surfaceView.getHeight() : 0;
+        subtitleView.setFixedTextSize(TypedValue.COMPLEX_UNIT_PX,
+                Math.max(videoH * TEXT_SIZE_FRACTION * fontScale, minPx));
     }
 
     private void applyBottomMargin() {

--- a/client/src/app/features/media-detail/media-detail.episode-morph.spec.ts
+++ b/client/src/app/features/media-detail/media-detail.episode-morph.spec.ts
@@ -62,7 +62,7 @@ function createFixture(media: Promise<unknown> = new Promise(() => {})) {
       { provide: AuthService, useValue: { hasPermission: () => false } },
       { provide: ProfilesService, useValue: {} },
       { provide: LibrariesApiService, useValue: {} },
-      { provide: NavbarService, useValue: { enterHeroPage: vi.fn(), leaveHeroPage: vi.fn() } },
+      { provide: NavbarService, useValue: { enterHeroPage: vi.fn(), leaveHeroPage: vi.fn(), navigatedBack: signal(false) } },
       { provide: BackgroundService, useValue: { clear: vi.fn(), setBackgrounds: vi.fn(), setBackground: vi.fn(), url: signal(null) } },
       { provide: ConfirmationService, useValue: {} },
       { provide: ToastService, useValue: { success: vi.fn(), error: vi.fn() } },

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -957,9 +957,9 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     // Only a back navigation earns the memorized offset. Opening a title from
     // anywhere else — a home card, a similar-movies card that swaps the page
     // under itself — starts at the top, whether or not it was read before.
-    const nav =
-      this.router.getCurrentNavigation() ?? untracked(this.router.lastSuccessfulNavigation);
-    const wentBack = nav?.trigger === 'popstate';
+    // Not the router trigger: Android's back gesture routes through
+    // `goBack()`, an imperative navigation the trigger reports as a fresh open.
+    const wentBack = untracked(() => this.navbarService.navigatedBack());
     this.scrollMemory.activate(this.scrollKey());
     if (!Number.isFinite(id) || id < 1) {
       this.loading.set(false);

--- a/client/src/app/features/player/player.spec.ts
+++ b/client/src/app/features/player/player.spec.ts
@@ -345,6 +345,46 @@ describe('PlayerComponent pre-roll', () => {
     expect(h.streamingApi.stopSessions).not.toHaveBeenCalled();
   });
 
+  /** Closing before the seek to the resume point lands must not write the
+   *  engine's 0 over it. ExoPlayer renders its first frame before that seek, so
+   *  the guard reads the clock rather than `videoStarted`. */
+  it.each([false, true])(
+    'reports the resume point while the clock still reads 0 (videoStarted=%s)',
+    async (started) => {
+      const h = createHarness();
+      (h.component as unknown as { pendingStartTime: number }).pendingStartTime = 3600;
+      h.state.videoStarted.set(started);
+      h.engine.currentTime = 0;
+
+      await h.component.savePosition();
+
+      expect(h.streamingApi.updatePlaybackState).toHaveBeenCalledWith(
+        MEDIA_ID,
+        expect.objectContaining({ positionSeconds: 3600 }),
+      );
+    },
+  );
+
+  it('reports the engine once it moves, and never substitutes again', async () => {
+    const h = createHarness();
+    const c = h.component as unknown as { pendingStartTime: number };
+    c.pendingStartTime = 3600;
+    h.engine.currentTime = 12;
+
+    await h.component.savePosition();
+    expect(c.pendingStartTime).toBe(0);
+
+    // A later reading of 0 is the truth: the user seeked to the start.
+    h.engine.currentTime = 0;
+    h.component.lastSaveAt = 0;
+    await h.component.savePosition();
+
+    expect(h.streamingApi.updatePlaybackState).toHaveBeenLastCalledWith(
+      MEDIA_ID,
+      expect.objectContaining({ positionSeconds: 0 }),
+    );
+  });
+
   it('records no progress while a pre-roll item is playing', async () => {
     const h = createHarness({ preRoll: [{ mediaFileId: TRAILER_FILE_ID }] });
     await h.component.maybeStartPreRoll(undefined, DEVICE_PROFILE);

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1210,6 +1210,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         const local = this.offlineSync.resumePositionFor(this.mediaId, this.episodeId);
         if (local && local.positionSeconds > 10) startTime = local.positionSeconds;
       }
+      this.pendingStartTime = startTime ?? 0;
 
       // Set MediaSession metadata
       if ('mediaSession' in navigator) {
@@ -2153,6 +2154,8 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       // until `awaitSeekUnlock` lets the engine resume driving it.
       this.state.seekLocked.set(true);
       this.state.currentTime.set(t);
+      // A seek to 0 is the user's, not an unsettled load.
+      this.pendingStartTime = 0;
       this.lastSeekAt = Date.now();
       if (this.desktopFarSeekNeedsReload(t)) void this.seekByReload(t);
       else void this.awaitSeekUnlock(t);
@@ -2616,6 +2619,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
           startTime = playbackState.positionSeconds;
         }
       }
+      this.pendingStartTime = startTime ?? 0;
 
       // Audio preference for the new file (UI/state; the backend picks the
       // default during playback-info negotiation).
@@ -4643,6 +4647,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     return this.engine?.getVariantTracks()?.find((t: any) => t.active) ?? null;
   }
 
+  /** Where the load in flight is seeking to; see {@link savePosition}. */
+  private pendingStartTime = 0;
+
   /** Wall-clock timestamp (ms) of the last PUT to /state. Used to dedup
    *  the cluster of saves that fire on exit (onBack, ngOnDestroy, the
    *  savePosition interval and the 'seeked' event all hit savePosition
@@ -4709,6 +4716,12 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       console.warn('[player] savePosition: neither cast nor engine is live, skipping');
       return;
     }
+
+    // The clock reads 0 until the load's seek to the resume point lands, and the
+    // first frame can render before it does, so report where the load is headed
+    // rather than that 0. Any true reading retires the substitute.
+    if (pos > 0) this.pendingStartTime = 0;
+    else if (this.pendingStartTime > 0) pos = this.pendingStartTime;
 
     // Heartbeat even at position 0 — a player paused at the very start is
     // still live and the backend refreshes the LiveSession TTL off this PUT.


### PR DESCRIPTION
Four unrelated defects reported from an Android device, one commit each.

## Resume position wiped by a quick close

Opening a title resumed at an hour and closing before it played wrote the engine's `0` back over the
stored position. `videoStarted` is not a usable guard here: ExoPlayer emits `onRenderedFirstFrame`
before the load's seek completes, and `NativeEngine._currentTime` only moves on
`nativePlayerTimeUpdate`, which the native side emits only while `isPlaying()`. So the forced save
that `firstFrameReportEffect` fires on that very frame carried the 0.

`savePosition` now reports where the load is headed for as long as the clock still reads 0, and the
first non-zero reading retires the substitute for good. The check sits after the whole branch chain,
so it covers the seek-locked and Cast paths too, and a deliberate seek to the start clears it.

## Scroll offset lost on the back gesture

`loadMedia` granted the memorized scroll offset only to a `popstate` navigation. Android's back
gesture goes through `NavbarService.goBack()`, an imperative navigation the router reports as a
fresh open, so the gesture landed at the top of the page where the browser's own back restored the
position. `NavbarService.navigatedBack()` already covers both, and the horizontal rails read it.

## Accidental open landing in continue-watching

A media opened and closed within a couple of seconds recorded a position of barely more than zero,
and the query surfaced everything above zero — rendered as a card at 0%. Both branches now ask for
the same `HISTORY_MIN_WATCH_SECONDS` of real progress that already keeps those clicks out of the
watch history. The 5–10s band still surfaces and still resumes from the start.

## Android cue size in both orientations

The height fraction was measured against the `SubtitleView`, which is laid out over the whole
screen. In portrait, where the picture is a strip in the middle, cues came out as tall as a tablet's;
on a phone in landscape the same fraction of a short screen read far too small. The size follows the
`SurfaceView` — the picture — and takes a floor in sp for the short pictures a phone shows either
way. That lands a phone at ~18dp in both orientations and leaves a tablet at ~25dp.

## Test

`player.spec.ts` gains both first-frame orderings and the retirement of the substitute;
`media-detail` specs updated for the new NavbarService read. 61/61 client, 9/9 backend playback,
`tsc` clean on both. The Java is not compiled here (no JDK on this machine) — it needs a device pass.