### PR TITLE
fix(desktop): apply the reconnect policy to direct play, not just hls

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -194,9 +194,10 @@ pkill -x electron        # NOT  pkill -f .../desktop
   there, not a bug. **macOS** attempts EDR passthrough for PQ/HLG on displays with
   headroom and falls back to SDR tonemap otherwise.
 - **Resume into a transcode** (seek to a high segment): the backend produces
-  seg-0/init a beat after the playlist. mpv's ffmpeg HLS demuxer is configured to
-  **reconnect on HTTP 4xx/5xx** (`demuxer-lavf-o` in `addon.cc`) so it retries
-  like Shaka instead of aborting on the first 404/503.
+  seg-0/init a beat after the playlist. mpv is configured to **reconnect on HTTP
+  4xx/5xx** (`demuxer-lavf-o` for the hls manifest, `stream-lavf-o` for every
+  other open, both in `shared/mpv-stream-options.ts`) so it retries like Shaka
+  instead of aborting on the first 404/503.
 - `isNative` is true for Electron (the UA matches `\bElectron\/`), so the desktop
   resolves to the `DESKTOP` engine kind (`client/.../engine-traits.ts`), which
   sets `probesSegZero: true` (Shaka-like: backend pre-spawns the seg-0 companion).

--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -119,8 +119,8 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
    *  verify, HTTP status, unsupported codec) is in these log lines, so we
    *  buffer them and attach them to the error event. */
   private errorLog: string[] = [];
-  /** Set when a buffered error/fatal log line is mpv's own libcurl/TLS failure
-   *  signature — log prefix exactly `curl`/`tls`, or a "Failed to open"
+  /** Set when a buffered error/fatal log line carries mpv's own transport
+   *  failure signature — log prefix exactly `curl`/`tls`, or a "Failed to open"
    *  message. Reset alongside `errorLog`. Deliberately strict: a bare `stream`
    *  prefix or any other line must not set this, or a genuine decode failure
    *  (e.g. Dolby Vision) would misreport as a transport fault. */
@@ -394,7 +394,7 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
    *  the single place the three error-emitting sites read `errorLog` and
    *  `sawTransportError`, so the transport classification can't drift between
    *  them. `code` follows MediaError semantics: 2 (MEDIA_ERR_NETWORK) when
