### PR TITLE
fix(media-card): stop the artwork reveal replaying on the next navigation

### DIFF
--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -793,9 +793,12 @@ body.tv .mosaic-art > * > img:nth-child(4) {
   }
 }
 /* Held until the next navigation, so art that lands from the revalidation
-   behind a restored page stays as quiet as the art already on it. */
+   behind a restored page stays as quiet as the art already on it. Through the
+   duration, never `animation: none`: dropping the name and putting it back is
+   a new animation, so the next forward navigation replayed the reveal on every
+   card at once and its snapshot came out with grey boxes for artwork. */
 html.nav-back .card-img-reveal {
-  animation: none;
+  animation-duration: 0s;
 }
 
 /* One promotion source fewer, and the reveal stays (the art is still hidden


### PR DESCRIPTION
## Symptom

Opening a media page showed the list behind it with grey boxes instead of artwork — badges, progress bars and titles all intact. Visible on desktop browsers, unmissable on a slow Android tablet, where it read as "the home loses all its images during the transition".

## Cause

`html.nav-back .card-img-reveal { animation: none }` holds the reveal back on a restored page by dropping the animation name. `NavbarService` removes `nav-back` on the next forward navigation, the name comes back, and that is a **new** animation to the engine: every visible card image restarts from `opacity: 0`. The view-transition snapshot is captured during that flash.

Measured over CDP on the device, toggling the class by hand:

```
nav-back added   → animationName: none,            opacity 1
nav-back removed → card-img-reveal, currentTime 0, running, opacity 0
```

## Fix

Gate through `animation-duration: 0s`. A duration change keeps the animation's start time, so it stays finished and a change of gate cannot restart it. Verified the same way: opaque in both directions, nothing started.

Nothing about the morph, the GPU or the device is involved — earlier attempts at those were wrong and are not in this change.

## Test

`ng test --include='**/media-card.spec.ts' --include='**/view-transition.spec.ts'` — 45 passed. Reveal-on-load and the quiet restore both still behave: the animation still runs once when an image lands on a page opened fresh, and stays silent behind a restored one.