### PR TITLE
refactor(paths): rename the images directory to data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,10 +144,10 @@ ENV TVDB_API_KEY=${TVDB_API_KEY}
 
 # Persistent dirs, group=root + g=u: writable by root, by an arbitrary uid
 # with gid 0, or via `--user <uid> --group-add 0` — no USER directive needed.
-RUN mkdir -p /app/conf /app/images /app/transcode \
- && chgrp -R 0 /app/conf /app/images /app/transcode \
- && chmod -R g=u /app/conf /app/images /app/transcode
-VOLUME /app/conf /app/images /app/transcode
+RUN mkdir -p /app/conf /app/data /app/transcode \
+ && chgrp -R 0 /app/conf /app/data /app/transcode \
+ && chmod -R g=u /app/conf /app/data /app/transcode
+VOLUME /app/conf /app/data /app/transcode
 
 EXPOSE 4848
 

--- a/backend/src/common/constants/paths.spec.ts
+++ b/backend/src/common/constants/paths.spec.ts
@@ -1,4 +1,6 @@
+import * as fs from 'fs';
 import * as os from 'os';
+import * as path from 'path';
 
 describe('TRANSCODE_DIR', () => {
   const OLD_ENV = process.env;
@@ -36,5 +38,59 @@ describe('TRANSCODE_DIR', () => {
   it('honours FLIKS_TRANSCODE_DIR on any platform', () => {
     expect(loadWith('win32', '/data/scratch')).toBe('/data/scratch');
     expect(loadWith('linux', '/data/scratch')).toBe('/data/scratch');
+  });
+});
+
+describe('getDataDir', () => {
+  const OLD_ENV = process.env;
+  let cwd: string;
+  let cwdSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetModules();
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'fliks-datadir-'));
+    cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(cwd);
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    cwdSpy.mockRestore();
+    fs.rmSync(cwd, { recursive: true, force: true });
+    jest.resetModules();
+  });
+
+  function load(env: Record<string, string | undefined> = {}): string {
+    process.env = { ...OLD_ENV, ...env };
+    return (require('./paths') as typeof import('./paths')).getDataDir();
+  }
+
+  it('defaults to data/ under the working directory', () => {
+    expect(load()).toBe(path.join(cwd, 'data'));
+  });
+
+  it('honours FLIKS_DATA_DIR', () => {
+    const dir = path.join(cwd, 'elsewhere');
+    expect(load({ FLIKS_DATA_DIR: dir })).toBe(dir);
+  });
+
+  // An install that upgrades without editing its compose file: the volume is
+  // still mounted at images/, and its avatars are not re-fetchable.
+  it('keeps using images/ when a volume is still mounted there', () => {
+    fs.mkdirSync(path.join(cwd, 'images'));
+    expect(load()).toBe(path.join(cwd, 'images'));
+  });
+
+  it('prefers data/ once images/ is gone', () => {
+    expect(load()).toBe(path.join(cwd, 'data'));
+  });
+
+  it('still accepts the deprecated FLIKS_IMAGES_DIR', () => {
+    const dir = path.join(cwd, 'legacy-override');
+    expect(load({ FLIKS_IMAGES_DIR: dir })).toBe(dir);
+  });
+
+  it('lets FLIKS_DATA_DIR win over the deprecated variable', () => {
+    const dir = path.join(cwd, 'wins');
+    expect(load({ FLIKS_DATA_DIR: dir, FLIKS_IMAGES_DIR: path.join(cwd, 'loses') })).toBe(dir);
   });
 });

