### PR TITLE
feat(imports): surface the orphan batch in the activity table

### DIFF
--- a/backend/src/modules/imports/disk-import.orphan-activity.spec.ts
+++ b/backend/src/modules/imports/disk-import.orphan-activity.spec.ts
@@ -1,0 +1,77 @@
+import { ActivityRegistryService } from '../scheduler/activity-registry.service';
+import { DiskImportService, ORPHAN_IMPORT_PROGRESS } from './disk-import.service';
+import { RelinkOrphansDto } from './dto/relink-orphans.dto';
+import { MediaType } from '../../common/enums';
+
+const group = (folderName: string): RelinkOrphansDto =>
+  ({
+    libraryId: 1,
+    type: MediaType.MOVIE,
+    externalId: '1',
+    folderName,
+    files: [],
+  }) as RelinkOrphansDto;
+
+function makeService(registry: ActivityRegistryService) {
+  return new DiskImportService(
+    null as never, // mediaRepo
+    null as never, // fileRepo
+    null as never, // seasonRepo
+    null as never, // episodeRepo
+    null as never, // mediaService
+    null as never, // naming
+    null as never, // libraries — makes every relinkOrphans throw
+    null as never, // metadata
+    null as never, // nfo
+    null as never, // libraryIngest
+    null as never, // postImportQueue
+    null as never, // mediaServers
+    { emit: jest.fn() } as never,
+    registry,
+  );
+}
+
+describe('orphan batch activity', () => {
+  let registry: ActivityRegistryService;
+  let service: DiskImportService;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    registry = new ActivityRegistryService({ emit: jest.fn() } as never);
+    service = makeService(registry);
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('pre-registers the whole backlog under the batch row', async () => {
+    const pending = jest.spyOn(registry, 'upsertPending');
+    await service.relinkOrphansBatch([group('A Folder'), group('B Folder')], null);
+
+    expect(pending).toHaveBeenCalledTimes(2);
+    for (const [id, type, subject, parentId] of pending.mock.calls) {
+      expect(type).toBe(ORPHAN_IMPORT_PROGRESS);
+      expect(parentId).toBe(ORPHAN_IMPORT_PROGRESS);
+      expect(id).toContain(subject?.title);
+    }
+  });
+
+  it('reports the group the batch is on against the total', async () => {
+    const running = jest.spyOn(registry, 'upsertRunning');
+    await service.relinkOrphansBatch([group('A Folder'), group('B Folder')], null);
+
+    const batchRows = running.mock.calls.filter(([id]) => id === ORPHAN_IMPORT_PROGRESS);
+    expect(batchRows.map(([, , , current, total]) => [current, total])).toEqual([
+      [1, 2],
+      [2, 2],
+    ]);
+  });
+
+  // Every group fails here (no repositories), which is the case that would leak.
+  it('leaves nothing in the registry once the batch is done', async () => {
+    await service.relinkOrphansBatch([group('A Folder'), group('B Folder')], null);
+    expect(registry.list(1, 50)).toMatchObject({ data: [], total: 0 });
+  });
+});

--- a/backend/src/modules/imports/disk-import.orphan-scan.spec.ts
+++ b/backend/src/modules/imports/disk-import.orphan-scan.spec.ts
@@ -48,6 +48,7 @@ function makeService(nfo: NfoMetadataService) {
     null as never, // postImportQueue
     null as never, // mediaServers
     { emit: jest.fn() } as never,
+    { upsertPending: jest.fn(), upsertRunning: jest.fn(), remove: jest.fn() } as never,
   );
 }
 

--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -30,6 +30,7 @@ import {
 } from './dto/orphan-scan.dto';
 import { NfoMetadataService } from './nfo-metadata.service';
 import { EventsService } from '../scheduler/events.service';
+import { ActivityRegistryService } from '../scheduler/activity-registry.service';
 import { mapWithConcurrency } from '../../common/utils/concurrency';
 import { MediaService } from '../media/media.service';
 import { MediaMetadataService } from '../media/media-service/media-metadata.service';
