### PR TITLE
fix(remote-picker): accent the cast row only while casting, and pin it on top

### DIFF
--- a/client/src/app/shared/remote-picker/remote-picker.html
+++ b/client/src/app/shared/remote-picker/remote-picker.html
@@ -42,7 +42,9 @@
   @for (row of pickerRows(); track row.kind + row.id) {
     <button type="button" class="dropdown-item text-white" (click)="selectRow(row)">
       @if (row.icon === 'cast') {
-        <svg lucideCast class="h-5 w-5 shrink-0 text-info"></svg>
+        <!-- Accented only for the device actually being cast to: on every row it
+             read as a state the list does not have. -->
+        <svg lucideCast class="h-5 w-5 shrink-0" [class.text-info]="row.connected"></svg>
       } @else if (row.icon === 'tv') {
         <svg lucideTv class="h-5 w-5 shrink-0"></svg>
       } @else if (row.icon === 'tablet') {

--- a/client/src/app/shared/remote-picker/remote-picker.ts
+++ b/client/src/app/shared/remote-picker/remote-picker.ts
@@ -100,14 +100,12 @@ export class RemotePickerComponent {
           : null,
       });
     }
+    // Cast devices pinned above the remote targets, last-used first inside each
+    // group. The sort is stable, so rows that tie keep discovery order.
     const last = this.lastUsedId();
-    if (last) {
-      rows.sort((a, b) => {
-        if (a.kind === 'cast-web') return -1;
-        if (b.kind === 'cast-web') return 1;
-        return a.id === last ? -1 : b.id === last ? 1 : 0;
-      });
-    }
+    const group = (r: PickerRow) => (r.kind === 'remote' ? 1 : 0);
+    const recent = (r: PickerRow) => (r.id === last ? 0 : 1);
+    rows.sort((a, b) => group(a) - group(b) || recent(a) - recent(b));
     return rows;
   });
 


### PR DESCRIPTION
Two picker tweaks.

**The accent meant nothing.** The cast glyph was `text-info` on every Chromecast row, so the colour read as a state the list does not carry. It now marks the device actually being cast to — the same thing the accent means on the top-bar trigger.

**Cast pinned on top.** Cast devices now sort above the remote targets instead of competing with last-used for first place; the web `cast-web` row was already special-cased to the top and this generalises it. Last-used still wins inside each group, and the sort is stable so ties keep discovery order.

## Verification

On an **SM-S931B**, with the remote target as the last-used row (so the old sort would have put it first):

| | result |
|---|---|
| idle | `Salon / Chromecast` first, glyph neutral; `Chrome sur Linux` below |
| connected | `Salon / Se déconnecter` first, glyph accented |

`ng build` green.
