### PR TITLE
fix(player): open on the fanart, not the poster

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -48,6 +48,7 @@ import {
   leafRoutePath,
   markViewTransition,
   stampChromeInsets,
+  WATCH_PATH,
 } from './shared/utils/view-transition';
 
 /** Read the persisted server URL, sessions and credentials before bootstrap:
@@ -71,7 +72,6 @@ export function loadPersistedState(): Promise<unknown> {
 }
 
 const EPISODE_PATH = 'series/:id/episode/:episodeId';
-const WATCH_PATH = 'watch/:mediaFileId';
 const PLAYER_CLOSE_CLASS = 'vt-player-close';
 const POSTER_IN_CLASS = 'vt-poster-in';
 const POSTER_OUT_CLASS = 'vt-poster-out';

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -482,7 +482,7 @@ export class MediaInfoHeaderComponent {
       episodeId: resumeEpId ?? this.episodeId(),
       title: this.title(),
       episodeTitle: this.resumeEpisodeLabel() ?? this.episodeLabel() ?? undefined,
-      fanartUrl: this.posterUrl() ?? this.fanartUrl() ?? null,
+      fanartUrl: this.fanartUrl() ?? this.posterUrl() ?? null,
       streamInfo: file?.streamInfo,
     }, fromStart);
   }

--- a/client/src/app/shared/utils/view-transition.spec.ts
+++ b/client/src/app/shared/utils/view-transition.spec.ts
@@ -80,6 +80,9 @@ describe('view-transition poster stamps', () => {
       expect(leavingPosterPage(route(''), route('movies/:id'))).toBe(false);
       // Detail to detail stays on a poster on both sides.
       expect(leavingPosterPage(route('movies/:id'), route('series/:id'))).toBe(false);
+      // Opening the player is not a return to a list of cards: the hero would
+      // find no partner there and animate alone over the backdrop.
+      expect(leavingPosterPage(route('movies/:id'), route('watch/:mediaFileId'))).toBe(false);
     });
 
     it('holds on the way in and not on the way back', () => {
@@ -88,6 +91,8 @@ describe('view-transition poster stamps', () => {
       expect(enteringPosterPage(route('movies/:id'), route(''))).toBe(false);
       // Detail to detail keeps both sides on a poster: nothing to reshape.
       expect(enteringPosterPage(route('movies/:id'), route('series/:id'))).toBe(false);
+      // Closing the player back onto the detail page: its own shrink owns that.
+      expect(enteringPosterPage(route('watch/:mediaFileId'), route('movies/:id'))).toBe(false);
     });
   });
 
@@ -108,6 +113,18 @@ describe('view-transition poster stamps', () => {
       // Back navigation: the morph reads the stamp on the re-attached card.
       clearStalePosterStamps(route('series/:id'), route(''));
       expect(card.style.viewTransitionName).toBe('media-poster-7');
+    });
+
+    it('drops the stamp when the player is on either side', () => {
+      const card = img();
+      stampPoster(card, 7);
+
+      clearStalePosterStamps(route('movies/:id'), route('watch/:mediaFileId'));
+      expect(card.style.viewTransitionName).toBe('');
+
+      stampPoster(card, 7);
+      clearStalePosterStamps(route('watch/:mediaFileId'), route('movies/:id'));
+      expect(card.style.viewTransitionName).toBe('');
     });
 
     it('drops a stamp left over from an earlier detail visit', () => {

--- a/client/src/app/shared/utils/view-transition.ts
+++ b/client/src/app/shared/utils/view-transition.ts
@@ -48,6 +48,10 @@ const POSTER_ROUTES = new Set<string | undefined>([
   'series/:id/episode/:episodeId',
 ]);
 
+/** The player pairs with nothing — it has no poster, and its own close animation
+ *  owns the swap — so neither poster trip may claim a trip to or from it. */
+export const WATCH_PATH = 'watch/:mediaFileId';
+
 /** Router hands the transition hook the ROOT snapshots, whose routeConfig is null. */
 export function leafRoutePath(root: RouteNode): string | undefined {
   let leaf = root;
@@ -57,12 +61,20 @@ export function leafRoutePath(root: RouteNode): string | undefined {
 
 /** A card opening the page that carries the other half of its morph. */
 export function enteringPosterPage(from: RouteNode, to: RouteNode): boolean {
-  return POSTER_ROUTES.has(leafRoutePath(to)) && !POSTER_ROUTES.has(leafRoutePath(from));
+  return (
+    POSTER_ROUTES.has(leafRoutePath(to)) &&
+    !POSTER_ROUTES.has(leafRoutePath(from)) &&
+    leafRoutePath(from) !== WATCH_PATH
+  );
 }
 
 /** The way back: the page that owns the hero returns to a list of cards. */
 export function leavingPosterPage(from: RouteNode, to: RouteNode): boolean {
-  return POSTER_ROUTES.has(leafRoutePath(from)) && !POSTER_ROUTES.has(leafRoutePath(to));
+  return (
+    POSTER_ROUTES.has(leafRoutePath(from)) &&
+    !POSTER_ROUTES.has(leafRoutePath(to)) &&
+    leafRoutePath(to) !== WATCH_PATH
+  );
 }
 
 /**
@@ -71,7 +83,11 @@ export function leavingPosterPage(from: RouteNode, to: RouteNode): boolean {
  * the figure that rounds it and animate on its own.
  */
 export function clearStalePosterStamps(from: RouteNode, to: RouteNode): void {
-  if (POSTER_ROUTES.has(leafRoutePath(from)) || POSTER_ROUTES.has(leafRoutePath(to))) return;
+  const player =
+    leafRoutePath(from) === WATCH_PATH || leafRoutePath(to) === WATCH_PATH;
+  const pairs =
+    POSTER_ROUTES.has(leafRoutePath(from)) || POSTER_ROUTES.has(leafRoutePath(to));
+  if (!player && pairs) return;
   clearPosterStamps();
 }
 


### PR DESCRIPTION
Opening the player showed an extra image that did not belong to the shot.

## The wrong image is the poster (confirmed on device)

The detail page's play button passed `posterUrl() ?? fanartUrl()` as the eager backdrop. The
player paints that on its first tick, before the media API answers, so the portrait poster
went up across a landscape viewport under `object-cover` — cropped hard, unrecognisable — and
was replaced by the real fanart a second later.

Every other caller already orders these the other way (`home.ts`, `playable-media.service.ts`,
`media-card.ts`), so this is one inverted fallback, not a pattern.

It also explains why Continue Watching looked different: that tile passes a landscape
`stillUrl`/fanart, so it never had the extra step — only the thumb-then-full-res progressive
load, which is intended (`player.html`).

Ruled out on the way: `player.ts` overwriting `fanartUrl` with `media.fanartUrl` just before
`applyEpisodeMetadata()` sets the episode still. Both are synchronous in the same tick, so the
intermediate value never paints.

## Second commit: the hero morphing alone (browser only, not verified on device)

Separate defect, same symptom family. `leavingPosterPage` counted a detail page opening the
player as a return to a list of cards, so the transition took `vt-poster-out`, and
`clearStalePosterStamps` held the stamp back because one side is a poster route. The hero kept
its `view-transition-name`, found no partner in the player, and animated on its own over the
backdrop.

The player pairs with nothing — no poster, and its own close animation already owns the swap —
so both poster trips exclude it and the stamps are cleared whenever it is on either side.
`WATCH_PATH` moves into `view-transition.ts` rather than being declared twice.

This one is **browser only**: `viewTransitionsEnabled()` is false on the TV WebView, which has
no `document.startViewTransition`. Covered by unit tests (10 pass), but not confirmed by eye —
drop this commit if you would rather see it demonstrated first.

## Test

- Samsung Q80B: opening the player from a detail page no longer flashes the poster.
- `view-transition.spec.ts`: 10 passed.
