### PR TITLE
feat(media-card): move the actions trigger to the bottom-right corner

### DIFF
--- a/client/src/app/core/services/card-actions.service.ts
+++ b/client/src/app/core/services/card-actions.service.ts
@@ -59,8 +59,11 @@ export interface CardAction {
  *   • `button` — dropdown's right edge aligns with the anchor's right edge,
  *     drops just below it. Used by the desktop `⋯` button so the menu appears
  *     under the button and overlays the card body.
+ *   • `card-top` — dropdown overlays the anchor, its top and right edges flush
+ *     with the anchor's. Anchor the card figure so a trigger at the card's
+ *     bottom still opens the menu from the card's top.
  */
-export type CardActionsPlacement = 'card' | 'button';
+export type CardActionsPlacement = 'card' | 'button' | 'card-top';
 
 @Injectable({ providedIn: 'root' })
 export class CardActionsService {

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
@@ -130,17 +130,25 @@ export class CardActionsPanelComponent {
   readonly imageAspect = this.service.imageAspect;
   readonly subtitle = this.service.subtitle;
 
-  /** `button` aligns the menu's right edge under the ⋯ trigger; `card` centres
-   *  it under the card figure. */
-  readonly placement = computed(() =>
-    this.service.placement() === 'button' ? 'bottom-end' : 'bottom-center',
-  );
+  /** `button` drops the menu under the ⋯ trigger, right edges flush;
+   *  `card-top` overlays the card from its top edge; `card` centres it under
+   *  the card figure. */
+  readonly placement = computed(() => {
+    switch (this.service.placement()) {
+      case 'button':
+        return 'bottom-end';
+      case 'card-top':
+        return 'start-end';
+      default:
+        return 'bottom-center';
+    }
+  });
   /** Compact under the ⋯ button; about the card's width under a figure. */
   readonly width = computed(() => {
     const anchor = this.service.anchor();
     // Wider than a card menu used to need: the rows now include submenu parents
     // and longer labels, and a wrapped row reads badly.
-    if (this.service.placement() === 'button' || !anchor) return 280;
+    if (this.service.placement() !== 'card' || !anchor) return 280;
     return Math.min(340, Math.max(280, anchor.getBoundingClientRect().width));
   });
 

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -158,7 +158,7 @@
     @if (showHoverOverlay() && cardActions().length) {
       <button
         type="button"
-        class="absolute top-2 right-2 z-10 btn btn-circle btn-sm border-0 bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-neutral-500/50 pointer-events-auto"
+        class="absolute bottom-2 right-2 z-10 btn btn-circle btn-sm border-0 bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-neutral-500/50 pointer-events-auto"
         (click)="openActions($event)"
         [attr.aria-label]="'media_card.actions' | translate"
       >

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -258,9 +258,9 @@ export class MediaCardComponent {
 
   /**
    * Desktop affordance — opens the same contextual panel that TV's menu key
-   * and mobile's long-press use. The button itself is the anchor with
-   * placement 'button' so the dropdown drops right under the ⋯ glyph and
-   * overlays the card body, instead of stacking below the whole figure.
+   * and mobile's long-press use. The figure is the anchor with placement
+   * 'card-top' so the menu overlays the card from its top edge, even though
+   * the ⋯ glyph sits at the bottom.
    */
   protected openActions(event: Event) {
     event.stopPropagation();
@@ -269,12 +269,12 @@ export class MediaCardComponent {
     if (!button) return;
     this.cardActionsService.register({
       actions: this.cardActions(),
-      anchor: button,
+      anchor: button.closest('figure') ?? button,
       title: this._title(),
       imageUrl: this._img(),
       imageAspect: this.aspect(),
       subtitle: this._subtitle(),
-      placement: 'button',
+      placement: 'card-top',
     });
     this.cardActionsService.show();
   }

--- a/client/src/app/shared/components/popover-menu.ts
+++ b/client/src/app/shared/components/popover-menu.ts
@@ -103,7 +103,8 @@ export class PopoverMenuComponent {
   readonly anchor = input<HTMLElement | null>(null);
   /** Where the dropdown opens relative to the anchor. `*-center` centers it
    *  under the anchor; `right-start` / `left-start` are side flyouts (used for
-   *  submenus) that open beside the anchor. */
+   *  submenus) that open beside the anchor; `start-end` overlays the anchor,
+   *  top and right edges aligned with it. */
   readonly placement = input<
     | 'bottom-end'
     | 'bottom-start'
@@ -112,6 +113,7 @@ export class PopoverMenuComponent {
     | 'top-start'
     | 'right-start'
     | 'left-start'
+    | 'start-end'
   >('bottom-end');
   /** Dropdown width in px (the sheet ignores it). */
   readonly width = input(240);
@@ -279,6 +281,27 @@ export class PopoverMenuComponent {
       const top = Math.min(
         Math.max(GUTTER, r.top),
         Math.max(GUTTER, viewportH - MIN_HEIGHT - GUTTER),
+      );
+      return {
+        top,
+        bottom: null as number | null,
+        left,
+        width: WIDTH,
+        maxHeight: Math.max(MIN_HEIGHT, viewportH - top - GUTTER),
+      };
+    }
+
+    // Overlay drop: top edge just under the anchor's top, right edges flush,
+    // so a trigger low in the anchor still opens the menu from its top.
+    if (placement === 'start-end') {
+      const INSET = 10;
+      const top = Math.min(
+        Math.max(GUTTER, r.top + INSET),
+        Math.max(GUTTER, viewportH - MIN_HEIGHT - GUTTER),
+      );
+      const left = Math.min(
+        Math.max(GUTTER, r.right - WIDTH),
+        Math.max(GUTTER, viewportW - WIDTH - GUTTER),
       );
       return {
         top,


### PR DESCRIPTION
## What

The desktop `⋯` actions button on a media card moves from the top-right corner to the bottom-right one.

The panel keeps opening from the **top** of the card: it is now anchored to the card `<figure>` with a new `card-top` placement (`start-end` in `popover-menu`) that aligns the menu's top and right edges with the anchor's, offset 10px down, and lets the content scroll inside the box when the space below is tight.

## Why

The top-right corner already hosts the watched toggle and the discover/library/pending badges, so the hover-only glyph stacked on top of them. Moving it to the free bottom-right corner clears the overlap, and re-anchoring the panel to the figure avoids the menu dropping below the whole card, far from where the user clicked.

## Changes

- `popover-menu.ts`: new `start-end` placement — top/right edges flush with the anchor, 10px down, clamped into the viewport, `maxHeight` from the remaining space below.
- `card-actions.service.ts`: new `card-top` value in `CardActionsPlacement`.
- `card-actions-panel.ts`: maps `card-top` → `start-end`, and keeps the compact 280px width for every non-`card` placement.
- `media-card`: button at `bottom-2 right-2`, anchor is the `<figure>`, placement `card-top`.

Other `button` callers (`subtitles-modal`, `media-info-header`) are untouched.

## Test

- `tsc -p tsconfig.app.json --noEmit` clean.
- `ng test --include='**/popover-menu.spec.ts' --include='**/media-card.spec.ts'` — 38 tests pass.