### PR TITLE
docs(readme): document the data volume rename and how to move onto it

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,31 @@ Intel QSV and VAAPI work out of the box once you uncomment the
 `nvidia-container-toolkit` on the host and a slightly different Compose
 snippet — the example Compose carries both, commented.
 
+### The data volume was renamed
+
+The volume that holds artwork, seek-preview sprites, extracted subtitles
+and uploaded avatars is now `/app/data` (`fliks_data`), not `/app/images`.
+It was never only images, and it is not a cache: the avatars in it cannot
+be re-fetched.
+
+**Existing installs need no change.** `FLIKS_IMAGES_DIR` still works, and
+a volume still mounted at `/app/images` is detected and used as-is — the
+boot log names it once so you know you are on the old path.
+
+To move onto the new name, copy before removing anything:
+
+```bash
+docker compose down
+docker volume create fliks_data
+docker run --rm -v fliks_images:/from -v fliks_data:/to alpine sh -c 'cp -a /from/. /to/'
+# in your Compose file: `- fliks_data:/app/data` replaces `- fliks_images:/app/images`
+docker compose up -d
+docker volume rm fliks_images   # only once the boot log stops naming the old path
+```
+
+With a bind mount instead of a named volume, `mv` the host directory and
+update the left side of the mapping.
+
 ### Update checks
 
 Fliks asks the **public GitHub releases API** whether a newer version


### PR DESCRIPTION
Follow-up to #1233.

## Why this exists

#1233 landed as a `refactor`, and release-please renders only `feat`, `fix`, `perf` and breaking
changes — its run on that merge reported *"PR #1153 remained the same"*. So the one change in the
4.0.0 release with an upgrade implication was going to ship with no mention in the release notes at
all.

A `BREAKING CHANGE:` footer is the only channel that crosses that type filter, so this commit
carries one. The wording is accurate rather than alarming: it says the path moved, that existing
installs need no change, and where the recipe is. Because it travels in a commit rather than a
hand-edit of the release PR, every regeneration reproduces it.

4.0.0 already has a `⚠ BREAKING CHANGES` section (the `pluginApi: 0` drop), so this adds no version
bump — it joins a section users already read on a major upgrade.

## The README section

Added under **Hosting notes**, next to the other operational notes: what the volume holds, why it is
not a cache (uploaded avatars are not re-fetchable), that nothing needs doing, and the copy-first
recipe for anyone who does want the new name. Bind-mount case covered in a line.

## Verification

Rendered the section locally; `docker volume`/`docker run` recipe is the one used to migrate a real
install (a bind mount, via `mv`), confirmed by a restart with 890 MB intact, artwork serving 200,
and no legacy-path warning in the boot log.