@@ -136,6 +137,7 @@ export class DiskImportService {
     private readonly postImportQueue: PostImportQueueService,
     private readonly mediaServers: MediaServersService,
     private readonly events: EventsService,
+    private readonly activityRegistry: ActivityRegistryService,
   ) {}
 
   /**
@@ -348,25 +350,59 @@ export class DiskImportService {
     let linked = 0;
     let failed = 0;
     let index = 0;
+    const activityId = (item: RelinkOrphansDto) =>
+      `${ORPHAN_IMPORT_PROGRESS}:${item.type}:${item.folderName}`;
+    // The whole backlog up front: this loop runs for hours on a large series, and
+    // the queued groups are the part the user can't otherwise see.
     for (const item of items) {
-      this.events.emit({
-        type: 'task.progress',
-        command: ORPHAN_IMPORT_PROGRESS,
-        current: index++,
-        total: items.length,
-        message: item.folderName,
-      });
-      try {
-        const res = await this.relinkOrphans(item, userId);
-        if (res.created) created++;
-        linked += res.linked;
-        if (res.linked === 0) failed++;
-      } catch (e) {
-        failed++;
-        this.logger.warn(
-          `Orphan batch: "${item.folderName}" failed — ${(e as Error).message}`,
+      this.activityRegistry.upsertPending(
+        activityId(item),
+        ORPHAN_IMPORT_PROGRESS,
+        { title: item.folderName },
+        ORPHAN_IMPORT_PROGRESS,
+      );
+    }
+    try {
+      for (const item of items) {
+        this.events.emit({
+          type: 'task.progress',
+          command: ORPHAN_IMPORT_PROGRESS,
+          current: index++,
+          total: items.length,
+          message: item.folderName,
+        });
+        this.activityRegistry.upsertRunning(
+          ORPHAN_IMPORT_PROGRESS,
+          ORPHAN_IMPORT_PROGRESS,
+          { title: item.folderName },
+          index,
+          items.length,
         );
+        this.activityRegistry.upsertRunning(
+          activityId(item),
+          ORPHAN_IMPORT_PROGRESS,
+          { title: item.folderName },
+          undefined,
+          undefined,
+          ORPHAN_IMPORT_PROGRESS,
+        );
+        try {
+          const res = await this.relinkOrphans(item, userId);
+          if (res.created) created++;
+          linked += res.linked;
+          if (res.linked === 0) failed++;
+        } catch (e) {
+          failed++;
+          this.logger.warn(
+            `Orphan batch: "${item.folderName}" failed — ${(e as Error).message}`,
+          );
+        } finally {
+          this.activityRegistry.remove(activityId(item));
+        }
       }
+    } finally {
+      for (const item of items) this.activityRegistry.remove(activityId(item));
+      this.activityRegistry.remove(ORPHAN_IMPORT_PROGRESS);
     }
     this.events.emit({
       type: 'task.progress',

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1291,6 +1291,7 @@
     "cmd_warmup_subtitles": "Untertitel extrahieren",
     "cmd_post_import_enrich": "Import abschließen",
     "cmd_post_import_enrich_queue": "Imports werden abgeschlossen",
+    "cmd_orphan_import": "Erkannte Medien importieren",
     "cmd_subtitle_search": "Fehlende Untertitel suchen",
     "cmd_subtitle_upgrade": "Untertitelqualität verbessern",
     "cmd_group_media": "Medien",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1299,6 +1299,7 @@
     "cmd_warmup_subtitles": "Extract subtitles",
     "cmd_post_import_enrich": "Finalize import",
     "cmd_post_import_enrich_queue": "Finalizing imports",
+    "cmd_orphan_import": "Import detected media",
     "cmd_subtitle_search": "Search for missing subtitles",
     "cmd_subtitle_upgrade": "Upgrade subtitle quality",
     "cmd_group_media": "Media",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1291,6 +1291,7 @@
     "cmd_warmup_subtitles": "Extraer los subtítulos",
     "cmd_post_import_enrich": "Finalizar la importación",
     "cmd_post_import_enrich_queue": "Finalizando importaciones",
+    "cmd_orphan_import": "Importar medios detectados",
     "cmd_subtitle_search": "Buscar los subtítulos faltantes",
     "cmd_subtitle_upgrade": "Mejorar la calidad de los subtítulos",
     "cmd_group_media": "Medios",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1299,6 +1299,7 @@
     "cmd_warmup_subtitles": "Extraire les sous-titres",
     "cmd_post_import_enrich": "Finaliser l'import",
     "cmd_post_import_enrich_queue": "Finalisation des imports",
+    "cmd_orphan_import": "Import des médias détectés",
     "cmd_subtitle_search": "Rechercher les sous-titres manquants",
     "cmd_subtitle_upgrade": "Améliorer la qualité des sous-titres",
     "cmd_group_media": "Médias",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1291,6 +1291,7 @@
     "cmd_warmup_subtitles": "Estrai i sottotitoli",
     "cmd_post_import_enrich": "Finalizza l'importazione",
     "cmd_post_import_enrich_queue": "Finalizzazione importazioni",
+    "cmd_orphan_import": "Importa i file multimediali rilevati",
     "cmd_subtitle_search": "Cerca i sottotitoli mancanti",
     "cmd_subtitle_upgrade": "Migliora la qualità dei sottotitoli",
     "cmd_group_media": "File multimediali",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1291,6 +1291,7 @@
     "cmd_warmup_subtitles": "Extrair as legendas",
     "cmd_post_import_enrich": "Finalizar a importação",
     "cmd_post_import_enrich_queue": "Finalizando importações",
+    "cmd_orphan_import": "Importar medias detetadas",
     "cmd_subtitle_search": "Procurar as legendas em falta",
     "cmd_subtitle_upgrade": "Melhorar a qualidade das legendas",
     "cmd_group_media": "Medias",

--- a/client/src/app/features/system/status/status.ts
+++ b/client/src/app/features/system/status/status.ts
@@ -127,6 +127,7 @@ export class SystemStatusComponent implements OnInit, OnDestroy {
     { name: 'WarmupSubtitles', label: 'system.cmd_warmup_subtitles' },
     { name: 'PostImportEnrich', label: 'system.cmd_post_import_enrich' },
     { name: 'PostImportEnrichQueue', label: 'system.cmd_post_import_enrich_queue' },
+    { name: 'OrphanImport', label: 'system.cmd_orphan_import' },
   ]);
 
   constructor() {


### PR DESCRIPTION
Residual finding from #1131, filed there as out of scope for the banner fix.

## The gap

`relinkOrphansBatch` emitted `task.progress` but never touched `ActivityRegistryService`, so the
batch the library wizard queues was absent from `GET /api/system/activity` — and therefore from
System > Activity — while every other long-running producer (the enrich queue, sprites, subtitle
warmup, the scheduler loops) appears there. That batch is the longest-running thing the import path
does: sequential per group, hours for a large series on a weak CPU.

## Shape

Mirrors the `GenerateSprite` idiom rather than the flat `RefreshMetadata` one: the whole backlog is
pre-registered as pending children under the `OrphanImport` parent up front. That is what the
registry's 20k cap was raised for, and it is the only way the *queued* groups become visible — a
single parent row would show progress but not what is still waiting, which is the actual question a
user staring at a stalled library asks.

Each group flips to running as the loop reaches it and is removed as it completes. A `finally`
clears every child plus the parent, so no entry outlives the batch even when a group throws — the
registry's contract is that an entry can never survive its task.

Rows carry `{ title: folderName }` as their subject. The DTO has no resolved title (only
`externalId` and `folderName`), and `MediaProgressSubject` documents ids as optional with the client
rendering such a row as plain text, so this is the intended shape for a producer without the id
cheaply in hand.

`ActivityRegistryService` comes from `EventsModule`, already imported here for `EventsService`, so
there is no new module wiring.

## Client

`OrphanImport` had no entry in the status page's label map, so the row would have rendered its raw
type string. Added, with `system.cmd_orphan_import` across the six locales.

## Verification

`tsc --noEmit` clean on both backend and client; `jest src/modules/imports src/modules/scheduler` —
14 suites, 193 tests passing.

New `disk-import.orphan-activity.spec.ts` covers the three things that can break: the backlog is
pre-registered under the parent, the parent reports the current group against the total, and the
registry is empty once the batch finishes. That last one runs with no repositories wired, so every
group throws — the case that would leak entries.

Still worth a manual look: run a wizard import of 30+ groups and confirm System > Activity shows
"Import detected media" with the backlog nested under it, and that the rows drain rather than
lingering once the batch ends.