### PR TITLE
fix(cast): discover Chromecast devices on Android

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/CastPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/CastPlugin.java
@@ -69,6 +69,7 @@ public class CastPlugin extends Plugin {
     private WifiManager.WifiLock wifiLock;
     /** True between the user picking a device and the session starting/failing. */
     private volatile boolean sessionPending = false;
+    private boolean routeDiscoveryActive = false;
 
     /**
      * Cast session updates must stay on the main thread (same as Session / isConnected rules).
@@ -215,7 +216,7 @@ public class CastPlugin extends Plugin {
                 castContext = CastContext.getSharedInstance(getContext());
                 sessionManager = castContext.getSessionManager();
                 sessionManager.addSessionManagerListener(sessionListener, CastSession.class);
-                MediaRouter.getInstance(getContext()).addCallback(buildCastSelector(), routeCallback);
+                startRouteDiscovery();
 
                 // Check if already connected
                 castSession = sessionManager.getCurrentCastSession();
@@ -242,11 +243,44 @@ public class CastPlugin extends Plugin {
     }
 
     /** Shared by requestSession (native dialog) and getCastDevices/selectCastDevice (custom list). */
+    /** The SDK's own selector, so the category matches the receiver id in
+     *  CastOptions: a device is only discovered for the app it was asked for. */
     private MediaRouteSelector buildCastSelector() {
+        if (castContext != null) return castContext.getMergedSelector();
         return new MediaRouteSelector.Builder()
             .addControlCategory(CastMediaControlIntent.categoryForCast(
-                CastMediaControlIntent.DEFAULT_MEDIA_RECEIVER_APPLICATION_ID))
+                getContext().getString(R.string.cast_receiver_app_id)))
             .build();
+    }
+
+    /** CALLBACK_FLAG_REQUEST_DISCOVERY is what makes the router discover at all:
+     *  registered without it, the callback fires but no provider ever scans, so
+     *  getRoutes() only ever holds the default route. */
+    private void startRouteDiscovery() {
+        if (routeDiscoveryActive) return;
+        MediaRouter.getInstance(getContext()).addCallback(
+            buildCastSelector(), routeCallback, MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY);
+        routeDiscoveryActive = true;
+    }
+
+    private void stopRouteDiscovery() {
+        if (!routeDiscoveryActive) return;
+        MediaRouter.getInstance(getContext()).removeCallback(routeCallback);
+        routeDiscoveryActive = false;
+    }
+
+    /** Discovery costs battery and network, so it lives with the foreground and
+     *  not with the plugin: an existing session is unaffected by dropping it. */
+    @Override
+    protected void handleOnStart() {
+        super.handleOnStart();
+        if (castContext != null) runOnMainThread(this::startRouteDiscovery);
+    }
+
+    @Override
+    protected void handleOnStop() {
+        super.handleOnStop();
+        runOnMainThread(this::stopRouteDiscovery);
     }
 
     @PluginMethod()
@@ -301,6 +335,8 @@ public class CastPlugin extends Plugin {
                 if (modelName != null) device.put("modelName", modelName);
                 devices.put(device);
             }
+            Log.d(TAG, "getCastDevices: " + devices.length() + " cast route(s) of "
+                    + router.getRoutes().size() + " total, discovery=" + routeDiscoveryActive);
             call.resolve(new JSObject().put("devices", devices));
         });
     }


### PR DESCRIPTION
## Symptom

On Android, no Chromecast ever appeared in "Lire sur un autre appareil" — the list only ever held remote targets.

## Root cause

`CastPlugin` registered its route callback with the two-argument `addCallback(selector, callback)`. AndroidX documents that form as "the same effect as calling `addCallback(MediaRouteSelector, Callback, int)` without flags", and without `CALLBACK_FLAG_REQUEST_DISCOVERY` the router never asks any provider to discover: the callback is wired up but nothing scans, `getRoutes()` holds only the default route, and `getCastDevices()` filtered that one out. The code even reads as intentional — *"Passive route discovery: the picker's own list doesn't warrant an active scan on top"* — but `REQUEST_DISCOVERY` **is** the passive-discovery flag; zero flags is not passive discovery, it is none. iOS has had the equivalent explicit `discoveryManager.startDiscovery()` in `AppDelegate` since day one; Android had no counterpart.

Second defect, on the same path: the selector was built from `DEFAULT_MEDIA_RECEIVER_APPLICATION_ID` while the session runs the Fliks receiver, so it asked for a Cast category the app never uses. It now comes from `CastContext.getMergedSelector()`, which the SDK builds from the receiver id in `CastOptions` (one source of truth, `strings.xml`).

## Also

Discovery now follows the foreground via `handleOnStart` / `handleOnStop` instead of living for the whole process — the AndroidX docs call out its battery and network cost, and an established session is unaffected by dropping it. `getCastDevices` logs what it found, which is what made this diagnosable.

## Verification

On an **SM-S931B** over adb, same build, flag toggled:

| | cast routes | total routes |
|---|---|---|
| without `CALLBACK_FLAG_REQUEST_DISCOVERY` | 0 | 1 |
| with it | 1 (within ~400 ms) | 2 |

And the picker then lists the device:

```
Lire sur un autre appareil
  [cast] Salon — Chromecast
  [monitor] Chrome sur Linux
```

Casting to it end to end (loadMedia, transport, tracks) was not re-exercised — this change only affects discovery.
