### PR TITLE
fix(view-transition): keep the poster morph out of the app chrome

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -47,6 +47,7 @@ import {
   leavingPosterPage,
   leafRoutePath,
   markViewTransition,
+  stampChromeInsets,
 } from './shared/utils/view-transition';
 
 /** Read the persisted server URL, sessions and credentials before bootstrap:
@@ -144,6 +145,7 @@ export const appConfig: ApplicationConfig = {
                   (enteringPosterPage(from, to) && POSTER_IN_CLASS);
                 if (posterTrip) {
                   const root = document.documentElement;
+                  stampChromeInsets();
                   root.classList.add(posterTrip);
                   const done = () => root.classList.remove(posterTrip);
                   void transition.finished.then(done, done);

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -297,7 +297,7 @@
 
   <div class="drawer-side z-40" [class.hidden]="isNative && device.isPhone()">
     <label for="sidebar" [attr.aria-label]="'nav.close_menu' | translate" class="drawer-overlay"></label>
-    <aside class="w-64 min-h-full flex flex-col"
+    <aside class="app-chrome-side w-64 min-h-full flex flex-col"
            [class.bg-base-100]="!background.url()"
            [class.app-sidebar-veil]="!!background.url()"
            [class.backdrop-blur-sm]="!!background.url()"

--- a/client/src/app/shared/utils/view-transition.ts
+++ b/client/src/app/shared/utils/view-transition.ts
@@ -92,3 +92,16 @@ export function markViewTransition(transition: { finished: Promise<unknown> }): 
 export function viewTransitionRunning(): boolean {
   return document.documentElement.classList.contains(VIEW_TRANSITION_CLASS);
 }
+
+/**
+ * The chrome the morph must not paint over, as insets the clip in `styles.css`
+ * reads. Measured per trip: the sidebar is only docked at some widths, and the
+ * dock only exists on a native phone.
+ */
+export function stampChromeInsets(): void {
+  const side = document.querySelector('.app-chrome-side')?.getBoundingClientRect();
+  const dock = document.querySelector('.dock')?.getBoundingClientRect();
+  const style = document.documentElement.style;
+  style.setProperty('--vt-chrome-left', `${Math.max(0, side?.right ?? 0)}px`);
+  style.setProperty('--vt-chrome-bottom', `${dock ? Math.max(0, window.innerHeight - dock.top) : 0}px`);
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1228,6 +1228,20 @@ html.vt-poster-out::view-transition-new(.poster) {
   object-fit: cover;
 }
 
+/* A card scrolled out of its row still owns its real rect, so the box flies to
+   it over the sidebar or the native dock. Dropping the root snapshot leaves the
+   page itself painting under the pseudo-tree, so the box can be clipped to the
+   content area without the chrome going with it: the sidebar's translucent veil
+   then reads the live page behind it, not the poster passing under. */
+html.vt-poster-in,
+html.vt-poster-out {
+  view-transition-name: none;
+}
+html.vt-poster-in::view-transition,
+html.vt-poster-out::view-transition {
+  clip-path: inset(0 0 var(--vt-chrome-bottom, 0px) var(--vt-chrome-left, 0px));
+}
+
 /* Force the hero (poster) morph above root. The default pseudo-tree order
    should put named groups above root, but with `animation: none` on root
    the old/new pair stays fully opaque for the whole transition and on some


### PR DESCRIPTION
## Problem

The morphing poster travels to the card's real rect, and a card scrolled out of its row still owns one. Coming back from a media page, the picture landed over the sidebar on desktop and over the native dock on Android; going in, it started there.

## What was tried and dropped

- Clipping `::view-transition` alone: the root snapshot is clipped with it, and since a captured root stops the live page from painting, the sidebar disappeared for the length of the animation.
- Scrolling the target card back into view before capture: it loses the race against the scroll restorers (`horizontal-scroller` re-applies its parked offset on `attached$` + rAF, `ScrollMemoryService.restoreSticky` re-applies `scrollY` for 600 ms).
- Capturing the chrome as its own layer above the box: the poster then reads through the sidebar's 40% veil.

## Fix

`view-transition-name: none` on the root for the two poster trips. Without a root capture the page keeps painting under the pseudo-tree, which now holds only the travelling box and the card badges, so the clip applies to the box alone. The sidebar and the dock stay real and translucent, and what shows through them is the live page.

Insets are measured per trip (`stampChromeInsets`): the sidebar is only docked at some widths, the dock only exists on a native phone. Nothing is clipped at the top, where a hero page runs its picture under the transparent navbar on purpose.

Side effect: two viewport-sized snapshots less per navigation — what the muted root pair was already after on weak GPUs — but the destination page is now live during the morph, so a scroll restore shows instead of being frozen behind a still.

## Test

`ng test --include='**/view-transition.spec.ts'` — 9 passed. Behaviour checked by hand on desktop and Android through the earlier attempts; this last iteration still needs a look on both.