-   *  this attempt's buffered log matched mpv's own TLS/libcurl signature,
+   *  this attempt's buffered log matched mpv's own transport signature,
    *  else -1 (no MediaError equivalent — decode/format/unknown). */
   private errorPayload(message: string): { code: number; message: string; detail?: string } {
     return {

--- a/desktop/src/shared/contract.ts
+++ b/desktop/src/shared/contract.ts
@@ -77,7 +77,7 @@ export type DesktopEvent =
       type: 'error';
       /** `code` follows MediaError semantics where applicable: 2
        *  (MEDIA_ERR_NETWORK) marks a transport-level failure (mpv's own
-       *  TLS/libcurl signature — see `MpvPlayer.errorPayload`), so the client
+       *  transport signature — see `MpvPlayer.errorPayload`), so the client
        *  classifies it as network/abort instead of blaming the decode path
        *  (e.g. Dolby Vision). Any other value carries no MediaError meaning. */
       payload: { code: number; message: string; detail?: string };

--- a/desktop/src/shared/mpv-stream-options.ts
+++ b/desktop/src/shared/mpv-stream-options.ts
@@ -2,9 +2,9 @@
 // buffering + resume behaviour can't drift per platform. Single source of truth:
 //   • Windows subprocess (mpv-player.ts) maps each to a `--name=value` CLI arg.
 //   • Linux compositor (index.ts) + macOS in-process player (mac-mpv-player.ts)
-//     apply each via the addon's `setProperty` right after start (all seven are
-//     runtime-mutable and set before the first load, so this matches the addons'
-//     former pre-init set_option_string exactly).
+//     apply each via the addon's `setProperty` right after start (all are
+//     runtime-mutable and read at the next open, so this matches a pre-init
+//     set_option_string exactly).
 //
 // Rationale for the tuning:
 //   • Buffer like the web (Shaka) engine: ~30s forward (cache-secs is the binding
@@ -16,7 +16,13 @@
 //     4xx/5xx status — so reconnect_on_network_error is needed alongside
 //     reconnect_on_http_error. The `4xx,5xx` value carries a comma, so it uses
 //     mpv's `%len%` escaping (7 = strlen("4xx,5xx")) to survive the key-value-list
-//     parser.
+//     parser. The policy is set twice because the two opens are disjoint: lavf
+//     opens the URL itself only for a `no_stream` demuxer (hls), while every
+//     other input is opened by mpv's stream layer and handed to lavf as a
+//     wrapped AVIOContext the demuxer dict never reaches.
+
+const RECONNECT =
+  'reconnect=1,reconnect_streamed=1,reconnect_on_network_error=1,reconnect_on_http_error=%7%4xx,5xx,reconnect_delay_max=5';
 
 export const MPV_STREAM_OPTIONS: readonly (readonly [name: string, value: string])[] = [
   ['cache', 'yes'],
@@ -25,8 +31,8 @@ export const MPV_STREAM_OPTIONS: readonly (readonly [name: string, value: string
   ['demuxer-max-bytes', '256MiB'],
   ['demuxer-max-back-bytes', '96MiB'],
   ['cache-pause-wait', '1'],
-  [
-    'demuxer-lavf-o',
-    'reconnect=1,reconnect_streamed=1,reconnect_on_network_error=1,reconnect_on_http_error=%7%4xx,5xx,reconnect_delay_max=5',
-  ],
+  // hls: the manifest is demuxer-opened.
+  ['demuxer-lavf-o', RECONNECT],
+  // Direct play: mpv's stream layer opens the URL, so this is the one that applies.
+  ['stream-lavf-o', RECONNECT],
 ];


### PR DESCRIPTION
Closes #1125.

## The issue's diagnosis was half right

Confirmed: `demuxer-lavf-o` never reaches direct-play HTTP. `demux_lavf` passes those options as an `AVDictionary` to `avformat_open_input`, but for a normal container mpv opens the URL itself (`stream_lavf.c` → `avio_open2`) and hands lavf a custom `AVIOContext`, so the http protocol never sees the dict — mpv just prints `Could not set AVOption reconnect='1'` at verbose level. HLS escapes this because `demuxer-lavf-format=hls` selects a demuxer marked `no_stream`, so lavf opens the URL and the dict applies.

Refuted, and it changes the fix:

- **mpv has no libcurl stream backend, on any platform.** The vendored `libmpv.so.2` (mpv v0.41, FFmpeg n8.1.1) contains zero curl strings, and the Windows build is the same upstream mpv from the pinned `zhongfly/mpv-winbuild`. The belief traces to a commit that stated it as an assumption.
- **This is therefore not Windows-only.** macOS and Linux direct play hit the same `stream_lavf` path and lose the policy too. Only HLS ever had it.
- **`ffmpeg://` would not have fixed it.** That prefix *is* `stream_lavf`, which `https://` already resolves to. The options are attached to the `AVFormatContext`, and mpv's `avio_alloc_context` wrapper has no `av_class` for `AV_OPT_SEARCH_CHILDREN` to descend into, so prefixing changes nothing except breaking the `.m3u8` assumptions.

## The fix

`stream-lavf-o` is the dict mpv passes to `avio_open2` in `stream_lavf.c` — exactly the direct-play open. It is present in the shipped mpv, is a plain key-value-list option read at the next stream open, and takes the same `%len%` escaping, so the existing value survives unchanged on both the CLI and `setProperty` paths.

Added rather than swapped: switching the name would strip the HLS manifest reconnect and regress the documented resume-into-transcode behaviour, since `stream-lavf-o` does not apply to a `no_stream` demuxer. The two knobs cover disjoint opens.

The `curl`/`tls` log-prefix classification in `mpv-player.ts` is left alone. `curl` is certainly dead, but whether `tls` fires depends on how this build names ffmpeg child logs, which only a field log answers; removing a defensive prefix on that basis would risk a Windows regression for no gain.

## Telemetry

Nothing to adapt. ffmpeg logs `Will reconnect at <offset> in N second(s)` at warning level, mpv forwards it as `warn`, and `player-session.ts` already writes every `warn` to `%APPDATA%\Fliks\logs\desktop.log`. The change is self-instrumenting on the Windows path.

## Verification

`tsc --noEmit` clean. All three consumers (`mpv-player.ts` CLI, `index.ts`, `mac-mpv-player.ts`) read the shared array, so no further wiring.

Runtime behaviour needs a Windows box and cannot be validated here:

1. `set FLIKS_MPV_LOGLEVEL=v`, launch from a console, start a direct-play title, and count `Could not set AVOption reconnect` occurrences — they drop for the stream open. The `demuxer-lavf-o` leftovers are still printed for direct play, so count rather than grep for presence.
2. Play direct play, buffer ~30s, cut the path to the server for ~10s. Expect `Will reconnect at …` in `desktop.log` and playback continuing, instead of `state: buffering` then `error:` once the cache drains.
3. Scrub before and after as a regression check on `avio_seek` → Range re-open.
4. Confirm the resume-into-transcode 404/503 retry still works — that is the `demuxer-lavf-o` entry being kept.

**Known ceiling:** reconnect prevents the stop, not necessarily the stall. `--network-timeout` (rw_timeout, default 60s) gates how long a blackholed read blocks before ffmpeg errors and reconnects, which is longer than the 30s cache. If the field log shows ~60s dead reads, that is the next knob — not more reconnect options.

This also neither fixes nor worsens the parked "first direct-play open fails TLS, second works" issue: ffmpeg's `reconnect*` covers mid-stream read errors, not a failed initial handshake.