### PR TITLE
feat(post-import): build sprites and markers when new files land

### DIFF
--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -546,6 +546,14 @@ export class DiskImportService {
           );
         }
       }
+      // The reorganize branch above emits this from LibraryIngestService.
+      if (linked > 0) {
+        this.events.emitDomain({
+          type: 'media.files.imported',
+          mediaId: media.id,
+          source: 'disk',
+        });
+      }
     }
 
     // Backfill metadata for any season/episode slot invented while linking.

--- a/backend/src/modules/markers/markers.service.ts
+++ b/backend/src/modules/markers/markers.service.ts
@@ -3,12 +3,9 @@ import {
   Injectable,
   Logger,
   NotFoundException,
-  OnModuleDestroy,
-  OnModuleInit,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { Subscription } from 'rxjs';
 import { EpisodeMarker, MarkerType } from './entities/episode-marker.entity';
 import { Episode } from '../media/entities/episode.entity';
 import { Season } from '../media/entities/season.entity';
@@ -20,9 +17,8 @@ import { CreateMarkerDto } from './dto/create-marker.dto';
 import { UpdateMarkerDto } from './dto/update-marker.dto';
 
 @Injectable()
-export class MarkersService implements OnModuleInit, OnModuleDestroy {
+export class MarkersService {
   private readonly log = new Logger(MarkersService.name);
-  private rescanSub?: Subscription;
   /** Seasons currently being processed — guards against duplicate enqueues. */
   private readonly inFlight = new Set<number>();
 
@@ -39,23 +35,6 @@ export class MarkersService implements OnModuleInit, OnModuleDestroy {
     private readonly settings: SettingsService,
     private readonly detector: IntroDetectionService,
   ) {}
-
-  onModuleInit() {
-    // Auto-detect intros after a series rescan brings in new episode files.
-    this.rescanSub = this.events.subscribe((event) => {
-      if (event.type !== 'rescan.completed') return;
-      if (event.added <= 0) return;
-      void this.maybeAutoDetect(event.mediaId).catch((err) =>
-        this.log.warn(
-          `auto intro detection failed for media #${event.mediaId}: ${(err as Error).message}`,
-        ),
-      );
-    });
-  }
-
-  onModuleDestroy() {
-    this.rescanSub?.unsubscribe();
-  }
 
   // ─────────────────────────────────────────────────────────────────────────
   // Reads
@@ -186,49 +165,42 @@ export class MarkersService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
-   * Return the list of seasons eligible for automatic marker detection
-   * (non-special, belonging to a series). When `onlyMissing` is true, returns
-   * only seasons with at least one episode lacking an intro OR outro marker.
+   * Seasons eligible for automatic marker detection (non-special, belonging
+   * to a series). `onlyMissing` keeps those with at least one unscanned
+   * episode on disk; `mediaId` narrows the sweep to a single title.
    */
   async listSeasonsForScan(
     onlyMissing: boolean,
+    mediaId?: number,
   ): Promise<
     { id: number; mediaId: number; seasonNumber: number; mediaTitle: string }[]
   > {
-    if (!onlyMissing) {
-      const rows: {
-        id: number;
-        mediaId: number;
-        seasonNumber: number;
-        mediaTitle: string;
-      }[] = await this.seasonRepo.query(`
-        SELECT s.id, s."mediaId", s."seasonNumber", m.title AS "mediaTitle"
-        FROM seasons s
-        JOIN media m ON m.id = s."mediaId"
-        WHERE s."seasonNumber" > 0 AND m.type = 'series'
-        ORDER BY m.title ASC, s."seasonNumber" ASC
-      `);
-      return rows;
+    const clauses = [`s."seasonNumber" > 0`, `m.type = 'series'`];
+    const params: unknown[] = [];
+    if (mediaId != null) {
+      params.push(mediaId);
+      clauses.push(`s."mediaId" = $${params.length}`);
     }
-    const rows: {
-      id: number;
-      mediaId: number;
-      seasonNumber: number;
-      mediaTitle: string;
-    }[] = await this.seasonRepo.query(`
-      SELECT s.id, s."mediaId", s."seasonNumber", m.title AS "mediaTitle"
-      FROM seasons s
-      JOIN media m ON m.id = s."mediaId"
-      WHERE s."seasonNumber" > 0 AND m.type = 'series'
-        AND EXISTS (
+    if (onlyMissing) {
+      clauses.push(`EXISTS (
           SELECT 1 FROM episodes e
           WHERE e."seasonId" = s.id
             AND e."hasFile" = true
             AND e."markersScannedAt" IS NULL
-        )
+        )`);
+    }
+    return this.seasonRepo.query(
+      `
+      SELECT s.id, s."mediaId", s."seasonNumber", m.title AS "mediaTitle"
+      FROM seasons s
+      JOIN media m ON m.id = s."mediaId"
+      WHERE ${clauses.join(' AND ')}
       ORDER BY m.title ASC, s."seasonNumber" ASC
-    `);
-    return rows;
+    `,
+      params,
+    ) as Promise<
+      { id: number; mediaId: number; seasonNumber: number; mediaTitle: string }[]
+    >;
   }
 
   /**
@@ -366,16 +338,16 @@ export class MarkersService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  private async maybeAutoDetect(mediaId: number): Promise<void> {
+  /**
+   * Detect markers for the seasons of `mediaId` that still hold an unscanned
+   * episode. Enqueued as commands so the run shows up in the task list.
+   */
+  async autoDetectMissing(mediaId: number): Promise<void> {
     const enabled =
-      (await this.settings.get('enableAutoIntroDetection')) ?? 'true';
+      (await this.settings.get('markers_auto_detect_on_import')) ?? 'true';
     if (enabled !== 'true') return;
-    // Only series have seasons; movies skipped naturally because findOne
-    // below returns no seasons.
-    const seasons = await this.seasonRepo.find({
-      where: { media: { id: mediaId } },
-    });
-    for (const s of seasons.filter((x) => x.seasonNumber > 0)) {
+    const seasons = await this.listSeasonsForScan(true, mediaId);
+    for (const s of seasons) {
       try {
         await this.detectSeason(s.id, 'auto');
       } catch (err) {

--- a/backend/src/modules/media/media-service/media-mutation.service.spec.ts
+++ b/backend/src/modules/media/media-service/media-mutation.service.spec.ts
@@ -85,6 +85,7 @@ describe('MediaMutationService monitoring cascade', () => {
       metadata as never,
       requestLifecycle as never,
       { emitDomain: jest.fn() } as never,
+      { deleteForFile: jest.fn() } as never,
     );
   });
 
@@ -186,6 +187,7 @@ describe('MediaMutationService remove disk cleanup', () => {
       {} as never,
       requestLifecycle as never,
       { emitDomain: jest.fn() } as never,
+      { deleteForFile: jest.fn() } as never,
     );
   });
 

--- a/backend/src/modules/media/media-service/media-mutation.service.ts
+++ b/backend/src/modules/media/media-service/media-mutation.service.ts
@@ -26,6 +26,7 @@ import { EventsService } from '../../scheduler/events.service';
 import { RequestLifecycleService } from '../../requests/request-lifecycle.service';
 import { MediaQueryService } from './media-query.service';
 import { MediaMetadataService } from './media-metadata.service';
+import { ThumbnailService } from '../../streaming/thumbnail.service';
 
 @Injectable()
 export class MediaMutationService {
@@ -49,6 +50,7 @@ export class MediaMutationService {
     @Inject(forwardRef(() => RequestLifecycleService))
     private readonly requestLifecycle: RequestLifecycleService,
     private readonly events: EventsService,
+    private readonly thumbnails: ThumbnailService,
   ) {}
 
   async update(id: number, dto: UpdateMediaDto): Promise<Media> {
@@ -215,8 +217,12 @@ export class MediaMutationService {
     const tmdbId = media.tmdbId;
     const mediaType = media.type;
     const diskPath = this.resolveSafeMediaDir(media);
+    // Sprites live outside the media folder, keyed by file id — the cascade
+    // that drops the file rows would strand them.
+    const fileIds = (media.files ?? []).map((f) => f.id);
     await this.requestLifecycle.onMediaRemoved(media);
     await this.mediaRepo.remove(media);
+    for (const fileId of fileIds) void this.thumbnails.deleteForFile(fileId);
     this.events.emitDomain({
       type: 'media.removed',
       mediaId: id,
@@ -345,6 +351,7 @@ export class MediaMutationService {
 
     const episodeId = file.episodeId;
     await this.mediaFileRepo.remove(file);
+    void this.thumbnails.deleteForFile(file.id);
     if (episodeId != null) {
       const remaining = await this.mediaFileRepo.count({
         where: { episode: { id: episodeId } },

--- a/backend/src/modules/media/media-service/media-rescan.service.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.ts
@@ -499,6 +499,7 @@ export class MediaRescanService {
         const episodeId = dbFile.episodeId;
         try {
           await this.mediaFileRepo.remove(dbFile);
+          void this.thumbnailService.deleteForFile(dbFile.id);
           removed++;
           this.log.log(
             `Rescan: removed missing file "${normPath}" for media #${mediaId}`,

--- a/backend/src/modules/scheduler/post-import.service.spec.ts
+++ b/backend/src/modules/scheduler/post-import.service.spec.ts
@@ -1,0 +1,144 @@
+import { existsSync } from 'fs';
+import { Subject } from 'rxjs';
+import { PostImportService } from './post-import.service';
+import type { DomainEvent, SseEvent } from './events.service';
+
+jest.mock('fs', () => ({
+  ...(jest.requireActual('fs') as object),
+  existsSync: jest.fn(),
+}));
+
+const hasSprite = existsSync as jest.MockedFunction<typeof existsSync>;
+
+/** Let the (timer-free) post-import promise chain run to completion. */
+const settle = async () => {
+  for (let i = 0; i < 10; i++) await new Promise(process.nextTick);
+};
+
+function harness() {
+  const domain = new Subject<DomainEvent>();
+  const sse = new Subject<SseEvent>();
+  const files = [{ id: 1 }, { id: 2 }];
+  const mediaFileRepo = {
+    find: jest.fn().mockResolvedValue(files),
+    findOne: jest.fn().mockImplementation(({ where }: { where: { id: number } }) =>
+      Promise.resolve({
+        id: where.id,
+        relativePath: `f${where.id}.mkv`,
+        episodeId: null,
+        media: { path: '/lib/show', title: 'Placeholder Show' },
+      }),
+    ),
+  };
+  const episodeRepo = { findOne: jest.fn() };
+  const events = {
+    onDomain: (h: (e: DomainEvent) => void) => domain.subscribe(h),
+    subscribe: (h: (e: SseEvent) => void) => sse.subscribe(h),
+    emit: jest.fn(),
+  };
+  const thumbnails = {
+    getMetadataPath: (id: number) => `/cache/${id}/sprite.json`,
+    generateForFile: jest.fn().mockResolvedValue({ interval: 5 }),
+  };
+  const markers = { autoDetectMissing: jest.fn().mockResolvedValue(undefined) };
+  const settings = { get: jest.fn().mockResolvedValue(null) };
+  const service = new PostImportService(
+    mediaFileRepo as never,
+    episodeRepo as never,
+    events as never,
+    thumbnails as never,
+    markers as never,
+    settings as never,
+  );
+  service.onModuleInit();
+  return { service, domain, sse, events, mediaFileRepo, thumbnails, markers, settings };
+}
+
+describe('PostImportService', () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+    hasSprite.mockReturnValue(false);
+  });
+  afterEach(() => jest.useRealTimers());
+
+  it('generates the missing sprites and detects markers after an import settles', async () => {
+    const h = harness();
+
+    h.domain.next({ type: 'media.files.imported', mediaId: 7, source: 'download' });
+    expect(h.thumbnails.generateForFile).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(PostImportService.SETTLE_MS);
+    await settle();
+
+    expect(h.thumbnails.generateForFile).toHaveBeenCalledTimes(2);
+    expect(h.markers.autoDetectMissing).toHaveBeenCalledWith(7);
+    h.service.onModuleDestroy();
+  });
+
+  it('skips files that already have a sprite on disk', async () => {
+    const h = harness();
+    hasSprite.mockImplementation((p) => String(p).includes('/1/'));
+
+    h.sse.next({ type: 'rescan.completed', mediaId: 7, title: 't', added: 1, removed: 0, updated: 0 });
+    jest.advanceTimersByTime(PostImportService.SETTLE_MS);
+    await settle();
+
+    expect(h.thumbnails.generateForFile).toHaveBeenCalledTimes(1);
+    expect(h.thumbnails.generateForFile.mock.calls[0][0]).toMatchObject({ id: 2 });
+    h.service.onModuleDestroy();
+  });
+
+  it('coalesces an import wave into a single pass per media', async () => {
+    const h = harness();
+
+    for (const episodeNumber of [1, 2, 3]) {
+      h.domain.next({ type: 'media.files.imported', mediaId: 7, seasonNumber: 1, episodeNumber, source: 'download' });
+      jest.advanceTimersByTime(PostImportService.SETTLE_MS / 2);
+    }
+    jest.advanceTimersByTime(PostImportService.SETTLE_MS);
+    await settle();
+
+    expect(h.mediaFileRepo.find).toHaveBeenCalledTimes(1);
+    expect(h.markers.autoDetectMissing).toHaveBeenCalledTimes(1);
+    h.service.onModuleDestroy();
+  });
+
+  it('skips sprite generation when the toggle is off, markers still run', async () => {
+    const h = harness();
+    h.settings.get.mockImplementation((key: string) =>
+      Promise.resolve(key === 'sprites_auto_generate_on_import' ? 'false' : null),
+    );
+
+    h.domain.next({ type: 'media.files.imported', mediaId: 7, source: 'download' });
+    jest.advanceTimersByTime(PostImportService.SETTLE_MS);
+    await settle();
+
+    expect(h.thumbnails.generateForFile).not.toHaveBeenCalled();
+    expect(h.markers.autoDetectMissing).toHaveBeenCalledWith(7);
+    h.service.onModuleDestroy();
+  });
+
+  it('reports progress under the bulk sprite command scoped to the media', async () => {
+    const h = harness();
+
+    h.domain.next({ type: 'media.files.imported', mediaId: 7, source: 'download' });
+    jest.advanceTimersByTime(PostImportService.SETTLE_MS);
+    await settle();
+
+    const commands = h.events.emit.mock.calls.map((c) => c[0].command);
+    expect(new Set(commands)).toEqual(new Set(['GenerateMissingSprites:7']));
+    const last = h.events.emit.mock.calls.at(-1)![0];
+    expect(last.current).toBe(last.total);
+    h.service.onModuleDestroy();
+  });
+
+  it('does not fire a pass for a rescan that added nothing', () => {
+    const h = harness();
+
+    h.sse.next({ type: 'rescan.completed', mediaId: 7, title: 't', added: 0, removed: 2, updated: 0 });
+    jest.advanceTimersByTime(PostImportService.SETTLE_MS);
+
+    expect(h.mediaFileRepo.find).not.toHaveBeenCalled();
+    h.service.onModuleDestroy();
+  });
+});

--- a/backend/src/modules/scheduler/post-import.service.ts
+++ b/backend/src/modules/scheduler/post-import.service.ts
@@ -1,0 +1,176 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Subscription } from 'rxjs';
+import { existsSync } from 'fs';
+import { MediaFile } from '../media/entities/media-file.entity';
+import { Episode } from '../media/entities/episode.entity';
+import { EventsService } from './events.service';
+import {
+  ThumbnailService,
+  buildSpriteLabel,
+  type SpriteMetadata,
+} from '../streaming/thumbnail.service';
+import { MarkersService } from '../markers/markers.service';
+import { SettingsService } from '../settings/settings.service';
+
+/**
+ * Derived artefacts every newly landed file needs before playback: seek
+ * sprites and intro/outro markers. Driven by events so plugin downloads,
+ * disk imports and rescans all reach it through the same path.
+ */
+@Injectable()
+export class PostImportService implements OnModuleInit, OnModuleDestroy {
+  private readonly log = new Logger(PostImportService.name);
+  private readonly subs = new Subscription();
+
+  /** An import wave lands file by file — wait for it to settle so a season
+   *  pack costs one marker scan instead of one per episode. */
+  static readonly SETTLE_MS = 60_000;
+  private readonly pending = new Map<number, NodeJS.Timeout>();
+
+  constructor(
+    @InjectRepository(MediaFile)
+    private readonly mediaFileRepo: Repository<MediaFile>,
+    @InjectRepository(Episode)
+    private readonly episodeRepo: Repository<Episode>,
+    private readonly events: EventsService,
+    private readonly thumbnails: ThumbnailService,
+    private readonly markers: MarkersService,
+    private readonly settings: SettingsService,
+  ) {}
+
+  onModuleInit(): void {
+    this.subs.add(
+      this.events.onDomain((event) => {
+        if (event.type === 'media.files.imported') this.schedule(event.mediaId);
+      }),
+    );
+    this.subs.add(
+      this.events.subscribe((event) => {
+        if (event.type === 'rescan.completed' && event.added > 0) {
+          this.schedule(event.mediaId);
+        }
+      }),
+    );
+  }
+
+  onModuleDestroy(): void {
+    for (const timer of this.pending.values()) clearTimeout(timer);
+    this.pending.clear();
+    this.subs.unsubscribe();
+  }
+
+  private schedule(mediaId: number): void {
+    const queued = this.pending.get(mediaId);
+    if (queued) clearTimeout(queued);
+    this.pending.set(
+      mediaId,
+      setTimeout(() => {
+        this.pending.delete(mediaId);
+        void this.run(mediaId);
+      }, PostImportService.SETTLE_MS),
+    );
+  }
+
+  /** Sprites first: they are per-file and cheap next to a season-wide
+   *  fingerprint pass, and both compete for the same ffmpeg budget. */
+  private async run(mediaId: number): Promise<void> {
+    if (await this.enabled('sprites_auto_generate_on_import')) {
+      try {
+        const generated = await this.generateMissingSprites(mediaId);
+        if (generated) {
+          this.log.log(
+            `Post-import[media #${mediaId}]: generated ${generated} sprite(s)`,
+          );
+        }
+      } catch (err) {
+        this.log.warn(
+          `Post-import[media #${mediaId}]: sprite generation failed — ${(err as Error).message}`,
+        );
+      }
+    }
+    try {
+      await this.markers.autoDetectMissing(mediaId);
+    } catch (err) {
+      this.log.warn(
+        `Post-import[media #${mediaId}]: marker detection failed — ${(err as Error).message}`,
+      );
+    }
+  }
+
+  /** Both automation toggles default to on when the key was never written. */
+  private async enabled(key: string): Promise<boolean> {
+    return ((await this.settings.get(key)) ?? 'true') === 'true';
+  }
+
+  /**
+   * Sprites are tracked as progress rather than `Command` rows: the table is
+   * never pruned, and a first library import would leave one row per file.
+   */
+  private async generateMissingSprites(mediaId: number): Promise<number> {
+    const files = await this.mediaFileRepo.find({
+      where: { media: { id: mediaId } },
+      select: { id: true },
+    });
+    const missing = files.filter(
+      ({ id }) => !existsSync(this.thumbnails.getMetadataPath(id)),
+    );
+    if (!missing.length) return 0;
+
+    const command = `GenerateMissingSprites:${mediaId}`;
+    let generated = 0;
+    for (const [index, { id }] of missing.entries()) {
+      this.events.emit({
+        type: 'task.progress',
+        command,
+        current: index,
+        total: missing.length,
+        message: `#${id}`,
+      });
+      if (await this.generateSprite(id, false)) generated++;
+    }
+    this.events.emit({
+      type: 'task.progress',
+      command,
+      current: missing.length,
+      total: missing.length,
+      message: command,
+    });
+    return generated;
+  }
+
+  /**
+   * Resolve the file's absolute path + sprite label from its own rows and
+   * queue generation. Shared with the bulk scheduler commands.
+   */
+  async generateSprite(
+    mediaFileId: number,
+    force: boolean,
+  ): Promise<SpriteMetadata | null> {
+    const file = await this.mediaFileRepo.findOne({
+      where: { id: mediaFileId },
+      relations: ['media'],
+    });
+    if (!file?.media) return null;
+
+    let label = file.media.title;
+    if (file.episodeId) {
+      const ep = await this.episodeRepo.findOne({
+        where: { id: file.episodeId },
+        relations: ['season'],
+      });
+      if (ep) {
+        label = buildSpriteLabel(file.media, {
+          seasonNumber: ep.season?.seasonNumber,
+          episodeNumber: ep.episodeNumber,
+          title: ep.title,
+        });
+      }
+    }
+    return this.thumbnails.generateForFile(file, file.media, label, {
+      force,
+      skipTracking: true,
+    });
+  }
+}

--- a/backend/src/modules/scheduler/scheduler.module.ts
+++ b/backend/src/modules/scheduler/scheduler.module.ts
@@ -19,6 +19,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
 import { MediaModule } from '../media/media.module';
 import { AuthModule } from '../auth/auth.module';
 import { SubtitleSchedulerService } from './subtitle-scheduler.service';
+import { PostImportService } from './post-import.service';
 import { SubtitlesModule } from '../subtitles/subtitles.module';
 import { SettingsModule } from '../settings/settings.module';
 import { MediaServersModule } from '../media-servers/media-servers.module';
@@ -63,6 +64,7 @@ import { ScheduledJobRegistryModule } from './scheduled-job-registry.module';
     BackupService,
     UpdateCheckService,
     SubtitleSchedulerService,
+    PostImportService,
   ],
   exports: [
     SchedulerService,

--- a/backend/src/modules/scheduler/scheduler.service.spec.ts
+++ b/backend/src/modules/scheduler/scheduler.service.spec.ts
@@ -31,6 +31,7 @@ function makeService(pluginJobs: ReturnType<typeof fakePluginJobs>, jobRegistry:
     jobRegistry as unknown as ScheduledJobRegistry,
     unused,
     unused,
+    unused,
   );
 }
 

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -21,11 +21,9 @@ import { ConfigService } from '@nestjs/config';
 import { SubtitleSchedulerService } from './subtitle-scheduler.service';
 import { EventsService } from './events.service';
 import { MediaFile } from '../media/entities/media-file.entity';
-import {
-  ThumbnailService,
-  buildSpriteLabel,
-} from '../streaming/thumbnail.service';
+import { ThumbnailService } from '../streaming/thumbnail.service';
 import { MarkersService } from '../markers/markers.service';
+import { PostImportService } from './post-import.service';
 import { CORE_TRIGGER_ONLY_JOB_NAMES, CoreSchedulerJobName, PLUGIN_SOURCE_REFRESH_CRON } from '../../common/constants/core-scheduler-jobs';
 import { PluginJobsService } from '../plugins/plugin-jobs.service';
 import { ScheduledJobRegistry } from './scheduled-job-registry.service';
@@ -60,6 +58,7 @@ export class SchedulerService implements OnModuleInit {
     private readonly jobRegistry: ScheduledJobRegistry,
     private readonly catalogClient: PluginCatalogClientService,
     private readonly pluginAutoUpdate: PluginAutoUpdateService,
+    private readonly postImport: PostImportService,
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -426,36 +425,7 @@ export class SchedulerService implements OnModuleInit {
 
       const promises = batch.map(async ({ id }) => {
         try {
-          const file = await this.mediaFileRepo.findOne({
-            where: { id },
-            relations: ['media'],
-          });
-          if (!file?.media) return null;
-
-          let label = file.media.title;
-          if (file.episodeId) {
-            const ep = await this.episodeRepo.findOne({
-              where: { id: file.episodeId },
-              relations: ['season'],
-            });
-            if (ep) {
-              label = buildSpriteLabel(
-                { title: ep.title ?? '' },
-                {
-                  seasonNumber: ep.season.seasonNumber,
-                  episodeNumber: ep.episodeNumber,
-                  title: ep.title,
-                },
-              );
-            }
-          }
-
-          return this.thumbnailService.generateForFile(
-            file,
-            file.media,
-            label,
-            { force, skipTracking: true },
-          );
+          return await this.postImport.generateSprite(id, force);
         } catch (e) {
           this.log.warn(
             `${commandName}: failed for file ${id}: ${(e as Error).message}`,

--- a/backend/src/modules/settings/entities/app-setting.entity.ts
+++ b/backend/src/modules/settings/entities/app-setting.entity.ts
@@ -14,6 +14,8 @@ import { BaseEntity } from '../../../common/entities/base.entity';
  *   naming_season_folder_format — e.g. "Season {season:00}"
  *   companion_file_extensions — comma-separated list, e.g. ".nfo,.srt,.jpg"
  *   search_missing_auto   — "true" | "false"
+ *   markers_auto_detect_on_import — "true" | "false" (intro/outro detection after an import)
+ *   sprites_auto_generate_on_import — "true" | "false" (seek sprites after an import)
  *   rss_sync_interval     — minutes, e.g. "15"
  *   streaming_auto_quality_mode — "directplay" | "abr" (how "Auto" quality resolves)
  *   subtitle_translation_enabled — "true" | "false" (machine translation)

--- a/backend/src/modules/streaming/thumbnail.service.ts
+++ b/backend/src/modules/streaming/thumbnail.service.ts
@@ -217,6 +217,19 @@ export class ThumbnailService {
     }
   }
 
+  /** Drop a file's sprite + metadata. Nothing regenerates them from an id
+   *  that no longer exists, so a removed file would leak its sheet forever. */
+  async deleteForFile(mediaFileId: number): Promise<void> {
+    const dir = path.join(baseDir(), String(mediaFileId));
+    try {
+      await fsp.rm(dir, { recursive: true, force: true });
+    } catch (err) {
+      this.log.warn(
+        `Sprite cleanup failed for file #${mediaFileId}: ${(err as Error).message}`,
+      );
+    }
+  }
+
   private processQueue(): void {
     while (this.running < SPRITE_CONCURRENCY && this.queue.length > 0) {
       const item = this.queue.shift()!;

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1587,16 +1587,14 @@
       "metadata_region_hint": "Region für Veröffentlichungsdaten und kommende Veröffentlichungen. Kann pro Bibliothek überschrieben werden.",
       "section_automation": "Automatisierung",
       "auto_detect_markers_on_import": "Intros / Vorspanne beim Import von Serien erkennen",
+      "auto_generate_sprites_on_import": "Vorschaubilder für die Zeitleiste beim Import erzeugen",
+      "auto_generate_sprites_on_import_hint": "Ein Dekodierdurchlauf pro Datei. Auf einem schwachen Server deaktivieren und die Aufgabe manuell starten.",
       "saved": "Einstellungen gespeichert.",
       "save_error": "Speichern nicht möglich.",
       "load_error": "Die Einstellungen konnten nicht geladen werden.",
       "no_default": "Keiner (manuelle Auswahl)",
       "companion_extensions": "Erweiterungen der Begleitdateien",
-      "companion_extensions_hint": "Mit der Videodatei kopierte Erweiterungen (durch Kommas getrennt).",
-      "section_post_import": "Post-Import",
-      "post_import_script": "Post-Import-Skript",
-      "post_import_script_hint": "/path/to/script.sh",
-      "post_import_script_vars": "Variablen: FLIKS_MEDIA_TITLE, FLIKS_MEDIA_ID, FLIKS_MEDIA_TYPE, FLIKS_QUALITY, FLIKS_FILE_COUNT, FLIKS_SOURCE_TITLE"
+      "companion_extensions_hint": "Mit der Videodatei kopierte Erweiterungen (durch Kommas getrennt)."
     },
     "quality_profiles": {
       "title": "Qualitätsprofile",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1597,16 +1597,14 @@
       "metadata_region_hint": "Region used for release dates and upcoming releases. Can be overridden per library.",
       "section_automation": "Automation",
       "auto_detect_markers_on_import": "Detect intros / credits when importing series",
+      "auto_generate_sprites_on_import": "Generate seek thumbnails when importing",
+      "auto_generate_sprites_on_import_hint": "One decoding pass per file. Turn it off on a low-power server and run the task manually.",
       "saved": "Settings saved.",
       "save_error": "Unable to save.",
       "load_error": "Unable to load the settings.",
       "no_default": "None (manual selection)",
       "companion_extensions": "Companion file extensions",
-      "companion_extensions_hint": "Extensions copied with the video file (comma-separated).",
-      "section_post_import": "Post-import",
-      "post_import_script": "Post-import script",
-      "post_import_script_hint": "/path/to/script.sh",
-      "post_import_script_vars": "Variables: FLIKS_MEDIA_TITLE, FLIKS_MEDIA_ID, FLIKS_MEDIA_TYPE, FLIKS_QUALITY, FLIKS_FILE_COUNT, FLIKS_SOURCE_TITLE"
+      "companion_extensions_hint": "Extensions copied with the video file (comma-separated)."
     },
     "quality_profiles": {
       "title": "Quality profiles",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1587,16 +1587,14 @@
       "metadata_region_hint": "Región utilizada para las fechas de estreno y los próximos estrenos. Puede sobrescribirse por biblioteca.",
       "section_automation": "Automatización",
       "auto_detect_markers_on_import": "Detectar las intros / créditos al importar las series",
+      "auto_generate_sprites_on_import": "Generar las miniaturas de navegación al importar",
+      "auto_generate_sprites_on_import_hint": "Una pasada de decodificación por archivo. Desactívalo en un servidor de baja potencia y lanza la tarea manualmente.",
       "saved": "Ajustes guardados.",
       "save_error": "No se puede guardar.",
       "load_error": "No se pueden cargar los ajustes.",
       "no_default": "Ninguno (selección manual)",
       "companion_extensions": "Extensiones de los archivos complementarios",
-      "companion_extensions_hint": "Extensiones copiadas con el archivo de vídeo (separadas por comas).",
-      "section_post_import": "Post-importación",
-      "post_import_script": "Script post-importación",
-      "post_import_script_hint": "/path/to/script.sh",
-      "post_import_script_vars": "Variables: FLIKS_MEDIA_TITLE, FLIKS_MEDIA_ID, FLIKS_MEDIA_TYPE, FLIKS_QUALITY, FLIKS_FILE_COUNT, FLIKS_SOURCE_TITLE"
+      "companion_extensions_hint": "Extensiones copiadas con el archivo de vídeo (separadas por comas)."
     },
     "quality_profiles": {
       "title": "Perfiles de calidad",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1597,16 +1597,14 @@
       "metadata_region_hint": "Région utilisée pour les dates de sortie et les prochaines sorties. Peut être surchargée par bibliothèque.",
       "section_automation": "Automatisation",
       "auto_detect_markers_on_import": "Détecter les intros / génériques à l'import des séries",
+      "auto_generate_sprites_on_import": "Générer les vignettes de navigation à l'import",
+      "auto_generate_sprites_on_import_hint": "Un passage de décodage par fichier. À désactiver sur un serveur peu puissant, puis lancer la tâche manuellement.",
       "saved": "Paramètres enregistrés.",
       "save_error": "Impossible d'enregistrer.",
       "load_error": "Impossible de charger les paramètres.",
       "no_default": "Aucun (sélection manuelle)",
       "companion_extensions": "Extensions des fichiers compagnons",
-      "companion_extensions_hint": "Extensions copiées avec le fichier vidéo (séparées par des virgules).",
-      "section_post_import": "Post-import",
-      "post_import_script": "Script post-import",
-      "post_import_script_hint": "/path/to/script.sh",
-      "post_import_script_vars": "Variables : FLIKS_MEDIA_TITLE, FLIKS_MEDIA_ID, FLIKS_MEDIA_TYPE, FLIKS_QUALITY, FLIKS_FILE_COUNT, FLIKS_SOURCE_TITLE"
+      "companion_extensions_hint": "Extensions copiées avec le fichier vidéo (séparées par des virgules)."
     },
     "quality_profiles": {
       "title": "Profils de qualité",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1587,16 +1587,14 @@
       "metadata_region_hint": "Regione usata per le date di uscita e le prossime uscite. Può essere sovrascritta per libreria.",
       "section_automation": "Automazione",
       "auto_detect_markers_on_import": "Rileva le intro / titoli di testa all'import delle serie",
+      "auto_generate_sprites_on_import": "Genera le miniature di navigazione all'import",
+      "auto_generate_sprites_on_import_hint": "Una passata di decodifica per file. Disattivalo su un server poco potente e avvia l'attività manualmente.",
       "saved": "Impostazioni salvate.",
       "save_error": "Impossibile salvare.",
       "load_error": "Impossibile caricare le impostazioni.",
       "no_default": "Nessuno (selezione manuale)",
       "companion_extensions": "Estensioni dei file compagni",
-      "companion_extensions_hint": "Estensioni copiate con il file video (separate da virgole).",
-      "section_post_import": "Post-import",
-      "post_import_script": "Script post-import",
-      "post_import_script_hint": "/path/to/script.sh",
-      "post_import_script_vars": "Variabili: FLIKS_MEDIA_TITLE, FLIKS_MEDIA_ID, FLIKS_MEDIA_TYPE, FLIKS_QUALITY, FLIKS_FILE_COUNT, FLIKS_SOURCE_TITLE"
+      "companion_extensions_hint": "Estensioni copiate con il file video (separate da virgole)."
     },
     "quality_profiles": {
       "title": "Profili di qualità",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1587,16 +1587,14 @@
       "metadata_region_hint": "Região utilizada para as datas de estreia e as próximas estreias. Pode ser substituída por biblioteca.",
       "section_automation": "Automatização",
       "auto_detect_markers_on_import": "Detetar as intros / genéricos na importação das séries",
+      "auto_generate_sprites_on_import": "Gerar as miniaturas de navegação na importação",
+      "auto_generate_sprites_on_import_hint": "Uma passagem de descodificação por ficheiro. Desative num servidor pouco potente e execute a tarefa manualmente.",
       "saved": "Definições guardadas.",
       "save_error": "Não foi possível guardar.",
       "load_error": "Não foi possível carregar as definições.",
       "no_default": "Nenhum (seleção manual)",
       "companion_extensions": "Extensões dos ficheiros companheiros",
-      "companion_extensions_hint": "Extensões copiadas com o ficheiro de vídeo (separadas por vírgulas).",
-      "section_post_import": "Pós-importação",
-      "post_import_script": "Script pós-importação",
-      "post_import_script_hint": "/path/to/script.sh",
-      "post_import_script_vars": "Variáveis: FLIKS_MEDIA_TITLE, FLIKS_MEDIA_ID, FLIKS_MEDIA_TYPE, FLIKS_QUALITY, FLIKS_FILE_COUNT, FLIKS_SOURCE_TITLE"
+      "companion_extensions_hint": "Extensões copiadas com o ficheiro de vídeo (separadas por vírgulas)."
     },
     "quality_profiles": {
       "title": "Perfis de qualidade",

--- a/client/src/app/features/settings/general/general.html
+++ b/client/src/app/features/settings/general/general.html
@@ -127,6 +127,19 @@
           <span class="label-text">{{ 'settings.general.auto_detect_markers_on_import' | translate }}</span>
         </label>
 
+        <label class="label cursor-pointer justify-start gap-3 max-w-max">
+          <input
+            type="checkbox"
+            class="toggle toggle-sm"
+            [ngModel]="autoGenerateSpritesOnImport() === 'true'"
+            (ngModelChange)="autoGenerateSpritesOnImport.set($event ? 'true' : 'false')"
+          />
+          <span class="label-text">{{ 'settings.general.auto_generate_sprites_on_import' | translate }}</span>
+        </label>
+        <div class="label -mt-2">
+          <span class="label-text-alt text-base-content/50">{{ 'settings.general.auto_generate_sprites_on_import_hint' | translate }}</span>
+        </div>
+
         <label class="form-control w-full">
           <div class="label">
             <span class="label-text">{{ 'settings.general.companion_extensions' | translate }}</span>
@@ -142,28 +155,6 @@
         <div class="card-actions justify-end">
           <button type="button" class="btn btn-primary" (click)="saveAutomation()" [disabled]="savingAutomation()">
             @if (savingAutomation()) { <span class="loading loading-spinner loading-sm"></span> }
-            {{ 'common.save' | translate }}
-          </button>
-        </div>
-      </div>
-    </div>
-
-    <!-- Post-import -->
-    <div class="card bg-base-100 border border-base-200">
-      <div class="card-body gap-5">
-        <h2 class="card-title text-base">{{ 'settings.general.section_post_import' | translate }}</h2>
-
-        <label class="form-control w-full">
-          <span class="label-text">{{ 'settings.general.post_import_script' | translate }}</span>
-          <input type="text" class="input input-bordered input-sm w-full"
-            [ngModel]="postImportScript()" (ngModelChange)="postImportScript.set($event)"
-            [placeholder]="'settings.general.post_import_script_hint' | translate" />
-          <span class="label-text-alt text-base-content/50">{{ 'settings.general.post_import_script_vars' | translate }}</span>
-        </label>
-
-        <div class="card-actions justify-end">
-          <button type="button" class="btn btn-primary" (click)="savePostImport()" [disabled]="savingPostImport()">
-            @if (savingPostImport()) { <span class="loading loading-spinner loading-sm"></span> }
             {{ 'common.save' | translate }}
           </button>
         </div>

--- a/client/src/app/features/settings/general/general.ts
+++ b/client/src/app/features/settings/general/general.ts
@@ -44,12 +44,9 @@ export class GeneralSettingsComponent implements OnInit {
 
   // Automation
   readonly autoDetectMarkersOnImport = signal('true');
+  readonly autoGenerateSpritesOnImport = signal('true');
   readonly companionFileExtensions = signal('');
   readonly savingAutomation = signal(false);
-
-  // Post-import
-  readonly postImportScript = signal('');
-  readonly savingPostImport = signal(false);
 
   async ngOnInit() {
     try {
@@ -59,7 +56,7 @@ export class GeneralSettingsComponent implements OnInit {
       this.metadataLanguage.set(map['metadata_language'] ?? 'en');
       this.metadataRegion.set(map['metadata_region'] ?? 'US');
       this.autoDetectMarkersOnImport.set(map['markers_auto_detect_on_import'] ?? 'true');
-      this.postImportScript.set(map['post_import_script'] ?? '');
+      this.autoGenerateSpritesOnImport.set(map['sprites_auto_generate_on_import'] ?? 'true');
       this.companionFileExtensions.set(
         map['companion_file_extensions'] ??
         '.nfo,.srt,.ass,.ssa,.sub,.idx,.vtt,.sup,.txt,.jpg,.jpeg,.png,.tbn,.nfo-orig',
@@ -98,17 +95,10 @@ export class GeneralSettingsComponent implements OnInit {
     try {
       await this.api.setBulk({
         markers_auto_detect_on_import: this.autoDetectMarkersOnImport(),
+        sprites_auto_generate_on_import: this.autoGenerateSpritesOnImport(),
         companion_file_extensions: this.companionFileExtensions(),
       });
       this.toast.success(this.translate.instant('settings.general.saved'));
     } catch { /* interceptor */ } finally { this.savingAutomation.set(false); }
-  }
-
-  async savePostImport() {
-    this.savingPostImport.set(true);
-    try {
-      await this.api.setBulk({ post_import_script: this.postImportScript() });
-      this.toast.success(this.translate.instant('settings.general.saved'));
-    } catch { /* interceptor */ } finally { this.savingPostImport.set(false); }
   }
 }


### PR DESCRIPTION
## Problem

Seek sprites and intro/outro markers were only ever produced by the trigger-only
`GenerateSprites` / `DetectMarkers` commands. Neither has a cron, and the import pipeline
never called them, so an episode arriving from a download plugin or a disk import stayed
without seek thumbnails and without markers until an admin pressed the buttons by hand.
The `sprite.json` endpoint deliberately refuses to generate on demand, so opening the
player simply showed nothing.

Import only ran ffprobe, cropdetect, the OpenSubtitles hash and the subtitle pipeline.

## What lands

`PostImportService` (scheduler module, which already had `ThumbnailService` and
`MarkersService` wired) reacts to `media.files.imported` and to a `rescan.completed` that
added files, so every path that lands a file reaches the same place:

- a 60 s settle window per media collapses an import wave, so a season pack costs one
  season-wide fingerprint pass instead of one per episode
- sprites first, then markers: both compete for the same ffmpeg budget
- the per-file sprite work moves out of `doGenerateSprites` and is shared with the bulk
  commands, dropping ~30 duplicated lines and a label bug that passed the episode title
  as the media title

Marker detection is scoped to the seasons holding an unscanned episode
(`markersScannedAt IS NULL`) instead of refingerprinting all seasons of the title, and
`listSeasonsForScan` merges its two near-identical queries into one.

## Toggles

Settings > General > Automation:

- **Detect intros / credits when importing** was a dead switch. The UI writes
  `markers_auto_detect_on_import`; the backend read `enableAutoIntroDetection`, a key
  nothing has ever written. The backend now reads the key the UI writes.
- **Generate seek thumbnails when importing** is new (`sprites_auto_generate_on_import`,
  default on), with a hint pointing low-power servers at the manual task. Translated in
  all six locales.

Sprites report `task.progress` under `GenerateMissingSprites:<mediaId>` and keep
`skipTracking: true`: the `commands` table is never pruned, so a row per sprite would grow
without bound on a first library import. The existing progress panel picks the label up
for free (`commandLabelKey` already splits on `:`).

## Two adjacent gaps

- The orphan relink path in disk import created `MediaFile` rows through
  `linkExistingFileInPlace`, bypassing `LibraryIngestService`, so it emitted no import
  event. It emits one now.
- Nothing ever deleted a sprite sheet. They live in `images/thumbnails/<fileId>/`, outside
  the media folder, so every removed file stranded a few MB for good.
  `ThumbnailService.deleteForFile()` is wired into the three exits: manual file deletion,
  a file gone from disk at rescan, and media deletion (ids collected before the cascade
  drops the rows).

The post-import script field is removed from the settings page: nothing in the backend has
ever read `post_import_script`. Rows already stored are inert and left alone.

## Verification

- `tsc --noEmit` clean on backend and client
- 755 tests green across scheduler, markers, media, imports, streaming and library-ingest
- 6 new tests on `PostImportService`: sprite/marker fan-out, the "already has a sprite"
  filter, wave coalescing, `added: 0` firing nothing, the toggle off path, and the progress
  scope

## Not covered

Sprite staleness after an in-place file replacement. A download upgrade lands a new
`relativePath`, hence a new row and a new sprite; only a `force: true` ingest would reuse
the row, and no download path passes it.
