### PR TITLE
fix(streaming): anchor a resumed MPEG-TS run on the playlist grid

### DIFF
--- a/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-args.ts
@@ -74,6 +74,7 @@ function hlsMuxerArgs(o: {
   useTs: boolean;
   hlsTime: string;
   startSegment: number;
+  seekSeconds: number;
   segType: string;
   initFilename: string;
   varStreamMap?: string;
@@ -82,6 +83,13 @@ function hlsMuxerArgs(o: {
 }): string[] {
   return [
     ...(o.useTs ? [] : ['-movflags', '+cmaf']),
+    // The muxer restarts its output timeline near zero on every run, so a
+    // seeked run's segments contradict the playlist that places them at
+    // `index · realSeg`. fMP4 is re-anchored on serve by `rewriteSegmentTfdt`;
+    // MPEG-TS carries no `tfdt` to rewrite, so the offset is applied here.
+    ...(o.useTs && o.seekSeconds > 0
+      ? ['-output_ts_offset', String(o.seekSeconds)]
+      : []),
     '-f',
     'hls',
     '-hls_time',
@@ -453,6 +461,10 @@ function buildAudioAndMuxerArgs(opts: {
     outputDir,
   } = opts;
   const args: string[] = [];
+  // Content time this run starts at, matching the playlist's placement of
+  // `seg-startSegment`. Equals `segmentIndexToSeconds`, which is exactly
+  // `startSegment · realSeg`.
+  const runStartSeconds = startSegment > 0 ? startSegment * realSeg : 0;
 
   // Use var_stream_map whenever the caller asked for the EXT-X-MEDIA
   // layout (`videoOnly + audioStreams[]`), even for a SINGLE audio
@@ -498,6 +510,7 @@ function buildAudioAndMuxerArgs(opts: {
         useTs,
         hlsTime: String(realSeg),
         startSegment,
+        seekSeconds: runStartSeconds,
         segType,
         initFilename: 'init_%v.mp4',
         varStreamMap: varParts.join(' '),
@@ -536,6 +549,7 @@ function buildAudioAndMuxerArgs(opts: {
       useTs,
       hlsTime: String(segmentDuration),
       startSegment,
+      seekSeconds: runStartSeconds,
       segType,
       initFilename: 'init.mp4',
       segmentFilename: ffOutPath(outputDir, `seg-%04d.${segExt}`),
@@ -1235,6 +1249,7 @@ export function buildAudioOnlyFfmpegArgs(
       useTs,
       hlsTime: String(realSeg),
       startSegment,
+      seekSeconds,
       segType,
       initFilename: 'init.mp4',
       segmentFilename: ffOutPath(outputDir, `seg-%04d.${segExt}`),
@@ -1390,6 +1405,7 @@ export function buildRemuxArgs(
       useTs: false,
       hlsTime: String(segmentDuration),
       startSegment,
+      seekSeconds: 0,
       segType: 'fmp4',
       initFilename: 'init.mp4',
       segmentFilename: ffOutPath(outputDir, 'seg-%04d.m4s'),

--- a/backend/src/modules/streaming/transcoding/ts-timeline-offset.spec.ts
+++ b/backend/src/modules/streaming/transcoding/ts-timeline-offset.spec.ts
@@ -1,0 +1,82 @@
+import { Logger } from '@nestjs/common';
+import { buildFfmpegArgs } from './ffmpeg-args';
+import type { BuildFfmpegArgsOptions } from './ffmpeg-args';
+import { realSegmentSeconds } from './constants';
+import type { CodecVariant } from './codec/types';
+
+/**
+ * The HLS muxer restarts its output timeline near zero on every run, so a
+ * resumed run's segments contradict the playlist that places `seg-N` at
+ * `N · realSeg`. fMP4 is re-anchored on serve (`rewriteSegmentTfdt`); MPEG-TS
+ * carries no `tfdt`, so the offset has to be applied at encode time or the
+ * segment's own PTS stay run-relative. Tizen takes the TS path on
+ * single-audio sources (`useTsOnSingleAudio`), which is where the video froze
+ * for one segment on resume while audio played.
+ */
+describe('MPEG-TS resume timeline offset', () => {
+  const silentLog = {
+    debug: () => {},
+    log: () => {},
+    warn: () => {},
+    error: () => {},
+  } as unknown as Logger;
+
+  const H264_SDR: CodecVariant = { codec: 'h264', bitDepth: 8, hdr: null };
+
+  const opts = (over: Partial<BuildFfmpegArgsOptions>): BuildFfmpegArgsOptions =>
+    ({
+      inputPath: '/media/in.mkv',
+      outputDir: '/cache/out',
+      hwAccel: 'none',
+      profile: {
+        name: '1080p',
+        maxWidth: 1920,
+        maxHeight: 1080,
+        videoBitrate: '8M',
+        audioBitrate: '192k',
+      },
+      videoVariant: H264_SDR,
+      sourceWidth: 1920,
+      sourceHeight: 1080,
+      trustedStreamInfo: true,
+      ...over,
+    }) as BuildFfmpegArgsOptions;
+
+  const offsetOf = (args: string[]): string | undefined => {
+    const i = args.indexOf('-output_ts_offset');
+    return i === -1 ? undefined : args[i + 1];
+  };
+
+  it('anchors a resumed TS run on the playlist grid', () => {
+    const fps = 24000 / 1001; // 23.976
+    const args = buildFfmpegArgs(
+      opts({ useTs: true, startSegment: 20, sourceFps: fps }),
+      silentLog,
+    );
+    // The content time the playlist gives seg-0020, on the fps-aware grid
+    // (20 × 3.003 at the default 3s setting), not the integer 20 × 3.
+    expect(offsetOf(args)).toBe(String(20 * realSegmentSeconds(3, fps)));
+    expect(offsetOf(args)).not.toBe(String(20 * 3));
+    // Applied to the muxer, so it must precede the output format.
+    expect(args.indexOf('-output_ts_offset')).toBeLessThan(
+      args.indexOf('-f'),
+    );
+  });
+
+  it('leaves a TS run that starts at zero alone', () => {
+    const args = buildFfmpegArgs(
+      opts({ useTs: true, startSegment: 0, sourceFps: 24 }),
+      silentLog,
+    );
+    expect(offsetOf(args)).toBeUndefined();
+  });
+
+  it('never offsets fMP4 — the tfdt rewrite owns that timeline', () => {
+    const args = buildFfmpegArgs(
+      opts({ useTs: false, startSegment: 20, sourceFps: 24000 / 1001 }),
+      silentLog,
+    );
+    // Both would double-shift: the rewrite adds the run start on serve.
+    expect(offsetOf(args)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Resuming a film or episode on Tizen started the audio promptly and froze the picture for
exactly one segment before recovering. Only single-audio sources were affected.

## Cause

The HLS muxer restarts its output timeline near zero on every run. A resume spawns a run at
`seg-N`, so the segments it writes carry run-relative timestamps while the playlist places
`seg-N` at `N · realSeg`.

Measured in the dev container (jellyfin-ffmpeg 8.1.2): a run seeked to 120.12s emits a first
video PTS of `0.083` despite `-copyts`. A plain `-f mpegts` output does the same, so this is
the muxer, not the HLS layer.

fMP4 never showed it because served segments are re-anchored — that is exactly what
`timeline.ts` is for, and its preamble describes this muxer behaviour. But the gate is an
extension match:

```ts
const m = /(?:^|\/)seg-(\d+)\.m4s$/.exec(filePath);
if (!m) return buf;
```

and its docstring waves MPEG-TS through on the grounds that it "carries no `tfdt`". That is
true, and beside the point: its PTS/DTS/PCR are rebased just the same, and nothing corrects
them. Only Tizen reaches the TS path, and only when the source has one audio track
(`useTsOnSingleAudio`, `streaming.controller.ts`) — hence a bug that looked
container-specific. AVPlay anchors on the audio it can place and holds the picture until the
next segment reconciles.

## Fix

`-output_ts_offset` carries the run's content start. It lives in `hlsMuxerArgs` and is gated
on `useTs`, so none of the four call sites can omit it. fMP4 stays excluded on purpose: the
`tfdt` rewrite already shifts by the same value and the two would compound.

## Verification

Bench in the dev container, across seek index, grid setting and frame rate:

| start | grid | fps | expected | got | frames |
|---|---|---|---|---|---|
| 20 | 6s | 23.976 | 120.120 | 120.120 | 144 |
| 37 | 6s | 23.976 | 222.222 | 222.222 | 144 |
| 41 | 3s | 23.976 | 123.123 | 123.123 | 72 |
| 13 | 6s | 25 | 78.000 | 78.000 | 150 |
| 0 | 6s | 23.976 | no-op | unchanged | 144 |

Every segment opens on a keyframe and holds exactly `gopSize` frames. 513 streaming specs
pass, `tsc` clean, plus three dedicated cases in `ts-timeline-offset.spec.ts`.

**Not yet confirmed on the panel** — the bug only surfaces against a cold cache, so it needs
a resume on preprod (or locally after purging `/tmp/transcode/cache/u*/<mediaFileId>` and
resuming without playing from the start first).

## Rejected lead

The single-stream path passes the integer `segmentDuration` as `-hls_time` where the
var_stream_map path passes the fps-aware `realSeg`. That looked like #791, but the bench
disproves it: every TS segment is exactly `gopSize` frames with a leading keyframe. A
threshold *below* one GOP is harmless — #791 needed one above. The line is left alone.
