### PR TITLE
feat(cast): leave a Chromecast from the picker, and only one destination at a time

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/CastPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/CastPlugin.java
@@ -15,6 +15,7 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
+import com.google.android.gms.cast.CastDevice;
 import com.google.android.gms.cast.CastMediaControlIntent;
 import com.google.android.gms.cast.MediaInfo;
 import com.google.android.gms.cast.MediaLoadRequestData;
@@ -325,14 +326,23 @@ public class CastPlugin extends Plugin {
         runOnMainThread(() -> {
             MediaRouteSelector selector = buildCastSelector();
             MediaRouter router = MediaRouter.getInstance(getContext());
+            // Which row the caller is already casting to: the selected route, and
+            // only while a session actually stands behind it.
+            String connectedId = castSession != null && castSession.isConnected()
+                ? router.getSelectedRoute().getId()
+                : null;
             JSArray devices = new JSArray();
             for (MediaRouter.RouteInfo route : router.getRoutes()) {
                 if (route.isDefaultOrBluetooth() || !route.matchesSelector(selector)) continue;
                 JSObject device = new JSObject();
                 device.put("id", route.getId());
                 device.put("name", route.getName());
-                String modelName = route.getDescription();
+                // The device's model, not route.getDescription(): that one turns into
+                // the name of whatever receiver is running, so the row read "Fliks".
+                CastDevice castDevice = CastDevice.getFromBundle(route.getExtras());
+                String modelName = castDevice != null ? castDevice.getModelName() : null;
                 if (modelName != null) device.put("modelName", modelName);
+                device.put("connected", route.getId().equals(connectedId));
                 devices.put(device);
             }
             Log.d(TAG, "getCastDevices: " + devices.length() + " cast route(s) of "

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2416,6 +2416,7 @@
     "empty_state": "Keine Geräte im Netzwerk gefunden.",
     "searching": "Geräte werden gesucht…",
     "chromecast_row": "Chromecast…",
+    "disconnect_row": "Trennen",
     "owned_by": "Gerät von {{username}}",
     "error_cast_select_failed": "Verbindung zu diesem Chromecast fehlgeschlagen.",
     "error_command_failed": "Gerät nicht erreichbar.",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2443,6 +2443,7 @@
     "empty_state": "No devices found on your network.",
     "searching": "Searching for devices…",
     "chromecast_row": "Chromecast…",
+    "disconnect_row": "Disconnect",
     "owned_by": "{{username}}'s device",
     "error_cast_select_failed": "Couldn't connect to that Chromecast device.",
     "error_command_failed": "Couldn't reach that device.",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2416,6 +2416,7 @@
     "empty_state": "No se encontraron dispositivos en tu red.",
     "searching": "Buscando dispositivos…",
     "chromecast_row": "Chromecast…",
+    "disconnect_row": "Desconectar",
     "owned_by": "Dispositivo de {{username}}",
     "error_cast_select_failed": "No se pudo conectar a ese Chromecast.",
     "error_command_failed": "No se pudo contactar con ese dispositivo.",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2443,6 +2443,7 @@
     "empty_state": "Aucun appareil trouvé sur votre réseau.",
     "searching": "Recherche d'appareils…",
     "chromecast_row": "Chromecast…",
+    "disconnect_row": "Se déconnecter",
     "owned_by": "Appareil de {{username}}",
     "error_cast_select_failed": "Impossible de se connecter à ce Chromecast.",
     "error_command_failed": "Impossible de joindre cet appareil.",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2416,6 +2416,7 @@
     "empty_state": "Nessun dispositivo trovato sulla rete.",
     "searching": "Ricerca dispositivi…",
     "chromecast_row": "Chromecast…",
+    "disconnect_row": "Disconnetti",
     "owned_by": "Dispositivo di {{username}}",
     "error_cast_select_failed": "Impossibile connettersi a quel Chromecast.",
     "error_command_failed": "Impossibile raggiungere quel dispositivo.",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2416,6 +2416,7 @@
     "empty_state": "Nenhum dispositivo encontrado na rede.",
     "searching": "A procurar dispositivos…",
     "chromecast_row": "Chromecast…",
+    "disconnect_row": "Desconectar",
     "owned_by": "Dispositivo de {{username}}",
     "error_cast_select_failed": "Não foi possível ligar a esse Chromecast.",
     "error_command_failed": "Não foi possível contactar esse dispositivo.",

--- a/client/src/app/core/services/cast-playback-target.ts
+++ b/client/src/app/core/services/cast-playback-target.ts
@@ -147,12 +147,17 @@ export class CastPlaybackTarget implements PlaybackTarget {
     });
   }
 
+  /** Stop the media but stay on the device: the session outlives it, and the
+   *  top-bar chip is how you come back to it. */
   stopPlayback(): void {
-    this.disconnect();
+    this.cast.stop();
+    this.cp.clear();
+    this.cp.expanded.set(false);
   }
 
+  /** Leave the device. Ends the Cast session, which stops the receiver with it. */
   disconnect(): void {
-    this.cast.stop();
+    this.cast.disconnect();
     this.cp.clear();
     this.cp.expanded.set(false);
   }

--- a/client/src/app/core/services/cast.service.ts
+++ b/client/src/app/core/services/cast.service.ts
@@ -82,7 +82,7 @@ interface NativeCastPlugin {
   requestSession(): Promise<void>;
   /** Native-only device enumeration + selection backing the unified picker
    *  (`shared/remote-picker`): the web Cast SDK has no equivalent. */
-  getCastDevices(): Promise<{ devices: { id: string; name: string; modelName?: string }[] }>;
+  getCastDevices(): Promise<{ devices: CastDevice[] }>;
   selectCastDevice(opts: { id: string }): Promise<void>;
   loadMedia(opts: NativeCastLoadOpts): Promise<void>;
   play(): Promise<void>;
@@ -96,6 +96,15 @@ interface NativeCastPlugin {
    *  volume, not the phone's — the OS volume keys already do the latter. */
   setVolume(opts: { level: number }): Promise<void>;
   setMuted(opts: { muted: boolean }): Promise<void>;
+}
+
+/** One row of native discovery. `connected` marks the device this sender is
+ *  casting to, so the picker can offer to leave it. */
+export interface CastDevice {
+  id: string;
+  name: string;
+  modelName?: string;
+  connected?: boolean;
 }
 
 const NativeCast = registerPlugin<NativeCastPlugin>('NativeCast');
@@ -141,7 +150,7 @@ export class CastService implements OnDestroy {
   readonly castStreamBaseUrl = signal('');
   /** Cast devices visible to native discovery. Always empty on web: the
    *  Chrome Cast SDK exposes no enumeration API (see getCastDevices()). */
-  readonly castDevices = signal<{ id: string; name: string; modelName?: string }[]>([]);
+  readonly castDevices = signal<CastDevice[]>([]);
 
   // ── Seek coalescing (see CAST_SEEK_* above) ──
   private seekCoalesceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -203,6 +212,9 @@ export class CastService implements OnDestroy {
         this.isConnected.set(connected);
         if (connected) this.endConnecting();
         else this.buffering.set(false);
+        // `connected` rides the device listing, so the picker's rows are stale
+        // the moment a session starts or ends.
+        void this.getCastDevices();
       }) as EventListener);
 
       // Picker dismissed without selecting a device
@@ -428,7 +440,7 @@ export class CastService implements OnDestroy {
   /** List Cast devices visible to native discovery. Web has no enumeration
    *  API, so this always resolves empty: the picker shows a single row that
    *  falls back to `requestSession()` there instead. */
-  async getCastDevices(): Promise<{ id: string; name: string; modelName?: string }[]> {
+  async getCastDevices(): Promise<CastDevice[]> {
     if (!this.isNative) return [];
     try {
       const { devices } = await NativeCast.getCastDevices();

--- a/client/src/app/core/services/remote.service.ts
+++ b/client/src/app/core/services/remote.service.ts
@@ -6,6 +6,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { RemoteCommand, RemoteQualityRung, SseService } from './sse.service';
 import { ToastService } from './toast.service';
 import { CastSettingsService } from './cast-settings.service';
+import { CastService } from './cast.service';
 
 export type RemoteAction = RemoteCommand['action'];
 
@@ -92,6 +93,7 @@ export class RemoteService {
   private readonly router = inject(Router);
   private readonly toast = inject(ToastService);
   private readonly castSettings = inject(CastSettingsService);
+  private readonly cast = inject(CastService);
   private readonly translate = inject(TranslateService);
 
   // ── Controllee ──
@@ -382,6 +384,10 @@ export class RemoteService {
   }
 
   selectTarget(targetId: string | null): void {
+    // One destination at a time: the control card reads whichever is active and
+    // prefers a remote target, so a Cast session left running behind one would
+    // keep playing with nothing on screen able to reach it.
+    if (targetId && this.cast.isConnected()) this.cast.disconnect();
     this.selectedTargetId.set(targetId);
     this.reportedState.set(null);
     this.targetOffline.set(false);

--- a/client/src/app/shared/remote-picker/remote-picker.ts
+++ b/client/src/app/shared/remote-picker/remote-picker.ts
@@ -12,6 +12,7 @@ import {
 } from '@lucide/angular';
 import { DropdownMenuComponent } from '../components/dropdown-menu';
 import { CastService } from '../../core/services/cast.service';
+import { CastPlaybackTarget } from '../../core/services/cast-playback-target';
 import { RemoteService, RemoteTarget } from '../../core/services/remote.service';
 import { ToastService } from '../../core/services/toast.service';
 import { remoteOverlayOpen } from '../../core/services/remote-playback-target';
@@ -25,6 +26,8 @@ interface PickerRow {
   icon: 'tv' | 'tablet' | 'phone' | 'monitor' | 'cast';
   label: string;
   subtitle: string | null;
+  /** Casting to this row already: pressing it leaves the device instead. */
+  connected?: boolean;
 }
 
 /**
@@ -47,6 +50,7 @@ interface PickerRow {
 export class RemotePickerComponent {
   protected readonly remote = inject(RemoteService);
   protected readonly castService = inject(CastService);
+  private readonly castTarget = inject(CastPlaybackTarget);
   private readonly toast = inject(ToastService);
   private readonly translate = inject(TranslateService);
 
@@ -61,16 +65,29 @@ export class RemotePickerComponent {
   protected readonly pickerRows: Signal<PickerRow[]> = computed(() => {
     const rows: PickerRow[] = [];
     if (!this.isNative) {
+      const connected = this.castService.isConnected();
       rows.push({
         kind: 'cast-web',
         id: 'web-chromecast',
         icon: 'cast',
         label: this.translate.instant('remote.chromecast_row'),
-        subtitle: null,
+        subtitle: connected ? this.translate.instant('remote.disconnect_row') : null,
+        connected,
       });
     }
     for (const d of this.castService.castDevices()) {
-      rows.push({ kind: 'cast', id: d.id, icon: 'cast', label: d.name, subtitle: d.modelName ?? null });
+      rows.push({
+        kind: 'cast',
+        id: d.id,
+        icon: 'cast',
+        label: d.name,
+        // The device's own model name is what the row says until we are on it;
+        // then the row's only remaining action is to leave, so it says that.
+        subtitle: d.connected
+          ? this.translate.instant('remote.disconnect_row')
+          : (d.modelName ?? null),
+        connected: d.connected,
+      });
     }
     for (const t of this.remote.targets()) {
       rows.push({
@@ -103,7 +120,18 @@ export class RemotePickerComponent {
   }
 
   selectRow(row: PickerRow): void {
+    // Pressing the device already being cast to is the only way out of a Cast
+    // session: the control card can stop the media but never leaves the device.
+    if (row.connected) {
+      this.castTarget.disconnect();
+      return;
+    }
     this.setLastUsed(row.id);
+    if (row.kind === 'cast' || row.kind === 'cast-web') {
+      // One destination at a time, the same rule `selectTarget` applies the
+      // other way round.
+      this.remote.selectTarget(null);
+    }
     if (row.kind === 'cast') {
       void this.selectCastDevice(row.id);
     } else if (row.kind === 'cast-web') {


### PR DESCRIPTION
Three things, all on the "play on another device" picker.

## You could not leave a Chromecast

Nothing in the UI ended a Cast session. `CastPlaybackTarget.disconnect()` called `cast.stop()` — it stopped the receiver's media and kept the session — and it is not even rendered for Cast (`canStopControlling` is false), so the session outlived every gesture available. Only the app's own death ended it.

Pressing the device you are already casting to now leaves it: the same shape as the remote card's "stop controlling", in the place you already go to switch destination. `disconnect()` now actually ends the session; `stopPlayback()` keeps its old meaning (stop the media, stay on the device) so the control card's "Arrêter la lecture" is unchanged.

## The row said "Fliks"

The subtitle came from `MediaRouter.RouteInfo.getDescription()`, which the framework turns into the name of whatever receiver is running — so once casting, the row described our own app instead of the device. It now comes from `CastDevice.getModelName()` ("Chromecast"), and while connected the row says **Se déconnecter**, since leaving is the only action it has left. `getCastDevices` reports which row that is, taken from the selected route and only while a session actually stands behind it.

## Cast and a remote target could both be live

The control card reads whichever destination is active and prefers the remote one, so a Cast session running behind a selected target kept playing with nothing on screen able to reach it. `selectTarget` now ends any Cast session, and the picker drops the target before connecting — the invariant holds from both sides, in the two places a destination is actually established, rather than at each call site.

Note the picker is replaced by the destination chip while a target is selected, so the remote-to-cast direction is only reachable once that target goes offline (the picker returns, `isRemoting()` still true). The guard covers it; that state was not staged on device.

## Verification

On an **SM-S931B** over adb:

| | result |
|---|---|
| picker while idle | `Salon` / **Chromecast** (model, though the Fliks receiver was still running) |
| connect, reopen picker | `Salon` / **Se déconnecter** |
| tap the connected row | `stopApplication 66BF4DAE`, `onApplicationDisconnected SUCCESS`, route unselected; icon back to idle |
| reopen after that | subtitle back to **Chromecast** |
| pick the remote target while casting | session torn down first, topbar switches to the remote chip |

`ng build`, spec typecheck, `remote.service.spec` (18) and `layout.spec` (10) green.