--- a/backend/src/common/constants/paths.ts
+++ b/backend/src/common/constants/paths.ts
@@ -1,5 +1,7 @@
+import { existsSync } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { Logger } from '@nestjs/common';
 import { resolveWritableDir } from './writable-dir';
 
 /** Base directory for transient transcode/thumbnail data.
@@ -13,23 +15,48 @@ export const TRANSCODE_DIR =
       ? path.join(os.tmpdir(), 'fliks-transcode')
       : '/tmp/transcode';
 
-let cachedImagesDir: string | null = null;
+let cachedDataDir: string | null = null;
+
+/** Picked before the write probe so a legacy mount is honoured rather than
+ *  shadowed by an empty default. */
+function intendedDataDir(): string {
+  const override = process.env.FLIKS_DATA_DIR?.trim();
+  if (override) return override;
+  const legacyOverride = process.env.FLIKS_IMAGES_DIR?.trim();
+  if (legacyOverride) {
+    new Logger('DataDir').warn(
+      'FLIKS_IMAGES_DIR is deprecated — rename it to FLIKS_DATA_DIR (same value)',
+    );
+    return legacyOverride;
+  }
+  // The image no longer creates `images/`, so its presence means a volume is
+  // still mounted there: keep writing to it instead of starting an empty tree.
+  const legacyDir = path.join(process.cwd(), 'images');
+  if (existsSync(legacyDir)) {
+    new Logger('DataDir').warn(
+      `Using the legacy data directory "${legacyDir}" — remount it at ` +
+        `"${path.join(process.cwd(), 'data')}" (or set FLIKS_DATA_DIR) when convenient`,
+    );
+    return legacyDir;
+  }
+  return path.join(process.cwd(), 'data');
+}
 
 /**
- * Posters, fanart and seek-preview sprites. `FLIKS_IMAGES_DIR` overrides;
- * falls back to a temp dir (wiped on restart) if `/app/images` isn't
- * writable at the container's uid. Resolved and probed once, on first call.
+ * Artwork, seek-preview sprites, the extracted-subtitle cache and uploaded user
+ * avatars. `FLIKS_DATA_DIR` overrides; falls back to a temp dir (wiped on
+ * restart) if it isn't writable at the container's uid. Probed once, on first
+ * call. Not a cache: the avatars in here cannot be re-fetched.
  */
