### PR TITLE
fix(player): release the screen wake lock while playback is paused

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/NativePlayerPlugin.java
@@ -158,9 +158,6 @@ public class NativePlayerPlugin extends Plugin {
             webView.setBackgroundColor(Color.TRANSPARENT);
             webView.setLayerType(View.LAYER_TYPE_HARDWARE, null);
 
-            // Keep screen on during playback
-            getActivity().getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-
             call.resolve();
         });
     }
@@ -193,8 +190,6 @@ public class NativePlayerPlugin extends Plugin {
                 surfaceView = null;
             }
             subtitleConfigs.clear();
-            // Allow screen to sleep again
-            getActivity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
             call.resolve();
         });
     }
@@ -203,6 +198,15 @@ public class NativePlayerPlugin extends Plugin {
     public void resize(PluginCall call) {
         // Wrapper is MATCH_PARENT — no resize needed. Kept for interface compatibility.
         call.resolve();
+    }
+
+    /** Screen stays awake while the session is advancing or stalled mid-play;
+     *  pause, end and idle release it. On the view so a detach frees it too. */
+    private void syncKeepScreenOn() {
+        if (surfaceView == null || player == null) return;
+        int state = player.getPlaybackState();
+        surfaceView.setKeepScreenOn(player.getPlayWhenReady()
+                && (state == Player.STATE_READY || state == Player.STATE_BUFFERING));
     }
 
     // ── Playback ──
@@ -328,12 +332,17 @@ public class NativePlayerPlugin extends Plugin {
             player.addListener(new Player.Listener() {
                 @Override
                 public void onPlaybackStateChanged(int state) {
+                    syncKeepScreenOn();
                     switch (state) {
                         case Player.STATE_BUFFERING: emitStateChanged("buffering"); break;
                         case Player.STATE_READY: emitStateChanged(player.getPlayWhenReady() ? "playing" : "paused"); break;
                         case Player.STATE_ENDED: emitStateChanged("ended"); break;
                         default: emitStateChanged("idle");
                     }
+                }
+
+                @Override public void onPlayWhenReadyChanged(boolean playWhenReady, int reason) {
+                    syncKeepScreenOn();
                 }
 
                 @Override public void onIsPlayingChanged(boolean isPlaying) {

--- a/client/ios/App/App/NativePlayerPlugin.swift
+++ b/client/ios/App/App/NativePlayerPlugin.swift
@@ -145,9 +145,6 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             view.addSubview(overlay)
             self.subtitleOverlay = overlay
 
-            // Keep screen awake during playback
-            UIApplication.shared.isIdleTimerDisabled = true
-
             call.resolve()
         }
     }
@@ -782,6 +779,11 @@ public class NativePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         // already `.playing` emits too; a cold load reports `.paused` here,
         // harmlessly, just before play() starts it.
         timeControlObserver = player.observe(\.timeControlStatus, options: [.initial, .new]) { [weak self] player, _ in
+            // Screen stays awake while advancing or stalled mid-play; a pause
+            // (user pause or end of item) lets it sleep. KVO can land off the
+            // main thread, so the UIKit flag has to be hopped over.
+            let awake = player.timeControlStatus != .paused
+            DispatchQueue.main.async { UIApplication.shared.isIdleTimerDisabled = awake }
             switch player.timeControlStatus {
             case .paused:
                 self?.emitStateChanged("paused")


### PR DESCRIPTION
## Problem

Both native players held the screen wake lock for the entire player session, not for the duration of actual playback:

- **Android** — `FLAG_KEEP_SCREEN_ON` was added to the window in `create()` and cleared in `destroy()`.
- **iOS** — `isIdleTimerDisabled = true` at open, reset in `cleanup()`.

So a paused video kept the panel lit indefinitely: battery drain on phones, OLED burn-in, and no screensaver on Android TV. The WebView player is unaffected — Chromium's own VideoWakeLock already releases on pause.

The desktop client already does this correctly: `powerSaveBlocker('prevent-display-sleep')` driven by `keepAwakeForState()`, which holds the lock only for `playing` / `buffering`. This change brings the mobile players in line.

## Changes

**Android** — a `syncKeepScreenOn()` helper sets `setKeepScreenOn` on the `SurfaceView` from `playWhenReady && (STATE_READY || STATE_BUFFERING)`, called from `onPlaybackStateChanged` and a new `onPlayWhenReadyChanged`. Driving it from `playWhenReady` rather than `isPlaying` means a mid-playback rebuffer keeps the screen lit, while pause, end of stream and idle release it. Using the view-level flag instead of the window flag also makes the release automatic: the wrapper detach in `destroy()` frees it, so the explicit `clearFlags` is gone.

**iOS** — the existing `timeControlStatus` observer sets `isIdleTimerDisabled` from `status != .paused`. `.paused` covers both a user pause and the end of the item; `.waitingToPlayAtSpecifiedRate` keeps the lock during a stall. The assignment is hopped onto the main thread because the KVO callback is not guaranteed to land there (the neighbouring `emitStateChanged` already dispatches for the same reason).

## Testing

Neither toolchain is available on this machine (no JDK, no Xcode), so this is unbuilt and needs on-device validation:

- Play, then pause and leave the app in the foreground — the screen should dim and sleep on its own; resuming should keep it awake again.
- Let a video reach the end while the player is still open — the screen should be free to sleep.
- Force a rebuffer (throttle the link) — the screen must stay lit through the stall.
- Android TV: pause and confirm the screensaver eventually starts.