### PR TITLE
chore(backend): translate the remaining french strings and comments

### DIFF
--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -155,8 +155,8 @@ export class AuthController {
   }
 
   /**
-   * JWT Cast (4h) + base d’URL des flux (EXTERNAL_URL / Host).
-   * À appeler juste avant loadMedia côté client pour limiter l’écart avec les requêtes du receiver.
+   * Cast JWT (4h) + the stream base URL (EXTERNAL_URL / Host). Called right
+   * before loadMedia so it can't drift from the receiver's own requests.
    */
   @Post('cast-info')
   @UseGuards(JwtOrApiKeyGuard)

--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -429,7 +429,7 @@ export class DiskImportService {
     const library = await this.libraries.requirePathFor(dto.libraryId);
     if (!library.mediaTypes?.includes(dto.type)) {
       throw new BadRequestException(
-        `La bibliothèque "${library.name}" n'accepte pas ${dto.type}`,
+        `Library "${library.name}" does not accept ${dto.type}`,
       );
     }
 
@@ -479,7 +479,7 @@ export class DiskImportService {
     }
     if (media.library && media.library.id !== dto.libraryId) {
       throw new BadRequestException(
-        `Ce média est déjà rattaché à une autre bibliothèque ("${media.library.name}")`,
+        `Media already belongs to another library ("${media.library.name}")`,
       );
     }
 
@@ -702,7 +702,7 @@ export class DiskImportService {
         );
         if (!library.mediaTypes?.includes(media.type as MediaType)) {
           errors.push(
-            `${path.basename(entry.filePath)}: la bibliothèque "${library.name}" n'accepte pas ${media.type}`,
+            `${path.basename(entry.filePath)}: library "${library.name}" does not accept ${media.type}`,
           );
           continue;
         }

--- a/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tmdb.provider.ts
@@ -410,7 +410,8 @@ export class TmdbProvider implements IMetadataProvider {
   }
 
   /**
-   * Saisons + nombre d'épisodes (un seul appel API), pour import bibliothèque sans N requêtes /season.
+   * Seasons + episode counts in one API call, so a library import does not fan
+   * out into N /season requests.
    */
   async getTvSeasonStubs(
     externalId: string,


### PR DESCRIPTION
Flagged while working on #1231.

## What was there

A repo-wide scan for French in `backend/src` turned up five sites, three of them user-facing:

- `disk-import.service.ts` — `relinkOrphans` threw ``La bibliothèque "…" n'accepte pas …``, four
  lines above an already-English `Media not found after import` in the same function.
- `disk-import.service.ts` — ``Ce média est déjà rattaché à une autre bibliothèque ("…")``.
- `disk-import.service.ts` — the same library-type refusal pushed onto the `errors` array of the
  confirm-import path.
- `auth.controller.ts` and `tmdb.provider.ts` — two French doc comments.

The backend is English-only and the client carries its own translations, so none of this should be
locale-specific. The exception messages surface through the global error toast, so they were showing
French to every user regardless of their UI language.

## Not changed

`subsynchro.provider.ts` declares a `fichier: string` field. That names a key in the Subsynchro API
response, not our own text, so it stays as the remote payload spells it.

## Verification

`tsc --noEmit` clean; `jest src/modules/imports src/modules/auth src/modules/metadata-providers` —
10 suites, 43 tests passing. Grepped the client for anything matching on the old message text
(nothing does — errors are surfaced verbatim by the interceptor, never string-matched).