### PR TITLE
fix(import-progress): show the orphan batch counter instead of the enrich tail

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1936,7 +1936,7 @@
       "media_type": "Typ",
       "scan_folder": "Ordner scannen",
       "scan_required": "Scannen Sie den Ordner, um die gefundenen Medien vor dem Erstellen der Bibliothek zu prüfen.",
-      "scan_importing": "{{done}}/{{total}} Medien werden importiert…",
+      "scan_preparing": "{{done}}/{{total}} Medien werden vorbereitet…",
       "scan_queued": "Import von {{count}} Medien im Hintergrund gestartet.",
       "scan_title": "Ordner-Scan",
       "scan_scanning": "Dateien werden gescannt…",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1953,7 +1953,7 @@
       "media_type": "Type",
       "scan_folder": "Scan the folder",
       "scan_required": "Scan the folder to review the media found before creating the library.",
-      "scan_importing": "Importing {{done}}/{{total}} media…",
+      "scan_preparing": "Preparing {{done}}/{{total}} media…",
       "scan_queued": "Import of {{count}} media started in the background.",
       "scan_title": "Folder scan",
       "scan_scanning": "Scanning files…",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1936,7 +1936,7 @@
       "media_type": "Tipo",
       "scan_folder": "Analizar la carpeta",
       "scan_required": "Analiza la carpeta para revisar los medios encontrados antes de crear la biblioteca.",
-      "scan_importing": "Importando {{done}}/{{total}} medios…",
+      "scan_preparing": "Preparando {{done}}/{{total}} medios…",
       "scan_queued": "Importación de {{count}} medios iniciada en segundo plano.",
       "scan_title": "Análisis de la carpeta",
       "scan_scanning": "Análisis de los archivos en curso…",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1953,7 +1953,7 @@
       "media_type": "Type",
       "scan_folder": "Analyser le dossier",
       "scan_required": "Analysez le dossier pour vérifier les médias trouvés avant de créer la bibliothèque.",
-      "scan_importing": "Import de {{done}}/{{total}} médias…",
+      "scan_preparing": "Préparation de {{done}}/{{total}} médias…",
       "scan_queued": "Import de {{count}} médias lancé en arrière-plan.",
       "scan_title": "Analyse du dossier",
       "scan_scanning": "Analyse des fichiers en cours…",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1936,7 +1936,7 @@
       "media_type": "Tipo",
       "scan_folder": "Analizza la cartella",
       "scan_required": "Analizza la cartella per verificare i file multimediali trovati prima di creare la libreria.",
-      "scan_importing": "Importazione di {{done}}/{{total}} file multimediali…",
+      "scan_preparing": "Preparazione di {{done}}/{{total}} file multimediali…",
       "scan_queued": "Importazione di {{count}} file multimediali avviata in background.",
       "scan_title": "Analisi della cartella",
       "scan_scanning": "Analisi dei file in corso…",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1936,7 +1936,7 @@
       "media_type": "Tipo",
       "scan_folder": "Analisar a pasta",
       "scan_required": "Analise a pasta para verificar as medias encontradas antes de criar a biblioteca.",
-      "scan_importing": "A importar {{done}}/{{total}} medias…",
+      "scan_preparing": "A preparar {{done}}/{{total}} medias…",
       "scan_queued": "Importação de {{count}} medias iniciada em segundo plano.",
       "scan_title": "Análise da pasta",
       "scan_scanning": "Análise dos ficheiros em curso…",

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
@@ -26,7 +26,7 @@
 
   @if (importTotal() > 0) {
     <p class="text-sm text-base-content/60">
-      {{ 'settings.libraries.scan_importing' | translate: { done: imported(), total: importTotal() } }}
+      {{ 'settings.libraries.scan_preparing' | translate: { done: imported(), total: importTotal() } }}
     </p>
   }
 

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
@@ -88,7 +88,8 @@ export class OrphanScanPanelComponent {
   readonly scanProgress = computed(() => this.sse.activeProgress().get('OrphanScan') ?? null);
 
   readonly page = signal(1);
-  /** Groups imported so far / to import, for the creation wizard's progress. */
+  /** Groups matched and queued so far; the import itself runs server-side and is
+   *  reported by the library page's banner. */
   readonly imported = signal(0);
   readonly importTotal = signal(0);
   readonly autoImporting = signal(false);

--- a/client/src/app/shared/components/import-progress-banner/import-progress-banner.spec.ts
+++ b/client/src/app/shared/components/import-progress-banner/import-progress-banner.spec.ts
@@ -1,0 +1,46 @@
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { ImportProgressBannerComponent } from './import-progress-banner';
+import { SseService, TaskProgress } from '../../../core/services/sse.service';
+
+const progress = (command: string, current: number, total: number): TaskProgress => ({
+  type: 'task.progress',
+  command,
+  current,
+  total,
+  message: 'A Folder',
+});
+
+const setup = (...rows: TaskProgress[]) => {
+  const activeProgress = signal(new Map(rows.map((r) => [r.command, r])));
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideTranslateService({
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+      }),
+      { provide: SseService, useValue: { activeProgress } },
+    ],
+  });
+  return TestBed.createComponent(ImportProgressBannerComponent).componentInstance;
+};
+
+describe('ImportProgressBannerComponent', () => {
+  it('is silent with no import in flight', () => {
+    expect(setup().active()).toBeNull();
+  });
+
+  it('shows the batch counter while enrichment of earlier files runs alongside it', () => {
+    const c = setup(progress('PostImportEnrich', 3, 400), progress('OrphanImport', 42, 300));
+    expect(c.active()?.labelKey).toBe('import_progress.importing');
+    expect(c.percent()).toBe(14);
+  });
+
+  it('falls through to the enrich tail once the batch retires', () => {
+    expect(setup(progress('PostImportEnrich', 3, 4)).active()?.labelKey).toBe(
+      'import_progress.enriching',
+    );
+  });
+});

