### PR TITLE
fix(subtitles): cache extracted vtt in the images volume, not the library

### DIFF
--- a/backend/src/common/utils/media-cache.util.ts
+++ b/backend/src/common/utils/media-cache.util.ts
@@ -4,14 +4,9 @@ import * as path from 'path';
 /**
  * Per-media on-disk cache convention.
  *
- * `.cache/` lives at the root of every media folder and is shared between
- * features:
- *   - `.cache/subs/<mediaFileId>/emb-<streamIndex>.vtt`  (SubtitleStreamService)
- *   - future: `.cache/sprite/...`, `.cache/trickplay/...`, etc.
- *
- * The whole `.cache/` tree is disposable — it's wiped on a full rescan
- * (`clearMediaCache`) and recreated on demand. Any new feature that wants
- * cheap persistence across restarts should land here.
+ * `.cache/` at a media root is only ever removed, never written: a library can
+ * be mounted read-only or moved without the app, so cached artefacts live in the
+ * managed images volume instead.
  */
 
 /** Absolute path to the `.cache/` directory at the media root. */

--- a/backend/src/modules/media/media-service/media-mutation.service.spec.ts
+++ b/backend/src/modules/media/media-service/media-mutation.service.spec.ts
@@ -86,6 +86,7 @@ describe('MediaMutationService monitoring cascade', () => {
       requestLifecycle as never,
       { emitDomain: jest.fn() } as never,
       { deleteForFile: jest.fn() } as never,
+      { clearMediaFileSubtitleCache: jest.fn() } as never,
     );
   });
 
@@ -188,6 +189,7 @@ describe('MediaMutationService remove disk cleanup', () => {
       requestLifecycle as never,
       { emitDomain: jest.fn() } as never,
       { deleteForFile: jest.fn() } as never,
+      { clearMediaFileSubtitleCache: jest.fn() } as never,
     );
   });
 

--- a/backend/src/modules/media/media-service/media-mutation.service.ts
+++ b/backend/src/modules/media/media-service/media-mutation.service.ts
@@ -27,6 +27,7 @@ import { RequestLifecycleService } from '../../requests/request-lifecycle.servic
 import { MediaQueryService } from './media-query.service';
 import { MediaMetadataService } from './media-metadata.service';
 import { ThumbnailService } from '../../streaming/thumbnail.service';
