### PR TITLE
feat(desktop): cast to chromecast from the electron client

### DIFF
--- a/client/src/app/core/services/cast.service.ts
+++ b/client/src/app/core/services/cast.service.ts
@@ -69,11 +69,25 @@ interface NativeCastLoadOpts {
   currentTime: number;
   subtitles: { url: string; language: string; label: string }[];
   activeSubtitleTrackId: number;
+  autoplay: boolean;
   customData?: Record<string, unknown>;
   /** Optional — when present, native plugin builds the platform's
    *  text-track-style equivalent (TextTrackStyle on Android, GCKMedia-
    *  TextTrackStyle on iOS) and attaches to MediaInformation. */
   textTrackStyle?: CastSubtitleStyle;
+  /** The same styling already in Cast wire form. The desktop bridge talks the
+   *  protocol directly and has no platform type to map the presets onto. */
+  castTextTrackStyle?: CastTextTrackStyle;
+}
+
+/** `TextTrackStyle` as the Cast protocol carries it. */
+export interface CastTextTrackStyle {
+  fontGenericFamily: string;
+  fontScale: number;
+  foregroundColor: string;
+  backgroundColor: string;
+  edgeType: string;
+  edgeColor: string;
 }
 
 interface NativeCastPlugin {
@@ -107,7 +121,18 @@ export interface CastDevice {
   connected?: boolean;
 }
 
-const NativeCast = registerPlugin<NativeCastPlugin>('NativeCast');
+/** The Electron main process exposes the very same surface as the Capacitor
+ *  plugin (see `desktop/src/shared/contract.ts`), plus an event subscription:
+ *  contextIsolation keeps preload-world objects out of the page, so the desktop
+ *  events arrive here and get re-dispatched as the window events the plugin
+ *  fires natively. */
+interface DesktopCastBridge extends NativeCastPlugin {
+  on(handler: (event: { name: string; detail: unknown }) => void): () => void;
+}
+
+const DesktopCast = (globalThis as { fliksCast?: DesktopCastBridge }).fliksCast;
+const CastBridge: NativeCastPlugin =
+  DesktopCast ?? registerPlugin<NativeCastPlugin>('NativeCast');
 const CAST_APP_ID = environment.castAppId;
 /** Ceiling on a connect attempt: a cold receiver launch is ~2 s on a Chromecast. */
 const CONNECT_TIMEOUT_MS = 30_000;
@@ -167,7 +192,15 @@ export class CastService implements OnDestroy {
    *  custom error message; consumed by CastPlayerService to reload. */
   readonly playbackError$ = new Subject<{ position?: number }>();
 
-  private readonly isNative = Capacitor.isNativePlatform();
+  /** Whether a native-process Cast sender backs this client — the Capacitor
+   *  plugin on mobile, the Electron main process on desktop. Without one we are
+   *  in a browser and drive the Cast Web SDK instead. */
+  private readonly hasCastBridge = Capacitor.isNativePlatform() || !!DesktopCast;
+
+  /** True when the backing sender enumerates devices itself, so the picker
+   *  lists them instead of offering the single row that opens the browser's
+   *  own Cast dialog. */
+  readonly enumerates = this.hasCastBridge;
   private readonly castSettings = inject(CastSettingsService);
   private readonly toast = inject(ToastService);
   private readonly translate = inject(TranslateService);
@@ -182,7 +215,10 @@ export class CastService implements OnDestroy {
   private remotePlayerController: any = null;
 
   constructor() {
-    if (this.isNative) {
+    DesktopCast?.on((event) =>
+      window.dispatchEvent(new CustomEvent(event.name, { detail: event.detail })),
+    );
+    if (this.hasCastBridge) {
       this.initNative();
     } else {
       this.initWeb();
@@ -205,7 +241,7 @@ export class CastService implements OnDestroy {
 
   private async initNative() {
     try {
-      const { available } = await NativeCast.initialize({ appId: CAST_APP_ID });
+      const { available } = await CastBridge.initialize({ appId: CAST_APP_ID });
       this.isAvailable.set(available);
       if (available) void this.getCastDevices();
 
@@ -251,7 +287,7 @@ export class CastService implements OnDestroy {
       // castAvailabilityChanged whenever the route list moves.
       window.addEventListener('castDevicesChanged', () => void this.getCastDevices());
     } catch (e) {
-      console.warn('NativeCast.initialize failed', e);
+      console.warn('CastBridge.initialize failed', e);
       this.isAvailable.set(false);
     }
   }
@@ -428,9 +464,9 @@ export class CastService implements OnDestroy {
 
   requestSession() {
     this.beginConnecting();
-    if (this.isNative) {
+    if (this.hasCastBridge) {
       // The plugin resolves immediately; castStateChanged fires on connect OR dismiss.
-      NativeCast.requestSession().catch(() => this.endConnecting());
+      CastBridge.requestSession().catch(() => this.endConnecting());
     } else {
       cast.framework.CastContext.getInstance().requestSession().catch(() => this.endConnecting());
     }
@@ -459,13 +495,13 @@ export class CastService implements OnDestroy {
    *  API, so this always resolves empty: the picker shows a single row that
    *  falls back to `requestSession()` there instead. */
   async getCastDevices(): Promise<CastDevice[]> {
-    if (!this.isNative) return [];
+    if (!this.hasCastBridge) return [];
     try {
-      const { devices } = await NativeCast.getCastDevices();
+      const { devices } = await CastBridge.getCastDevices();
       this.castDevices.set(devices);
       return devices;
     } catch (err) {
-      console.warn('NativeCast.getCastDevices failed', err);
+      console.warn('CastBridge.getCastDevices failed', err);
       this.castDevices.set([]);
       return [];
     }
@@ -477,7 +513,7 @@ export class CastService implements OnDestroy {
   async selectCastDevice(id: string): Promise<void> {
     this.beginConnecting();
     try {
-      await NativeCast.selectCastDevice({ id });
+      await CastBridge.selectCastDevice({ id });
     } catch (err) {
       this.endConnecting();
       throw err;
@@ -502,9 +538,9 @@ export class CastService implements OnDestroy {
 
     const subtitleStyle = this.castSettings.get().subtitleStyle;
 
-    if (this.isNative) {
+    if (this.hasCastBridge) {
       try {
-        await NativeCast.loadMedia({
+        await CastBridge.loadMedia({
           url: info.url,
           contentType: info.contentType,
           title: info.title,
@@ -513,11 +549,13 @@ export class CastService implements OnDestroy {
           currentTime: info.currentTime ?? 0,
           subtitles: info.subtitles ?? [],
           activeSubtitleTrackId: info.activeSubtitleTrackId ?? 0,
+          autoplay: info.autoplay ?? true,
           customData,
           textTrackStyle: subtitleStyle,
+          castTextTrackStyle: buildCastTextTrackStyle(subtitleStyle),
         });
       } catch (err) {
-        console.error('NativeCast.loadMedia failed:', err);
+        console.error('CastBridge.loadMedia failed:', err);
       }
       this.isPaused.set(false);
       this.mediaTitle.set(info.title);
@@ -575,21 +613,21 @@ export class CastService implements OnDestroy {
   }
 
   play() {
-    if (this.isNative) { NativeCast.play(); this.isPaused.set(false); return; }
+    if (this.hasCastBridge) { CastBridge.play(); this.isPaused.set(false); return; }
     if (!this.remotePlayerController) return;
     this.isPaused.set(false);
     if (this.remotePlayer?.isPaused) this.remotePlayerController.playOrPause();
   }
 
   pause() {
-    if (this.isNative) { NativeCast.pause(); this.isPaused.set(true); return; }
+    if (this.hasCastBridge) { CastBridge.pause(); this.isPaused.set(true); return; }
     if (!this.remotePlayerController) return;
     this.isPaused.set(true);
     if (!this.remotePlayer?.isPaused) this.remotePlayerController.playOrPause();
   }
 
   togglePlayPause() {
-    if (this.isNative) {
+    if (this.hasCastBridge) {
       if (this.isPaused()) this.play(); else this.pause();
       return;
     }
@@ -605,7 +643,7 @@ export class CastService implements OnDestroy {
     const v = Math.min(1, Math.max(0, level));
     this.volume.set(v);
     if (v > 0 && this.muted()) this.setMuted(false);
-    if (this.isNative) { NativeCast.setVolume({ level: v }).catch(() => {}); return; }
+    if (this.hasCastBridge) { CastBridge.setVolume({ level: v }).catch(() => {}); return; }
     if (!this.remotePlayer || !this.remotePlayerController) return;
     this.remotePlayer.volumeLevel = v;
     this.remotePlayerController.setVolumeLevel();
@@ -613,7 +651,7 @@ export class CastService implements OnDestroy {
 
   setMuted(muted: boolean) {
     this.muted.set(muted);
-    if (this.isNative) { NativeCast.setMuted({ muted }).catch(() => {}); return; }
+    if (this.hasCastBridge) { CastBridge.setMuted({ muted }).catch(() => {}); return; }
     if (!this.remotePlayer || !this.remotePlayerController) return;
     // muteOrUnmute() toggles receiver-side, so only fire it when the receiver's
     // current state differs from the target — avoids a double-toggle no-op.
@@ -668,7 +706,7 @@ export class CastService implements OnDestroy {
   private dispatchSeek(time: number) {
     this.lastDispatchedSeekTarget = time;
     this.seekSettleUntil = Date.now() + CAST_SEEK_SETTLE_MS;
-    if (this.isNative) { NativeCast.seek({ time }); return; }
+    if (this.hasCastBridge) { CastBridge.seek({ time }); return; }
     if (!this.remotePlayer) return;
     this.remotePlayer.currentTime = time;
     this.remotePlayerController?.seek();
@@ -699,12 +737,12 @@ export class CastService implements OnDestroy {
   }
 
   stop() {
-    if (this.isNative) { NativeCast.stop(); return; }
+    if (this.hasCastBridge) { CastBridge.stop(); return; }
     this.remotePlayerController?.stop();
   }
 
   disconnect() {
-    if (this.isNative) { NativeCast.disconnect(); }
+    if (this.hasCastBridge) { CastBridge.disconnect(); }
     else { cast.framework.CastContext.getInstance().endCurrentSession(true); }
     this.isConnected.set(false);
     this.session = null;
@@ -713,8 +751,8 @@ export class CastService implements OnDestroy {
   }
 
   setActiveSubtitle(trackId: number) {
-    if (this.isNative) {
-      NativeCast.setActiveSubtitle({ trackId });
+    if (this.hasCastBridge) {
+      CastBridge.setActiveSubtitle({ trackId });
       return;
     }
     this.applyActiveTracks({ textId: trackId > 0 ? trackId : null });
@@ -731,9 +769,9 @@ export class CastService implements OnDestroy {
    * to a full ffmpeg-restart reload in that case.
    */
   async setActiveAudioLanguage(language: string, name: string): Promise<boolean> {
-    if (this.isNative) {
+    if (this.hasCastBridge) {
       try {
-        const { success } = await NativeCast.setActiveAudioLanguage({ language, name });
+        const { success } = await CastBridge.setActiveAudioLanguage({ language, name });
         return success;
       } catch {
         return false;
@@ -796,16 +834,26 @@ export class CastService implements OnDestroy {
    *  `TextTrackStyle`. Native plugins replicate this mapping for parity
    *  so the receiver sees identical Cast values regardless of sender. */
   private buildWebTextTrackStyle(s: CastSubtitleStyle) {
+    const wire = buildCastTextTrackStyle(s);
     const style = new chrome.cast.media.TextTrackStyle();
-    style.fontGenericFamily = chrome.cast.media.TextTrackFontGenericFamily.SANS_SERIF;
-    style.fontScale = SUB_SIZE_SCALE[s.size] ?? SUB_SIZE_SCALE['normal'];
-    style.foregroundColor = SUB_FG_COLOR[s.color] ?? SUB_FG_COLOR['white'];
-    style.backgroundColor = SUB_BG_COLOR[s.background] ?? SUB_BG_COLOR['transparent'];
-    const shadow = SUB_SHADOW[s.shadow] ?? SUB_SHADOW['drop'];
-    style.edgeType = chrome.cast.media.TextTrackEdgeType[shadow.edge];
-    style.edgeColor = shadow.color;
+    Object.assign(style, wire);
+    // The SDK's own enum member rather than its name, in case the two ever
+    // diverge; every other field is a plain string or number either way.
+    style.edgeType = chrome.cast.media.TextTrackEdgeType[wire.edgeType];
     return style;
   }
+}
+
+function buildCastTextTrackStyle(s: CastSubtitleStyle): CastTextTrackStyle {
+  const shadow = SUB_SHADOW[s.shadow] ?? SUB_SHADOW['drop'];
+  return {
+    fontGenericFamily: 'SANS_SERIF',
+    fontScale: SUB_SIZE_SCALE[s.size] ?? SUB_SIZE_SCALE['normal'],
+    foregroundColor: SUB_FG_COLOR[s.color] ?? SUB_FG_COLOR['white'],
+    backgroundColor: SUB_BG_COLOR[s.background] ?? SUB_BG_COLOR['transparent'],
+    edgeType: shadow.edge,
+    edgeColor: shadow.color,
+  };
 }
 
 // Cast Web SDK wire format mappings. The size-scale table is

--- a/client/src/app/shared/remote-picker/remote-picker.ts
+++ b/client/src/app/shared/remote-picker/remote-picker.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, Signal, computed, inject, signal } from '@angular/core';
-import { Capacitor } from '@capacitor/core';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { RouterLink } from '@angular/router';
 import {
@@ -54,17 +53,20 @@ export class RemotePickerComponent {
   private readonly toast = inject(ToastService);
   private readonly translate = inject(TranslateService);
 
-  protected readonly isNative = Capacitor.isNativePlatform();
+  /** Whether the Cast backend lists devices itself (mobile plugin, desktop
+   *  bridge) — a browser has no enumeration API and delegates to its own
+   *  dialog through the single `cast-web` row. */
+  protected readonly enumerates = this.castService.enumerates;
 
   private readonly lastUsedId = signal<string | null>(this.readLastUsed());
 
   protected readonly castSearching = computed(
-    () => this.isNative && this.castService.isAvailable() && this.castService.castDevices().length === 0,
+    () => this.enumerates && this.castService.isAvailable() && this.castService.castDevices().length === 0,
   );
 
   protected readonly pickerRows: Signal<PickerRow[]> = computed(() => {
     const rows: PickerRow[] = [];
-    if (!this.isNative) {
+    if (!this.enumerates) {
       const connected = this.castService.isConnected();
       rows.push({
         kind: 'cast-web',
@@ -114,7 +116,7 @@ export class RemotePickerComponent {
    *  on close is harmless. */
   protected onTriggerPress(): void {
     void this.remote.refreshTargets();
-    if (this.isNative) void this.castService.getCastDevices();
+    if (this.enumerates) void this.castService.getCastDevices();
   }
 
   selectRow(row: PickerRow): void {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,6 +9,7 @@
   "main": "dist/main/index.cjs",
   "scripts": {
     "typecheck": "tsc -p tsconfig.json",
+    "test": "node --test src/main/**/*.test.ts",
     "build:main": "esbuild src/main/index.ts --bundle --platform=node --target=node20 --format=cjs --external:electron --external:electron-updater --outfile=dist/main/index.cjs",
     "build:preload": "esbuild src/preload/index.ts --bundle --platform=node --target=node20 --format=cjs --external:electron --outfile=dist/preload/index.cjs",
     "build": "npm run build:main && npm run build:preload",

--- a/desktop/src/main/cast/cast.test.ts
+++ b/desktop/src/main/cast/cast.test.ts
@@ -1,0 +1,205 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { absorb, buildQuery, collect, parseRecords, parseTxt } from './mdns.ts';
+import { decodeMessage, encodeFrame, splitFrames } from './protocol.ts';
+import { mediaStatusEvent, mergeActiveTracks, pickAudioTrack } from './status.ts';
+
+test('CastMessage survives an encode/decode round trip', () => {
+  const msg = {
+    sourceId: 'sender-abc',
+    destinationId: 'receiver-0',
+    namespace: 'urn:x-cast:com.google.cast.receiver',
+    data: JSON.stringify({ type: 'LAUNCH', appId: '66BF4DAE', requestId: 2 }),
+  };
+  const { messages, rest } = splitFrames(encodeFrame(msg));
+  assert.equal(rest.length, 0);
+  assert.equal(messages.length, 1);
+  assert.deepEqual(decodeMessage(messages[0]), msg);
+});
+
+test('splitFrames keeps a partial frame for the next chunk', () => {
+  const a = encodeFrame({ sourceId: 's', destinationId: 'd', namespace: 'n', data: '{"a":1}' });
+  const b = encodeFrame({ sourceId: 's', destinationId: 'd', namespace: 'n', data: '{"b":2}' });
+  const stream = Buffer.concat([a, b]);
+  const cut = stream.subarray(0, a.length + 3);
+  const first = splitFrames(cut);
+  assert.equal(first.messages.length, 1);
+  assert.equal(first.rest.length, 3);
+
+  const second = splitFrames(Buffer.concat([first.rest, stream.subarray(cut.length)]));
+  assert.equal(second.messages.length, 1);
+  assert.equal(decodeMessage(second.messages[0]).data, '{"b":2}');
+});
+
+test('a payload longer than 127 bytes keeps its multi-byte length prefix', () => {
+  const data = JSON.stringify({ blob: 'x'.repeat(500) });
+  const { messages } = splitFrames(
+    encodeFrame({ sourceId: 's', destinationId: 'd', namespace: 'n', data }),
+  );
+  assert.equal(decodeMessage(messages[0]).data, data);
+});
+
+// ── mDNS ──
+
+/** Assemble a response packet the way a Chromecast answers a PTR query: the
+ *  instance and host names appear once and every later reference is a
+ *  compression pointer, which is the part worth testing. */
+function buildResponse(): Buffer {
+  const parts: Buffer[] = [];
+  let length = 0;
+  const push = (buf: Buffer): number => {
+    parts.push(buf);
+    length += buf.length;
+    return length - buf.length;
+  };
+  const name = (value: string): Buffer =>
+    Buffer.concat([
+      ...value.split('.').map((l) => Buffer.concat([Buffer.from([l.length]), Buffer.from(l)])),
+      Buffer.from([0]),
+    ]);
+  const pointer = (offset: number): Buffer => Buffer.from([0xc0 | (offset >> 8), offset & 0xff]);
+  const rr = (type: number, rdata: Buffer): Buffer => {
+    const head = Buffer.alloc(10);
+    head.writeUInt16BE(type, 0);
+    head.writeUInt16BE(1, 2);
+    head.writeUInt32BE(120, 4);
+    head.writeUInt16BE(rdata.length, 8);
+    return Buffer.concat([head, rdata]);
+  };
+
+  const header = Buffer.alloc(12);
+  header.writeUInt16BE(0x8400, 2);
+  header.writeUInt16BE(1, 6); // one answer
+  header.writeUInt16BE(3, 10); // three additionals
+  push(header);
+
+  const serviceOffset = push(name('_googlecast._tcp.local'));
+  // PTR rdata is the instance name: one fresh label, then a pointer back.
+  const instanceLabel = Buffer.concat([Buffer.from([14]), Buffer.from('Chromecast-abc')]);
+  const ptrRdata = Buffer.concat([instanceLabel, pointer(serviceOffset)]);
+  const instanceOffset = push(rr(12, ptrRdata)) + 10;
+
+  const srvHead = Buffer.alloc(6);
+  srvHead.writeUInt16BE(8009, 4);
+  const srvStart = push(pointer(instanceOffset));
+  const targetOffset = srvStart + 2 + 10 + srvHead.length;
+  push(rr(33, Buffer.concat([srvHead, name('abc.local')])));
+
+  push(pointer(instanceOffset));
+  const txt = ['id=uuid-1', 'fn=Salon', 'md=Chromecast Ultra'];
+  push(
+    rr(
+      16,
+      Buffer.concat(txt.map((t) => Buffer.concat([Buffer.from([t.length]), Buffer.from(t)]))),
+    ),
+  );
+
+  push(pointer(targetOffset));
+  push(rr(1, Buffer.from([192, 168, 1, 42])));
+
+  return Buffer.concat(parts);
+}
+
+test('a Cast announcement resolves to a complete device', () => {
+  const services = new Map();
+  const addresses = new Map();
+  absorb(buildResponse(), services, addresses);
+  assert.deepEqual(collect(services, addresses), [
+    {
+      id: 'uuid-1',
+      name: 'Salon',
+      modelName: 'Chromecast Ultra',
+      host: '192.168.1.42',
+      port: 8009,
+    },
+  ]);
+});
+
+test('a foreign mDNS service on the segment is not mistaken for a Cast device', () => {
+  const services = new Map();
+  const addresses = new Map();
+  // The socket sees the whole segment; only what a googlecast PTR introduced counts.
+  absorb(buildResponse(), services, addresses);
+  const printer = buildResponse();
+  printer.write('_printerxx', printer.indexOf('_googlecast'));
+  absorb(printer, services, addresses);
+  assert.equal(collect(services, addresses).length, 1);
+});
+
+test('a device is withheld until its address record lands', () => {
+  const services = new Map([['Chromecast-abc._googlecast._tcp.local', { target: 'abc.local', port: 8009 }]]);
+  assert.deepEqual(collect(services, new Map()), []);
+});
+
+test('the PTR query is a well-formed single question', () => {
+  const query = buildQuery();
+  assert.equal(query.readUInt16BE(4), 1);
+  assert.equal(query.readUInt16BE(6), 0);
+  assert.deepEqual(parseRecords(query), []);
+  assert.equal(query.readUInt16BE(query.length - 4), 12);
+});
+
+test('TXT rdata splits on the first "=" only', () => {
+  const entry = 'fn=Salon=TV';
+  const buf = Buffer.concat([Buffer.from([entry.length]), Buffer.from(entry)]);
+  assert.deepEqual(parseTxt(buf, 0, buf.length), { fn: 'Salon=TV' });
+});
+
+// ── receiver status ──
+
+test('a playing status becomes a media update', () => {
+  const event = mediaStatusEvent(
+    { playerState: 'PLAYING', currentTime: 42.5, volume: { level: 0.6, muted: false } },
+    { duration: 3600 },
+  );
+  assert.deepEqual(event, {
+    name: 'castMediaUpdate',
+    detail: {
+      currentTime: 42.5,
+      duration: 3600,
+      isPaused: false,
+      buffering: false,
+      volume: 0.6,
+      muted: false,
+    },
+  });
+});
+
+test('IDLE/ERROR becomes a recoverable error carrying the playhead', () => {
+  const event = mediaStatusEvent(
+    { playerState: 'IDLE', idleReason: 'ERROR', currentTime: 128 },
+    { duration: 3600 },
+  );
+  assert.deepEqual(event, { name: 'castError', detail: { position: 128 } });
+});
+
+test('IDLE without an error reason is an ordinary update, not a failure', () => {
+  const event = mediaStatusEvent({ playerState: 'IDLE', idleReason: 'FINISHED' }, undefined);
+  assert.equal(event.name, 'castMediaUpdate');
+});
+
+const TRACKS = [
+  { trackId: 1, type: 'TEXT', name: 'French', language: 'fr' },
+  { trackId: 2, type: 'TEXT', name: 'English', language: 'en' },
+  { trackId: 3, type: 'AUDIO', name: 'VF', language: 'fr' },
+  { trackId: 4, type: 'AUDIO', name: 'VO', language: 'en' },
+];
+
+test('changing the subtitle keeps the active audio alive', () => {
+  assert.deepEqual(mergeActiveTracks(TRACKS, [2, 4], { textId: 1 }), [4, 1]);
+});
+
+test('changing the audio keeps the active subtitle alive', () => {
+  assert.deepEqual(mergeActiveTracks(TRACKS, [2, 4], { audioId: 3 }), [3, 2]);
+});
+
+test('a null id disables that track type and nothing else', () => {
+  assert.deepEqual(mergeActiveTracks(TRACKS, [2, 4], { textId: null }), [4]);
+});
+
+test('audio matches on name before language, for 3-letter sources', () => {
+  // Shaka rewrote the manifest's "fre" to "fr", so only the NAME still matches.
+  assert.equal(pickAudioTrack(TRACKS, 'fre', 'VF')?.trackId, 3);
+  assert.equal(pickAudioTrack(TRACKS, 'en', 'Nonexistent')?.trackId, 4);
+  assert.equal(pickAudioTrack(TRACKS, 'de', 'German'), undefined);
+});

--- a/desktop/src/main/cast/index.ts
+++ b/desktop/src/main/cast/index.ts
@@ -1,0 +1,330 @@
+import { BrowserWindow, ipcMain } from 'electron';
+import { CAST_IPC } from '../../shared/contract';
+import type {
+  DesktopCastDevice,
+  DesktopCastEvent,
+  DesktopCastLoadOptions,
+} from '../../shared/contract';
+import { CastDiscovery, type DiscoveredDevice } from './mdns';
+import {
+  mediaStatusEvent,
+  mergeActiveTracks,
+  pickAudioTrack,
+  type CastTrack,
+} from './status';
+import {
+  CastChannel,
+  NS_MEDIA,
+  NS_RECEIVER,
+  PLATFORM_RECEIVER,
+} from './protocol';
+
+/** Receiver → sender bus the Fliks CAF receiver pushes player errors on.
+ *  Kept in sync with `cast-receiver/receiver.js` and the web sender. */
+const NS_FLIKS = 'urn:x-cast:media.fliks.app';
+
+/** MEDIA_STATUS only arrives on receiver-side transitions, so the playhead is
+ *  polled to keep the renderer's seekbar moving — the same job the web SDK's
+ *  RemotePlayer does for itself. 1Hz is what a cast progress bar needs. */
+const STATUS_POLL_MS = 1_000;
+
+function broadcast(event: DesktopCastEvent): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) win.webContents.send(CAST_IPC.event, event);
+  }
+}
+
+/**
+ * Cast sender for the desktop client: mDNS discovery plus a CASTV2 session,
+ * exposing the same method surface the mobile `NativeCast` Capacitor plugin
+ * does so the Angular `CastService` drives all three senders identically.
+ */
+class CastSender {
+  private readonly discovery = new CastDiscovery((devices) => this.onDevices(devices));
+  private channel: CastChannel | null = null;
+  private devices: DiscoveredDevice[] = [];
+  private appId = '';
+  private deviceId: string | null = null;
+  private transportId = '';
+  private sessionId = '';
+  private mediaSessionId: number | null = null;
+  private tracks: CastTrack[] = [];
+  private media: Record<string, unknown> | undefined;
+  private activeTrackIds: number[] = [];
+  private poll: ReturnType<typeof setInterval> | null = null;
+
+  initialize(appId: string): { available: boolean } {
+    this.appId = appId;
+    this.discovery.start();
+    return { available: this.devices.length > 0 };
+  }
+
+  listDevices(): DesktopCastDevice[] {
+    return this.devices.map((d) => ({
+      id: d.id,
+      name: d.name,
+      modelName: d.modelName,
+      connected: d.id === this.deviceId && this.isConnected(),
+    }));
+  }
+
+  refresh(): void {
+    this.discovery.query();
+  }
+
+  isConnected(): boolean {
+    return !!this.channel?.isOpen && !!this.transportId;
+  }
+
+  private onDevices(devices: DiscoveredDevice[]): void {
+    this.devices = devices;
+    broadcast({ name: 'castAvailabilityChanged', detail: { available: devices.length > 0 } });
+    broadcast({ name: 'castDevicesChanged', detail: {} });
+  }
+
+  async select(id: string): Promise<void> {
+    const device = this.devices.find((d) => d.id === id);
+    if (!device) throw new Error(`unknown cast device: ${id}`);
+    this.teardown();
+
+    const channel = new CastChannel();
+    this.channel = channel;
+    channel.on('message', (ns: string, data: Record<string, unknown>) =>
+      this.onMessage(ns, data),
+    );
+    channel.on('close', () => {
+      if (this.channel === channel) this.teardown();
+    });
+
+    await channel.connect(device.host, device.port);
+    const status = await channel.request(NS_RECEIVER, PLATFORM_RECEIVER, {
+      type: 'LAUNCH',
+      appId: this.appId,
+    }, 30_000);
+    if (!this.adoptReceiverStatus(status)) {
+      this.teardown();
+      throw new Error('receiver did not launch the Fliks app');
+    }
+    this.deviceId = device.id;
+    channel.virtualConnect(this.transportId);
+    this.startPolling();
+    broadcast({ name: 'castStateChanged', detail: { connected: true } });
+    broadcast({ name: 'castDevicesChanged', detail: {} });
+  }
+
+  /** Pull our app's transport out of a RECEIVER_STATUS. Returns false when the
+   *  Fliks receiver isn't among the running applications. */
+  private adoptReceiverStatus(message: Record<string, unknown>): boolean {
+    const status = message['status'] as Record<string, unknown> | undefined;
+    const volume = status?.['volume'] as { level?: number; muted?: boolean } | undefined;
+    if (volume) {
+      broadcast({
+        name: 'castMediaUpdate',
+        detail: { volume: volume.level, muted: volume.muted },
+      });
+    }
+    const apps = (status?.['applications'] ?? []) as Record<string, unknown>[];
+    const app = apps.find((a) => a['appId'] === this.appId);
+    if (!app) return false;
+    this.transportId = String(app['transportId'] ?? '');
+    this.sessionId = String(app['sessionId'] ?? '');
+    return !!this.transportId;
+  }
+
+  private onMessage(ns: string, data: Record<string, unknown>): void {
+    if (ns === NS_RECEIVER && data['type'] === 'RECEIVER_STATUS') {
+      const status = data['status'] as Record<string, unknown> | undefined;
+      const apps = (status?.['applications'] ?? []) as Record<string, unknown>[];
+      // The user can stop the app from the TV or another sender; the session is
+      // over even though the TCP channel is still up.
+      if (this.transportId && !apps.some((a) => a['appId'] === this.appId)) {
+        this.teardown();
+        return;
+      }
+      this.adoptReceiverStatus(data);
+      return;
+    }
+    if (ns === NS_MEDIA && data['type'] === 'MEDIA_STATUS') {
+      this.onMediaStatus((data['status'] ?? []) as Record<string, unknown>[]);
+      return;
+    }
+    if (ns === NS_FLIKS && data['kind'] === 'player_error') {
+      broadcast({ name: 'castError', detail: { position: Number(data['at']) || undefined } });
+    }
+  }
+
+  private onMediaStatus(statuses: Record<string, unknown>[]): void {
+    const status = statuses[0];
+    if (!status) return;
+    this.mediaSessionId = Number(status['mediaSessionId']) || this.mediaSessionId;
+    if (Array.isArray(status['activeTrackIds'])) {
+      this.activeTrackIds = status['activeTrackIds'] as number[];
+    }
+    const media = status['media'] as Record<string, unknown> | undefined;
+    // `media` rides only the first status after a LOAD; later ones omit it.
+    if (Array.isArray(media?.['tracks'])) this.tracks = media['tracks'] as CastTrack[];
+    if (media) this.media = media;
+    broadcast(mediaStatusEvent(status, this.media));
+  }
+
+  private startPolling(): void {
+    if (this.poll) return;
+    this.poll = setInterval(() => {
+      if (!this.isConnected()) return;
+      this.mediaSend({ type: 'GET_STATUS' });
+    }, STATUS_POLL_MS);
+  }
+
+  private mediaSend(payload: Record<string, unknown>): void {
+    if (!this.channel || !this.transportId) return;
+    const withSession =
+      this.mediaSessionId != null ? { ...payload, mediaSessionId: this.mediaSessionId } : payload;
+    this.channel.send(NS_MEDIA, this.transportId, {
+      ...withSession,
+      requestId: Math.floor(Math.random() * 1e6),
+    });
+  }
+
+  load(opts: DesktopCastLoadOptions): void {
+    if (!this.channel || !this.transportId) return;
+    const tracks = opts.subtitles.map((sub, i) => ({
+      trackId: i + 1,
+      type: 'TEXT',
+      trackContentId: sub.url,
+      trackContentType: 'text/vtt',
+      subtype: 'SUBTITLES',
+      name: sub.label,
+      language: sub.language,
+    }));
+    // A fresh LOAD invalidates the previous session's tracks and id; the
+    // MEDIA_STATUS that answers this one repopulates them.
+    this.mediaSessionId = null;
+    this.tracks = [];
+    this.activeTrackIds = [];
+    this.media = undefined;
+    this.channel.send(NS_MEDIA, this.transportId, {
+      type: 'LOAD',
+      requestId: Math.floor(Math.random() * 1e6),
+      sessionId: this.sessionId,
+      autoplay: opts.autoplay,
+      currentTime: opts.currentTime,
+      activeTrackIds: opts.activeSubtitleTrackId ? [opts.activeSubtitleTrackId] : [],
+      media: {
+        contentId: opts.url,
+        contentType: opts.contentType,
+        streamType: 'BUFFERED',
+        metadata: {
+          metadataType: 0,
+          title: opts.title,
+          subtitle: opts.subtitle,
+          images: opts.posterUrl ? [{ url: opts.posterUrl }] : [],
+        },
+        tracks,
+        textTrackStyle: opts.castTextTrackStyle,
+        customData: opts.customData,
+      },
+    });
+  }
+
+  play(): void { this.mediaSend({ type: 'PLAY' }); }
+  pause(): void { this.mediaSend({ type: 'PAUSE' }); }
+  seek(time: number): void { this.mediaSend({ type: 'SEEK', currentTime: time }); }
+  stop(): void { this.mediaSend({ type: 'STOP' }); }
+
+  setVolume(level: number): void {
+    this.channel?.send(NS_RECEIVER, PLATFORM_RECEIVER, {
+      type: 'SET_VOLUME',
+      requestId: Math.floor(Math.random() * 1e6),
+      volume: { level },
+    });
+  }
+
+  setMuted(muted: boolean): void {
+    this.channel?.send(NS_RECEIVER, PLATFORM_RECEIVER, {
+      type: 'SET_VOLUME',
+      requestId: Math.floor(Math.random() * 1e6),
+      volume: { muted },
+    });
+  }
+
+  setActiveSubtitle(trackId: number): void {
+    this.editTracks({ textId: trackId > 0 ? trackId : null });
+  }
+
+  /** Match the audio rendition by name first: Shaka rewrites HLS LANGUAGE from
+   *  ISO 639-2 to 639-1, so language equality misses 3-letter sources. */
+  setActiveAudioLanguage(language: string, name: string): boolean {
+    const target = pickAudioTrack(this.tracks, language, name);
+    if (!target) return false;
+    return this.editTracks({ audioId: target.trackId });
+  }
+
+  private editTracks(update: { audioId?: number | null; textId?: number | null }): boolean {
+    if (!this.channel || !this.transportId || this.mediaSessionId == null) return false;
+    const activeTrackIds = mergeActiveTracks(this.tracks, this.activeTrackIds, update);
+    this.mediaSend({ type: 'EDIT_TRACKS_INFO', activeTrackIds });
+    this.activeTrackIds = activeTrackIds;
+    return true;
+  }
+
+  disconnect(): void {
+    if (this.channel && this.transportId) {
+      this.channel.send(NS_RECEIVER, PLATFORM_RECEIVER, {
+        type: 'STOP',
+        requestId: Math.floor(Math.random() * 1e6),
+        sessionId: this.sessionId,
+      });
+    }
+    this.teardown();
+  }
+
+  private teardown(): void {
+    const wasConnected = this.isConnected();
+    if (this.poll) clearInterval(this.poll);
+    this.poll = null;
+    this.channel?.removeAllListeners();
+    this.channel?.close();
+    this.channel = null;
+    this.deviceId = null;
+    this.transportId = '';
+    this.sessionId = '';
+    this.mediaSessionId = null;
+    this.tracks = [];
+    this.activeTrackIds = [];
+    this.media = undefined;
+    if (wasConnected) {
+      broadcast({ name: 'castStateChanged', detail: { connected: false } });
+      broadcast({ name: 'castDevicesChanged', detail: {} });
+    }
+  }
+}
+
+export function registerCastIpc(): void {
+  const sender = new CastSender();
+  ipcMain.handle(CAST_IPC.initialize, (_e, appId: string) => sender.initialize(appId));
+  ipcMain.handle(CAST_IPC.isConnected, () => ({ connected: sender.isConnected() }));
+  ipcMain.handle(CAST_IPC.getDevices, () => {
+    sender.refresh();
+    return sender.listDevices();
+  });
+  ipcMain.handle(CAST_IPC.selectDevice, (_e, id: string) => sender.select(id));
+  // Desktop has no OS-level route picker to open — the app's own picker lists
+  // the discovered devices — so end the caller's "connecting" state at once.
+  ipcMain.handle(CAST_IPC.requestSession, () =>
+    broadcast({ name: 'castPickerDismissed', detail: {} }),
+  );
+  ipcMain.handle(CAST_IPC.load, (_e, opts: DesktopCastLoadOptions) => sender.load(opts));
+  ipcMain.handle(CAST_IPC.play, () => sender.play());
+  ipcMain.handle(CAST_IPC.pause, () => sender.pause());
+  ipcMain.handle(CAST_IPC.seek, (_e, time: number) => sender.seek(time));
+  ipcMain.handle(CAST_IPC.stop, () => sender.stop());
+  ipcMain.handle(CAST_IPC.disconnect, () => sender.disconnect());
+  ipcMain.handle(CAST_IPC.setVolume, (_e, level: number) => sender.setVolume(level));
+  ipcMain.handle(CAST_IPC.setMuted, (_e, muted: boolean) => sender.setMuted(muted));
+  ipcMain.handle(CAST_IPC.setActiveSubtitle, (_e, trackId: number) =>
+    sender.setActiveSubtitle(trackId),
+  );
+  ipcMain.handle(CAST_IPC.setActiveAudioLanguage, (_e, language: string, name: string) => ({
+    success: sender.setActiveAudioLanguage(language, name),
+  }));
+}

--- a/desktop/src/main/cast/mdns.ts
+++ b/desktop/src/main/cast/mdns.ts
@@ -1,0 +1,246 @@
+import dgram from 'node:dgram';
+
+/** Minimal mDNS browser for `_googlecast._tcp.local`, enough to feed the Cast
+ *  picker: PTR → instance, SRV → host + port, TXT → id / friendly name / model.
+ *  Node has no stdlib mDNS and the protocol surface we need is one query type,
+ *  so the packets are built and parsed here rather than pulling a resolver in. */
+
+const MDNS_ADDR = '224.0.0.251';
+const MDNS_PORT = 5353;
+const SERVICE = '_googlecast._tcp.local';
+
+const TYPE_A = 1;
+const TYPE_PTR = 12;
+const TYPE_TXT = 16;
+const TYPE_SRV = 33;
+
+export interface DiscoveredDevice {
+  id: string;
+  name: string;
+  modelName?: string;
+  host: string;
+  port: number;
+}
+
+interface Rr {
+  name: string;
+  type: number;
+  start: number;
+  length: number;
+}
+
+/** Read a DNS name at `offset`, following compression pointers. Returns the
+ *  name and the offset just past the name *in the record stream* — a pointer
+ *  consumes 2 bytes there however far it jumps. */
+function readName(buf: Buffer, offset: number): [string, number] {
+  const labels: string[] = [];
+  let pos = offset;
+  let next = offset;
+  let jumped = false;
+  // A malformed packet can point a name at itself; cap the walk.
+  for (let guard = 0; guard < 128; guard++) {
+    if (pos >= buf.length) break;
+    const len = buf[pos];
+    if (len === 0) {
+      if (!jumped) next = pos + 1;
+      break;
+    }
+    if ((len & 0xc0) === 0xc0) {
+      if (pos + 1 >= buf.length) break;
+      const ptr = ((len & 0x3f) << 8) | buf[pos + 1];
+      if (!jumped) next = pos + 2;
+      jumped = true;
+      pos = ptr;
+      continue;
+    }
+    labels.push(buf.toString('utf8', pos + 1, pos + 1 + len));
+    pos += 1 + len;
+    if (!jumped) next = pos;
+  }
+  return [labels.join('.'), next];
+}
+
+export function parseRecords(buf: Buffer): Rr[] {
+  if (buf.length < 12) return [];
+  const qd = buf.readUInt16BE(4);
+  const rrCount = buf.readUInt16BE(6) + buf.readUInt16BE(8) + buf.readUInt16BE(10);
+  let pos = 12;
+  for (let i = 0; i < qd; i++) {
+    [, pos] = readName(buf, pos);
+    pos += 4;
+  }
+  const out: Rr[] = [];
+  for (let i = 0; i < rrCount && pos + 10 <= buf.length; i++) {
+    let name: string;
+    [name, pos] = readName(buf, pos);
+    if (pos + 10 > buf.length) break;
+    const type = buf.readUInt16BE(pos);
+    const length = buf.readUInt16BE(pos + 8);
+    pos += 10;
+    out.push({ name, type, start: pos, length });
+    pos += length;
+  }
+  return out;
+}
+
+/** TXT rdata is a run of length-prefixed `key=value` strings. */
+export function parseTxt(buf: Buffer, start: number, length: number): Record<string, string> {
+  const out: Record<string, string> = {};
+  let pos = start;
+  const end = Math.min(start + length, buf.length);
+  while (pos < end) {
+    const len = buf[pos];
+    const text = buf.toString('utf8', pos + 1, Math.min(pos + 1 + len, end));
+    const eq = text.indexOf('=');
+    if (eq > 0) out[text.slice(0, eq)] = text.slice(eq + 1);
+    pos += 1 + len;
+  }
+  return out;
+}
+
+export function buildQuery(): Buffer {
+  const labels = SERVICE.split('.');
+  const nameLen = labels.reduce((n, l) => n + 1 + l.length, 0) + 1;
+  const buf = Buffer.alloc(12 + nameLen + 4);
+  buf.writeUInt16BE(1, 4); // one question, everything else stays zero
+  let pos = 12;
+  for (const label of labels) {
+    buf.writeUInt8(label.length, pos++);
+    pos += buf.write(label, pos, 'utf8');
+  }
+  buf.writeUInt8(0, pos++);
+  buf.writeUInt16BE(TYPE_PTR, pos);
+  buf.writeUInt16BE(1, pos + 2);
+  return buf;
+}
+
+interface Partial {
+  host?: string;
+  port?: number;
+  target?: string;
+  txt?: Record<string, string>;
+}
+
+/** Fold one response packet into the instance → partial-record map. Exported
+ *  for the codec test: a device is only complete once SRV, TXT and A have all
+ *  landed, which can take several packets. */
+export function absorb(
+  buf: Buffer,
+  services: Map<string, Partial>,
+  addresses: Map<string, string>,
+): void {
+  for (const rr of parseRecords(buf)) {
+    if (rr.type === TYPE_PTR && rr.name === SERVICE) {
+      const [instance] = readName(buf, rr.start);
+      if (!services.has(instance)) services.set(instance, {});
+    } else if (rr.type === TYPE_SRV) {
+      // Only ever fill in an instance a googlecast PTR introduced: the socket
+      // sees every mDNS conversation on the segment, and a printer's SRV would
+      // otherwise register as a Cast device.
+      const entry = services.get(rr.name);
+      if (entry) {
+        entry.port = buf.readUInt16BE(rr.start + 4);
+        [entry.target] = readName(buf, rr.start + 6);
+      }
+    } else if (rr.type === TYPE_TXT) {
+      const entry = services.get(rr.name);
+      if (entry) entry.txt = parseTxt(buf, rr.start, rr.length);
+    } else if (rr.type === TYPE_A && rr.length === 4) {
+      addresses.set(rr.name, Array.from(buf.subarray(rr.start, rr.start + 4)).join('.'));
+    }
+  }
+}
+
+export function collect(
+  services: Map<string, Partial>,
+  addresses: Map<string, string>,
+): DiscoveredDevice[] {
+  const out: DiscoveredDevice[] = [];
+  for (const [instance, entry] of services) {
+    const host = entry.target ? addresses.get(entry.target) : undefined;
+    if (!host || !entry.port) continue;
+    const txt = entry.txt ?? {};
+    out.push({
+      // `id` is the device UUID, stable across reboots; the instance label is
+      // the only fallback when a TXT record hasn't arrived yet.
+      id: txt['id'] || instance,
+      name: txt['fn'] || instance.split('.')[0],
+      modelName: txt['md'],
+      host,
+      port: entry.port,
+    });
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export class CastDiscovery {
+  private socket: dgram.Socket | null = null;
+  private readonly services = new Map<string, Partial>();
+  private readonly addresses = new Map<string, string>();
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  private readonly onChange: (devices: DiscoveredDevice[]) => void;
+
+  constructor(onChange: (devices: DiscoveredDevice[]) => void) {
+    this.onChange = onChange;
+  }
+
+  start(): void {
+    if (this.socket) return;
+    // reuseAddr is what lets us share 5353 with the OS responder (mDNSResponder,
+    // avahi); without it the bind fails on any machine already running one.
+    const socket = dgram.createSocket({ type: 'udp4', reuseAddr: true });
+    this.socket = socket;
+    socket.on('message', (msg) => {
+      const before = this.snapshot();
+      absorb(msg, this.services, this.addresses);
+      const after = this.snapshot();
+      if (before !== after) this.onChange(this.devices());
+    });
+    socket.on('error', (err) => {
+      console.warn('[cast] mdns socket error', err.message);
+      this.stop();
+    });
+    socket.bind(MDNS_PORT, () => {
+      try {
+        socket.addMembership(MDNS_ADDR);
+      } catch (err) {
+        console.warn('[cast] mdns membership failed', (err as Error).message);
+      }
+      this.query();
+      // Chromecasts answer a query once; they don't heartbeat their presence at
+      // a useful cadence, so re-ask to notice devices that appear or vanish.
+      this.timer = setInterval(() => this.query(), 30_000);
+    });
+  }
+
+  /** Re-send the PTR query. Called on every picker open so a device powered on
+   *  since the last sweep shows up without waiting for the 30s tick. */
+  query(): void {
+    if (!this.socket) return;
+    // ponytail: default multicast interface only; enumerate os.networkInterfaces()
+    // and send per-interface if multi-homed hosts turn out to miss devices.
+    this.socket.send(buildQuery(), MDNS_PORT, MDNS_ADDR, (err) => {
+      if (err) console.warn('[cast] mdns query failed', err.message);
+    });
+  }
+
+  devices(): DiscoveredDevice[] {
+    return collect(this.services, this.addresses);
+  }
+
+  private snapshot(): string {
+    return this.devices().map((d) => `${d.id}@${d.host}:${d.port}/${d.name}`).join('|');
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+    try {
+      this.socket?.close();
+    } catch {
+      /* already closed */
+    }
+    this.socket = null;
+  }
+}

--- a/desktop/src/main/cast/protocol.ts
+++ b/desktop/src/main/cast/protocol.ts
@@ -1,0 +1,243 @@
+import { EventEmitter } from 'node:events';
+import tls from 'node:tls';
+
+/** CASTV2 wire protocol: length-prefixed `CastMessage` protobuf frames over
+ *  TLS/8009. The message has seven scalar fields, so it is encoded by hand
+ *  rather than dragging a protobuf runtime into the bundle. */
+
+export const NS_CONNECTION = 'urn:x-cast:com.google.cast.tp.connection';
+export const NS_HEARTBEAT = 'urn:x-cast:com.google.cast.tp.heartbeat';
+export const NS_RECEIVER = 'urn:x-cast:com.google.cast.receiver';
+export const NS_MEDIA = 'urn:x-cast:com.google.cast.media';
+
+export const PLATFORM_RECEIVER = 'receiver-0';
+
+const HEARTBEAT_MS = 5_000;
+/** Two missed PINGs: the device is gone (unplugged, off the network). */
+const HEARTBEAT_TIMEOUT_MS = 15_000;
+
+export interface CastMessage {
+  sourceId: string;
+  destinationId: string;
+  namespace: string;
+  data: string;
+}
+
+function writeVarint(value: number): Buffer {
+  const bytes: number[] = [];
+  let v = value;
+  do {
+    let byte = v & 0x7f;
+    v >>>= 7;
+    if (v) byte |= 0x80;
+    bytes.push(byte);
+  } while (v);
+  return Buffer.from(bytes);
+}
+
+function readVarint(buf: Buffer, offset: number): [number, number] {
+  let value = 0;
+  let shift = 0;
+  let pos = offset;
+  while (pos < buf.length) {
+    const byte = buf[pos++];
+    value |= (byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) break;
+    shift += 7;
+  }
+  return [value >>> 0, pos];
+}
+
+function stringField(tag: number, value: string): Buffer {
+  const body = Buffer.from(value, 'utf8');
+  return Buffer.concat([Buffer.from([tag]), writeVarint(body.length), body]);
+}
+
+/** Encode a CastMessage into a complete frame (4-byte big-endian length + body). */
+export function encodeFrame(msg: CastMessage): Buffer {
+  const body = Buffer.concat([
+    Buffer.from([0x08, 0x00]), // protocol_version = CASTV2_1_0
+    stringField(0x12, msg.sourceId),
+    stringField(0x1a, msg.destinationId),
+    stringField(0x22, msg.namespace),
+    Buffer.from([0x28, 0x00]), // payload_type = STRING
+    stringField(0x32, msg.data),
+  ]);
+  const frame = Buffer.alloc(4 + body.length);
+  frame.writeUInt32BE(body.length, 0);
+  body.copy(frame, 4);
+  return frame;
+}
+
+/** Decode a CastMessage body (the frame without its length prefix). */
+export function decodeMessage(body: Buffer): CastMessage {
+  const msg: CastMessage = { sourceId: '', destinationId: '', namespace: '', data: '' };
+  let pos = 0;
+  while (pos < body.length) {
+    const [tag, afterTag] = readVarint(body, pos);
+    pos = afterTag;
+    const wire = tag & 7;
+    if (wire === 0) {
+      [, pos] = readVarint(body, pos);
+      continue;
+    }
+    if (wire !== 2) break; // castv2 uses varint + length-delimited only
+    const [size, afterSize] = readVarint(body, pos);
+    pos = afterSize;
+    const value = body.subarray(pos, pos + size);
+    pos += size;
+    switch (tag >>> 3) {
+      case 2: msg.sourceId = value.toString('utf8'); break;
+      case 3: msg.destinationId = value.toString('utf8'); break;
+      case 4: msg.namespace = value.toString('utf8'); break;
+      case 6: msg.data = value.toString('utf8'); break;
+    }
+  }
+  return msg;
+}
+
+/** Split a byte stream into CastMessage bodies, keeping any partial tail. */
+export function splitFrames(buffer: Buffer): { messages: Buffer[]; rest: Buffer } {
+  const messages: Buffer[] = [];
+  let pos = 0;
+  while (buffer.length - pos >= 4) {
+    const size = buffer.readUInt32BE(pos);
+    if (buffer.length - pos - 4 < size) break;
+    messages.push(buffer.subarray(pos + 4, pos + 4 + size));
+    pos += 4 + size;
+  }
+  return { messages, rest: buffer.subarray(pos) };
+}
+
+/**
+ * One TLS connection to a Cast device. Owns the framing, the virtual
+ * connection handshake and the heartbeat; everything above it (launching an
+ * app, media control) speaks in JSON payloads on a namespace.
+ *
+ * Events: `message` (namespace, payload, sourceId), `close`.
+ */
+export class CastChannel extends EventEmitter {
+  private socket: tls.TLSSocket | null = null;
+  private buffer: Buffer = Buffer.alloc(0);
+  private heartbeat: ReturnType<typeof setInterval> | null = null;
+  private lastPong = 0;
+  private readonly connected = new Set<string>();
+  private requestId = 1;
+
+  readonly sourceId = `sender-${Math.random().toString(36).slice(2, 10)}`;
+
+  connect(host: string, port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      // Cast devices present a self-signed cert chained to a Google device CA
+      // that no trust store carries; the LAN pairing is the trust boundary.
+      const socket = tls.connect({ host, port, rejectUnauthorized: false }, () => {
+        this.lastPong = Date.now();
+        this.virtualConnect(PLATFORM_RECEIVER);
+        this.startHeartbeat();
+        resolve();
+      });
+      socket.setNoDelay(true);
+      socket.on('data', (chunk: Buffer) => this.onData(chunk));
+      socket.on('error', (err) => {
+        reject(err);
+        this.close();
+      });
+      socket.on('close', () => this.close());
+      this.socket = socket;
+    });
+  }
+
+  /** Open a virtual connection to a destination — required before that
+   *  destination will accept anything, the app transport included. */
+  virtualConnect(destinationId: string): void {
+    if (this.connected.has(destinationId)) return;
+    this.connected.add(destinationId);
+    this.send(NS_CONNECTION, destinationId, { type: 'CONNECT' });
+  }
+
+  send(namespace: string, destinationId: string, payload: Record<string, unknown>): void {
+    if (!this.socket || this.socket.destroyed) return;
+    this.socket.write(
+      encodeFrame({
+        sourceId: this.sourceId,
+        destinationId,
+        namespace,
+        data: JSON.stringify(payload),
+      }),
+    );
+  }
+
+  /** Send a request and resolve with the reply carrying the same requestId.
+   *  Rejects on timeout so a caller never hangs on a receiver that went away. */
+  request(
+    namespace: string,
+    destinationId: string,
+    payload: Record<string, unknown>,
+    timeoutMs = 10_000,
+  ): Promise<Record<string, unknown>> {
+    const requestId = ++this.requestId;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.off('message', listener);
+        reject(new Error(`cast request timed out: ${String(payload['type'])}`));
+      }, timeoutMs);
+      const listener = (_ns: string, data: Record<string, unknown>) => {
+        if (data['requestId'] !== requestId) return;
+        clearTimeout(timer);
+        this.off('message', listener);
+        resolve(data);
+      };
+      this.on('message', listener);
+      this.send(namespace, destinationId, { ...payload, requestId });
+    });
+  }
+
+  private onData(chunk: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    const { messages, rest } = splitFrames(this.buffer);
+    this.buffer = rest;
+    for (const body of messages) {
+      const msg = decodeMessage(body);
+      let data: Record<string, unknown>;
+      try {
+        data = JSON.parse(msg.data) as Record<string, unknown>;
+      } catch {
+        continue; // binary payloads are not part of the surface we use
+      }
+      if (msg.namespace === NS_HEARTBEAT) {
+        if (data['type'] === 'PONG') this.lastPong = Date.now();
+        else if (data['type'] === 'PING') this.send(NS_HEARTBEAT, msg.sourceId, { type: 'PONG' });
+        continue;
+      }
+      this.emit('message', msg.namespace, data, msg.sourceId);
+    }
+  }
+
+  private startHeartbeat(): void {
+    this.heartbeat = setInterval(() => {
+      if (Date.now() - this.lastPong > HEARTBEAT_TIMEOUT_MS) {
+        console.warn('[cast] heartbeat lost, dropping the channel');
+        this.close();
+        return;
+      }
+      this.send(NS_HEARTBEAT, PLATFORM_RECEIVER, { type: 'PING' });
+    }, HEARTBEAT_MS);
+  }
+
+  close(): void {
+    if (this.heartbeat) clearInterval(this.heartbeat);
+    this.heartbeat = null;
+    const socket = this.socket;
+    this.socket = null;
+    this.connected.clear();
+    if (socket) {
+      socket.removeAllListeners('close');
+      socket.destroy();
+      this.emit('close');
+    }
+  }
+
+  get isOpen(): boolean {
+    return !!this.socket && !this.socket.destroyed;
+  }
+}

--- a/desktop/src/main/cast/status.ts
+++ b/desktop/src/main/cast/status.ts
@@ -1,0 +1,71 @@
+import type { DesktopCastEvent } from '../../shared/contract';
+
+/** Pure mapping of the receiver's media bus onto the events the renderer
+ *  consumes. Kept apart from the sender so it stays free of Electron and can
+ *  be exercised directly. */
+
+export interface CastTrack {
+  trackId: number;
+  type?: string;
+  name?: string;
+  language?: string;
+}
+
+/** Translate one MEDIA_STATUS entry. `duration` rides the `media` block, which
+ *  the receiver only sends on the first status after a LOAD, so the caller
+ *  keeps the last one it saw. */
+export function mediaStatusEvent(
+  status: Record<string, unknown>,
+  media: Record<string, unknown> | undefined,
+): DesktopCastEvent {
+  const playerState = String(status['playerState'] ?? '');
+  if (playerState === 'IDLE' && status['idleReason'] === 'ERROR') {
+    return {
+      name: 'castError',
+      detail: { position: Number(status['currentTime']) || undefined },
+    };
+  }
+  const volume = status['volume'] as { level?: number; muted?: boolean } | undefined;
+  return {
+    name: 'castMediaUpdate',
+    detail: {
+      currentTime: Number(status['currentTime']) || 0,
+      duration: Number(media?.['duration']) || undefined,
+      isPaused: playerState === 'PAUSED',
+      buffering: playerState === 'BUFFERING',
+      volume: volume?.level,
+      muted: volume?.muted,
+    },
+  };
+}
+
+/**
+ * Build the activeTrackIds for an EDIT_TRACKS_INFO. CAF replaces the whole
+ * active set in one shot, so the track type left unspecified has to be re-sent
+ * from the current selection or it goes silent.
+ *   undefined → keep whatever is active for that type
+ *   null      → disable that type
+ *   number    → make it the active track of that type
+ */
+export function mergeActiveTracks(
+  tracks: CastTrack[],
+  active: number[],
+  update: { audioId?: number | null; textId?: number | null },
+): number[] {
+  const activeOfType = (type: string) =>
+    active.find((id) => tracks.some((t) => t.trackId === id && t.type === type));
+  const audioId = update.audioId === undefined ? activeOfType('AUDIO') : update.audioId;
+  const textId = update.textId === undefined ? activeOfType('TEXT') : update.textId;
+  return [audioId, textId].filter((id): id is number => id != null);
+}
+
+/** Match an audio rendition by name first: Shaka rewrites HLS LANGUAGE from
+ *  ISO 639-2 to 639-1, so plain language equality misses 3-letter sources. */
+export function pickAudioTrack(
+  tracks: CastTrack[],
+  language: string,
+  name: string,
+): CastTrack | undefined {
+  const audio = tracks.filter((t) => t.type === 'AUDIO');
+  return audio.find((t) => t.name === name) ?? audio.find((t) => t.language === language);
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -9,6 +9,7 @@ import { installCorsBypass } from './cors';
 import { appendLog, redactQuery } from './log-file';
 import { setupUpdater } from './updater';
 import { registerDownloadIpc } from './download';
+import { registerCastIpc } from './cast';
 import { setPlaybackKeepAwake, keepAwakeForState } from './power';
 import { IPC, type DesktopEvent, type DesktopSubtitleStyle } from '../shared/contract';
 import { mpvSubtitleProps } from './mpv/subtitle-style';
@@ -258,6 +259,11 @@ app.whenReady().then(async () => {
   // Offline downloads (renderer→main fetch-to-disk). Registered on every
   // platform path so the desktop download UI works regardless of playback backend.
   registerDownloadIpc();
+
+  // Chromecast sender (mDNS discovery + CASTV2). Electron carries no Cast SDK —
+  // the web sender's cast_sender.js needs Chrome's media router — so the
+  // protocol is spoken from the main process. Registered on every platform path.
+  registerCastIpc();
 
   const dir = webDir();
   const haveApp = fs.existsSync(path.join(dir, 'index.html'));

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -3,6 +3,7 @@ import {
   IPC,
   UPDATE_IPC,
   DOWNLOAD_IPC,
+  CAST_IPC,
   type DesktopDownloadRequest,
   type DesktopDownloadStatus,
   type DesktopEvent,
@@ -12,6 +13,9 @@ import {
   type DesktopUpdateStatus,
   type FliksDesktopApi,
   type FliksDownloaderApi,
+  type DesktopCastEvent,
+  type DesktopCastLoadOptions,
+  type FliksCastApi,
   type FliksUpdaterApi,
 } from '../shared/contract';
 
@@ -86,3 +90,35 @@ const downloader: FliksDownloaderApi = {
 };
 
 contextBridge.exposeInMainWorld('fliksDownloader', downloader);
+
+// Exposes the Chromecast sender on `window.fliksCast`. The Angular CastService
+// consumes this exactly as it consumes the Capacitor NativeCast plugin: it
+// re-dispatches each forwarded event as the window CustomEvent the plugin
+// emits. contextIsolation keeps preload-world objects out of the page, so the
+// events travel through contextBridge rather than a window dispatch here.
+const cast: FliksCastApi = {
+  initialize: (opts: { appId: string }) => ipcRenderer.invoke(CAST_IPC.initialize, opts.appId),
+  isConnected: () => ipcRenderer.invoke(CAST_IPC.isConnected),
+  requestSession: () => ipcRenderer.invoke(CAST_IPC.requestSession),
+  getCastDevices: async () => ({ devices: await ipcRenderer.invoke(CAST_IPC.getDevices) }),
+  selectCastDevice: (opts: { id: string }) => ipcRenderer.invoke(CAST_IPC.selectDevice, opts.id),
+  loadMedia: (opts: DesktopCastLoadOptions) => ipcRenderer.invoke(CAST_IPC.load, opts),
+  play: () => ipcRenderer.invoke(CAST_IPC.play),
+  pause: () => ipcRenderer.invoke(CAST_IPC.pause),
+  seek: (opts: { time: number }) => ipcRenderer.invoke(CAST_IPC.seek, opts.time),
+  stop: () => ipcRenderer.invoke(CAST_IPC.stop),
+  disconnect: () => ipcRenderer.invoke(CAST_IPC.disconnect),
+  setVolume: (opts: { level: number }) => ipcRenderer.invoke(CAST_IPC.setVolume, opts.level),
+  setMuted: (opts: { muted: boolean }) => ipcRenderer.invoke(CAST_IPC.setMuted, opts.muted),
+  setActiveSubtitle: (opts: { trackId: number }) =>
+    ipcRenderer.invoke(CAST_IPC.setActiveSubtitle, opts.trackId),
+  setActiveAudioLanguage: (opts: { language: string; name: string }) =>
+    ipcRenderer.invoke(CAST_IPC.setActiveAudioLanguage, opts.language, opts.name),
+  on: (handler: (event: DesktopCastEvent) => void) => {
+    const listener = (_e: unknown, event: DesktopCastEvent) => handler(event);
+    ipcRenderer.on(CAST_IPC.event, listener);
+    return () => ipcRenderer.removeListener(CAST_IPC.event, listener);
+  },
+};
+
+contextBridge.exposeInMainWorld('fliksCast', cast);

--- a/desktop/src/shared/contract.ts
+++ b/desktop/src/shared/contract.ts
@@ -245,3 +245,112 @@ export interface FliksDesktopApi {
   getSystemInfo(): Promise<DesktopSystemInfo>;
   on(handler: (event: DesktopEvent) => void): () => void;
 }
+
+// ── Chromecast ──
+// App-level like downloads. The method surface mirrors the mobile `NativeCast`
+// Capacitor plugin so the Angular `CastService` treats this bridge as one more
+// native sender; the preload re-emits the events under the same window event
+// names the plugin uses.
+
+export interface DesktopCastDevice {
+  id: string;
+  name: string;
+  modelName?: string;
+  /** True for the device this sender is casting to, so the picker offers to leave it. */
+  connected?: boolean;
+}
+
+/** Cast wire format for subtitle styling — built client-side from the user's
+ *  presets and forwarded to the receiver verbatim. */
+export interface DesktopCastTextTrackStyle {
+  fontGenericFamily: string;
+  fontScale: number;
+  foregroundColor: string;
+  backgroundColor: string;
+  edgeType: string;
+  edgeColor: string;
+}
+
+export interface DesktopCastLoadOptions {
+  url: string;
+  contentType: string;
+  title: string;
+  subtitle: string;
+  posterUrl: string;
+  currentTime: number;
+  autoplay: boolean;
+  subtitles: { url: string; language: string; label: string }[];
+  activeSubtitleTrackId: number;
+  /** Forwarded to the Fliks receiver; must stay free of secrets — the CAF debug
+   *  overlay logs it in plain text. */
+  customData?: Record<string, unknown>;
+  castTextTrackStyle?: DesktopCastTextTrackStyle;
+}
+
+export interface DesktopCastMediaUpdate {
+  currentTime?: number;
+  duration?: number;
+  isPaused?: boolean;
+  buffering?: boolean;
+  volume?: number;
+  muted?: boolean;
+}
+
+/** main → renderer, sent on the single CAST_IPC.event channel. `name` and
+ *  `detail` are the window CustomEvent the mobile NativeCast plugin emits, so
+ *  the client re-dispatches them verbatim and shares one listener set.
+ *  `castError` carries the playhead a recovery reload resumes from. */
+export interface DesktopCastEvent {
+  name:
+    | 'castAvailabilityChanged'
+    | 'castDevicesChanged'
+    | 'castStateChanged'
+    | 'castPickerDismissed'
+    | 'castMediaUpdate'
+    | 'castError';
+  detail: DesktopCastMediaUpdate & {
+    available?: boolean;
+    connected?: boolean;
+    position?: number;
+  };
+}
+
+export const CAST_IPC = {
+  initialize: 'cast:initialize',
+  isConnected: 'cast:isConnected',
+  requestSession: 'cast:requestSession',
+  getDevices: 'cast:getDevices',
+  selectDevice: 'cast:selectDevice',
+  load: 'cast:load',
+  play: 'cast:play',
+  pause: 'cast:pause',
+  seek: 'cast:seek',
+  stop: 'cast:stop',
+  disconnect: 'cast:disconnect',
+  setVolume: 'cast:setVolume',
+  setMuted: 'cast:setMuted',
+  setActiveSubtitle: 'cast:setActiveSubtitle',
+  setActiveAudioLanguage: 'cast:setActiveAudioLanguage',
+  /** main → renderer (discriminated by DesktopCastEvent.type). */
+  event: 'cast:event',
+} as const;
+
+/** Exposed on `window.fliksCast` by the preload bridge. */
+export interface FliksCastApi {
+  initialize(opts: { appId: string }): Promise<{ available: boolean }>;
+  isConnected(): Promise<{ connected: boolean }>;
+  requestSession(): Promise<void>;
+  getCastDevices(): Promise<{ devices: DesktopCastDevice[] }>;
+  selectCastDevice(opts: { id: string }): Promise<void>;
+  loadMedia(opts: DesktopCastLoadOptions): Promise<void>;
+  play(): Promise<void>;
+  pause(): Promise<void>;
+  seek(opts: { time: number }): Promise<void>;
+  stop(): Promise<void>;
+  disconnect(): Promise<void>;
+  setActiveSubtitle(opts: { trackId: number }): Promise<void>;
+  setActiveAudioLanguage(opts: { language: string; name: string }): Promise<{ success: boolean }>;
+  setVolume(opts: { level: number }): Promise<void>;
+  setMuted(opts: { muted: boolean }): Promise<void>;
+  on(handler: (event: DesktopCastEvent) => void): () => void;
+}

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    // node --test strips types in place, so the test imports carry .ts paths.
+    "allowImportingTsExtensions": true,
     "lib": ["ES2022", "DOM"],
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Why

Electron ships no Cast SDK. `cast_sender.js` needs Chrome's media router component, which Electron does not bundle, so `cast.framework` never appears, `isAvailable()` stays false and the desktop client has no way to reach a Chromecast — the only workaround today is to leave the app and cast from Chrome.

## What

The main process speaks CASTV2 directly:

- **`cast/mdns.ts`** — browses `_googlecast._tcp.local` (PTR → instance, SRV → host/port, TXT → id/name/model). Only instances a googlecast PTR introduced are kept: the socket sees every mDNS conversation on the segment, and without that filter a neighbouring service registers as a Cast device.
- **`cast/protocol.ts`** — `CastMessage` codec, length-prefixed framing, TLS/8009, the virtual-connection handshake and the heartbeat.
- **`cast/status.ts`** — the pure mapping of MEDIA_STATUS onto renderer events, and the EDIT_TRACKS_INFO active-set union.
- **`cast/index.ts`** — discovery + session + media control, exposed over IPC.

The bridge lands on `window.fliksCast` with the **exact method surface of the mobile `NativeCast` Capacitor plugin**, so `CastService` needed only to pick a bridge: every branch that read `isNative` now reads `hasCastBridge`, and the picker, cast overlay, `CastPlayerService` and receiver app are reused as-is. The Cast Web SDK branch is untouched.

`contextIsolation` keeps preload-world objects out of the page, so events cross through `contextBridge` and the client re-dispatches them as the same window `CustomEvent`s the plugin fires — one listener set for all three senders.

Two small additions travel with it: `autoplay` on the bridge load (a recovery reload of a paused cast no longer force-resumes) and the subtitle style in Cast wire form, since the desktop bridge has no platform type to map the presets onto.

No new dependency. The `CastMessage` protobuf is seven scalar fields and the mDNS query is a single PTR, so both are built by hand rather than adding a protocol library (and its protobuf runtime) to a bundle with one runtime dep today.

## Testing

`npm test` in `desktop/` — 15 checks on the node test runner, no framework added: protobuf round trip, frame splitting across a partial chunk, multi-byte length prefixes, an mDNS response assembled with real compression pointers, the foreign-service rejection, and the status/track-merge mapping.

Discovery is **validated against a real Chromecast** — it found `Salon` (Chromecast, 192.168.1.86:8009) and, before the PTR filter, also surfaced an unrelated mDNS service, which is what the filter and its regression test come from.

The **live session is unvalidated**: the dev host routes its own `192.168.1.0/24` into a VPN, so no LAN TCP leaves it. Launching the receiver, LOAD, transport control and track switching need a run on a machine with a direct route.

Client suite green (784 tests), both typechecks clean.