### PR TITLE
feat(cast-overlay): offer the next episode on the cast and remote controls

### DIFF
--- a/backend/src/modules/remote/remote.service.spec.ts
+++ b/backend/src/modules/remote/remote.service.spec.ts
@@ -270,6 +270,7 @@ function stateFrame(targetId: string): SseEvent {
     quality: null,
     qualities: null,
     autoplayBlocked: false,
+    hasNext: false,
     audioTrackIndex: null,
     subtitleTrackIndex: null,
     lastCmdId: null,

--- a/backend/src/modules/scheduler/events.service.ts
+++ b/backend/src/modules/scheduler/events.service.ts
@@ -303,6 +303,8 @@ export interface RemoteStatePayload {
   /** The target could not start on its own: a controller must say so rather than
    *  show a paused device whose play button is refused for the same reason. */
   autoplayBlocked: boolean;
+  /** The target has something queued after the current item. */
+  hasNext: boolean;
   audioTrackIndex: number | null;
   subtitleTrackIndex: number | null;
   /** Echo of the last command the target applied: the semantic ack. */

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -61,6 +61,8 @@ export interface LiveSession {
   attributedUserId: number | null;
   /** The target's browser refused to start playback without a user gesture. */
   autoplayBlocked: boolean;
+  /** The target has an item queued after this one, so a controller may offer it. */
+  hasNext: boolean;
   kind: SessionKind;
   deviceLabel: string | null;
   /** Real host OS name+version ("macOS 26") from the client DeviceProfile;
@@ -261,6 +263,7 @@ export function buildLiveSession(
       qualities: null,
       attributedUserId: input.attributedUserId ?? null,
       autoplayBlocked: false,
+      hasNext: false,
       kind: input.kind,
       deviceLabel: input.deviceLabel ?? null,
       systemName: input.systemName ?? null,
@@ -403,6 +406,7 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
       quality?: string | null;
       qualities?: RemoteQualityRung[] | null;
       autoplayBlocked?: boolean;
+      hasNext?: boolean;
       episodeLabel?: string | null;
       supportsVolume?: boolean;
       subtitleId?: string | null;
@@ -423,6 +427,7 @@ export class LiveSessionRegistry implements OnModuleInit, OnModuleDestroy {
     if (payload.autoplayBlocked !== undefined) {
       session.autoplayBlocked = payload.autoplayBlocked;
     }
+    if (payload.hasNext !== undefined) session.hasNext = payload.hasNext;
     if (payload.subtitleId !== undefined) {
       session.subtitleId = payload.subtitleId;
     }

--- a/backend/src/modules/streaming/playback.controller.ts
+++ b/backend/src/modules/streaming/playback.controller.ts
@@ -210,6 +210,7 @@ export class PlaybackController {
       quality?: string | null;
       qualities?: RemoteQualityRung[] | null;
       autoplayBlocked?: boolean;
+      hasNext?: boolean;
       episodeLabel?: string | null;
       supportsVolume?: boolean;
       subtitleId?: string | null;
@@ -245,6 +246,7 @@ export class PlaybackController {
         quality: body.quality,
         qualities: body.qualities,
         autoplayBlocked: body.autoplayBlocked,
+        hasNext: body.hasNext,
         episodeLabel: body.episodeLabel,
         supportsVolume: body.supportsVolume,
         subtitleId: body.subtitleId,
@@ -287,6 +289,7 @@ export class PlaybackController {
             quality: updated.quality,
             qualities: updated.qualities,
             autoplayBlocked: updated.autoplayBlocked,
+            hasNext: updated.hasNext,
             audioTrackIndex: updated.audioTrackIndex,
             subtitleTrackIndex: updated.subtitleTrackIndex,
             lastCmdId: body.lastCmdId ?? null,

--- a/client/src/app/core/services/cast-playback-target.ts
+++ b/client/src/app/core/services/cast-playback-target.ts
@@ -1,9 +1,12 @@
-import { Injectable, computed, inject } from '@angular/core';
+import { Injectable, computed, effect, inject, signal, untracked } from '@angular/core';
 import { CastService } from './cast.service';
 import { CastPlayerService, CastSubtitleOption } from './cast-player.service';
 import { parseAudioIndex } from '../utils/player.utils';
 import { TranslateService } from '@ngx-translate/core';
 import { PlaybackOption, PlaybackTarget } from './playback-target';
+import { MediaService } from './api/media.service';
+import { QueueItem } from './playback-queue.service';
+import { resolveNextEpisodeItem } from '../../shared/utils/media-play.util';
 
 /**
  * Pure pass-through to CastService + CastPlayerService: the Chromecast
@@ -14,6 +17,7 @@ export class CastPlaybackTarget implements PlaybackTarget {
   private readonly cast = inject(CastService);
   private readonly cp = inject(CastPlayerService);
   private readonly translate = inject(TranslateService);
+  private readonly mediaService = inject(MediaService);
 
   readonly buffering = this.cast.buffering;
   readonly currentTime = this.cast.currentTime;
@@ -102,6 +106,45 @@ export class CastPlaybackTarget implements PlaybackTarget {
 
   skip(): void {
     console.warn('[cast-playback-target] no skip cue on a Cast session');
+  }
+
+  /** Resolved ahead of the press: offering a next episode that turns out not to
+   *  exist would leave a button that does nothing on the last one. */
+  private readonly nextItem = signal<QueueItem | null>(null);
+  readonly canPlayNext = computed(() => this.nextItem() !== null);
+
+  private readonly nextItemEffect = effect(() => {
+    const mediaId = this.cp.mediaId();
+    const episodeId = this.cp.episodeId();
+    untracked(() => {
+      this.nextItem.set(null);
+      if (!mediaId || !episodeId) return;
+      void this.mediaService
+        .getOne(mediaId)
+        .then((m) => {
+          // The session may have moved on while the fetch was in flight.
+          if (this.cp.episodeId() !== episodeId) return;
+          this.nextItem.set(resolveNextEpisodeItem(m, episodeId));
+        })
+        .catch((err) => console.warn('[cast-playback-target] next episode lookup failed', err));
+    });
+  });
+
+  playNext(): void {
+    const next = this.nextItem();
+    if (!next?.mediaFileId) {
+      console.warn('[cast-playback-target] playNext with nothing queued');
+      return;
+    }
+    void this.cp.quickStart({
+      mediaFileId: next.mediaFileId,
+      mediaId: next.mediaId,
+      episodeId: next.episodeId,
+      title: next.title,
+      episodeTitle: next.episodeTitle,
+      fanartUrl: next.fanartUrl ?? null,
+      startTime: 0,
+    });
   }
 
   stopPlayback(): void {

--- a/client/src/app/core/services/playback-target.ts
+++ b/client/src/app/core/services/playback-target.ts
@@ -55,6 +55,11 @@ export interface PlaybackTarget {
   readonly skipCue: Signal<{ labelKey: string } | null>;
   /** Take the current skip offer. No-op when there is none. */
   skip(): void;
+  /** Something follows what is playing, so the surface can offer it whatever
+   *  the playhead is doing — unlike {@link skipCue}, which is outro-bound. */
+  readonly canPlayNext: Signal<boolean>;
+  /** Move to the next item. No-op when {@link canPlayNext} is false. */
+  playNext(): void;
   /** A load has been sent and the target has not reported back yet. Always
    *  false on Cast, whose sender mirrors the media locally from the start. */
   readonly isStarting: Signal<boolean>;

--- a/client/src/app/core/services/remote-playback-target.ts
+++ b/client/src/app/core/services/remote-playback-target.ts
@@ -219,6 +219,18 @@ export class RemotePlaybackTarget implements PlaybackTarget {
     console.warn('[remote-playback-target] skip with no cue active');
   }
 
+  /** The target's own answer: only it knows its queue. */
+  readonly canPlayNext = computed(() => this.remote.targetState()?.hasNext ?? false);
+
+  playNext(): void {
+    const targetId = this.remote.selectedTargetId();
+    if (!targetId) {
+      console.warn('[remote-playback-target] playNext with no selected target');
+      return;
+    }
+    void this.remote.send(targetId, { action: 'next' });
+  }
+
   stopPlayback(): void {
     const targetId = this.remote.selectedTargetId();
     if (!targetId) {

--- a/client/src/app/core/services/remote.service.spec.ts
+++ b/client/src/app/core/services/remote.service.spec.ts
@@ -30,6 +30,7 @@ function frame(over: Partial<RemoteState> = {}): RemoteState {
     quality: '1080p',
     qualities: null,
     autoplayBlocked: false,
+    hasNext: false,
     audioTrackIndex: 0,
     subtitleTrackIndex: null,
     lastCmdId: null,

--- a/client/src/app/core/services/remote.service.ts
+++ b/client/src/app/core/services/remote.service.ts
@@ -28,6 +28,8 @@ export interface RemoteNowPlaying {
   /** The target's own ladder: the only id space it accepts for a quality change. */
   qualities: RemoteQualityRung[] | null;
   autoplayBlocked: boolean;
+  /** The target has an item queued after this one. */
+  hasNext: boolean;
   audioTrackIndex: number | null;
   subtitleTrackIndex: number | null;
 }
@@ -507,6 +509,7 @@ export class RemoteService {
       quality: s.quality,
       qualities: s.qualities,
       autoplayBlocked: s.autoplayBlocked,
+      hasNext: s.hasNext,
       audioTrackIndex: s.audioTrackIndex,
       subtitleTrackIndex: s.subtitleTrackIndex,
     });

--- a/client/src/app/core/services/sse.service.ts
+++ b/client/src/app/core/services/sse.service.ts
@@ -65,6 +65,8 @@ export interface RemoteState {
   subtitleId: string | null;
   quality: string | null;
   qualities: RemoteQualityRung[] | null;
+  /** The target has something queued after the current item. */
+  hasNext: boolean;
   /** The target's browser refused to start without a gesture on that device. */
   autoplayBlocked: boolean;
   audioTrackIndex: number | null;

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -42,7 +42,7 @@ import { NavigationHistoryService } from '../../core/services/navigation-history
 import { ToastService } from '../../core/services/toast.service';
 import { NavbarService } from '../../core/services/navbar.service';
 import { PlaybackQueueService, QueueItem } from '../../core/services/playback-queue.service';
-import { resolvePlayableFile } from '../../shared/utils/media-play.util';
+import { buildSeriesQueueItems, resolvePlayableFile } from '../../shared/utils/media-play.util';
 import { audioChannelsLabel, formatAudioLabel, formatAudioParts, inIntroRange, inOutroRange, parseAudioIndex, SpriteMetadata, widthForProfile } from '../../core/utils/player.utils';
 import { classifyPlaybackError, formatErrorDiagnostics, userMessageKeyFor } from '../../core/services/playback-engine/playback-error';
 import { environment } from '../../../environments/environment';
@@ -2487,46 +2487,11 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
   private syncSeriesQueue(): void {
     if (this.queue.source() === 'playlist') return; // the playlist owns the queue
     const m = this.media;
-    if (!m || m.type !== 'series' || !this.episodeId || !m.seasons?.length) {
+    if (!m || !this.episodeId) {
       this.queue.clear();
       return;
     }
-    const flat: {
-      seasonNumber: number;
-      episodeNumber: number;
-      id: number;
-      title?: string | null;
-      stillUrl?: string | null;
-    }[] = [];
-    for (const s of m.seasons) {
-      if ((s.seasonNumber ?? 0) <= 0) continue; // skip specials
-      for (const ep of s.episodes ?? []) {
-        flat.push({
-          seasonNumber: s.seasonNumber,
-          episodeNumber: ep.episodeNumber ?? 0,
-          id: ep.id,
-          title: ep.title,
-          stillUrl: ep.stillUrl,
-        });
-      }
-    }
-    flat.sort(
-      (a, b) => a.seasonNumber - b.seasonNumber || a.episodeNumber - b.episodeNumber,
-    );
-    const items: QueueItem[] = [];
-    for (const e of flat) {
-      const file = (m.files ?? []).find((f) => f.episodeId === e.id);
-      if (!file) continue; // an episode with no available file isn't queue-able
-      items.push({
-        mediaId: m.id,
-        episodeId: e.id,
-        mediaFileId: file.id,
-        title: m.title,
-        episodeTitle: `S${e.seasonNumber}:E${e.episodeNumber}${e.title ? ` - ${e.title}` : ''}`,
-        fanartUrl: m.fanartUrl,
-        stillUrl: e.stillUrl ?? null,
-      });
-    }
+    const items = buildSeriesQueueItems(m);
     const idx = items.findIndex((it) => it.episodeId === this.episodeId);
     if (idx < 0 || items.length <= 1) {
       this.queue.clear();
@@ -4749,6 +4714,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       subtitleId?: string | null;
       qualities?: RemoteQualityRung[] | null;
       autoplayBlocked?: boolean;
+      hasNext?: boolean;
     } = {
       positionSeconds: pos,
       durationSeconds: dur || 0,
@@ -4780,6 +4746,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       payload.supportsVolume = this.engine?.supportsVolume ?? true;
       payload.subtitleId = this.activeSubtitleId();
       payload.autoplayBlocked = this.autoplayBlocked();
+      payload.hasNext = this.upNext() !== null;
     }
 
     // Offline queue persists position only — the heartbeat-related

--- a/client/src/app/shared/cast-overlay/cast-overlay.html
+++ b/client/src/app/shared/cast-overlay/cast-overlay.html
@@ -126,9 +126,11 @@
             </div>
           </div>
 
-          <!-- Playback buttons -->
-          <div class="flex items-center justify-center gap-6 lg:gap-4">
-            <button class="btn btn-ghost btn-circle lg:btn-sm" (click)="t.seek(t.currentTime() - 10)">
+          <!-- Playback buttons. Three columns rather than a centred flex row:
+               the next-episode button appears mid-playback, and a flex row
+               would have slid the play button off centre under a thumb. -->
+          <div class="grid grid-cols-[1fr_auto_1fr] items-center gap-6 lg:gap-4">
+            <button class="btn btn-ghost btn-circle lg:btn-sm justify-self-end" (click)="t.seek(t.currentTime() - 10)">
               <svg lucideRotateCcw class="h-7 w-7 lg:h-5 lg:w-5"></svg>
             </button>
             <button class="btn btn-primary btn-circle btn-lg lg:btn-md" (click)="t.togglePlayPause()">
@@ -142,9 +144,20 @@
                 <svg lucidePause class="h-8 w-8 lg:h-6 lg:w-6"></svg>
               }
             </button>
-            <button class="btn btn-ghost btn-circle lg:btn-sm" (click)="t.seek(t.currentTime() + 10)">
-              <svg lucideRotateCw class="h-7 w-7 lg:h-5 lg:w-5"></svg>
-            </button>
+            <div class="flex items-center gap-4 lg:gap-3 justify-self-start">
+              <button class="btn btn-ghost btn-circle lg:btn-sm" (click)="t.seek(t.currentTime() + 10)">
+                <svg lucideRotateCw class="h-7 w-7 lg:h-5 lg:w-5"></svg>
+              </button>
+              @if (t.canPlayNext()) {
+                <!-- A rung below the transport: secondary to play and to the
+                     two seeks it sits beside. -->
+                <button class="btn btn-ghost btn-circle btn-sm lg:btn-xs"
+                        [attr.aria-label]="'player.play_next' | translate"
+                        (click)="t.playNext()">
+                  <svg lucideSkipForward class="h-5 w-5 lg:h-4 lg:w-4"></svg>
+                </button>
+              }
+            </div>
           </div>
 
           <!-- Volume. Hidden where the target's platform owns the level: its

--- a/client/src/app/shared/cast-overlay/cast-overlay.ts
+++ b/client/src/app/shared/cast-overlay/cast-overlay.ts
@@ -23,6 +23,7 @@ import {
   LucidePlay,
   LucideRotateCcw,
   LucideRotateCw,
+  LucideSkipForward,
   LucideSquare,
   LucideVolume2,
   LucideVolumeX,
@@ -50,7 +51,7 @@ interface PickerRow {
   imports: [
     LucideCast,
     LucidePause, LucidePlay, LucideRotateCcw, LucideRotateCw,
-    LucideSquare, LucideVolume2, LucideVolumeX, LucideX,
+    LucideSkipForward, LucideSquare, LucideVolume2, LucideVolumeX, LucideX,
     SeekbarComponent,
     CachedSrcDirective,
     ResolveUrlPipe,

--- a/client/src/app/shared/utils/media-play.util.spec.ts
+++ b/client/src/app/shared/utils/media-play.util.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { Media } from '../../core/services/api/media.service';
+import { buildSeriesQueueItems, resolveNextEpisodeItem } from './media-play.util';
+
+/** S2 declared before S1, one special, and E2 with no file. */
+const series = {
+  id: 7,
+  title: 'A series',
+  type: 'series',
+  fanartUrl: '/f.jpg',
+  seasons: [
+    { seasonNumber: 2, episodes: [{ id: 21, episodeNumber: 1, title: 'Third' }] },
+    { seasonNumber: 0, episodes: [{ id: 90, episodeNumber: 1, title: 'Special' }] },
+    {
+      seasonNumber: 1,
+      episodes: [
+        { id: 11, episodeNumber: 1, title: 'First' },
+        { id: 12, episodeNumber: 2, title: 'Missing file' },
+        { id: 13, episodeNumber: 3, title: 'Second' },
+      ],
+    },
+  ],
+  files: [
+    { id: 111, episodeId: 11 },
+    { id: 113, episodeId: 13 },
+    { id: 121, episodeId: 21 },
+    { id: 190, episodeId: 90 },
+  ],
+} as unknown as Media;
+
+describe('buildSeriesQueueItems', () => {
+  it('orders by S/E, skips specials and episodes with no file', () => {
+    expect(buildSeriesQueueItems(series).map((i) => i.episodeId)).toEqual([11, 13, 21]);
+    expect(buildSeriesQueueItems(series)[0].episodeTitle).toBe('S1:E1 - First');
+    expect(buildSeriesQueueItems({ id: 1, type: 'movie' } as Media)).toEqual([]);
+  });
+});
+
+describe('resolveNextEpisodeItem', () => {
+  it('crosses the season boundary and stops on the last episode', () => {
+    expect(resolveNextEpisodeItem(series, 11)?.mediaFileId).toBe(113);
+    expect(resolveNextEpisodeItem(series, 13)?.episodeId).toBe(21);
+    expect(resolveNextEpisodeItem(series, 21)).toBeNull();
+    // Not queue-able itself, so it has no place to advance from.
+    expect(resolveNextEpisodeItem(series, 12)).toBeNull();
+  });
+});

--- a/client/src/app/shared/utils/media-play.util.ts
+++ b/client/src/app/shared/utils/media-play.util.ts
@@ -1,4 +1,5 @@
 import { Media } from '../../core/services/api/media.service';
+import { QueueItem } from '../../core/services/playback-queue.service';
 
 /** One entry of {@link Media.files}. */
 export type MediaFile = NonNullable<Media['files']>[number];
@@ -18,4 +19,56 @@ export function resolvePlayableFile(
     return files.find((f) => f.episodeId === episodeId) ?? null;
   }
   return files.find((f) => f.episodeId == null) ?? files[0] ?? null;
+}
+
+/**
+ * The series' episodes as queue items in S/E order — specials excluded, and
+ * episodes with no available file dropped (they aren't playable). Empty for
+ * anything that isn't a loaded series.
+ */
+export function buildSeriesQueueItems(m: Media): QueueItem[] {
+  if (m.type !== 'series' || !m.seasons?.length) return [];
+  const flat: {
+    seasonNumber: number;
+    episodeNumber: number;
+    id: number;
+    title?: string | null;
+    stillUrl?: string | null;
+  }[] = [];
+  for (const s of m.seasons) {
+    if ((s.seasonNumber ?? 0) <= 0) continue;
+    for (const ep of s.episodes ?? []) {
+      flat.push({
+        seasonNumber: s.seasonNumber,
+        episodeNumber: ep.episodeNumber ?? 0,
+        id: ep.id,
+        title: ep.title,
+        stillUrl: ep.stillUrl,
+      });
+    }
+  }
+  flat.sort((a, b) => a.seasonNumber - b.seasonNumber || a.episodeNumber - b.episodeNumber);
+  const items: QueueItem[] = [];
+  for (const e of flat) {
+    const file = (m.files ?? []).find((f) => f.episodeId === e.id);
+    if (!file) continue;
+    items.push({
+      mediaId: m.id,
+      episodeId: e.id,
+      mediaFileId: file.id,
+      title: m.title,
+      episodeTitle: `S${e.seasonNumber}:E${e.episodeNumber}${e.title ? ` - ${e.title}` : ''}`,
+      fanartUrl: m.fanartUrl,
+      stillUrl: e.stillUrl ?? null,
+    });
+  }
+  return items;
+}
+
+/** The item after `episodeId` in {@link buildSeriesQueueItems}, or null on the
+ *  last episode (or when the episode itself isn't in the list). */
+export function resolveNextEpisodeItem(m: Media, episodeId: number): QueueItem | null {
+  const items = buildSeriesQueueItems(m);
+  const idx = items.findIndex((it) => it.episodeId === episodeId);
+  return idx < 0 ? null : (items[idx + 1] ?? null);
 }


### PR DESCRIPTION
## Why

The cast/remote control card could only reach the next item through the outro cue, so between two outros there was no way to skip ahead from the controlling device — while the in-player controls carry that button permanently.

## What

A next button in the transport row of `cast-overlay`, on both targets it drives.

**Remote.** The `next` action already existed in the protocol (the outro cue sent it); what was missing was knowing *whether* something follows. Only the target holds the queue, so it reports `hasNext` on its heartbeat, plumbed exactly like `autoplayBlocked` (payload → `LiveSession` → `remote.state` → controller). A target on an older build simply sends nothing and the button stays hidden — never a press that logs and does nothing.

**Cast.** A Cast session plays the single launched item and the queue is cleared on purpose, so the next episode is resolved from the media ahead of the press (cached fetch, re-run when the episode changes) and `quickStart` takes it.

**Shared.** The S/E episode flattening was the player's own; it moves to `media-play.util` (`buildSeriesQueueItems` / `resolveNextEpisodeItem`) so cast and the player order and label episodes identically. `player.ts` loses ~40 lines.

The transport row becomes `grid-cols-[1fr_auto_1fr]` so the play button stays centred when the next button appears mid-playback instead of sliding out from under a thumb.

## Verification

- `tsc` backend, `ng build`, `tsconfig.spec` — green.
- `remote.service.spec` (18), `player.spec` (32), new `media-play.util.spec` (2), backend remote/live-session/playback specs (45).
- Remote round trip against the dev stack: live session minted via `playback-info`, heartbeat sent with `hasNext: true`, and the `remote.state` frame received on the controller's SSE stream carries `"hasNext":true`.

Not yet exercised on a real second device or a Chromecast.

## Note

The reporting side is the target, so a device running a frozen bundle (installed Tizen app, APK, desktop) shows no button until it is updated.