+import { SubtitleStreamService } from '../../streaming/subtitle-stream.service';
 
 @Injectable()
 export class MediaMutationService {
@@ -51,6 +52,7 @@ export class MediaMutationService {
     private readonly requestLifecycle: RequestLifecycleService,
     private readonly events: EventsService,
     private readonly thumbnails: ThumbnailService,
+    private readonly subtitleStream: SubtitleStreamService,
   ) {}
 
   async update(id: number, dto: UpdateMediaDto): Promise<Media> {
@@ -222,7 +224,10 @@ export class MediaMutationService {
     const fileIds = (media.files ?? []).map((f) => f.id);
     await this.requestLifecycle.onMediaRemoved(media);
     await this.mediaRepo.remove(media);
-    for (const fileId of fileIds) void this.thumbnails.deleteForFile(fileId);
+    for (const fileId of fileIds) {
+      void this.thumbnails.deleteForFile(fileId);
+      void this.subtitleStream.clearMediaFileSubtitleCache(fileId);
+    }
     this.events.emitDomain({
       type: 'media.removed',
       mediaId: id,
@@ -352,6 +357,7 @@ export class MediaMutationService {
     const episodeId = file.episodeId;
     await this.mediaFileRepo.remove(file);
     void this.thumbnails.deleteForFile(file.id);
+    void this.subtitleStream.clearMediaFileSubtitleCache(file.id);
     if (episodeId != null) {
       const remaining = await this.mediaFileRepo.count({
         where: { episode: { id: episodeId } },

--- a/backend/src/modules/media/media-service/media-rescan.service.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.ts
@@ -333,11 +333,10 @@ export class MediaRescanService {
         : null,
     );
     void this.subtitleStream
-      .clearMediaFileSubtitleCache(media?.path, file.id)
+      .clearMediaFileSubtitleCache(file.id)
       .then(() =>
         this.subtitleStream.warmupCache(
           absPath,
-          media?.path,
           file.id,
           file.streamInfo?.subtitles,
           subject,
@@ -449,6 +448,11 @@ export class MediaRescanService {
         `Rescan[media #${mediaId}]: clearMediaCache failed for "${media.path}": ${err instanceof Error ? err.message : err}`,
       );
     }
+    // The subtitle cache lives outside `.cache/`, in the images volume, so it
+    // needs its own invalidation to preserve "full rescan wipes every cached VTT".
+    for (const f of media.files ?? []) {
+      void this.subtitleStream.clearMediaFileSubtitleCache(f.id);
+    }
 
     const mediaDir = path.resolve(media.path);
     if (!(await pathExists(mediaDir))) {
@@ -519,6 +523,7 @@ export class MediaRescanService {
         try {
           await this.mediaFileRepo.remove(dbFile);
           void this.thumbnailService.deleteForFile(dbFile.id);
+          void this.subtitleStream.clearMediaFileSubtitleCache(dbFile.id);
           removed++;
           this.log.log(
             `Rescan: removed missing file "${normPath}" for media #${mediaId}`,
@@ -689,7 +694,6 @@ export class MediaRescanService {
         if (!options?.skipWarmup) {
           void this.subtitleStream.warmupCache(
             absPath,
-            media.path,
             dbFile.id,
             streamInfo?.subtitles,
             buildMediaProgressSubject(media, epForProgress),
@@ -808,7 +812,6 @@ export class MediaRescanService {
         if (!options?.skipWarmup) {
           void this.subtitleStream.warmupCache(
             absPath,
-            media.path,
             savedFile.id,
             probed.streamInfo.subtitles,
             buildMediaProgressSubject(media, epForProgress),

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -728,7 +728,6 @@ export class StreamingController {
     void this.subtitleStreamService
       .warmupCache(
         resolved.absolutePath,
-        resolved.media.path,
         mediaFileId,
         resolved.mediaFile.streamInfo?.subtitles,
         {

--- a/backend/src/modules/streaming/subtitle-cache-path.spec.ts
+++ b/backend/src/modules/streaming/subtitle-cache-path.spec.ts
@@ -1,0 +1,55 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+/** `cacheDirFor`/`cachePathFor` are private, so intersecting them with the
+ *  class collapses to `never` — name them alone and cast through `unknown`. */
+type Svc = {
+  cacheDirFor(mediaFileId: number): string;
+  cachePathFor(mediaFileId: number, streamIndex: number): string;
+};
+
+describe('subtitle cache path', () => {
+  const OLD_ENV = process.env;
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'sub-cache-path-'));
+  });
+  afterAll(async () => {
+    process.env = OLD_ENV;
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  function loadSvc(): Svc {
+    jest.resetModules();
+    process.env = { ...OLD_ENV, FLIKS_IMAGES_DIR: dir };
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { SubtitleStreamService } = require('./subtitle-stream.service');
+    return new SubtitleStreamService(
+      null as never,
+      null as never,
+      null as never,
+      null as never,
+      null as never,
+      null as never,
+    ) as unknown as Svc;
+  }
+
+  it('resolves under the images volume, not the media folder', () => {
+    const svc = loadSvc();
+    expect(svc.cachePathFor(7, 2)).toBe(
+      path.join(dir, 'subs', '7', 'emb-2.vtt'),
+    );
+  });
+
+  it('never contains a `.cache` segment', () => {
+    const svc = loadSvc();
+    expect(svc.cachePathFor(7, 2).split(path.sep)).not.toContain('.cache');
+  });
+
+  it('cacheDirFor is the dirname of cachePathFor, as clearMediaFileSubtitleCache assumes', () => {
+    const svc = loadSvc();
+    expect(svc.cacheDirFor(7)).toBe(path.dirname(svc.cachePathFor(7, 2)));
+  });
+});

--- a/backend/src/modules/streaming/subtitle-prewarm.spec.ts
+++ b/backend/src/modules/streaming/subtitle-prewarm.spec.ts
@@ -24,7 +24,7 @@ const SUBS = [
 ];
 
 const warm = (svc: SubtitleStreamService, trigger: 'import' | 'playback') =>
-  svc.warmupCache('/m/s01e01.mkv', '/m', 1, SUBS, { title: 'Ep' }, trigger);
+  svc.warmupCache('/m/s01e01.mkv', 1, SUBS, { title: 'Ep' }, trigger);
 
 describe('subtitle prewarm', () => {
   it.each([
@@ -42,13 +42,13 @@ describe('subtitle prewarm', () => {
 
   it('defaults to the import trigger, so a caller that forgets stays gated', async () => {
     const { svc, queued } = makeService('playback');
-    await svc.warmupCache('/m/s01e01.mkv', '/m', 1, SUBS, { title: 'Ep' });
+    await svc.warmupCache('/m/s01e01.mkv', 1, SUBS, { title: 'Ep' });
     expect(queued).not.toHaveBeenCalled();
   });
 
   it('never queues image-based tracks: they burn in, they have no VTT form', async () => {
     const { svc, queued } = makeService('import');
-    await svc.warmupCache('/m/s01e01.mkv', '/m', 1, [SUBS[1]], { title: 'Ep' }, 'import');
+    await svc.warmupCache('/m/s01e01.mkv', 1, [SUBS[1]], { title: 'Ep' }, 'import');
     expect(queued).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/streaming/subtitle-stream.service.ts
+++ b/backend/src/modules/streaming/subtitle-stream.service.ts
@@ -28,12 +28,16 @@ import { resolveSubtitleAbsolutePath } from '../subtitles/subtitle-path.util';
 import { normalizeLanguageCode } from '../../common/constants/app-languages';
 import type { SubtitleRenditionMeta } from './transcoding/types';
 import { withFfmpegSlot } from '../../common/utils/ffmpeg-slots';
+import { getImagesDir } from '../../common/constants/paths';
 import {
   formatMediaProgressSubject,
   type MediaProgressSubject,
 } from '../../common/utils/media-progress-subject.util';
 
 const execFileAsync = promisify(execFile);
+
+/** getImagesDir() probes the filesystem on its first call — keep this lazy. */
+const subsDir = () => path.join(getImagesDir(), 'subs');
 
 /**
  * Global cap on concurrent warmup extractions — a full library refresh can
@@ -50,7 +54,6 @@ const EXTRACT_TIMEOUT_MS = 15 * 60_000;
 
 interface WarmupTask {
   absolutePath: string;
-  mediaRoot: string;
   mediaFileId: number;
   /**
    * All subtitle stream indices to extract in a single FFmpeg invocation.
@@ -260,13 +263,7 @@ export class SubtitleStreamService {
     }
 
     const resolved = await this.streamingService.resolveFile(mediaFileId, user);
-    const mediaRoot = resolved.media.path;
-    if (!mediaRoot) {
-      throw new NotFoundException(
-        `Media file #${mediaFileId} has no media root — cannot cache subtitle`,
-      );
-    }
-    const cachePath = this.cachePathFor(mediaRoot, mediaFileId, streamIndex);
+    const cachePath = this.cachePathFor(mediaFileId, streamIndex);
     if (fsSync.existsSync(cachePath)) {
       return fsSync.createReadStream(cachePath);
     }
@@ -285,15 +282,11 @@ export class SubtitleStreamService {
       ) ?? [];
     const uncachedIndices = textSubs
       .map((s) => s.streamIndex)
-      .filter(
-        (idx) =>
-          !fsSync.existsSync(this.cachePathFor(mediaRoot, mediaFileId, idx)),
-      );
+      .filter((idx) => !fsSync.existsSync(this.cachePathFor(mediaFileId, idx)));
 
     if (uncachedIndices.length > 1 && uncachedIndices.includes(streamIndex)) {
       await this.extractBatchDeduped(
         resolved.absolutePath,
-        mediaRoot,
         mediaFileId,
         uncachedIndices,
         false,
@@ -301,7 +294,6 @@ export class SubtitleStreamService {
     } else {
       await this.extractDeduped(
         resolved.absolutePath,
-        mediaRoot,
         mediaFileId,
         streamIndex,
         false,
@@ -325,13 +317,11 @@ export class SubtitleStreamService {
    */
   async warmupCache(
     absolutePath: string,
-    mediaRoot: string | null | undefined,
     mediaFileId: number,
     subtitles: { streamIndex: number; isImageBased: boolean }[] | undefined,
     subject: MediaProgressSubject,
     trigger: 'import' | 'playback' = 'import',
   ): Promise<void> {
-    if (!mediaRoot) return;
     if (!subtitles?.length) return;
     const mode = (await this.streamingSettings.get()).subtitlePrewarm;
     if (mode === 'off' || (mode === 'playback' && trigger === 'import')) return;
@@ -346,10 +336,7 @@ export class SubtitleStreamService {
 
     // Skip subs whose cache file is already on disk.
     const pending = textSubs.filter(
-      (s) =>
-        !fsSync.existsSync(
-          this.cachePathFor(mediaRoot, mediaFileId, s.streamIndex),
-        ),
+      (s) => !fsSync.existsSync(this.cachePathFor(mediaFileId, s.streamIndex)),
     );
     if (!pending.length) return;
 
@@ -395,7 +382,6 @@ export class SubtitleStreamService {
     // One task per file (multi-output ffmpeg) instead of one per stream.
     this.warmupQueue.push({
       absolutePath,
-      mediaRoot,
       mediaFileId,
       streamIndices: pending.map((s) => s.streamIndex),
       batch,
@@ -457,22 +443,12 @@ export class SubtitleStreamService {
   }
 
   /**
-   * Delete a single media file's subtitle cache subdirectory
-   * (`.cache/subs/<mediaFileId>/`) — called when one file is re-probed so
-   * the upcoming warmup regenerates its VTTs from the fresh streamInfo.
-   * Leaves the rest of `.cache/` (other files, other features) untouched.
+   * Delete a single media file's subtitle cache subdirectory — called when a
+   * file is re-probed or removed so a later warmup regenerates its VTTs from
+   * fresh streamInfo, or so nothing lingers once the file is gone.
    */
-  async clearMediaFileSubtitleCache(
-    mediaRoot: string | null | undefined,
-    mediaFileId: number,
-  ): Promise<void> {
-    if (!mediaRoot) return;
-    const cacheDir = path.join(
-      mediaRoot,
-      '.cache',
-      'subs',
-      String(mediaFileId),
-    );
+  async clearMediaFileSubtitleCache(mediaFileId: number): Promise<void> {
+    const cacheDir = this.cacheDirFor(mediaFileId);
     try {
       await fs.rm(cacheDir, { recursive: true, force: true });
     } catch (err) {
@@ -499,8 +475,7 @@ export class SubtitleStreamService {
    * if the batch fails (one corrupt sub shouldn't kill the others).
    */
   private async runWarmupTask(task: WarmupTask): Promise<void> {
-    const { absolutePath, mediaRoot, mediaFileId, streamIndices, batch, trigger } =
-      task;
+    const { absolutePath, mediaFileId, streamIndices, batch, trigger } = task;
     // Only an import-time warmup competes for the shared ffmpeg slot pool; a
     // playback-triggered one must extract immediately, same as a live cache miss.
     const background = trigger === 'import';
@@ -517,7 +492,6 @@ export class SubtitleStreamService {
       try {
         await this.extractBatchDeduped(
           absolutePath,
-          mediaRoot,
           mediaFileId,
           streamIndices,
           background,
@@ -534,7 +508,6 @@ export class SubtitleStreamService {
           try {
             await this.extractDeduped(
               absolutePath,
-              mediaRoot,
               mediaFileId,
               idx,
               background,
@@ -584,7 +557,6 @@ export class SubtitleStreamService {
 
   private extractDeduped(
     absolutePath: string,
-    mediaRoot: string,
     mediaFileId: number,
     streamIndex: number,
     background: boolean,
@@ -594,14 +566,11 @@ export class SubtitleStreamService {
     if (inflight) return inflight;
     // Also re-check the file — it may have been written between the
     // queue push and the actual dequeue.
-    if (
-      fsSync.existsSync(this.cachePathFor(mediaRoot, mediaFileId, streamIndex))
-    ) {
+    if (fsSync.existsSync(this.cachePathFor(mediaFileId, streamIndex))) {
       return Promise.resolve();
     }
     const promise = this.extractToCache(
       absolutePath,
-      mediaRoot,
       mediaFileId,
       streamIndex,
       background,
@@ -622,7 +591,6 @@ export class SubtitleStreamService {
    */
   private async extractBatchDeduped(
     absolutePath: string,
-    mediaRoot: string,
     mediaFileId: number,
     streamIndices: number[],
     background: boolean,
@@ -637,9 +605,7 @@ export class SubtitleStreamService {
       const existing = this.inflight.get(key);
       if (existing) {
         joinPromises.push(existing);
-      } else if (
-        fsSync.existsSync(this.cachePathFor(mediaRoot, mediaFileId, idx))
-      ) {
+      } else if (fsSync.existsSync(this.cachePathFor(mediaFileId, idx))) {
         // Already on disk — nothing to do for this index.
       } else {
         ownIndices.push(idx);
@@ -654,7 +620,6 @@ export class SubtitleStreamService {
 
     const sharedPromise = this.extractBatchToCache(
       absolutePath,
-      mediaRoot,
       mediaFileId,
       ownIndices,
       background,
@@ -675,22 +640,16 @@ export class SubtitleStreamService {
   }
 
   /**
-   * Cache path: `<media.path>/.cache/subs/<mediaFileId>/emb-<streamIndex>.vtt`.
-   * Living alongside the media means the cache survives server restarts and
-   * gets wiped naturally when the user deletes the media folder.
+   * Cache path: `<imagesDir>/subs/<mediaFileId>/emb-<streamIndex>.vtt`. The
+   * managed images volume (not the library mount) survives library moves and
+   * still works when the library is mounted read-only.
    */
-  private cachePathFor(
-    mediaRoot: string,
-    mediaFileId: number,
-    streamIndex: number,
-  ): string {
-    return path.join(
-      mediaRoot,
-      '.cache',
-      'subs',
-      String(mediaFileId),
-      `emb-${streamIndex}.vtt`,
-    );
+  private cacheDirFor(mediaFileId: number): string {
+    return path.join(subsDir(), String(mediaFileId));
+  }
+
+  private cachePathFor(mediaFileId: number, streamIndex: number): string {
+    return path.join(this.cacheDirFor(mediaFileId), `emb-${streamIndex}.vtt`);
   }
 
   /**
@@ -702,19 +661,15 @@ export class SubtitleStreamService {
    */
   private async extractBatchToCache(
     absolutePath: string,
-    mediaRoot: string,
     mediaFileId: number,
     streamIndices: number[],
     background: boolean,
   ): Promise<void> {
     if (!streamIndices.length) return;
-    const cacheDir = path.dirname(
-      this.cachePathFor(mediaRoot, mediaFileId, streamIndices[0]),
-    );
-    await fs.mkdir(cacheDir, { recursive: true });
+    await fs.mkdir(this.cacheDirFor(mediaFileId), { recursive: true });
 
     const outputs = streamIndices.map((idx) => {
-      const final = this.cachePathFor(mediaRoot, mediaFileId, idx);
+      const final = this.cachePathFor(mediaFileId, idx);
       return { idx, final, tmp: `${final}.tmp` };
     });
 
@@ -800,12 +755,11 @@ export class SubtitleStreamService {
 
   private async extractToCache(
     absolutePath: string,
-    mediaRoot: string,
     mediaFileId: number,
     streamIndex: number,
     background: boolean,
   ): Promise<void> {
-    const cachePath = this.cachePathFor(mediaRoot, mediaFileId, streamIndex);
+    const cachePath = this.cachePathFor(mediaFileId, streamIndex);
     const tmpPath = `${cachePath}.tmp`;
     await fs.mkdir(path.dirname(cachePath), { recursive: true });
     const runFfmpeg = () =>

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -90,7 +90,7 @@ services:
       - /path/to/download/folder:/downloads
       # JWT key: lose it and everyone is logged out.
       - fliks_conf:/app/conf
-      # Posters, fanart, seek-preview sprites.
+      # Posters, fanart, seek-preview sprites, extracted subtitle cache.
       - fliks_images:/app/images
       # HLS segment cache, paired with FLIKS_TRANSCODE_DIR above. Drop both to
       # leave it in /tmp.


### PR DESCRIPTION
Closes #1132.

## The defect, and one correction to the issue

`cachePathFor()` wrote extracted WebVTT to `<media folder>/.cache/subs/<mediaFileId>/`, inside the
mount the user supplied.

The issue says a read-only library "re-reads the whole container on every request". It is worse
than that: `extractToCache` / `extractBatchToCache` call `fs.mkdir(cacheDir, { recursive: true })`
**before** spawning ffmpeg. On a read-only mount that rejects `EROFS` and propagates unhandled
through `extractEmbeddedSubtitle` to the controller, which has no try/catch, to the global
exception filter — **HTTP 500, no subtitle at all, ever**. It never reads the container.

The other two consequences hold as filed: the cache is orphaned when media moves (keyed by a
`mediaFileId` the relocated tree no longer matches), and it pollutes the user's library and their
backups with app-private state.

## Where it goes

`getImagesDir()/subs/<mediaFileId>/emb-<streamIndex>.vtt`. No new env var, no new volume, no
Dockerfile change.

`getImagesDir()` resolves through `resolveWritableDir`, which opens and deletes a real `.probe`
file rather than trusting `fs.access` — that is the existing answer to a root-owned directory the
container uid cannot write, demoting to tmp with a warning instead of crashing at first write. The
image already does `chgrp -R 0 && chmod -R g=u` on `/app/images`, which is what makes TrueNAS uid
568, unraid 99:100 and arbitrary-uid hosts work. `ThumbnailService` already does exactly this
(`getImagesDir()/thumbnails`) for per-`mediaFileId` artefacts with the same lifecycle.

`FLIKS_TRANSCODE_DIR` was the other candidate and is wrong for this: no writability probe, defaults
to `/tmp` (tmpfs on many hosts, so the cache dies on restart), and a byte-capped LRU GC runs over
it that a durable warmup cache would fight.

A dedicated `FLIKS_SUBS_DIR` + volume was skipped: it would need a Dockerfile line, a compose
volume and docs, and would silently land in the container's writable layer — lost on
`--force-recreate` — for every existing user who does not edit their compose file. Reusing the
images volume ships correct for existing deployments on day one. Add one when the VTT cache needs
its own disk.

## Migration: none

Moving the trees means a pass over every `Media.path`, statting per file, across what is almost
certainly a different filesystem (so `EXDEV`, so copy+unlink rather than rename), which cannot run
at all on the read-only mounts that motivated the issue — and it is dead code maintained forever
after one run. Re-extraction costs one container read per track, once: the same cost a user already
pays on the first playback of any un-warmed file, and invisible when `subtitlePrewarm` is on.

The stale trees are not left behind: `clearMediaCache(media.path)` already `rm -rf`s the whole
`.cache` tree at the start of every full rescan, wrapped in try/catch + warn so a read-only mount
just logs, and nothing recreates it now. No boot-time sweeper.

## Lifecycle

The cache no longer dies with the media folder, so it needs explicit invalidation. Mirrored
one-for-one onto the three existing `thumbnails.deleteForFile` sites — media removal, single-file
deletion, and a file found missing during rescan — plus a loop over `media.files` on a full rescan
to preserve today's "a full rescan invalidates every cached VTT for this media".

`MediaMutationService` gains `SubtitleStreamService`; it is already exported by `StreamingModule`
and already injected in `MediaRescanService`, so no new module wiring.

## Also removed

Three silent guards that existed only because the path depended on the media root, and which
dropped work with no log — the defect shape this repo keeps hitting: `warmupCache` self-disabling
prewarm for any media with a null path, `clearMediaFileSubtitleCache` no-oping so a stale cache
survived a re-probe undetected, and the `NotFoundException` in `extractEmbeddedSubtitle`.

## Verification

`tsc --noEmit` clean; `jest src/modules/streaming src/modules/media` — 65 suites, 578 tests
passing. New `subtitle-cache-path.spec.ts` pins the resolved path under `FLIKS_IMAGES_DIR`, asserts
no `.cache` segment survives, and asserts `cacheDirFor(id) === dirname(cachePathFor(id, idx))` —
the invariant `clearMediaFileSubtitleCache` depends on.

Manual pass still wanted, the read-only case above all:

1. Remount a library `:ro`, restart, request an embedded subtitle. Was 500 with an `EROFS` stack;
   should be 200, with the second request served from the images volume and no ffmpeg spawn.
2. The offline-download endpoint on the same read-only mount — it inherits the fix through
   `extractEmbeddedSubtitle` and needed no change of its own.
3. Rename a media folder on disk and rescan: the cache is keyed by `mediaFileId` and survives.
4. Delete a media, then a single file: only the matching directories disappear.
5. On an install with a pre-existing `<library>/.cache/subs`, run a full rescan and confirm the tree
   is gone and no new one appears.
6. Run with `user: '568:568'` + `group_add: ['0']` and confirm no `WritableDir` warning at boot and
   that `subs/` lands under `/app/images`, not the tmp fallback.

## Out of scope

`subtitle-ocr.service.ts` and `subtitle-translation.service.ts` also write next to the video, but
those are user-visible sidecars persisted as `SubtitleFile.relativePath`, not caches; moving them
would change DB semantics. They break on read-only mounts too — worth its own issue.