-export function getImagesDir(): string {
-  if (cachedImagesDir) return cachedImagesDir;
-  const override = process.env.FLIKS_IMAGES_DIR?.trim();
-  cachedImagesDir = resolveWritableDir(
-    [override || path.join(process.cwd(), 'images'), path.join(os.tmpdir(), 'fliks-images')],
-    'Cannot write to the images directory — posters, fanart and seek-preview ' +
-      'sprites will not survive a restart. Set FLIKS_IMAGES_DIR, or mount ' +
-      '/app/images writable for this container user.',
+export function getDataDir(): string {
+  if (cachedDataDir) return cachedDataDir;
+  cachedDataDir = resolveWritableDir(
+    [intendedDataDir(), path.join(os.tmpdir(), 'fliks-data')],
+    'Cannot write to the data directory — artwork, sprites and uploaded ' +
+      'avatars will not survive a restart. Set FLIKS_DATA_DIR, or mount ' +
+      '/app/data writable for this container user.',
   );
-  return cachedImagesDir;
+  return cachedDataDir;
 }
 
 let cachedPluginsRuntimeDir: string | null = null;

--- a/backend/src/modules/images/image.service.spec.ts
+++ b/backend/src/modules/images/image.service.spec.ts
@@ -16,7 +16,7 @@ describe('ImageService.downloadAndStore caching', () => {
 
   beforeAll(async () => {
     dir = mkdtempSync(join(tmpdir(), 'fliks-image-test-'));
-    process.env.FLIKS_IMAGES_DIR = dir;
+    process.env.FLIKS_DATA_DIR = dir;
     service = new ImageService();
 
     // A real decodable JPEG, sharp must actually resize it for the

--- a/backend/src/modules/images/image.service.ts
+++ b/backend/src/modules/images/image.service.ts
@@ -4,7 +4,7 @@ import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import sharp from 'sharp';
-import { getImagesDir } from '../../common/constants/paths';
+import { getDataDir } from '../../common/constants/paths';
 
 // libvips defaults to one worker thread per core plus a decoded-image cache,
 // pure overhead for one-shot resizes on a low-core, low-RAM box.
@@ -110,7 +110,7 @@ function sizeTokenWidth(token: string): number | null {
 @Injectable()
 export class ImageService {
   private readonly logger = new Logger(ImageService.name);
-  private readonly baseDir = getImagesDir();
+  private readonly baseDir = getDataDir();
   /** Keyed by `type/id/variant`. Lets a second concurrent call for the same
    *  target join the first instead of racing it: two overlapping calls with
    *  different URLs would otherwise interleave writes and leave the sidecar

--- a/backend/src/modules/streaming/subtitle-cache-path.spec.ts
+++ b/backend/src/modules/streaming/subtitle-cache-path.spec.ts
@@ -23,7 +23,7 @@ describe('subtitle cache path', () => {
 
   function loadSvc(): Svc {
     jest.resetModules();
-    process.env = { ...OLD_ENV, FLIKS_IMAGES_DIR: dir };
+    process.env = { ...OLD_ENV, FLIKS_DATA_DIR: dir };
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { SubtitleStreamService } = require('./subtitle-stream.service');
     return new SubtitleStreamService(

--- a/backend/src/modules/streaming/subtitle-stream.service.ts
+++ b/backend/src/modules/streaming/subtitle-stream.service.ts
@@ -28,7 +28,7 @@ import { resolveSubtitleAbsolutePath } from '../subtitles/subtitle-path.util';
 import { normalizeLanguageCode } from '../../common/constants/app-languages';
 import type { SubtitleRenditionMeta } from './transcoding/types';
 import { withFfmpegSlot } from '../../common/utils/ffmpeg-slots';
-import { getImagesDir } from '../../common/constants/paths';
+import { getDataDir } from '../../common/constants/paths';
 import {
   formatMediaProgressSubject,
   type MediaProgressSubject,
@@ -36,8 +36,8 @@ import {
 
 const execFileAsync = promisify(execFile);
 
-/** getImagesDir() probes the filesystem on its first call — keep this lazy. */
-const subsDir = () => path.join(getImagesDir(), 'subs');
+/** getDataDir() probes the filesystem on its first call — keep this lazy. */
+const subsDir = () => path.join(getDataDir(), 'subs');
 
 /**
  * Global cap on concurrent warmup extractions — a full library refresh can

--- a/backend/src/modules/streaming/thumbnail.service.ts
+++ b/backend/src/modules/streaming/thumbnail.service.ts
@@ -6,7 +6,7 @@ import { promisify } from 'util';
 import { existsSync } from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
-import { getImagesDir } from '../../common/constants/paths';
+import { getDataDir } from '../../common/constants/paths';
 import { EventsService } from '../scheduler/events.service';
 import { ActivityRegistryService } from '../scheduler/activity-registry.service';
 import { Command } from '../scheduler/entities/command.entity';
@@ -42,8 +42,8 @@ export interface SpriteMetadata {
   count: number;
 }
 
-const baseDir = () => path.join(getImagesDir(), 'thumbnails');
-const framesTmpDir = () => path.join(getImagesDir(), 'thumbnails-tmp');
+const baseDir = () => path.join(getDataDir(), 'thumbnails');
+const framesTmpDir = () => path.join(getDataDir(), 'thumbnails-tmp');
 
 const COLUMNS = 10;
 const THUMB_WIDTH = 240;

--- a/docker-compose.dev.example.yml
+++ b/docker-compose.dev.example.yml
@@ -39,7 +39,7 @@ services:
       # Throwaway cache, container-only: /src is root-owned in the image, so the
       # non-root user it runs as needs a path it can actually write.
       FLIKS_TRANSCODE_DIR: /tmp/transcode
-      FLIKS_IMAGES_DIR: /src/images
+      FLIKS_DATA_DIR: /src/data
     ports:
       - '3000:3000'
     # Keeps the host's own node_modules out of the container.
@@ -49,7 +49,7 @@ services:
       - ./backend:/src/backend
       - ./.dev/downloads:/downloads
       - ./.dev/medias:/medias
-      - ./.dev/images:/src/images
+      - ./.dev/data:/src/data
 
   client:
     build:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -28,7 +28,7 @@ services:
     # Uncomment if your platform pins the container user (TrueNAS catalog uid
     # 568, unraid 99:100, Kubernetes runAsNonRoot, OpenShift arbitrary uid).
     # Any uid works as long as gid 0 is in the group list — the image's
-    # /app/conf, /app/images and /app/transcode are group-writable by root.
+    # /app/conf, /app/data and /app/transcode are group-writable by root.
     # user: '568:568'
     # group_add: ['0']
     # mDNS doesn't cross a bridge network, so Chromecast auto-discovery needs
@@ -90,8 +90,9 @@ services:
       - /path/to/download/folder:/downloads
       # JWT key: lose it and everyone is logged out.
       - fliks_conf:/app/conf
-      # Posters, fanart, seek-preview sprites, extracted subtitle cache.
-      - fliks_images:/app/images
+      # Artwork, seek-preview sprites, extracted subtitle cache and uploaded
+      # avatars. Not disposable: the avatars can't be re-fetched.
+      - fliks_data:/app/data
       # HLS segment cache, paired with FLIKS_TRANSCODE_DIR above. Drop both to
       # leave it in /tmp.
       - fliks_transcode:/app/transcode
@@ -114,5 +115,5 @@ services:
 volumes:
   fliks_pgdata:
   fliks_conf:
-  fliks_images:
+  fliks_data:
   fliks_transcode:


### PR DESCRIPTION
Follow-up to #1230, which put the extracted-subtitle cache in the images volume and left its name
describing only part of what it holds.

## Why `data` and not `cache`

The directory holds artwork, seek-preview sprites, thumbnails, the extracted-subtitle cache — and
**uploaded user avatars** (`ImageService.storeAvatar` writes `users/<id>.jpg` there). That last one
is not re-fetchable from anywhere, so calling the volume a cache would be a lie that eventually
costs someone their avatars when they mount it on tmpfs or prune it. `data` says the one thing all
of it shares: the app owns it and it has to survive a restart.

## This is not a breaking change, by construction

A plain rename would have been one, and the failure mode is nasty: the app would silently start an
empty tree, re-download all artwork, and lose every avatar. Three things prevent it, so an existing
install upgrades with **no action at all**:

- `FLIKS_IMAGES_DIR` keeps working as a deprecated alias, warning once at boot with the new name.
- The image no longer creates `/app/images`, so that path existing now *means* a volume is still
  mounted there. The resolver detects it and keeps writing to it, warning once with the path to
  remount when convenient. This is why the directory is chosen before the write probe rather than
  after — otherwise an empty default would shadow a live legacy mount.
- `/api/images/...` routes are untouched. They never derived from the directory name, so no stored
  DB path and no client URL moves.

New installs get `/app/data` and the `fliks_data` volume.

## Migrating for real (optional)

Nothing forces it, but to actually move onto the new name:

```sh
docker compose down
docker volume create fliks_data
docker run --rm -v fliks_images:/from -v fliks_data:/to alpine sh -c 'cp -a /from/. /to/'
# then in compose: `- fliks_data:/app/data` replaces `- fliks_images:/app/images`
docker compose up -d
docker volume rm fliks_images   # only once the boot log no longer mentions the legacy directory
```

For a bind mount, `mv /host/path/images /host/path/data` and update the left side of the mapping.
Either way the copy is what protects the avatars — do not start with `docker volume rm`.

## Changed

- `getImagesDir()` → `getDataDir()`, with the alias/legacy resolution above (`paths.ts`).
- Four call sites: `image.service.ts`, `thumbnail.service.ts` (×2), `subtitle-stream.service.ts`.
- `Dockerfile`: `/app/data` in the mkdir/chgrp/chmod/VOLUME line, and no longer creating
  `/app/images` — the legacy detection depends on that.
- Both compose examples, including the uid-pinning comment that enumerates the group-writable dirs.

## Verification

`tsc --noEmit` clean; **full backend suite: 180 suites / 2001 tests passing.**

`paths.spec.ts` gains six cases covering the resolution order, because that is the part where a
mistake costs data: the default, the new variable, the legacy directory being honoured when a
volume is mounted there, `data/` winning once it is gone, the deprecated variable still working, and
the new variable beating the deprecated one.

Worth one manual pass before release: start a container with an existing `fliks_images` volume and
no env override, and confirm the boot log names the legacy directory and that artwork and avatars
still resolve.