### PR TITLE
fix(media-detail): repaint the page when an import lands

### DIFF
--- a/backend/src/modules/plugins/host/fliks-host.service.ts
+++ b/backend/src/modules/plugins/host/fliks-host.service.ts
@@ -983,7 +983,9 @@ export class FliksHostImpl implements PluginHostApi {
           quality: event.quality,
           sourceTitle: event.sourceTitle,
         });
-        const recipients = await this.sseAudience.recipientsForMedia(
+        // Same audience as `download.progress`: this event retires the badge
+        // that event put up, and repaints the page the file just landed on.
+        const recipients = await this.sseAudience.viewersForMedia(
           event.mediaId,
         );
         this.events.emitToUsers(recipients, {

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -133,6 +133,7 @@
     "rescan_completed": "Scan abgeschlossen: {{title}} — {{added}} hinzugefügt, {{removed}} entfernt, {{updated}} aktualisiert",
     "rescan_subtitles_cleaned": "{{missing}} Untertiteleintrag/-einträge ohne Datei entfernt, {{duplicates}} Duplikat(e) zusammengeführt",
     "rescan_failed": "Fehler beim Scan: {{title}}",
+    "import_failed": "Import fehlgeschlagen: {{title}}",
     "media_files_delete_failed": "Die Dateien von „{{title}}“ konnten nicht von der Festplatte gelöscht werden"
   },
   "permissions": {
@@ -949,7 +950,6 @@
     "indexer_cooldown": "Übersprungen — dieser Indexer pausiert nach einem Fehler.",
     "releases_error": "Die Releases konnten nicht geladen werden.",
     "grab_ok": "An den Download-Client gesendet.",
-    "grab_success": "Download erfolgreich gestartet.",
     "profiles_section": "Profile",
     "language_profile_label": "Sprachprofil",
     "profile_none": "Nicht festgelegt",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -138,6 +138,7 @@
     "rescan_completed": "Scan complete: {{title}} — {{added}} added, {{removed}} removed, {{updated}} updated",
     "rescan_subtitles_cleaned": "{{missing}} subtitle entry(ies) without file removed, {{duplicates}} duplicate(s) merged",
     "rescan_failed": "Error during scan: {{title}}",
+    "import_failed": "Import failed: {{title}}",
     "media_files_delete_failed": "The files of \"{{title}}\" could not be deleted from disk"
   },
   "permissions": {
@@ -954,7 +955,6 @@
     "indexer_cooldown": "Skipped — this indexer is cooling down after an error.",
     "releases_error": "Unable to load releases.",
     "grab_ok": "Sent to the download client.",
-    "grab_success": "Download started successfully.",
     "profiles_section": "Profiles",
     "language_profile_label": "Language profile",
     "profile_none": "Not set",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -133,6 +133,7 @@
     "rescan_completed": "Escaneo completado: {{title}} — {{added}} añadido(s), {{removed}} eliminado(s), {{updated}} actualizado(s)",
     "rescan_subtitles_cleaned": "{{missing}} entrada(s) de subtítulo sin archivo eliminada(s), {{duplicates}} duplicado(s) fusionado(s)",
     "rescan_failed": "Error durante el escaneo: {{title}}",
+    "import_failed": "Error al importar: {{title}}",
     "media_files_delete_failed": "No se pudieron eliminar del disco los archivos de «{{title}}»"
   },
   "permissions": {
@@ -949,7 +950,6 @@
     "indexer_cooldown": "Omitido — este indexador está en pausa tras un error.",
     "releases_error": "No se pueden cargar las releases.",
     "grab_ok": "Enviado al cliente de descarga.",
-    "grab_success": "Descarga iniciada correctamente.",
     "profiles_section": "Perfiles",
     "language_profile_label": "Perfil de idioma",
     "profile_none": "No definido",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -138,6 +138,7 @@
     "rescan_completed": "Scan terminé : {{title}} — {{added}} ajouté(s), {{removed}} supprimé(s), {{updated}} mis à jour",
     "rescan_subtitles_cleaned": "{{missing}} entrée(s) sous-titre sans fichier supprimée(s), {{duplicates}} doublon(s) fusionné(s)",
     "rescan_failed": "Erreur lors du scan : {{title}}",
+    "import_failed": "Échec de l'import : {{title}}",
     "media_files_delete_failed": "Les fichiers de « {{title}} » n'ont pas pu être supprimés du disque"
   },
   "permissions": {
@@ -954,7 +955,6 @@
     "indexer_cooldown": "Ignoré — cet indexeur est en pause après une erreur.",
     "releases_error": "Impossible de charger les releases.",
     "grab_ok": "Envoyé au client de téléchargement.",
-    "grab_success": "Téléchargement lancé avec succès.",
     "profiles_section": "Profils",
     "language_profile_label": "Profil de langue",
     "profile_none": "Non défini",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -133,6 +133,7 @@
     "rescan_completed": "Scansione completata: {{title}} — {{added}} aggiunto/i, {{removed}} rimosso/i, {{updated}} aggiornato/i",
     "rescan_subtitles_cleaned": "{{missing}} voce/i sottotitolo senza file rimossa/e, {{duplicates}} duplicato/i unito/i",
     "rescan_failed": "Errore durante la scansione: {{title}}",
+    "import_failed": "Importazione non riuscita: {{title}}",
     "media_files_delete_failed": "I file di « {{title}} » non sono stati eliminati dal disco"
   },
   "permissions": {
@@ -949,7 +950,6 @@
     "indexer_cooldown": "Ignorato — questo indicizzatore è in pausa dopo un errore.",
     "releases_error": "Impossibile caricare le release.",
     "grab_ok": "Inviato al client di download.",
-    "grab_success": "Download avviato con successo.",
     "profiles_section": "Profili",
     "language_profile_label": "Profilo di lingua",
     "profile_none": "Non definito",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -133,6 +133,7 @@
     "rescan_completed": "Análise concluída: {{title}} — {{added}} adicionado(s), {{removed}} removido(s), {{updated}} atualizado(s)",
     "rescan_subtitles_cleaned": "{{missing}} entrada(s) de legenda sem ficheiro removida(s), {{duplicates}} duplicado(s) fundido(s)",
     "rescan_failed": "Erro durante a análise: {{title}}",
+    "import_failed": "Falha na importação: {{title}}",
     "media_files_delete_failed": "Os ficheiros de «{{title}}» não puderam ser removidos do disco"
   },
   "permissions": {
@@ -949,7 +950,6 @@
     "indexer_cooldown": "Ignorado — este indexador está em pausa após um erro.",
     "releases_error": "Não foi possível carregar as releases.",
     "grab_ok": "Enviado para o cliente de transferência.",
-    "grab_success": "Transferência iniciada com sucesso.",
     "profiles_section": "Perfis",
     "language_profile_label": "Perfil de idioma",
     "profile_none": "Não definido",

--- a/client/src/app/core/services/sse.service.ts
+++ b/client/src/app/core/services/sse.service.ts
@@ -353,8 +353,16 @@ export class SseService implements OnDestroy {
           event['seasonNumber'] as number | undefined,
           event['episodeNumber'] as number | undefined,
         );
+        // A file landed with no client mutation behind it, so the cached media
+        // body still says the episode has none.
+        void invalidatePrefix('/api/media');
         // Import always finishes unattended (completion is polled by
         // a scheduler) — no toast, just retire the live progress above.
+        break;
+      case 'import.failed':
+        this.toast.error(
+          this.translate.instant('sse.import_failed', { title: event['title'] ?? '' }),
+        );
         break;
       case 'stalled.removed':
         // Unattended cleanup of a stalled download — no toast.

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -220,6 +220,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
         percent: null,
         badgeClass: 'badge-info',
         clickable,
+        busy: leaves.some((l) => l.leaf.state === 'searching'),
       };
     }
 
@@ -231,6 +232,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       percent: d.percent,
       badgeClass: d.badgeClass,
       clickable,
+      busy: d.busy,
     };
   }
 
