### PR TITLE
feat(hw-decode): cover nvidia, windows and macos for cropdetect and thumbnails

### DIFF
--- a/backend/src/modules/streaming/thumbnail-extractors/cuda.extractor.spec.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/cuda.extractor.spec.ts
@@ -1,0 +1,59 @@
+import { CudaExtractor } from './cuda.extractor';
+import type { ExtractArgs } from './types';
+
+describe('CudaExtractor', () => {
+  const ext = new CudaExtractor();
+  const base: ExtractArgs = {
+    inputPath: '/m/ep.mkv',
+    seekSeconds: 120,
+    outputPath: '/tmp/thumb.jpg',
+    thumbWidth: 240,
+  };
+
+  function vfOf(args: string[]): string {
+    return args[args.indexOf('-vf') + 1];
+  }
+
+  it('has the cuda backend name', () => {
+    expect(ext.name).toBe('cuda');
+  });
+
+  it('describes itself as cuda', () => {
+    expect(ext.describe()).toBe('cuda');
+  });
+
+  it('supports both the no-crop and crop cases', () => {
+    expect(ext.supports(undefined)).toBe(true);
+    expect(
+      ext.supports({ width: 3840, height: 1632, x: 0, y: 264 }),
+    ).toBe(true);
+  });
+
+  it('no-crop: scale_cuda then hwdownload to nv12', () => {
+    const args = ext.buildArgs(base);
+    expect(vfOf(args)).toBe(
+      'scale_cuda=w=240:h=-2:format=nv12,hwdownload,format=nv12',
+    );
+    expect(args.slice(0, 8)).toEqual([
+      '-nostdin',
+      '-hide_banner',
+      '-loglevel',
+      'error',
+      '-threads',
+      '1',
+      '-hwaccel',
+      'cuda',
+    ]);
+    expect(args).toEqual(
+      expect.arrayContaining(['-hwaccel_output_format', 'cuda']),
+    );
+  });
+
+  it('crop: full-frame hwdownload then CPU crop+scale', () => {
+    const args = ext.buildArgs({
+      ...base,
+      crop: { width: 3840, height: 1632, x: 0, y: 264 },
+    });
+    expect(vfOf(args)).toBe('hwdownload,crop=3840:1632:0:264,scale=240:-1');
+  });
+});

--- a/backend/src/modules/streaming/thumbnail-extractors/cuda.extractor.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/cuda.extractor.ts
@@ -1,0 +1,56 @@
+import type { CropArea, ExtractArgs, ExtractorBackend } from './types';
+
+/** CUDA/NVDEC backend for NVIDIA Linux hosts. `scale_cuda` converts p010→nv12
+ *  itself (untonemapped, like vaapi/qsv) but has no crop option, so the crop
+ *  case falls back to a CPU crop+scale. */
+export class CudaExtractor implements ExtractorBackend {
+  readonly name = 'cuda';
+
+  describe(): string {
+    return 'cuda';
+  }
+
+  supports(_crop?: CropArea): boolean {
+    return true;
+  }
+
+  buildArgs({
+    inputPath,
+    seekSeconds,
+    outputPath,
+    crop,
+    thumbWidth,
+  }: ExtractArgs): string[] {
+    const vf = crop
+      ? // ponytail: full-frame download on crop; cuvid -crop/-resize if benches say so
+        `hwdownload,crop=${crop.width}:${crop.height}:${crop.x}:${crop.y},scale=${thumbWidth}:-1`
+      : `scale_cuda=w=${thumbWidth}:h=-2:format=nv12,hwdownload,format=nv12`;
+    return [
+      '-nostdin',
+      '-hide_banner',
+      '-loglevel',
+      'error',
+      '-threads',
+      '1',
+      '-hwaccel',
+      'cuda',
+      '-hwaccel_output_format',
+      'cuda',
+      '-noaccurate_seek',
+      '-ss',
+      String(seekSeconds),
+      '-an',
+      '-sn',
+      '-i',
+      inputPath,
+      '-frames:v',
+      '1',
+      '-vf',
+      vf,
+      '-q:v',
+      '5',
+      '-y',
+      outputPath,
+    ];
+  }
+}