--- a/client/src/app/shared/components/import-progress-banner/import-progress-banner.ts
+++ b/client/src/app/shared/components/import-progress-banner/import-progress-banner.ts
@@ -11,12 +11,13 @@ const PHASE_LABEL_KEY: Record<ImportPhase, string> = {
   scan: 'import_progress.scanning',
 };
 
-/** Furthest-along phase first: when a library import is in flight, more than one
- *  of these keys can be active at once (e.g. enrichment of the first files while
- *  later folders are still being imported), and only one bar should show. */
+/** Outermost loop first: several of these keys are live at once during a library
+ *  import (enrichment of the first files runs while later folders are still being
+ *  imported), and only one bar shows. OrphanImport wins because it counts the
+ *  batch the user is waiting on; it retires and falls through to the enrich tail. */
 const PHASES: { command: string; phase: ImportPhase }[] = [
-  { command: 'PostImportEnrich', phase: 'enrich' },
   { command: 'OrphanImport', phase: 'import' },
+  { command: 'PostImportEnrich', phase: 'enrich' },
   { command: 'OrphanScan', phase: 'scan' },
 ];
 


### PR DESCRIPTION
Closes #1131.

## The defect

The library wizard queues every detected group and returns; `relinkOrphansBatch` then works through them sequentially, which is hours for a large series on a weak CPU. The banner that is supposed to report that batch was already mounted on the library detail page — the page the wizard lands on — but it never showed the batch.

`PHASES` in `import-progress-banner.ts` listed `PostImportEnrich` before `OrphanImport`. `relinkOrphans` enqueues a post-import enrich per linked file, and `PostImportQueueService.emitProgress()` fires on every enqueue, so enrich progress is live from the first linked file onward — concurrently with the relink loop, not after it. The banner takes the first match, so it showed the enrich wave's counter and the `42/300` group counter never appeared at all.

`OrphanImport` is the outer loop and the thing the user is waiting on, so it goes first. It only exists while a batch runs, and when it retires (`current >= total`, at which point `SseService` drops the key) the banner falls through to enrich for the tail. Correct on the single-media download→import→enrich chain too, since `OrphanImport` is absent there.

## The counter in the wizard

`scan_importing` is not purely wrong — `importAll` runs `if (!group.searched) await this.search(i)` over every group, and `searchPage()` only pre-searched the current page, so a 300-group scan does ~280 sequential provider searches inside that loop. That is real work worth a counter, but it is not the import, so the key is renamed to `scan_preparing` across the six locales.

## Not done, deliberately

- **No `libraryId` on the payload.** `relinkOrphansBatch` is a single global sequential loop and the wizard creates one library, so a per-library filter would cost a payload field, an interface field and a required input on a component currently mounted with no inputs, to fix only the two-concurrent-imports case. Backend diff is zero lines.
- **`task.progress` still absent from the SSE replay cache.** On reload `activeProgress` starts empty, but the enrich queue emits continuously for the whole import, so the banner repopulates within seconds and flips back to the group counter at the next group boundary. Adding it would mean a new cache dimension plus a TTL sweep, since `task.progress` is broadcast while the cache is audience-keyed.

## Verification

`ng test` — 783 passing, including three new banner specs covering the concurrent-phase case that regressed.

Needs a manual pass: point the wizard at a folder with 30+ unlinked titles and confirm the banner reads "Importing your media…" with a climbing group counter after it navigates, rather than "Enriching".