### PR TITLE
fix(media-card): show the badges and progress a stale TV guard hid

### DIFF
--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -57,7 +57,7 @@
     <!-- Badges, progress and hover affordances. Grouped so a single
          view-transition-name lifts them above the poster that morphs onto
          this card, which would otherwise hide them for the whole animation. -->
-    <div #cardOverlay data-card-overlay class="absolute inset-0 pointer-events-none">
+    <div #cardOverlay data-card-overlay class="absolute inset-0 z-10 pointer-events-none">
 
     <!-- Rating badge (bottom-left, portrait only) -->
     @if (_rating() > 0 && aspect() === 'portrait') {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -714,15 +714,6 @@ body.tv app-media-card p {
   opacity: 0.5;
 }
 
-/* Media-card simplification on TV: the card is a single focus target. The
-   internal hover overlay (play button, dismiss, etc.) is replaced by the
-   contextual actions panel, so we hide them entirely. The watched toggle stays
-   visible since it also acts as a status indicator. */
-body.tv app-media-card figure > .group-hover\:opacity-100,
-body.tv app-media-card figure > .absolute.inset-0,
-body.tv app-media-card .opacity-0.group-hover\:opacity-100 {
-  display: none !important;
-}
 /* Card focus — Lumen "lit-from-within" ring inspired by
    mediaplatform-hub/frontend-tv: 2 px spacer in the surface colour,
    4 px primary ring outside that, plus a soft primary glow and a
@@ -801,8 +792,9 @@ html.nav-back .card-img-reveal {
   animation-duration: 0s;
 }
 
-/* One promotion source fewer, and the reveal stays (the art is still hidden
-   until it has decoded — only the 200 ms tween goes). */
+/* The opacity animation promotes the img to its own layer, and this WebView then
+   drops the figure's radius clip for everything painted after it — the bottom
+   edge squares off for the length of the fade. */
 body.tv app-media-card figure img,
 body.tv .mosaic-art img {
   transition: none !important;


### PR DESCRIPTION
## What

On TV, media cards showed no rating, no status badge, no watched check and no progress bar. A
`body.tv` rule listed `app-media-card figure > .absolute.inset-0` to hide the mouse hover
overlay, but those elements were later grouped under a `data-card-overlay` wrapper carrying
exactly those classes as a direct `figure` child. The rule hid the whole group, and the
loading placeholder with it.

It was already dead for its stated purpose: the hover overlay and the actions button render
behind `showHoverOverlay()`, i.e. `device.input() === 'mouse'`, and every TV branch of
`detectDevice()` returns `dpad` — a TV is never `mouse`, even with a pointer remote. So the
rule is deleted rather than re-aimed; nothing it targeted is rendered on TV.

**Never gate a TV visual on geometry utility classes** (`.absolute.inset-0`,
`.group-hover:opacity-100`). They are not identity, and any refactor that introduces a
wrapper silently re-aims the selector.

## Also

The same wrapper had no `z-index` of its own — only its children did — so it stayed above the
artwork by DOM order alone. `card-img-reveal` animates the img's opacity, which promotes it to
its own compositor layer, and the progress bar dropped out for the length of the fade. The
wrapper now carries `z-10`.

The `body.tv` guard that keeps that fade off on TV is unchanged, but its comment is rewritten.
It read as belt-and-braces ("one promotion source fewer"), so it was removed during this work
and the card's squared bottom edge came straight back on the Q80B.

Self-rounding cannot rescue it the way it did the mosaic art. When the figure's clip is
dropped, the element on the bottom edge has to carry the corner itself — and that element is
the progress bar. A radius is scaled down when it exceeds half its box, so a 4px `h-1` bar can
only render a 4px corner against the card's 8px `--radius-lg`; it juts into the arc whatever
class it carries. Verified with a headless-chromium repro across clip on/off and bar height.
Both geometric fixes change the resting design on every platform for a 200ms artefact —
`h-2` so height >= radius (too thick), or insetting the bar past the corner — so the fade
stays off on TV, where it costs nothing visible: the art is still hidden until it has decoded.

## Test

Deployed to the Samsung Q80B and checked in the browser.

- TV: rating, status badge, watched check and progress bar are back on media cards; no squared
  corner during the reveal.
- Browser: the progress bar no longer disappears between the skeleton and the artwork.