--- a/backend/src/modules/streaming/thumbnail-extractors/index.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/index.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'fs';
+import { CudaExtractor } from './cuda.extractor';
 import { QsvExtractor } from './qsv.extractor';
 import { SwExtractor } from './sw.extractor';
 import type { CropArea, ExtractorBackend } from './types';
@@ -26,6 +27,11 @@ const HWACCEL_DEVICE: string | null = (() => {
   return null;
 })();
 
+/** The nvidia runtime injects `/dev/nvidiactl` but no `/dev/dri` node, so an
+ *  NVIDIA host never sets {@link HWACCEL_DEVICE} above. */
+const CUDA_AVAILABLE =
+  process.env.THUMB_HWACCEL_DEVICE !== 'off' && existsSync('/dev/nvidiactl');
+
 /**
  * Ordered list of available backends. The factory walks this list and
  * returns the first one whose {@link ExtractorBackend.supports} accepts
@@ -36,19 +42,23 @@ const HWACCEL_DEVICE: string | null = (() => {
  *   • VAAPI before QSV — VAAPI is markedly faster on no-crop sprites.
  *   • QSV before SW — QSV's `vpp_qsv` handles HW crop+scale.
  *   • VideoToolbox on Darwin replaces the Linux HW pair entirely.
+ *   • CUDA after VAAPI/QSV, before SW — mirrors the transcode probe order
+ *     (QSV → VAAPI → NVENC); only reached when no `/dev/dri` node exists.
  */
 const BACKENDS: ExtractorBackend[] = (() => {
   if (process.platform === 'darwin') {
     return [new VideoToolboxExtractor(), new SwExtractor()];
   }
+  const linux: ExtractorBackend[] = [];
   if (HWACCEL_DEVICE) {
-    return [
+    linux.push(
       new VaapiExtractor(HWACCEL_DEVICE),
       new QsvExtractor(HWACCEL_DEVICE),
-      new SwExtractor(),
-    ];
+    );
   }
-  return [new SwExtractor()];
+  if (CUDA_AVAILABLE) linux.push(new CudaExtractor());
+  linux.push(new SwExtractor());
+  return linux;
 })();
 
 /** Pick the highest-priority backend that can handle the given crop.

--- a/backend/src/modules/subtitles/cropdetect.spec.ts
+++ b/backend/src/modules/subtitles/cropdetect.spec.ts
@@ -31,9 +31,21 @@ describe('cropdetect', () => {
   const detect = (w = 1920, h = 1080) =>
     svc.detectCrop('/m/ep.mkv', 3600, w, h);
 
+  const platformDescriptor = Object.getOwnPropertyDescriptor(
+    process,
+    'platform',
+  )!;
+  function setPlatform(value: NodeJS.Platform) {
+    Object.defineProperty(process, 'platform', { value, configurable: true });
+  }
+
   beforeEach(() => {
     execFileMock.mockReset();
     existsSyncMock.mockReset();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', platformDescriptor);
   });
 
   it('normalises to 8-bit before cropdetect, with one limit for every source', () => {
@@ -52,7 +64,8 @@ describe('cropdetect', () => {
   });
 
   it('decodes on the GPU when a render node is there, and keeps 6 samples', async () => {
-    existsSyncMock.mockReturnValue(true);
+    setPlatform('linux');
+    existsSyncMock.mockImplementation((p: string) => p === '/dev/dri/renderD128');
     reply('crop=1920:800:0:140');
     await detect();
 
@@ -118,5 +131,66 @@ describe('cropdetect', () => {
     );
     // 1080 - 1072 = 8px total: below the 40px significance floor.
     expect(await detect()).toBeNull();
+  });
+
+  const CROP_FILTER = 'format=nv12,cropdetect=limit=24:round=16:reset=0:skip=24';
+
+  it('decodes on cuda when only /dev/nvidiactl exists (no render node)', async () => {
+    setPlatform('linux');
+    existsSyncMock.mockImplementation((p: string) => p === '/dev/nvidiactl');
+    reply('crop=1920:800:0:140');
+    await detect();
+
+    for (const argv of calls()) {
+      expect(argv.slice(0, 2)).toEqual(['-hwaccel', 'cuda']);
+      expect(argv.indexOf('-hwaccel')).toBeLessThan(argv.indexOf('-i'));
+      expect(argv[argv.indexOf('-vf') + 1]).toBe(CROP_FILTER);
+      expect(argv).not.toContain('-threads');
+    }
+  });
+
+  it('decodes on d3d11va on win32, ignoring existsSync', async () => {
+    setPlatform('win32');
+    existsSyncMock.mockReturnValue(false);
+    reply('crop=1920:800:0:140');
+    await detect();
+
+    for (const argv of calls()) {
+      expect(argv.slice(0, 2)).toEqual(['-hwaccel', 'd3d11va']);
+      expect(argv).not.toContain('-hwaccel_output_format');
+      expect(argv[argv.indexOf('-vf') + 1]).toBe(CROP_FILTER);
+    }
+  });
+
+  it('decodes on videotoolbox on darwin', async () => {
+    setPlatform('darwin');
+    existsSyncMock.mockReturnValue(false);
+    reply('crop=1920:800:0:140');
+    await detect();
+
+    for (const argv of calls()) {
+      expect(argv.slice(0, 2)).toEqual(['-hwaccel', 'videotoolbox']);
+      expect(argv).not.toContain('-hwaccel_output_format');
+      expect(argv[argv.indexOf('-vf') + 1]).toBe(CROP_FILTER);
+    }
+  });
+
+  it('falls back to software the same way on win32 (platform-agnostic fallback)', async () => {
+    setPlatform('win32');
+    existsSyncMock.mockReturnValue(false);
+    let n = 0;
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb: Cb) =>
+      ++n === 1
+        ? cb(new Error('d3d11va init failed'), { stdout: '', stderr: '' })
+        : cb(null, { stdout: '', stderr: 'crop=1920:800:0:140' }),
+    );
+
+    await detect();
+    // probe + the retried first sample + the 5 remaining ones
+    expect(calls()).toHaveLength(7);
+    for (const argv of calls().slice(1)) {
+      expect(argv).not.toContain('-hwaccel');
+      expect(argv).toContain('-threads');
+    }
   });
 });

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -26,21 +26,36 @@ type CropSample = {
   y: number;
 } | null;
 
-/** VAAPI decode args for the crop probe, or null when there is no usable
- *  render node. Covers Intel and AMD on Linux; NVIDIA (cuda) and Windows
- *  (qsv / d3d11va) need their own decode args. */
+/** HW decode args for the crop probe, or null when nothing usable is present.
+ *  Only VAAPI keeps frames on the device; the others omit
+ *  `-hwaccel_output_format` so ffmpeg auto-downloads, because `hwdownload` can
+ *  only target a surface's own sw_format and would fail on 10-bit. */
 function cropHwDecodeArgs(): string[] | null {
-  if (process.platform !== 'linux') return null;
-  const node = vaapiRenderNode();
-  if (!existsSync(node)) return null;
-  return [
-    '-hwaccel',
-    'vaapi',
-    '-hwaccel_device',
-    node,
-    '-hwaccel_output_format',
-    'vaapi',
-  ];
+  switch (process.platform) {
+    case 'linux': {
+      const node = vaapiRenderNode();
+      if (existsSync(node)) {
+        return [
+          '-hwaccel',
+          'vaapi',
+          '-hwaccel_device',
+          node,
+          '-hwaccel_output_format',
+          'vaapi',
+        ];
+      }
+      // The nvidia runtime injects /dev/nvidiactl but no /dev/dri node.
+      if (existsSync('/dev/nvidiactl')) return ['-hwaccel', 'cuda'];
+      return null;
+    }
+    case 'win32':
+      // d3d11va decodes Intel/AMD/NVIDIA alike, unlike QSV (see decoders/qsv.ts).
+      return ['-hwaccel', 'd3d11va'];
+    case 'darwin':
+      return ['-hwaccel', 'videotoolbox'];
+    default:
+      return null;
+  }
 }
 
 /** Seconds of packet timestamps sampled to measure the real frame rate. The
@@ -731,7 +746,9 @@ export class FfprobeService {
       // Whether the GPU can decode this file depends on its codec, not just on
       // the host, so the only honest check is the first sample. Software
       // produces the same nv12 pixels, so a mid-file switch stays consistent.
-      let hw = cropHwDecodeArgs() !== null;
+      const hwArgs = cropHwDecodeArgs();
+      const hwName = hwArgs ? hwArgs[1] : 'sw';
+      let hw = hwArgs !== null;
       const first = await this.cropSample(videoPath, timestamps[0], hw);
       if (hw && first.failed) {
         this.logger.log(
@@ -749,7 +766,7 @@ export class FfprobeService {
         async (ss) => (await this.cropSample(videoPath, ss, hw)).sample,
       );
       this.logger.log(
-        `cropdetect "${label}" (${originalWidth}x${originalHeight}, decode=${hw ? 'vaapi' : 'sw'})`,
+        `cropdetect "${label}" (${originalWidth}x${originalHeight}, decode=${hw ? hwName : 'sw'})`,
       );
 
       // Aggregate: pick the LARGEST crop observed (the loosest box that
@@ -800,11 +817,12 @@ export class FfprobeService {
     ss: number,
     hw: boolean,
   ): Promise<{ failed: boolean; sample: CropSample }> {
-    const decode = hw
-      ? (cropHwDecodeArgs() ?? [])
-      : // 2 decoder threads: a single-threaded software decode of a 4K sample
-        // can run past the 30s exec timeout on a weak CPU.
-        ['-threads', '2'];
+    const hwArgs = hw ? cropHwDecodeArgs() : null;
+    const decode =
+      hwArgs ??
+      // 2 decoder threads: a single-threaded software decode of a 4K sample
+      // can run past the 30s exec timeout on a weak CPU.
+      ['-threads', '2'];
     const ffmpegArgs = [
       ...decode,
       '-ss',
@@ -814,7 +832,9 @@ export class FfprobeService {
       '-t',
       '5',
       '-vf',
-      hw ? `hwdownload,${CROP_FILTER}` : CROP_FILTER,
+      hwArgs?.includes('-hwaccel_output_format')
+        ? `hwdownload,${CROP_FILTER}`
+        : CROP_FILTER,
       '-an',
       '-f',
       'null',


### PR DESCRIPTION
Closes #1127. Closes #1128. Closes #1129.

Three issues, one function and one list. Filed separately, but #1127 and #1128 edit the same
branch point and #1129 shares the NVIDIA detection rationale, so they ship together.

## cropdetect: platform coverage (#1128)

`cropHwDecodeArgs()` returned null on anything but Linux, so Windows and macOS decoded every
sample in software. On Linux the equivalent change cut a 4K HEVC detection from 52s to 8s of CPU.
The platform gate becomes a flat switch.

**Windows takes `d3d11va`, not `qsv`.** It decodes Intel, AMD and NVIDIA alike, which collapses
the issue's two Windows branches into one and covers NVIDIA-on-Windows for free; and it sidesteps
the native QSV AV1 decoder that `codec/decoders/qsv.ts` already avoids for the same reason, so the
issue's AV1 caveat disappears with it. AMF was never a candidate — it is encode-only.

`hw-detect.ts` is deliberately not reused: it probes **encoders**, cropdetect needs a **decoder**,
and the mapping breaks precisely on Windows. Its cached result also lives on `TranscodingService`
in a module `FfprobeService` cannot reach without a cycle risk, for what is a three-line branch.

## cropdetect: NVIDIA (#1127)

Root cause of NVIDIA hosts falling back to software: the nvidia container runtime injects
`/dev/nvidiactl` but **no `/dev/dri`**, so the render-node check never matched. One `existsSync`
mirroring the existing one, after VAAPI so validated Intel/AMD hosts are untouched.

## The hwdownload rule (why this diverges from #1127's stated recipe)

The issue proposed `-hwaccel cuda -hwaccel_output_format cuda … -vf hwdownload,format=nv12,…`.
Only VAAPI's driver reliably downloads a P010 surface straight to nv12 — that is why #1126 worked
on 10-bit HEVC. On the other backends `hwdownload` can only target the surface's own `sw_format`,
so `format=nv12` risks failing on exactly the 4K 10-bit files where the gain is largest, and the
per-file probe would then fall back to software silently.

Rather than adjudicate that on paper, the new backends omit `-hwaccel_output_format` and drop
`hwdownload` entirely: ffmpeg auto-downloads decoded frames to system memory in their native
format, and `CROP_FILTER`'s existing `format=nv12` normalises 10-bit in swscale, cheap next to the
decode. `codec/decoders/d3d11va.ts` already documents this exact behaviour, and it is the shorter
diff. VAAPI keeps its measured #1126 recipe untouched.

The `detectCrop` log stopped hardcoding `vaapi` and now names the backend actually in use.

## thumbnails: CUDA extractor (#1129)

Same NVIDIA hole in `thumbnail-extractors/`: a host with an NVIDIA card got NVENC transcoding but
decoded every sprite frame in software. `CudaExtractor` mirrors `VaapiExtractor` and sits after
the Intel pair, before the software fallback, matching the transcode probe order (QSV → VAAPI →
NVENC) so it cannot shadow a working render node. `supports()` accepts crop too: on an NVIDIA host
there is no QSV to hand the crop case to, and refusing it would leave letterboxed content on the
software path — the reported bug.

Unlike cropdetect this one *does* keep frames on the device, because `scale_cuda` needs a CUDA
frames context; it also does the p010→nv12 conversion itself, so 10-bit needs no special path.
`scale_cuda` has no crop option, so the crop case downloads the full frame and crops on the CPU —
marked in the source with its upgrade path.

Sprites are not tone-mapped, matching what the VAAPI and QSV extractors already do.

## Verification

`tsc --noEmit` clean; `jest src/modules/subtitles src/modules/streaming/thumbnail-extractors` —
13 suites, 87 tests passing, including new coverage for the cuda / d3d11va / videotoolbox argv
shapes and for the per-file software fallback on a non-Linux platform.

Needs real hosts, per the issues:

- **NVIDIA:** boot log reads `Thumbnail extraction backends: cuda → sw`; cropdetect logs
  `decode=cuda`; crop values match a software run on 8-bit h264 and 10-bit HEVC; `nvidia-smi dmon`
  shows NVDEC busy during a sprite run. The open question from #1127 is whether the PCIe
  device-to-host copy eats the gain on 4K 10-bit — if it does, the follow-up is a
  `scale_cuda=format=nv12` prefix to convert before the copy.
- **Windows Intel / AMD, macOS:** same crop-parity check plus CPU time against software, expecting
  the 3-6x range from #1126.
- **Pre-Ampere NVIDIA (no AV1 decode):** expect the "HW decode rejected this file — falling back to
  software" log rather than a hang. The fallback catches on exit code, not a stderr pattern, so it
  is decoder-agnostic and needed no change.

Known limit, unchanged from today's VAAPI path: if a codec has no hwaccel entry for the device type
at all, ffmpeg decodes in software while the log still names the hardware backend.