@@ -355,7 +357,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     this.backgroundService.setBackgrounds(pool);
   });
 
-  /** React to SSE rescan + metadata-refresh events for this media */
+  /** React to SSE rescan / import / metadata-refresh events for this media */
   private readonly sseEffect = effect(() => {
     const event = this.sse.lastEvent();
     const m = this.media();
@@ -363,10 +365,10 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     if ((event['mediaId'] as number) !== m.id) return;
     if (event === this.lastHandledSseEvent) return;
     this.lastHandledSseEvent = event;
-    if (event.type === 'rescan.completed') {
-      void this.reloadAfterRescan(m.id);
+    if (event.type === 'rescan.completed' || event.type === 'import.complete') {
+      void this.reloadMedia(m.id);
     } else if (event.type === 'metadata.refreshed') {
-      void this.reloadAfterRescan(m.id);
+      void this.reloadMedia(m.id);
       this.toast.success(this.translate.instant('media_detail.refresh_ok'));
     } else if (event.type === 'metadata.failed') {
       this.toast.error(
@@ -1320,7 +1322,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     busy.update((s) => new Set(s).add(id));
     try {
       await this.withGrabPhase(scope, grab);
-      this.toast.success(this.translate.instant('media_detail.grab_success'));
     } catch {
       /* error toast surfaced by the global interceptor */
     } finally {
@@ -1549,7 +1550,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
 
   onIdentified() {
     const m = this.media();
-    if (m) void this.reloadAfterRescan(m.id);
+    if (m) void this.reloadMedia(m.id);
   }
 
   openAnalyzeModal() {
@@ -1610,12 +1611,15 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     }
   }
 
-  private async reloadAfterRescan(mediaId: number) {
+  /** Re-read the media after something changed it under the page. Forced: a
+   *  server-side event invalidates no cache entry, so a plain read replays the
+   *  body that is missing the very file the event announced. */
+  private async reloadMedia(mediaId: number) {
     try {
-      const updated = await this.mediaService.getOne(mediaId);
+      const updated = await this.mediaService.getOne(mediaId, { force: true });
       this.media.set(updated);
       if (updated.type === 'series') this.syncActiveSeasonForSeriesFilter();
-      // Re-resolve focused episode after rescan
+      // Re-resolve the focused episode against the refreshed tree.
       const ep = this.focusedEpisode();
       if (ep) {
         for (const s of updated.seasons ?? []) {
@@ -1864,7 +1868,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
         this.releasePickerApi.grabEpisode(mediaId, episodeId, releaseGrabBody(r)),
       );
       this.epGrabState.update((s) => new Map(s).set(key, 'ok'));
-      this.toast.success(this.translate.instant('media_detail.grab_success'));
     } catch {
       this.epGrabState.update((s) => new Map(s).set(key, 'error'));
     } finally {
@@ -1923,7 +1926,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
         this.releasePickerApi.grabSeason(mediaId, season.id, releaseGrabBody(r)),
       );
       this.seasonReleaseGrabState.update((s) => new Map(s).set(key, 'ok'));
-      this.toast.success(this.translate.instant('media_detail.grab_success'));
     } catch {
       this.seasonReleaseGrabState.update((s) => new Map(s).set(key, 'error'));
     } finally {
@@ -1936,10 +1938,9 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     if (!m) return;
     try {
       await this.mediaService.deleteFile(m.id, fileId, deleteOnDisk);
-      this.media.update((media) =>
-        media ? { ...media, files: media.files?.filter((f) => f.id !== fileId) } : media,
-      );
-      this.syncActiveSeasonForSeriesFilter();
+      // Not a local splice: the server also flips the episode's `hasFile`, which
+      // the season tree renders from.
+      await this.reloadMedia(m.id);
     } catch {
       // ignore
     }
@@ -2044,7 +2045,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
         this.releasePickerApi.grabMovie(m.id, releaseGrabBody(r)),
       );
       this.grabState.update((s) => new Map(s).set(key, 'ok'));
-      this.toast.success(this.translate.instant('media_detail.grab_success'));
     } catch {
       this.grabState.update((s) => new Map(s).set(key, 'error'));
     } finally {

--- a/client/src/app/shared/components/data-table/data-table.spec.ts
+++ b/client/src/app/shared/components/data-table/data-table.spec.ts
@@ -794,6 +794,13 @@ describe('DataTableComponent — progress inside a badge', () => {
     expect(fixture.componentInstance.cellProgress(COL, { id: 1, state: 'active', progress: null })).toBeNull();
   });
 
+  it('VERDICT: a full row shows no percentage — an importing queue row is not "100%"', async () => {
+    const fixture = await createComponent({ http: { get: () => of([]) } });
+    expect(
+      fixture.componentInstance.cellProgress(COL, { id: 1, state: 'importing', progress: 100 }),
+    ).toBeNull();
+  });
+
   it('a column declaring no progressField never fills', async () => {
     const fixture = await createComponent({ http: { get: () => of([]) } });
     expect(

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -340,11 +340,15 @@ export class DataTableComponent implements OnInit {
   }
 
   /** The 0–100 fill for a badged cell that declares `progressField`, or null to render the
-   *  badge flat. A row reporting no number yet (an unreachable client) is not 0%. */
+   *  badge flat. A row reporting no number yet (an unreachable client) is not 0%, and one
+   *  sitting at 100 has nothing left to report — what it is doing now is the state beside it,
+   *  an import or a seed, not a percentage of itself. */
   cellProgress(col: TableColumn, row: TableRow): number | null {
     if (!col.progressField) return null;
     const value = row[col.progressField];
-    return typeof value === 'number' ? Math.round(value) : null;
+    if (typeof value !== 'number') return null;
+    const percent = Math.round(value);
+    return percent >= 100 ? null : percent;
   }
 
   /**

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -408,7 +408,7 @@
       [class.flex-1]="size === 'xl'"
       [label]="badgeLabel(b)"
       [percent]="b.percent"
-        [busy]="b.busy"
+      [busy]="b.busy"
       [badgeClass]="b.badgeClass"
       [size]="size ?? 'sm'"
     />

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -108,6 +108,9 @@ export interface MediaInfoHeaderBadge {
   labelParams: Record<string, unknown> | null;
   /** When true the badge renders as a button that emits openDownloadDetail. */
   clickable: boolean;
+  /** Spinner before the label, for a state with no percentage of its own —
+   *  a release still being searched for. */
+  busy: boolean;
 }
 
 interface AudioTrack {


### PR DESCRIPTION
Eight reported points on the download / import surface. Seven were real defects; one was a false alarm and is answered below rather than changed.

## An import that nobody was told about

`import.complete` was emitted to `recipientsForMedia` — the users who requested the title, falling back to admins only when no request exists — while `download.progress` goes to `viewersForMedia`, everyone with access to the library. An admin watching a title another user had requested therefore got the download badge and never the event that retires it or repaints the page. Both now use the same audience: this event exists to close what the other one opened.

The page ignored `import.complete` regardless, so a media-detail sitting open never re-read itself. And nothing invalidated the cached `/api/media` body — a server-side event mutates nothing through the HTTP interceptor, and the detail TTL is four hours, stale-while-revalidate. That is the "go back, come in again, still no episode" half of the report: the cache answered first, every time.

`reloadAfterRescan` had the same flaw for its own callers and is now `reloadMedia`, forced. A plain read after a server-side event replays the body that is missing the very file the event announced.

## A spinner that could not render

`describeDownload` computes `busy` for a release still being searched for, and the header template binds `[busy]="b.busy"` — but `MediaInfoHeaderBadge` never carried the field, so the bound value was always `undefined`. The badge sat there saying "Recherche du fichier" with nothing to show it was live. The flag is now on the model and set on both branches of `downloadBadge`.

## A state that was published too late to see

The completion poller emits its progress snapshot before the loop that imports finished torrents, so a row flipped to `importing` was only ever visible to a client if the ingest outlived a whole poll tick. It normally does not. Fixed on the plugin side (fk-plugin-download#61); nothing in this PR depends on it.

## The rest

- **Deleting a file left the season tree stale.** The handler spliced `media.files` locally, but the server also sets `episode.hasFile = false`, which is what the episode cards render from. Replaced with the same forced reload.
- **A failed import said nothing.** `import.failed` is emitted by the host and handled nowhere in the client. It now raises an error toast (`sse.import_failed`, six locales).
- **The queue's status badge appended `100%` while importing.** A cell at 100 has nothing left to report — what the row is doing then is the state beside it, an import or a seed, not a percentage of itself. `cellProgress` returns null there. Fixed in core rather than in the plugin that sends the 100, so it lands without a plugin republish.
- **The "download started successfully" toast is gone.** Four call sites and the now-unused key in six locales. The release row already turns to its ✓/✗ state and the header badge goes up on the click; a third confirmation of the same thing is noise.

## Not changed

Closing the download detail modal cannot cut the badge's listener. The modal is a pure view over an input signal and subscribes to nothing; the badge is fed by `DownloadProgressService`, `providedIn: 'root'`, off the app-wide `EventSource`. There is nothing modal-scoped to lose.

## Checks

`ng test` 779 passed (one added: a full row renders no percentage). Backend `src/modules/plugins` 852 passed. `tsc --noEmit` clean on both sides.
