### PR TITLE
fix(cast): clear the connect spinner when a selection changes nothing

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/CastPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/CastPlugin.java
@@ -358,6 +358,17 @@ public class CastPlugin extends Plugin {
                 call.reject("No matching Cast device");
                 return;
             }
+            // Selecting the route that is already selected transitions nothing, so no
+            // session callback ever comes: say what the state is instead of leaving the
+            // caller waiting on an event that cannot arrive.
+            if (id.equals(router.getSelectedRoute().getId())) {
+                boolean connected = castSession != null && castSession.isConnected();
+                Log.d(TAG, "selectCastDevice: already the selected route, connected=" + connected);
+                notifyJS("connected", connected);
+                if (!connected) notifyPickerDismissed();
+                call.resolve();
+                return;
+            }
             // Result surfaces via the existing SessionManagerListener (onSessionStarted / onSessionStartFailed).
             router.selectRoute(target);
             call.resolve();

--- a/client/src/app/core/services/cast.service.ts
+++ b/client/src/app/core/services/cast.service.ts
@@ -100,6 +100,8 @@ interface NativeCastPlugin {
 
 const NativeCast = registerPlugin<NativeCastPlugin>('NativeCast');
 const CAST_APP_ID = environment.castAppId;
+/** Ceiling on a connect attempt: a cold receiver launch is ~2 s on a Chromecast. */
+const CONNECT_TIMEOUT_MS = 30_000;
 
 /** Collapse a rapid seek burst (scrubbing / repeated ±10 taps) into a leading
  *  dispatch plus one trailing dispatch, so the Cast receiver's Shaka isn't hit
@@ -118,8 +120,12 @@ const CAST_SEEK_CONVERGE_TOL = 1.5;
 export class CastService implements OnDestroy {
   readonly isAvailable = signal(false);
   readonly isConnected = signal(false);
-  /** True while waiting for the Cast session to establish. */
+  /** True while waiting for the Cast session to establish. Written only through
+   *  {@link beginConnecting} / {@link endConnecting}: the trigger it drives is
+   *  disabled while it is set, so a connect whose outcome never arrives would
+   *  wedge the picker until the app restarts. */
   readonly connecting = signal(false);
+  private connectTimeout: ReturnType<typeof setTimeout> | null = null;
   readonly currentTime = signal(0);
   readonly duration = signal(0);
   readonly isPaused = signal(true);
@@ -178,6 +184,7 @@ export class CastService implements OnDestroy {
 
   ngOnDestroy() {
     this.clearSeekCoalescing();
+    this.endConnecting();
   }
 
   // ---------------------------------------------------------------------------
@@ -194,13 +201,13 @@ export class CastService implements OnDestroy {
       window.addEventListener('castStateChanged', ((e: CustomEvent) => {
         const connected = e.detail?.connected ?? false;
         this.isConnected.set(connected);
-        if (connected) this.connecting.set(false);
+        if (connected) this.endConnecting();
         else this.buffering.set(false);
       }) as EventListener);
 
       // Picker dismissed without selecting a device
       window.addEventListener('castPickerDismissed', () => {
-        this.connecting.set(false);
+        this.endConnecting();
       });
 
       window.addEventListener('castMediaUpdate', ((e: CustomEvent) => {
@@ -303,7 +310,7 @@ export class CastService implements OnDestroy {
   private onWebConnectionChanged() {
     const connected = this.remotePlayer?.isConnected ?? false;
     this.isConnected.set(connected);
-    this.connecting.set(false);
+    this.endConnecting();
     if (!connected) this.buffering.set(false);
     this.session = connected
       ? cast.framework.CastContext.getInstance().getCurrentSession()
@@ -390,13 +397,32 @@ export class CastService implements OnDestroy {
   // ---------------------------------------------------------------------------
 
   requestSession() {
-    this.connecting.set(true);
+    this.beginConnecting();
     if (this.isNative) {
       // The plugin resolves immediately; castStateChanged fires on connect OR dismiss.
-      NativeCast.requestSession().catch(() => this.connecting.set(false));
+      NativeCast.requestSession().catch(() => this.endConnecting());
     } else {
-      cast.framework.CastContext.getInstance().requestSession().catch(() => this.connecting.set(false));
+      cast.framework.CastContext.getInstance().requestSession().catch(() => this.endConnecting());
     }
+  }
+
+  /** A connect attempt whose outcome is an event, not the call's own return: the
+   *  deadline is the last resort for one that never reports either way. */
+  private beginConnecting(): void {
+    this.connecting.set(true);
+    if (this.connectTimeout) clearTimeout(this.connectTimeout);
+    this.connectTimeout = setTimeout(() => {
+      console.warn('[cast] no session outcome within the connect deadline');
+      this.endConnecting();
+    }, CONNECT_TIMEOUT_MS);
+  }
+
+  private endConnecting(): void {
+    if (this.connectTimeout) {
+      clearTimeout(this.connectTimeout);
+      this.connectTimeout = null;
+    }
+    this.connecting.set(false);
   }
 
   /** List Cast devices visible to native discovery. Web has no enumeration
@@ -419,11 +445,11 @@ export class CastService implements OnDestroy {
    *  route disappeared between listing and selection; the caller (the
    *  picker) surfaces that as a toast rather than looking stuck. */
   async selectCastDevice(id: string): Promise<void> {
-    this.connecting.set(true);
+    this.beginConnecting();
     try {
       await NativeCast.selectCastDevice({ id });
     } catch (err) {
-      this.connecting.set(false);
+      this.endConnecting();
       throw err;
     }
   }


### PR DESCRIPTION
## Symptom

On Android, picking the Chromecast left the topbar spinner running forever. Worse than cosmetic: the trigger is `[disabled]` while `connecting()` is set, so the picker could not be reopened — only an app restart cleared it.

## Root cause

`MediaRouter.selectRoute()` on the route that is **already selected** transitions nothing, so no `SessionManagerListener` callback fires at all. Confirmed on device: the tap produced zero session callbacks in logcat. And `castStateChanged` / `castPickerDismissed` — the only two things that clear the spinner — both ride on a session transition, so `connecting` stayed true.

This is the state you land in the moment you are already connected: the very natural gesture of reopening the picker and tapping the device you are casting to wedges the UI.

`selectCastDevice` now answers that case with the state it already holds instead of waiting for an event that cannot arrive.

## The wider class

The spinner could wedge on any connect whose outcome never reports either way, not just this one. `connecting` is now written only through `beginConnecting` / `endConnecting`, and `beginConnecting` arms a 30 s deadline (a cold receiver launch measures ~2 s), so the picker un-wedges itself rather than needing a restart. All four connect entry points and both platforms route through the pair.

## Verification

Full pass on an **SM-S931B** over adb, on the final build with the debug probes removed:

| | result |
|---|---|
| cold connect | session starts, icon turns blue, no spinner |
| re-select while connected (**the bug**) | no spinner, state preserved |
| cast an episode | plays on the device, control card shows 20:18 / 1:05:36 |
| pause / play | icon and position follow |
| seek +10 | 20:42 to 20:52 |
| next episode | S3:E1 to **S3:E2 - Une reine à bon Port**, from 0:02 |
| a movie | no next button, transport stays centred |
| stop playback | card closes, session kept (icon stays blue) |
| re-select after stop | no spinner |

Receiver launch was `66BF4DAE` / `name: Fliks` throughout, so the selector change from the previous PR is exercised too.
