### PR TITLE
fix(subtitles): match forced/HI flags across the whole acquisition chain

### DIFF
--- a/backend/src/common/constants/subtitle-codecs.spec.ts
+++ b/backend/src/common/constants/subtitle-codecs.spec.ts
@@ -1,6 +1,7 @@
 import { SubtitleStatus } from '../enums';
+import { SubtitleLanguageItem } from '../../modules/profiles/entities/language-profile.entity';
 import {
-  hasServableTextSub,
+  hasCoveringSub,
   isImageBasedSubtitleCodec,
 } from './subtitle-codecs';
 
@@ -13,12 +14,15 @@ describe('isImageBasedSubtitleCodec', () => {
   });
 });
 
-describe('hasServableTextSub', () => {
+const want = (over: Partial<SubtitleLanguageItem> = {}): SubtitleLanguageItem =>
+  ({ isoCode: 'fr', name: 'French', forced: false, hi: false, ...over }) as SubtitleLanguageItem;
+
+describe('hasCoveringSub', () => {
   it('treats a text subtitle as satisfying the language', () => {
     const subs = [
       { language: 'fr', codec: 'subrip', status: SubtitleStatus.DOWNLOADED },
     ];
-    expect(hasServableTextSub(subs, 'fr')).toBe(true);
+    expect(hasCoveringSub(subs, want())).toBe(true);
   });
 
   it('does not let an image-based track satisfy the language', () => {
@@ -29,27 +33,66 @@ describe('hasServableTextSub', () => {
         status: SubtitleStatus.EMBEDDED,
       },
     ];
-    expect(hasServableTextSub(subs, 'fr')).toBe(false);
+    expect(hasCoveringSub(subs, want())).toBe(false);
   });
 
   it('ignores failed text rows', () => {
     const subs = [
       { language: 'fr', codec: 'subrip', status: SubtitleStatus.FAILED },
     ];
-    expect(hasServableTextSub(subs, 'fr')).toBe(false);
+    expect(hasCoveringSub(subs, want())).toBe(false);
   });
 
   it('counts an in-progress OCR (text) row as covering the language', () => {
     const subs = [
       { language: 'fr', codec: 'subrip', status: SubtitleStatus.PROCESSING },
     ];
-    expect(hasServableTextSub(subs, 'fr')).toBe(true);
+    expect(hasCoveringSub(subs, want())).toBe(true);
+  });
+
+  it('does not let a forced track cover a full-subtitle request', () => {
+    const subs = [
+      { language: 'fr', forced: true, codec: 'subrip', status: SubtitleStatus.DOWNLOADED },
+    ];
+    expect(hasCoveringSub(subs, want())).toBe(false);
+    expect(hasCoveringSub(subs, want({ forced: true }))).toBe(true);
+  });
+
+  it('does not let a full subtitle cover a forced request', () => {
+    const subs = [
+      { language: 'fr', forced: false, codec: 'subrip', status: SubtitleStatus.DOWNLOADED },
+    ];
+    expect(hasCoveringSub(subs, want({ forced: true }))).toBe(false);
+  });
+
+  it('VERDICT: coverage ignores the HI mode entirely', () => {
+    const hi = [
+      { language: 'fr', hearingImpaired: true, codec: 'subrip', status: SubtitleStatus.DOWNLOADED },
+    ];
+    const plain = [
+      { language: 'fr', hearingImpaired: false, codec: 'subrip', status: SubtitleStatus.DOWNLOADED },
+    ];
+
+    // The HI mode picks what to fetch. Enforcing it here re-fetches forever
+    // when `subtitle_remove_hi_tags` clears the flag the profile requires.
+    for (const mode of ['prefer', 'avoid', 'require', 'forbid'] as const) {
+      expect(hasCoveringSub(hi, want({ hearingImpaired: mode }))).toBe(true);
+      expect(hasCoveringSub(plain, want({ hearingImpaired: mode }))).toBe(true);
+    }
+  });
+
+  it('counts an image track only when burn-in is accepted', () => {
+    const subs = [
+      { language: 'fr', codec: 'hdmv_pgs_subtitle', status: SubtitleStatus.EMBEDDED },
+    ];
+    expect(hasCoveringSub(subs, want(), { imageTracksCount: true })).toBe(true);
+    expect(hasCoveringSub(subs, want(), { imageTracksCount: false })).toBe(false);
   });
 
   it('matches only the requested language', () => {
     const subs = [
       { language: 'en', codec: 'subrip', status: SubtitleStatus.DOWNLOADED },
     ];
-    expect(hasServableTextSub(subs, 'fr')).toBe(false);
+    expect(hasCoveringSub(subs, want())).toBe(false);
   });
 });

--- a/backend/src/common/constants/subtitle-codecs.ts
+++ b/backend/src/common/constants/subtitle-codecs.ts
@@ -1,4 +1,10 @@
 import { SubtitleStatus } from '../enums';
+import {
+  SubtitleFlagsProbe,
+  SubtitleLanguageItem,
+  matchesRequestedFlags,
+  requestFlagsOf,
+} from './subtitle-flags';
 
 /**
  * Bitmap subtitle codecs. These carry rendered images rather than text, so
@@ -34,25 +40,40 @@ export function isOcrSupportedSubtitleCodec(codec: string | null | undefined): b
 }
 
 /** Minimal subtitle shape needed to decide whether a language is covered. */
-export interface ServableSubProbe {
+export interface ServableSubProbe extends SubtitleFlagsProbe {
   language: string;
   codec?: string | null;
   status?: SubtitleStatus | null;
 }
 
+export interface CoverageOptions {
+  /** Count an image track as covering the language. It is only playable via
+   *  burn-in, which forces a transcode on every session — off by default,
+   *  behind `subtitle_burn_in_covers_language`. */
+  imageTracksCount?: boolean;
+}
+
 /**
- * A profile language is satisfied only by a servable TEXT subtitle: an
- * image-based track is burn-in/OCR material, and a FAILED row never counts.
- * Shared so the post-import, missing-search and missing-list paths agree.
+ * A profile language item is satisfied only by a servable subtitle carrying
+ * the flags it asks for: a FAILED row never counts, a forced track never
+ * covers a full-subtitle request (nor the reverse), and an image track counts
+ * only when the caller accepts burn-in. Shared so the post-import,
+ * missing-search and missing-list paths agree.
  */
-export function hasServableTextSub(
+export function hasCoveringSub(
   subs: ServableSubProbe[],
-  isoCode: string,
+  item: SubtitleLanguageItem,
+  opts: CoverageOptions = {},
 ): boolean {
+  // Only `forced` decides coverage. The HI mode picks what to fetch, and a
+  // stored row can legitimately carry the opposite flag — cleaning the HI cues
+  // clears it — so enforcing it here would re-fetch the language forever.
+  const req = { forced: !!item.forced };
   return subs.some(
     (s) =>
-      s.language === isoCode &&
-      !isImageBasedSubtitleCodec(s.codec) &&
+      s.language === item.isoCode &&
+      matchesRequestedFlags(s, req) &&
+      (opts.imageTracksCount || !isImageBasedSubtitleCodec(s.codec)) &&
       s.status !== SubtitleStatus.FAILED,
   );
 }

--- a/backend/src/common/constants/subtitle-flags.spec.ts
+++ b/backend/src/common/constants/subtitle-flags.spec.ts
@@ -1,0 +1,65 @@
+import {
+  matchesRequestedFlags,
+  prefersHearingImpaired,
+  requestFlagsOf,
+  subtitleFlagsFromTitle,
+} from './subtitle-flags';
+import { SubtitleLanguageItem } from './subtitle-flags';
+
+const item = (over: Partial<SubtitleLanguageItem> = {}): SubtitleLanguageItem =>
+  ({ isoCode: 'fr', name: 'French', forced: false, hi: false, ...over }) as SubtitleLanguageItem;
+
+describe('matchesRequestedFlags', () => {
+  it('VERDICT: forced is exact in both directions', () => {
+    const req = requestFlagsOf(item());
+    expect(matchesRequestedFlags({ forced: false }, req)).toBe(true);
+    expect(matchesRequestedFlags({ forced: true }, req)).toBe(false);
+
+    const forcedReq = requestFlagsOf(item({ forced: true }));
+    expect(matchesRequestedFlags({ forced: true }, forcedReq)).toBe(true);
+    expect(matchesRequestedFlags({ forced: false }, forcedReq)).toBe(false);
+  });
+
+  it('VERDICT: an unstated forced constrains nothing (hand-driven search)', () => {
+    // the manual search modal passes no flags: it must still see forced results
+    expect(matchesRequestedFlags({ forced: true }, {})).toBe(true);
+    expect(matchesRequestedFlags({ forced: false }, {})).toBe(true);
+    // a profile item always states one, even when stored without the key
+    expect(requestFlagsOf({ isoCode: 'fr' } as SubtitleLanguageItem).forced).toBe(false);
+  });
+
+  it('treats null/undefined flags as false rather than dropping the candidate', () => {
+    expect(matchesRequestedFlags({}, requestFlagsOf(item()))).toBe(true);
+    expect(matchesRequestedFlags({ forced: null }, requestFlagsOf(item()))).toBe(true);
+  });
+
+  it('only require/forbid filter on HI; prefer/avoid just order', () => {
+    const hi = { forced: false, hearingImpaired: true };
+    expect(matchesRequestedFlags(hi, requestFlagsOf(item({ hearingImpaired: 'require' })))).toBe(true);
+    expect(matchesRequestedFlags(hi, requestFlagsOf(item({ hearingImpaired: 'forbid' })))).toBe(false);
+    expect(matchesRequestedFlags(hi, requestFlagsOf(item()))).toBe(true);
+    expect(matchesRequestedFlags(hi, requestFlagsOf(item({ hi: true })))).toBe(true);
+
+    expect(prefersHearingImpaired(requestFlagsOf(item({ hi: true })))).toBe(true);
+    expect(prefersHearingImpaired(requestFlagsOf(item()))).toBe(false);
+  });
+});
+
+describe('subtitleFlagsFromTitle', () => {
+  it('reads flags a muxer only put in the stream title', () => {
+    expect(subtitleFlagsFromTitle('Français (Forced)').forced).toBe(true);
+    expect(subtitleFlagsFromTitle('English Foreign Parts Only').forced).toBe(true);
+    expect(subtitleFlagsFromTitle('English SDH').hearingImpaired).toBe(true);
+    expect(subtitleFlagsFromTitle('English (closed captions)').hearingImpaired).toBe(true);
+  });
+
+  it('does not invent flags on a plain title', () => {
+    expect(subtitleFlagsFromTitle('Français')).toEqual({ forced: false, hearingImpaired: false });
+    expect(subtitleFlagsFromTitle(null)).toEqual({ forced: false, hearingImpaired: false });
+    // a bare "hi" in a title is Hindi far more often than hearing-impaired
+    expect(subtitleFlagsFromTitle('Hindi').hearingImpaired).toBe(false);
+    // substrings must not trigger: "unenforced", "accent"
+    expect(subtitleFlagsFromTitle('Unenforced').forced).toBe(false);
+    expect(subtitleFlagsFromTitle('Accented').hearingImpaired).toBe(false);
+  });
+});

--- a/backend/src/common/constants/subtitle-flags.ts
+++ b/backend/src/common/constants/subtitle-flags.ts
@@ -1,0 +1,98 @@
+export type HearingImpairedMode = 'prefer' | 'avoid' | 'require' | 'forbid';
+
+export interface SubtitleLanguageItem {
+  isoCode: string;
+  name: string;
+  forced: boolean;
+  hi: boolean;
+  /**
+   * Explicit per-language override, layered on top of the compact `hi`
+   * boolean every stored item carries: `hi=true` → `prefer`, `hi=false`
+   * → `avoid` when this field is absent.
+   *
+   * - `prefer`:  HI subs score the 1-point bit; non-HI don't.
+   * - `avoid`:   non-HI subs score the bit; HI don't. (Default.)
+   * - `require`: HI candidates only; non-HI filtered out before scoring.
+   * - `forbid`:  non-HI only; HI candidates filtered out.
+   */
+  hearingImpaired?: HearingImpairedMode;
+}
+
+/** Resolves a language item's effective HI mode from the compact `hi`
+ *  boolean — every stored item carries `hi`, not `hearingImpaired`. */
+export function resolveHearingImpairedMode(
+  item: SubtitleLanguageItem,
+): HearingImpairedMode {
+  return item.hearingImpaired ?? (item.hi ? 'prefer' : 'avoid');
+}
+
+/** Filename tokens marking a track forced / hearing-impaired, parsed
+ *  right-to-left out of `<video>.<lang>.<flags>.<ext>` sidecar names. */
+export const FORCED_FLAG_TOKENS = new Set(['forced', 'foreign']);
+export const HI_FLAG_TOKENS = new Set(['hi', 'cc', 'sdh']);
+
+const FORCED_TITLE_RE = /(?<!non[\s._-])(?<!not\s)\b(forced|foreign[\s._-]?parts?)\b/i;
+// 'hi' is deliberately absent: as a bare word in a stream title it's far more
+// often Hindi (or English) than a hearing-impaired marker.
+const HI_TITLE_RE = /\b(sdh|cc|hearing[\s._-]?impaired|closed[\s._-]?captions?)\b/i;
+
+/** Flags a muxer expressed only in the stream title: plenty of remuxes ship
+ *  `title="Forced"` with `disposition.forced=0`. */
+export function subtitleFlagsFromTitle(title?: string | null): {
+  forced: boolean;
+  hearingImpaired: boolean;
+} {
+  const t = title ?? '';
+  return {
+    forced: FORCED_TITLE_RE.test(t),
+    hearingImpaired: HI_TITLE_RE.test(t),
+  };
+}
+
+/** What a profile language item asks for beyond the language itself. */
+export interface SubtitleRequestFlags {
+  forced?: boolean;
+  hearingImpairedMode?: HearingImpairedMode;
+}
+
+/** Minimal shape of anything that can answer a request: a stored row, an
+ *  embedded track, or a provider candidate. */
+export interface SubtitleFlagsProbe {
+  forced?: boolean | null;
+  hearingImpaired?: boolean | null;
+}
+
+export function requestFlagsOf(item: SubtitleLanguageItem): SubtitleRequestFlags {
+  // Normalised, so a legacy profile item stored without `forced` still states
+  // a constraint rather than reading as "any".
+  return {
+    forced: !!item.forced,
+    hearingImpairedMode: resolveHearingImpairedMode(item),
+  };
+}
+
+/**
+ * True when a subtitle carries the flags the request asks for. A stated
+ * `forced` is an exact match in both directions: a forced track holds only
+ * foreign dialogue and can never stand in for a full one, nor a full one for a
+ * forced request. An absent `forced` states no constraint — a hand-driven
+ * search must still see every candidate. HI follows the mode: `require` /
+ * `forbid` are hard filters, `prefer` / `avoid` only order candidates (see
+ * `prefersHearingImpaired`).
+ */
+export function matchesRequestedFlags(
+  sub: SubtitleFlagsProbe,
+  req: SubtitleRequestFlags,
+): boolean {
+  if (req.forced !== undefined && !!sub.forced !== req.forced) return false;
+  const mode = req.hearingImpairedMode ?? 'avoid';
+  if (mode === 'require') return !!sub.hearingImpaired;
+  if (mode === 'forbid') return !sub.hearingImpaired;
+  return true;
+}
+
+/** Which side of the soft `prefer`/`avoid` modes a candidate should sit on. */
+export function prefersHearingImpaired(req: SubtitleRequestFlags): boolean {
+  const mode = req.hearingImpairedMode ?? 'avoid';
+  return mode === 'require' || mode === 'prefer';
+}

--- a/backend/src/common/services/file-transfer.service.spec.ts
+++ b/backend/src/common/services/file-transfer.service.spec.ts
@@ -80,6 +80,25 @@ describe('FileTransferService atomic transfer', () => {
     expect(fs.readdirSync(destDir)).toEqual([]);
   });
 
+  it('companions: keeps every trailing flag, not just the first', async () => {
+    for (const name of ['Old.en.hi.forced.srt', 'Old.fr.srt', 'Old.mkv']) {
+      await fsp.writeFile(path.join(srcDir, name), 'x');
+    }
+
+    await service.transferCompanions({
+      srcDir,
+      destDir,
+      sourceBaseName: 'Old',
+      newBaseName: 'New',
+      method: 'copy',
+      allowedExts: new Set(['.srt']),
+    });
+
+    // ".hi" alone would be re-parsed as Hindi on the next library rescan
+    const landed = (await fsp.readdir(destDir)).sort();
+    expect(landed).toEqual(['New.en.hi.forced.srt', 'New.fr.srt']);
+  });
+
   it('move (cross-device fallback): lands complete content, no temp file, source removed', async () => {
     const src = path.join(srcDir, 'movie.mp4');
     const dest = path.join(destDir, 'movie.mp4');

--- a/backend/src/common/services/file-transfer.service.ts
+++ b/backend/src/common/services/file-transfer.service.ts
@@ -141,9 +141,10 @@ export class FileTransferService {
       const stem = path.basename(entry.name, path.extname(entry.name));
       if (!stem.toLowerCase().startsWith(srcBase)) continue;
 
-      // Preserve trailing language hint: "name.en.srt" / "name.en.forced.srt"
-      // → keep the ".en[.forced]" suffix on top of newBaseName.
-      const langMatch = stem.match(/\.([a-z]{2,3}(?:\.[a-z]+)?)$/i);
+      // Preserve the whole trailing hint: "name.en.hi.forced.srt" → keep
+      // ".en.hi.forced". Dropping a flag makes the rescan re-read the name
+      // wrong ("hi" then parses as Hindi, not hearing-impaired).
+      const langMatch = stem.match(/\.([a-z]{2,3}(?:\.[a-z]+){0,2})$/i);
       const destName = langMatch
         ? `${opts.newBaseName}.${langMatch[1]}${ext}`
         : `${opts.newBaseName}${ext}`;

--- a/backend/src/modules/profiles/entities/language-profile.entity.ts
+++ b/backend/src/modules/profiles/entities/language-profile.entity.ts
@@ -1,5 +1,12 @@
 import { Entity, Column } from 'typeorm';
 import { BaseEntity } from '../../../common/entities/base.entity';
+import { SubtitleLanguageItem } from '../../../common/constants/subtitle-flags';
+
+export type {
+  HearingImpairedMode,
+  SubtitleLanguageItem,
+} from '../../../common/constants/subtitle-flags';
+export { resolveHearingImpairedMode } from '../../../common/constants/subtitle-flags';
 
 @Entity('language_profiles')
 export class LanguageProfile extends BaseEntity {
@@ -16,32 +23,4 @@ export class LanguageProfile extends BaseEntity {
 export interface AudioLanguageItem {
   isoCode: string;
   name: string;
-}
-
-export type HearingImpairedMode = 'prefer' | 'avoid' | 'require' | 'forbid';
-
-export interface SubtitleLanguageItem {
-  isoCode: string;
-  name: string;
-  forced: boolean;
-  hi: boolean;
-  /**
-   * Explicit per-language override, layered on top of the compact `hi`
-   * boolean every stored item carries: `hi=true` → `prefer`, `hi=false`
-   * → `avoid` when this field is absent.
-   *
-   * - `prefer`:  HI subs score the 1-point bit; non-HI don't.
-   * - `avoid`:   non-HI subs score the bit; HI don't. (Default.)
-   * - `require`: HI candidates only; non-HI filtered out before scoring.
-   * - `forbid`:  non-HI only; HI candidates filtered out.
-   */
-  hearingImpaired?: HearingImpairedMode;
-}
-
-/** Resolves a language item's effective HI mode from the compact `hi`
- *  boolean — every stored item carries `hi`, not `hearingImpaired`. */
-export function resolveHearingImpairedMode(
-  item: SubtitleLanguageItem,
-): HearingImpairedMode {
-  return item.hearingImpaired ?? (item.hi ? 'prefer' : 'avoid');
 }

--- a/backend/src/modules/scheduler/subtitle-scheduler.ocr-first.spec.ts
+++ b/backend/src/modules/scheduler/subtitle-scheduler.ocr-first.spec.ts
@@ -1,0 +1,126 @@
+import { SubtitleSchedulerService } from './subtitle-scheduler.service';
+import { SubtitleProviderType, SubtitleStatus } from '../../common/enums';
+import { SubtitleLanguageItem } from '../profiles/entities/language-profile.entity';
+
+/**
+ * A forced track holds only foreign dialogue. OCR'ing it to satisfy a request
+ * for the full subtitle would store a ~40-line file under the plain language
+ * tag, which then counts as servable and permanently closes the language.
+ */
+describe('SubtitleSchedulerService.tryOcrFirst — flag matching', () => {
+  let ocrSubtitle: jest.Mock;
+
+  function makeService() {
+    ocrSubtitle = jest.fn().mockResolvedValue({ id: 1 });
+    const service = new SubtitleSchedulerService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      { dispatch: jest.fn() } as never,
+      { get: () => Promise.resolve('true') } as never,
+      {} as never,
+      { ocrSubtitle } as never,
+      { dispatch: jest.fn() } as never,
+    );
+    return service;
+  }
+
+  const track = (over: Record<string, unknown>) => ({
+    id: 0,
+    language: 'fr',
+    forced: false,
+    hearingImpaired: false,
+    codec: 'hdmv_pgs_subtitle',
+    streamIndex: 3,
+    status: SubtitleStatus.DOWNLOADED,
+    providerType: SubtitleProviderType.EMBEDDED,
+    ...over,
+  });
+
+  const want = (over: Partial<SubtitleLanguageItem> = {}): SubtitleLanguageItem =>
+    ({ isoCode: 'fr', name: 'French', forced: false, hi: false, ...over }) as SubtitleLanguageItem;
+
+  const run = (subs: unknown[], item: SubtitleLanguageItem) =>
+    (makeService() as never as { tryOcrFirst: (s: unknown[], i: unknown) => Promise<boolean> })
+      .tryOcrFirst(subs, item);
+
+  it('VERDICT: picks the full track, not the forced one, for a full request', async () => {
+    // forced first, so a flag-blind `.find()` would take it
+    const subs = [track({ id: 10, forced: true }), track({ id: 11, forced: false })];
+
+    await expect(run(subs, want())).resolves.toBe(true);
+
+    expect(ocrSubtitle).toHaveBeenCalledWith(11, 'fr', { automatic: true });
+  });
+
+  it('picks the forced track when the profile asks for forced', async () => {
+    const subs = [track({ id: 11, forced: false }), track({ id: 10, forced: true })];
+
+    await run(subs, want({ forced: true }));
+
+    expect(ocrSubtitle).toHaveBeenCalledWith(10, 'fr', { automatic: true });
+  });
+
+  it('leaves the language to the providers when only a forced track exists', async () => {
+    await expect(run([track({ id: 10, forced: true })], want())).resolves.toBe(false);
+    expect(ocrSubtitle).not.toHaveBeenCalled();
+  });
+
+  it('an OCR run on the forced variant does not mark the full request handled', async () => {
+    const subs = [
+      track({ id: 10, forced: true, providerType: SubtitleProviderType.OCR, codec: 'subrip' }),
+      track({ id: 11, forced: false }),
+    ];
+
+    await run(subs, want());
+
+    expect(ocrSubtitle).toHaveBeenCalledWith(11, 'fr', { automatic: true });
+  });
+
+  it('VERDICT: a failed OCR run hands the language to the providers, no retry', async () => {
+    const subs = [
+      track({ id: 11, forced: false }),
+      track({
+        id: 12,
+        providerType: SubtitleProviderType.OCR,
+        codec: 'subrip',
+        status: SubtitleStatus.FAILED,
+      }),
+    ];
+
+    // the image track #11 is still there; without the FAILED row it would be
+    // re-OCR'd on every scheduled sweep and the providers never reached
+    await expect(run(subs, want())).resolves.toBe(false);
+    expect(ocrSubtitle).not.toHaveBeenCalled();
+  });
+
+  it('a failed run on another language does not block this one', async () => {
+    const subs = [
+      track({ id: 11, forced: false }),
+      track({
+        id: 12,
+        forced: true,
+        providerType: SubtitleProviderType.OCR,
+        codec: 'subrip',
+        status: SubtitleStatus.FAILED,
+      }),
+    ];
+
+    await run(subs, want());
+
+    expect(ocrSubtitle).toHaveBeenCalledWith(11, 'fr', { automatic: true });
+  });
+
+  it('honours the HI mode: require takes the HI track, forbid rejects it', async () => {
+    const subs = [track({ id: 11, hearingImpaired: false }), track({ id: 12, hearingImpaired: true })];
+
+    await run(subs, want({ hi: true, hearingImpaired: 'require' }));
+    expect(ocrSubtitle).toHaveBeenCalledWith(12, 'fr', { automatic: true });
+
+    await expect(
+      run([track({ id: 12, hearingImpaired: true })], want({ hearingImpaired: 'forbid' })),
+    ).resolves.toBe(false);
+  });
+});

--- a/backend/src/modules/scheduler/subtitle-scheduler.service.ts
+++ b/backend/src/modules/scheduler/subtitle-scheduler.service.ts
@@ -12,16 +12,27 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { SettingsService } from '../settings/settings.service';
 import { SubtitleProviderType, SubtitleStatus } from '../../common/enums';
 import {
-  hasServableTextSub,
+  CoverageOptions,
+  hasCoveringSub,
   isOcrSupportedSubtitleCodec,
 } from '../../common/constants/subtitle-codecs';
+import { SubtitleLanguageItem } from '../profiles/entities/language-profile.entity';
 import {
-  SubtitleLanguageItem,
-  resolveHearingImpairedMode,
-} from '../profiles/entities/language-profile.entity';
+  matchesRequestedFlags,
+  prefersHearingImpaired,
+  requestFlagsOf,
+} from '../../common/constants/subtitle-flags';
 import { EmbeddedSubtitleService } from '../subtitles/embedded-subtitle.service';
 import { SubtitleOcrService } from '../subtitles/subtitle-ocr.service';
 import { MediaServersService } from '../media-servers/media-servers.service';
+
+interface SearchOpts {
+  minScore: number;
+  autoSyncEnabled: boolean;
+  encodeUtf8: boolean;
+  /** Whether an image track counts as covering its language (burn-in only). */
+  burnInCovers: boolean;
+}
 
 @Injectable()
 export class SubtitleSchedulerService {
@@ -108,11 +119,7 @@ export class SubtitleSchedulerService {
   }
 
   /** Read the shared search/download settings in one place (no per-call drift). */
-  private async resolveSearchOpts(): Promise<{
-    minScore: number;
-    autoSyncEnabled: boolean;
-    encodeUtf8: boolean;
-  }> {
+  private async resolveSearchOpts(): Promise<SearchOpts> {
     // `subtitle_min_score` is read as PERCENT (0-100) of the centralised
     // scorer's max — see `subtitle-scorer.ts`.
     return {
@@ -120,6 +127,8 @@ export class SubtitleSchedulerService {
       autoSyncEnabled:
         (await this.settings.get('subtitle_auto_sync')) === 'true',
       encodeUtf8: (await this.settings.get('subtitle_encode_utf8')) !== 'false',
+      burnInCovers:
+        (await this.settings.get('subtitle_burn_in_covers_language')) === 'true',
     };
   }
 
@@ -132,7 +141,7 @@ export class SubtitleSchedulerService {
   private async searchMissingForFile(
     media: Media,
     file: MediaFile,
-    opts: { minScore: number; autoSyncEnabled: boolean; encodeUtf8: boolean },
+    opts: SearchOpts,
     skipEmbeddedDetect = false,
   ): Promise<string[]> {
     if (this.filesSearching.has(file.id)) return [];
@@ -147,7 +156,7 @@ export class SubtitleSchedulerService {
   private async doSearchMissingForFile(
     media: Media,
     file: MediaFile,
-    opts: { minScore: number; autoSyncEnabled: boolean; encodeUtf8: boolean },
+    opts: SearchOpts,
     skipEmbeddedDetect = false,
   ): Promise<string[]> {
     const subtitleLangs: SubtitleLanguageItem[] =
@@ -181,14 +190,23 @@ export class SubtitleSchedulerService {
     const downloaded: string[] = [];
 
     for (const langItem of subtitleLangs) {
-      if (hasServableTextSub(existingSubs, langItem.isoCode)) continue;
+      if (hasCoveringSub(existingSubs, langItem)) continue;
 
       // OCR-first: an embedded image track in this language is converted to
       // text in preference to a provider download — it's perfectly synced to
       // this exact file and costs no provider quota. Falls through to the
       // providers when there's no image track (or OCR is disabled).
-      if (await this.tryOcrFirst(existingSubs, langItem.isoCode)) {
+      if (await this.tryOcrFirst(existingSubs, langItem)) {
         downloaded.push(langItem.isoCode);
+        continue;
+      }
+
+      // An image track the viewer accepts burning in closes the language.
+      // Checked after OCR so a convertible track is still converted to text.
+      if (
+        opts.burnInCovers &&
+        hasCoveringSub(existingSubs, langItem, { imageTracksCount: true })
+      ) {
         continue;
       }
 
@@ -204,7 +222,7 @@ export class SubtitleSchedulerService {
           videoReleaseName,
           moviehash: file.osdbHash ?? undefined,
           moviebytesize: file.osdbBytesize ?? undefined,
-          hearingImpairedMode: resolveHearingImpairedMode(langItem),
+          ...requestFlagsOf(langItem),
         });
 
         const best = results.find((r) => r.score >= opts.minScore);
@@ -258,37 +276,47 @@ export class SubtitleSchedulerService {
 
   /**
    * OCR-first source for one wanted language. Kicks off a background OCR of an
-   * embedded image track in `isoCode` and returns true when OCR handles the
-   * language (a run started, or one is already in progress/done) so the caller
-   * skips the provider search. Returns false when OCR is disabled, no image
-   * track exists, or the run couldn't start — letting providers take over.
-   * Gated by `subtitle_ocr_burn_in_auto`. Untagged ('und') tracks are excluded
-   * since auto can't pick the OCR language; those stay to the manual flow.
+   * embedded image track matching the profile item and returns true when OCR
+   * handles it (a run started, or one is already in progress/done) so the
+   * caller skips the provider search. Returns false when OCR is disabled, no
+   * matching image track exists, or the run couldn't start — letting providers
+   * take over. Gated by `subtitle_ocr_burn_in_auto`. Untagged ('und') tracks
+   * are excluded since auto can't pick the OCR language; those stay to the
+   * manual flow.
    */
   private async tryOcrFirst(
     existingSubs: SubtitleFile[],
-    isoCode: string,
+    langItem: SubtitleLanguageItem,
   ): Promise<boolean> {
+    const isoCode = langItem.isoCode;
     if ((await this.settings.get('subtitle_ocr_burn_in_auto')) !== 'true') {
       return false;
     }
     if (!isoCode || isoCode === 'und') return false;
 
-    const alreadyHandled = existingSubs.some(
-      (s) =>
-        s.language === isoCode &&
-        s.providerType === SubtitleProviderType.OCR &&
-        s.status !== SubtitleStatus.FAILED,
-    );
-    if (alreadyHandled) return true;
+    const req = requestFlagsOf(langItem);
+    const matchesRequest = (s: SubtitleFile) =>
+      s.language === isoCode && matchesRequestedFlags(s, req);
 
-    const imageSub = existingSubs.find(
+    const ocrRuns = existingSubs.filter(
+      (s) => matchesRequest(s) && s.providerType === SubtitleProviderType.OCR,
+    );
+    if (ocrRuns.some((s) => s.status !== SubtitleStatus.FAILED)) return true;
+    // A failed run means this track can't be OCR'd — hand the language to the
+    // providers rather than burning the same CPU again on the next sweep.
+    if (ocrRuns.length) return false;
+
+    const candidates = existingSubs.filter(
       (s) =>
-        s.language === isoCode &&
+        matchesRequest(s) &&
         isOcrSupportedSubtitleCodec(s.codec) &&
         s.streamIndex != null &&
         s.status !== SubtitleStatus.FAILED,
     );
+    // `prefer`/`avoid` don't filter, they only order the remaining candidates.
+    const wantHi = prefersHearingImpaired(req);
+    const imageSub =
+      candidates.find((s) => !!s.hearingImpaired === wantHi) ?? candidates[0];
     if (!imageSub) return false;
 
     try {
@@ -372,6 +400,7 @@ export class SubtitleSchedulerService {
       const missingByFileId = await this.buildMissingLangsByFile(
         fileIds,
         lowScoreSubs,
+        { imageTracksCount: opts.burnInCovers },
       );
 
       await this.upgradeBatch(lowScoreSubs, missingByFileId, opts);
@@ -381,13 +410,15 @@ export class SubtitleSchedulerService {
   private async upgradeBatch(
     lowScoreSubs: SubtitleFile[],
     missingByFileId: Map<number, boolean>,
-    opts: { minScore: number; autoSyncEnabled: boolean; encodeUtf8: boolean },
+    opts: SearchOpts,
   ): Promise<void> {
     for (const sub of lowScoreSubs) {
-      // The profile is the contract: a language it doesn't ask for is never
-      // searched, downloaded, nor allowed to replace a file on disk.
+      // The profile is the contract: a language and flags it doesn't ask for
+      // are never searched, downloaded, nor allowed to replace a file on disk
+      // — `upgradeSubtitle` deletes the one it replaces.
       const langItem = sub.media?.languageProfile?.subtitleLanguages?.find(
-        (l) => l.isoCode === sub.language,
+        (l) =>
+          l.isoCode === sub.language && matchesRequestedFlags(sub, requestFlagsOf(l)),
       );
       if (!langItem) continue;
       if (sub.mediaFile?.id != null && missingByFileId.get(sub.mediaFile.id)) {
@@ -412,7 +443,7 @@ export class SubtitleSchedulerService {
           videoReleaseName,
           moviehash: sub.mediaFile?.osdbHash ?? undefined,
           moviebytesize: sub.mediaFile?.osdbBytesize ?? undefined,
-          hearingImpairedMode: resolveHearingImpairedMode(langItem),
+          ...requestFlagsOf(langItem),
         });
 
         // Invariant: a hash-matched sub is the perfect time sync — refuse
@@ -474,6 +505,7 @@ export class SubtitleSchedulerService {
   private async buildMissingLangsByFile(
     fileIds: number[],
     candidatesWithMedia: SubtitleFile[],
+    coverage: CoverageOptions,
   ): Promise<Map<number, boolean>> {
     const result = new Map<number, boolean>();
     if (!fileIds.length) return result;
@@ -507,6 +539,9 @@ export class SubtitleSchedulerService {
         result.set(fid, false);
         continue;
       }
+      // Language granularity on purpose: this only decides whether to defer
+      // upgrades, and a flag the providers can't supply would freeze the file
+      // for good.
       const present = new Set(
         (subsByFile.get(fid) ?? [])
           .filter((s) => s.status !== SubtitleStatus.FAILED)

--- a/backend/src/modules/scheduler/subtitle-scheduler.upgrade-walk.spec.ts
+++ b/backend/src/modules/scheduler/subtitle-scheduler.upgrade-walk.spec.ts
@@ -17,7 +17,10 @@ describe('SubtitleSchedulerService.upgradeSubtitles — walking a shrinking set'
 
   /** Query-builder stub that re-filters a live table per batch, honouring
    *  whichever cursor the service uses: `andWhere(sf.id > :lastId)` or `skip()`. */
-  function fakeSubtitleRepo(table: { id: number; score: number }[]) {
+  function fakeSubtitleRepo(
+    table: { id: number; score: number }[],
+    profileItem: Record<string, unknown> = { isoCode: 'fr', name: 'French' },
+  ) {
     const seen: number[] = [];
     const createQueryBuilder = () => {
       let lastId = 0;
@@ -51,7 +54,7 @@ describe('SubtitleSchedulerService.upgradeSubtitles — walking a shrinking set'
             media: {
               title: 'T',
               tmdbId: 1,
-              languageProfile: { subtitleLanguages: [{ isoCode: 'fr', name: 'French' }] },
+              languageProfile: { subtitleLanguages: [profileItem] },
             },
             mediaFile: { id: 500 + r.id, relativePath: 'a/b.mkv' },
           }));
@@ -77,8 +80,11 @@ describe('SubtitleSchedulerService.upgradeSubtitles — walking a shrinking set'
     };
   }
 
-  function makeService(table: { id: number; score: number }[]) {
-    const { seen, repo } = fakeSubtitleRepo(table);
+  function makeService(
+    table: { id: number; score: number }[],
+    profileItem?: Record<string, unknown>,
+  ) {
+    const { seen, repo } = fakeSubtitleRepo(table, profileItem);
     const service = new SubtitleSchedulerService(
       {} as never,
       {} as never,
@@ -115,6 +121,23 @@ describe('SubtitleSchedulerService.upgradeSubtitles — walking a shrinking set'
     expect([...seen].sort((a, b) => a - b)).toEqual(live.map((r) => r.id));
     expect(new Set(seen).size).toBe(seen.length);
     expect(live.every((r) => r.score === 99)).toBe(true);
+  });
+
+  it('VERDICT: never replaces a full subtitle with a forced-only candidate', async () => {
+    // rows carry forced=false; the profile asks for a forced track, so no
+    // profile item matches and `upgradeSubtitle` — which deletes the file on
+    // disk — must never run.
+    const table = [{ id: 1, score: 10 }];
+    const { service } = makeService(table, {
+      isoCode: 'fr',
+      name: 'French',
+      forced: true,
+      hi: false,
+    });
+
+    await service.upgradeSubtitles();
+
+    expect(table[0].score).toBe(10);
   });
 
   it('terminates when nothing is eligible', async () => {

--- a/backend/src/modules/subtitles/embedded-subtitle.service.ts
+++ b/backend/src/modules/subtitles/embedded-subtitle.service.ts
@@ -60,6 +60,7 @@ export class EmbeddedSubtitleService {
         where: {
           mediaFile: { id: mediaFileId },
           providerType: SubtitleProviderType.OCR,
+          status: SubtitleStatus.DOWNLOADED,
         },
       });
       skipIndices = new Set(

--- a/backend/src/modules/subtitles/ffprobe.service.ts
+++ b/backend/src/modules/subtitles/ffprobe.service.ts
@@ -4,6 +4,7 @@ import { promisify } from 'util';
 import * as path from 'path';
 import { inferLanguageCodeFromTitle } from '../../common/release-parsing/language.parser';
 import { isImageBasedSubtitleCodec } from '../../common/constants/subtitle-codecs';
+import { subtitleFlagsFromTitle } from '../../common/constants/subtitle-flags';
 import { existsSync } from 'fs';
 import { vaapiRenderNode } from '../streaming/transcoding/hw-device';
 import { mapWithConcurrency } from '../../common/utils/concurrency';
@@ -259,6 +260,21 @@ function tag(
  *  auto-pick logic downstream handles the unknown-language case by
  *  ordering / size heuristics. Both tags are read case-insensitively
  *  (see {@link tag}). */
+/** Flags of a subtitle stream. The disposition is authoritative when set;
+ *  a remux that only writes `title="Forced"` would otherwise land in the
+ *  library as a full subtitle. */
+function resolveSubtitleFlags(s: FfprobeStream): {
+  forced: boolean;
+  hearingImpaired: boolean;
+} {
+  const fromTitle = subtitleFlagsFromTitle(tag(s.tags, 'title'));
+  return {
+    forced: s.disposition?.forced === 1 || fromTitle.forced,
+    hearingImpaired:
+      s.disposition?.hearing_impaired === 1 || fromTitle.hearingImpaired,
+  };
+}
+
 function resolveStreamLanguage(s: {
   tags?: Record<string, string | undefined>;
 }): string {
@@ -367,8 +383,7 @@ export class FfprobeService {
           streamIndex: s.index,
           codec: s.codec_name ?? 'unknown',
           language: resolveStreamLanguage(s),
-          forced: s.disposition?.forced === 1,
-          hearingImpaired: s.disposition?.hearing_impaired === 1,
+          ...resolveSubtitleFlags(s),
           isImageBased: isImageBasedSubtitleCodec(s.codec_name),
         })),
       };
@@ -523,8 +538,7 @@ export class FfprobeService {
           codec: s.codec_name ?? 'unknown',
           language: resolveStreamLanguage(s),
           title: tag(s.tags, 'title'),
-          forced: s.disposition?.forced === 1,
-          hearingImpaired: s.disposition?.hearing_impaired === 1,
+          ...resolveSubtitleFlags(s),
           isImageBased: isImageBasedSubtitleCodec(s.codec_name),
         }));
 

--- a/backend/src/modules/subtitles/providers/subtitle-provider.interface.ts
+++ b/backend/src/modules/subtitles/providers/subtitle-provider.interface.ts
@@ -19,6 +19,10 @@ export interface SubtitleSearchParams {
    *  the 1-point scorer bit; `require` / `forbid` filter candidates
    *  in the orchestrator before scoring. Default `avoid`. */
   hearingImpairedMode?: 'prefer' | 'avoid' | 'require' | 'forbid';
+  /** Whether the profile asks for a forced (foreign-dialogue-only) track.
+   *  Exact match, filtered in the orchestrator: a forced candidate can't
+   *  serve a full request, nor the reverse. Default `false`. */
+  forced?: boolean;
 }
 
 /**

--- a/backend/src/modules/subtitles/subtitle-activity.controller.ts
+++ b/backend/src/modules/subtitles/subtitle-activity.controller.ts
@@ -16,10 +16,10 @@ import { Media } from '../media/entities/media.entity';
 import { MediaFile } from '../media/entities/media-file.entity';
 import { SubtitleProviderType } from '../../common/enums/subtitle-provider-type.enum';
 import {
-  hasServableTextSub,
   IMAGE_BASED_SUBTITLE_CODECS,
 } from '../../common/constants/subtitle-codecs';
 import { SubtitleProviderService } from './subtitle-provider.service';
+import { SettingsService } from '../settings/settings.service';
 import { SubtitlesService } from './subtitles.service';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
 import { PoliciesGuard } from '../auth/casl/policies.guard';
@@ -53,6 +53,7 @@ export class SubtitleActivityController {
     private readonly mediaFileRepo: Repository<MediaFile>,
     private readonly providerService: SubtitleProviderService,
     private readonly subtitlesService: SubtitlesService,
+    private readonly settings: SettingsService,
   ) {}
 
   @Get('history')
@@ -209,15 +210,20 @@ export class SubtitleActivityController {
    * thousands of sequential round trips holding a pool connection, which is why
    * the page hung and took the rest of the server with it.
    *
-   * The `NOT EXISTS` mirrors `hasServableTextSub`: an image codec never
-   * satisfies a language (it is burn-in/OCR material) and a FAILED row never
-   * counts. A NULL codec or status is servable, hence the COALESCE.
+   * The `NOT EXISTS` mirrors `hasCoveringSub` — it has to, since the set has
+   * to be computed in one statement: a FAILED row never counts, the flags must
+   * match (forced exactly, HI only under `require`/`forbid`), and an image
+   * codec satisfies a language only when burn-in is accepted, which is what
+   * the empty `$1` expresses. A NULL codec or status is servable, hence the
+   * COALESCE.
    */
   @Get('missing')
   @CheckPolicies((ability) => ability.can(Action.Read, SubtitleFile))
   async missing(@Query('page') page?: string, @Query('limit') limit?: string) {
     const take = Math.min(Math.max(Number(limit) || 50, 1), 500);
     const skip = (Math.max(Number(page) || 1, 1) - 1) * take;
+    const burnInCovers =
+      (await this.settings.get('subtitle_burn_in_covers_language')) === 'true';
 
     const rows = await this.mediaFileRepo.query(
       `
@@ -225,13 +231,19 @@ export class SubtitleActivityController {
         SELECT m.id            AS media_id,
                m.title         AS media_title,
                m.type::text    AS media_type,
-               lang->>'isoCode' AS language
+               lang->>'isoCode' AS language,
+               COALESCE((lang->>'forced')::boolean, false) AS forced,
+               COALESCE(
+                 lang->>'hearingImpaired',
+                 CASE WHEN COALESCE((lang->>'hi')::boolean, false)
+                      THEN 'prefer' ELSE 'avoid' END
+               ) AS hi_mode
         FROM media m
         JOIN language_profiles lp ON lp.id = m."languageProfileId"
         CROSS JOIN LATERAL jsonb_array_elements(lp."subtitleLanguages") AS lang
         WHERE m.monitored = true
       )
-      SELECT r.media_id, r.media_title, r.media_type, r.language,
+      SELECT r.media_id, r.media_title, r.media_type, r.language, r.forced,
              f.id AS file_id, f."relativePath", f."episodeId",
              s."seasonNumber", e."episodeNumber",
              COUNT(*) OVER () AS total
@@ -243,18 +255,21 @@ export class SubtitleActivityController {
         SELECT 1 FROM subtitle_files sf
         WHERE sf."mediaFileId" = f.id
           AND sf.language = r.language
+          AND sf.forced = r.forced
+          AND (r.hi_mode <> 'require' OR sf."hearingImpaired" = true)
+          AND (r.hi_mode <> 'forbid'  OR sf."hearingImpaired" = false)
           AND COALESCE(sf.codec, '') <> ALL ($1::text[])
           AND COALESCE(sf.status::text, '') <> 'failed'
       )
-      ORDER BY r.media_title, f.id, r.language
+      ORDER BY r.media_title, f.id, r.language, r.forced
       LIMIT $2 OFFSET $3
       `,
-      [[...IMAGE_BASED_SUBTITLE_CODECS], take, skip],
+      [burnInCovers ? [] : [...IMAGE_BASED_SUBTITLE_CODECS], take, skip],
     );
 
     return {
       total: Number(rows[0]?.total ?? 0),
-      data: (rows as Record<string, string | number | null>[]).map((r) => ({
+      data: (rows as Record<string, string | number | boolean | null>[]).map((r) => ({
         mediaId: Number(r.media_id),
         mediaTitle: String(r.media_title),
         mediaType: String(r.media_type),
@@ -266,6 +281,7 @@ export class SubtitleActivityController {
             ? null
             : `S${String(r.seasonNumber).padStart(2, '0')}E${String(r.episodeNumber).padStart(2, '0')}`,
         language: String(r.language),
+        forced: r.forced === true || r.forced === 'true',
       })),
     };
   }

--- a/backend/src/modules/subtitles/subtitle-filename.spec.ts
+++ b/backend/src/modules/subtitles/subtitle-filename.spec.ts
@@ -1,0 +1,48 @@
+import { SubtitlesService } from './subtitles.service';
+
+/**
+ * Names are parsed right to left, so a `hi` token is only Hindi until a real
+ * language token turns up further left. Fliks writes `.fr.hi.srt` itself, so
+ * getting this wrong mislabels the files it produced.
+ */
+describe('SubtitlesService.parseSubtitleFilename', () => {
+  const parse = (name: string) =>
+    (SubtitlesService.prototype as never as {
+      parseSubtitleFilename: (n: string) => Record<string, unknown> | null;
+    }).parseSubtitleFilename.call(
+      { resolveLanguageCode: (t: string) =>
+          ['fr', 'en', 'hi', 'es'].includes(t) ? t : null },
+      name,
+    );
+
+  it('VERDICT: a hi token left of a language is the HI flag, not Hindi', () => {
+    expect(parse('Movie.en.hi.srt')).toMatchObject({
+      language: 'en',
+      hearingImpaired: true,
+      hiPart: 2,
+    });
+  });
+
+  it('keeps a lone hi as Hindi', () => {
+    expect(parse('Movie.hi.srt')).toMatchObject({
+      language: 'hi',
+      hearingImpaired: false,
+    });
+  });
+
+  it('reads every flag of a name Fliks wrote itself', () => {
+    expect(parse('Movie.fr.hi.forced.srt')).toMatchObject({
+      language: 'fr',
+      forced: true,
+      hearingImpaired: true,
+    });
+  });
+
+  it('steps over its own .ocr marker to reach the language', () => {
+    expect(parse('Movie.fr.ocr.srt')).toMatchObject({ language: 'fr' });
+  });
+
+  it('ignores non-subtitle extensions', () => {
+    expect(parse('Movie.fr.mkv')).toBeNull();
+  });
+});

--- a/backend/src/modules/subtitles/subtitle-ocr.service.ts
+++ b/backend/src/modules/subtitles/subtitle-ocr.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   Logger,
   NotFoundException,
+  OnModuleInit,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -28,6 +29,8 @@ const execFileAsync = promisify(execFile);
 // pgsrip/subtile-ocr batch the whole track through Tesseract in one call —
 // a dense 2h+ track can take past 10 minutes, so this needs real headroom.
 const OCR_TOOL_TIMEOUT_MS = 1_800_000;
+// Demuxing a bitmap track out of a 40 GB remux on a NAS is minutes, not seconds.
+const EXTRACT_TIMEOUT_MS = 900_000;
 
 /** execFile's `timeout` option kills the child but throws the same generic
  *  "Command failed" message as a real crash — call this out explicitly so
@@ -72,7 +75,7 @@ const TESSERACT_LANG: Record<string, string> = {
  * SSE event the subtitle modal already reloads on.
  */
 @Injectable()
-export class SubtitleOcrService {
+export class SubtitleOcrService implements OnModuleInit {
   private readonly log = new Logger(SubtitleOcrService.name);
   private readonly tmpDir = '/tmp/fliks-ocr';
 
@@ -81,6 +84,16 @@ export class SubtitleOcrService {
   // number of heavy runs actually executing in parallel bounded.
   private ocrActive = 0;
   private readonly ocrWaiters: Array<() => void> = [];
+
+  /** No run survives a restart, so any PROCESSING row is a corpse: it would
+   *  otherwise cover its language forever and hide its own actions. */
+  async onModuleInit(): Promise<void> {
+    const { affected } = await this.repo.update(
+      { providerType: SubtitleProviderType.OCR, status: SubtitleStatus.PROCESSING },
+      { status: SubtitleStatus.FAILED },
+    );
+    if (affected) this.log.warn(`Marked ${affected} interrupted OCR run(s) as failed`);
+  }
 
   constructor(
     @InjectRepository(SubtitleFile)
@@ -269,10 +282,11 @@ export class SubtitleOcrService {
         error: String(err),
         automatic,
       });
-      // Leave nothing behind: drop the PROCESSING placeholder so a failed run
-      // never lingers in the subtitle list (temp artefacts are already removed
-      // by extractAndOcr's finally).
-      await this.repo.delete(placeholderId);
+      // The row stays as FAILED: it's what tells the auto pass this track was
+      // already tried, so the language falls through to the providers instead
+      // of re-running a 30-minute OCR on every scheduled sweep. Deleting it
+      // re-arms the automatic retry.
+      await this.repo.update(placeholderId, { status: SubtitleStatus.FAILED });
     }
   }
 
@@ -298,7 +312,7 @@ export class SubtitleOcrService {
         const sup = `${base}.${ietf}.sup`;
         await execFileOrTimeout('ffmpeg', [
           '-y', '-i', videoPath, '-map', `0:${streamIndex}`, '-c:s', 'copy', sup,
-        ], { timeout: 120_000 });
+        ], { timeout: EXTRACT_TIMEOUT_MS });
         const { stdout, stderr } = await execFileOrTimeout(
           'pgsrip',
           ['--language', ietf, sup],
@@ -326,7 +340,7 @@ export class SubtitleOcrService {
         try {
           await execFileOrTimeout('mkvextract', [
             'tracks', videoPath, `${streamIndex}:${base}.idx`,
-          ], { timeout: 120_000 });
+          ], { timeout: EXTRACT_TIMEOUT_MS });
         } catch (err) {
           // mkvextract exits non-zero on warnings too; only fatal when the
           // VobSub pair it should have written is missing.

--- a/backend/src/modules/subtitles/subtitles.service.ts
+++ b/backend/src/modules/subtitles/subtitles.service.ts
@@ -16,6 +16,11 @@ import { MediaFile } from '../media/entities/media-file.entity';
 import { SubtitleProviderService } from './subtitle-provider.service';
 import { SubtitleProviderFactory } from './providers/subtitle-provider.factory';
 import {
+  FORCED_FLAG_TOKENS,
+  HI_FLAG_TOKENS,
+  matchesRequestedFlags,
+} from '../../common/constants/subtitle-flags';
+import {
   SubtitleSearchParams,
   SubtitleSearchResult,
 } from './providers/subtitle-provider.interface';
@@ -130,15 +135,18 @@ export class SubtitlesService {
       );
     }
 
-    // Hearing-impaired hard filter. `require` keeps only HI candidates,
-    // `forbid` drops them; `prefer` / `avoid` leave the candidate set
-    // intact and only nudge the 1-point bit in the scorer below.
+    // Flag hard filter, shared with the missing/OCR/upgrade gates: `forced`
+    // is exact both ways, `require` / `forbid` keep or drop HI candidates,
+    // `prefer` / `avoid` leave the set intact and only nudge the 1-point bit
+    // in the scorer below.
     const hiMode = params.hearingImpairedMode ?? 'avoid';
-    const hiFiltered = filtered.filter((r) => {
-      if (hiMode === 'require') return r.hearingImpaired;
-      if (hiMode === 'forbid') return !r.hearingImpaired;
-      return true;
-    });
+    const flagFiltered = filtered.filter((r) => matchesRequestedFlags(r, params));
+    const droppedForFlags = filtered.length - flagFiltered.length;
+    if (droppedForFlags > 0) {
+      this.logger.debug(
+        `Subtitle search [${params.language}]: dropped ${droppedForFlags} candidate(s) not matching forced=${!!params.forced}/hi=${hiMode}`,
+      );
+    }
 
     // Cross-provider dedup: when the same release name + language + HI
     // flag appear from two providers, keep the first occurrence (encounter
@@ -147,7 +155,7 @@ export class SubtitlesService {
     // to the `providerType:providerFileId` axis which is already unique.
     const seenReleaseKey = new Set<string>();
     const deduped: SubtitleSearchResult[] = [];
-    for (const r of hiFiltered) {
+    for (const r of flagFiltered) {
       const releaseKey = r.releaseName
         ? `${r.releaseName.toLowerCase()}|${r.language}|${r.hearingImpaired ? 'hi' : 'normal'}|${r.forced ? 'forced' : 'full'}`
         : `${r.providerType}:${r.providerFileId}`;
@@ -518,8 +526,12 @@ export class SubtitlesService {
     let removedMissing = 0;
     let removedDuplicates = 0;
 
+    // A PROCESSING row has no file yet and a FAILED one never will; both are
+    // state, not stale sidecars — removing them restarts the work they record.
     const isExternalFile = (s: SubtitleFile) =>
-      s.providerType !== SubtitleProviderType.EMBEDDED;
+      s.providerType !== SubtitleProviderType.EMBEDDED &&
+      s.status !== SubtitleStatus.PROCESSING &&
+      s.status !== SubtitleStatus.FAILED;
 
     const pickWinner = (a: SubtitleFile, b: SubtitleFile): number => {
       if (a.locked !== b.locked) return a.locked ? -1 : 1;
@@ -588,10 +600,7 @@ export class SubtitlesService {
     '.sami',
   ]);
 
-  /** Flags parsed right-to-left from the filename suffix. */
-  private static readonly FORCED_FLAGS = new Set(['forced', 'foreign']);
-  private static readonly HI_FLAGS = new Set(['hi', 'cc', 'sdh']);
-  private static readonly SKIP_FLAGS = new Set(['default']);
+  private static readonly SKIP_FLAGS = new Set(['default', 'ocr']);
 
   /** Full language names → ISO 639-1 (built from APP_LANGUAGES). */
   private static readonly LANG_NAMES: Record<string, string> =
@@ -624,16 +633,19 @@ export class SubtitlesService {
     let forced = false;
     let hearingImpaired = false;
     let hiPart: number | null = null;
+    let hiCandidate: number | null = null;
 
     // Parse right-to-left (skip the leftmost parts = video name)
     for (let i = parts.length - 1; i >= 1; i--) {
       const token = parts[i].toLowerCase();
-      if (SubtitlesService.FORCED_FLAGS.has(token)) {
+      if (FORCED_FLAG_TOKENS.has(token)) {
         forced = true;
-      } else if (SubtitlesService.HI_FLAGS.has(token)) {
-        // Ambiguity: 'hi' = Hindi if no language yet, else hearing-impaired.
+      } else if (HI_FLAG_TOKENS.has(token)) {
+        // Ambiguity: a lone 'hi' is Hindi; one followed by a language token
+        // further left (`Movie.en.hi.srt`) is the hearing-impaired flag.
         if (token === 'hi' && language === 'und') {
           language = 'hi';
+          hiCandidate = i;
         } else {
           hearingImpaired = true;
           hiPart = i;
@@ -642,6 +654,11 @@ export class SubtitlesService {
         // ignore 'default'
       } else if (this.resolveLanguageCode(token)) {
         language = this.resolveLanguageCode(token)!;
+        if (hiCandidate !== null) {
+          hearingImpaired = true;
+          hiPart = hiCandidate;
+          hiCandidate = null;
+        }
       } else {
         // Stop: this part is the video name, not a flag/lang
         break;
@@ -784,6 +801,7 @@ export class SubtitlesService {
           mediaFile: { id: matchedFile.id },
           episode: matchedFile.episodeId ? { id: matchedFile.episodeId } : null,
           language: parsed.language,
+          codec: ext === '.sup' ? 'hdmv_pgs_subtitle' : null,
           forced: parsed.forced,
           hearingImpaired: parsed.hearingImpaired,
           providerType: SubtitleProviderType.DISK,

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1122,7 +1122,8 @@
     "metadata_group": "Metadaten",
     "advanced_group": "Erweitert",
     "add_to_list": "Zu Liste hinzufügen",
-    "unlike": "Gefällt mir nicht mehr"
+    "unlike": "Gefällt mir nicht mehr",
+    "subtitle_failed": "Fehlgeschlagen"
   },
   "requests": {
     "title": "Anfragen",
@@ -2183,6 +2184,8 @@
       "subtitle": "Konfiguration der Suche und des automatischen Downloads von Untertiteln.",
       "section_search": "Suche",
       "auto_search": "Automatische Untertitelsuche",
+      "burn_in_covers": "Eine Bildspur zählt als vorhandener Untertitel",
+      "burn_in_covers_hint": "Eine Bildspur (PGS, VobSub) in einer Profilsprache genügt, damit diese Sprache als abgedeckt gilt: kein Download und kein OCR werden dafür gestartet. Die Wiedergabe läuft dann über das Einbrennen, was bei jeder Sitzung eine vollständige Neukodierung erzwingt und Direct Play ausschließt.",
       "search_interval": "Suchintervall (Minuten)",
       "search_interval_hint": "Häufigkeit der Suche nach fehlenden Untertiteln (Standard: 360 = 6h).",
       "min_score": "Mindest-Score",
@@ -2197,8 +2200,8 @@
       "encode_utf8": "Nach dem Download in UTF-8 neu codieren",
       "section_cleaning": "Bereinigung",
       "remove_hi_tags": "HI-Tags entfernen ([Musik], (Seufzen), ♪ usw.)",
-      "ocr_burn_in_auto": "Bild-Untertitel beim Import automatisch in Text umwandeln (OCR)",
-      "ocr_burn_in_auto_hint": "Beim Import werden Bild-Untertitel extrahiert und per OCR in Text umgewandelt, dann wie normale Untertitel bereitgestellt. OCR ist ressourcenintensiv und läuft im Hintergrund.",
+      "ocr_burn_in_auto": "OCR eingebetteter Bildspuren einem Download vorziehen",
+      "ocr_burn_in_auto_hint": "Fehlt eine Profilsprache und existiert eine Bildspur (PGS, VobSub) in dieser Sprache, wird sie per OCR in Text umgewandelt, statt einen Untertitel herunterzuladen. Gilt für die Suche nach fehlenden Untertiteln, automatisch wie manuell. OCR ist rechenintensiv und läuft im Hintergrund; schlägt sie fehl, greift die Sprache wieder auf die Anbieter zurück.",
       "ocr_delete_source": "Bild-Untertitel nach der Extraktion löschen",
       "ocr_delete_source_hint": "Nach einer erfolgreichen OCR-Konvertierung wird die Quell-Bildspur gelöscht. Hinweis: Ein eingebetteter Untertitel befindet sich im Container — er wird bei der nächsten Analyse der Datei erneut erkannt.",
       "custom_exclusions": "Benutzerdefinierte Ausschlüsse (Regex)",
@@ -2220,7 +2223,8 @@
       "col_language": "Sprache",
       "search_one": "Diesen Untertitel suchen",
       "search_one_ok": "Untertitel {{lang}} für „{{title}}“ heruntergeladen",
-      "search_one_none": "Kein Untertitel {{lang}} mit ausreichendem Score gefunden"
+      "search_one_none": "Kein Untertitel {{lang}} mit ausreichendem Score gefunden",
+      "forced": "Erzwungen"
     },
     "plugins": {
       "title": "Plugins",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1130,7 +1130,8 @@
     "metadata_group": "Metadata",
     "advanced_group": "Advanced",
     "add_to_list": "Add to list",
-    "unlike": "Unlike"
+    "unlike": "Unlike",
+    "subtitle_failed": "Failed"
   },
   "requests": {
     "title": "Requests",
@@ -2210,6 +2211,8 @@
       "subtitle": "Configuration of automatic subtitle search and download.",
       "section_search": "Search",
       "auto_search": "Automatic subtitle search",
+      "burn_in_covers": "An image track counts as a present subtitle",
+      "burn_in_covers_hint": "An image track (PGS, VobSub) in a profile language is enough for that language to count as covered: no download or OCR runs for it. Playback then goes through burn-in, which forces a full re-encode on every session and rules out direct play.",
       "search_interval": "Search interval (minutes)",
       "search_interval_hint": "How often missing subtitles are searched for (default: 360 = 6h).",
       "min_score": "Minimum score",
@@ -2224,8 +2227,8 @@
       "encode_utf8": "Re-encode to UTF-8 after download",
       "section_cleaning": "Cleaning",
       "remove_hi_tags": "Remove HI tags ([music], (sigh), ♪, etc.)",
-      "ocr_burn_in_auto": "Automatically convert image subtitles to text (OCR) on import",
-      "ocr_burn_in_auto_hint": "On import, image subtitles are extracted and converted to text by OCR, then served as normal subtitles. OCR is resource-intensive and runs in the background.",
+      "ocr_burn_in_auto": "Prefer OCR of embedded image tracks over a download",
+      "ocr_burn_in_auto_hint": "When a profile language is missing and an image track (PGS, VobSub) exists in that language, it is converted to text by OCR instead of downloading a subtitle. Applies to missing-subtitle searches, automatic and manual. OCR is CPU-heavy and runs in the background; if it fails, the language falls back to the providers.",
       "ocr_delete_source": "Delete the image subtitle once extracted",
       "ocr_delete_source_hint": "After a successful OCR conversion, deletes the source image track. Note: an embedded subtitle is inside the container — it will be re-detected at the next file scan.",
       "custom_exclusions": "Custom exclusions (regex)",
@@ -2247,7 +2250,8 @@
       "col_language": "Language",
       "search_one": "Search for this subtitle",
       "search_one_ok": "{{lang}} subtitle downloaded for \"{{title}}\"",
-      "search_one_none": "No {{lang}} subtitle found with a sufficient score"
+      "search_one_none": "No {{lang}} subtitle found with a sufficient score",
+      "forced": "Forced"
     },
     "plugins": {
       "title": "Plugins",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1122,7 +1122,8 @@
     "metadata_group": "Metadatos",
     "advanced_group": "Avanzado",
     "add_to_list": "Añadir a una lista",
-    "unlike": "Ya no me gusta"
+    "unlike": "Ya no me gusta",
+    "subtitle_failed": "Error"
   },
   "requests": {
     "title": "Solicitudes",
@@ -2183,6 +2184,8 @@
       "subtitle": "Configuración de la búsqueda y la descarga automática de subtítulos.",
       "section_search": "Búsqueda",
       "auto_search": "Búsqueda automática de subtítulos",
+      "burn_in_covers": "Una pista de imagen cuenta como subtítulo presente",
+      "burn_in_covers_hint": "Una pista de imagen (PGS, VobSub) en un idioma del perfil basta para considerar ese idioma cubierto: no se lanzará ninguna descarga ni OCR. La reproducción pasa entonces por el incrustado, que obliga a recodificar por completo en cada sesión e impide la reproducción directa.",
       "search_interval": "Intervalo de búsqueda (minutos)",
       "search_interval_hint": "Frecuencia de búsqueda de los subtítulos faltantes (por defecto: 360 = 6h).",
       "min_score": "Puntuación mínima",
@@ -2197,8 +2200,8 @@
       "encode_utf8": "Recodificar a UTF-8 tras la descarga",
       "section_cleaning": "Limpieza",
       "remove_hi_tags": "Eliminar las etiquetas HI ([música], (suspiro), ♪, etc.)",
-      "ocr_burn_in_auto": "Convertir automáticamente los subtítulos de imagen a texto (OCR) al importar",
-      "ocr_burn_in_auto_hint": "Al importar, los subtítulos de imagen se extraen y convierten a texto por OCR, y luego se sirven como subtítulos normales. El OCR consume muchos recursos y se ejecuta en segundo plano.",
+      "ocr_burn_in_auto": "Preferir el OCR de las pistas de imagen incrustadas a una descarga",
+      "ocr_burn_in_auto_hint": "Cuando falta un idioma del perfil y existe una pista de imagen (PGS, VobSub) en ese idioma, se convierte a texto por OCR en lugar de descargar un subtítulo. Se aplica a las búsquedas de subtítulos faltantes, automáticas y manuales. El OCR consume mucha CPU y se ejecuta en segundo plano; si falla, el idioma vuelve a los proveedores.",
       "ocr_delete_source": "Eliminar el subtítulo de imagen una vez extraído",
       "ocr_delete_source_hint": "Tras una conversión OCR correcta, elimina la pista de imagen de origen. Nota: un subtítulo incrustado está en el contenedor — se volverá a detectar en el próximo análisis del archivo.",
       "custom_exclusions": "Exclusiones personalizadas (regex)",
@@ -2220,7 +2223,8 @@
       "col_language": "Idioma",
       "search_one": "Buscar este subtítulo",
       "search_one_ok": "Subtítulo {{lang}} descargado para «{{title}}»",
-      "search_one_none": "No se encontró ningún subtítulo {{lang}} con una puntuación suficiente"
+      "search_one_none": "No se encontró ningún subtítulo {{lang}} con una puntuación suficiente",
+      "forced": "Forzado"
     },
     "plugins": {
       "title": "Plugins",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1130,7 +1130,8 @@
     "metadata_group": "Métadonnées",
     "advanced_group": "Avancé",
     "add_to_list": "Ajouter à une liste",
-    "unlike": "Je n’aime plus"
+    "unlike": "Je n’aime plus",
+    "subtitle_failed": "Échec"
   },
   "requests": {
     "title": "Demandes",
@@ -2210,6 +2211,8 @@
       "subtitle": "Configuration de la recherche et du téléchargement automatique de sous-titres.",
       "section_search": "Recherche",
       "auto_search": "Recherche automatique de sous-titres",
+      "burn_in_covers": "Une piste image compte comme sous-titre présent",
+      "burn_in_covers_hint": "Une piste image (PGS, VobSub) dans une langue du profil suffit à considérer cette langue comme couverte : ni téléchargement ni OCR ne seront lancés pour elle. La lecture passe alors par la gravure, qui impose un réencodage complet à chaque session et interdit le direct play.",
       "search_interval": "Intervalle de recherche (minutes)",
       "search_interval_hint": "Fréquence de recherche des sous-titres manquants (défaut : 360 = 6h).",
       "min_score": "Score minimum",
@@ -2224,8 +2227,8 @@
       "encode_utf8": "Ré-encoder en UTF-8 après téléchargement",
       "section_cleaning": "Nettoyage",
       "remove_hi_tags": "Supprimer les tags HI ([musique], (soupir), ♪, etc.)",
-      "ocr_burn_in_auto": "Convertir automatiquement les sous-titres image en texte (OCR) à l'import",
-      "ocr_burn_in_auto_hint": "Dès l'import, les sous-titres image sont extraits et convertis en texte par OCR, puis servis comme des sous-titres normaux. L'OCR est gourmand et s'exécute en arrière-plan.",
+      "ocr_burn_in_auto": "Préférer l'OCR des pistes image embarquées à un téléchargement",
+      "ocr_burn_in_auto_hint": "Quand une langue du profil manque et qu'une piste image (PGS, VobSub) existe dans cette langue, elle est convertie en texte par OCR au lieu de télécharger un sous-titre. S'applique aux recherches de manquants, automatiques comme manuelles. L'OCR est gourmand et tourne en arrière-plan ; s'il échoue, la langue repart chez les fournisseurs.",
       "ocr_delete_source": "Supprimer le sous-titre image une fois extrait",
       "ocr_delete_source_hint": "Après une conversion OCR réussie, supprime la piste image source. Note : un sous-titre embarqué est dans le conteneur — il sera ré-détecté à la prochaine analyse du fichier.",
       "custom_exclusions": "Exclusions personnalisées (regex)",
@@ -2247,7 +2250,8 @@
       "col_language": "Langue",
       "search_one": "Rechercher ce sous-titre",
       "search_one_ok": "Sous-titre {{lang}} téléchargé pour « {{title}} »",
-      "search_one_none": "Aucun sous-titre {{lang}} trouvé avec un score suffisant"
+      "search_one_none": "Aucun sous-titre {{lang}} trouvé avec un score suffisant",
+      "forced": "Forcé"
     },
     "plugins": {
       "title": "Plugins",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1122,7 +1122,8 @@
     "metadata_group": "Metadati",
     "advanced_group": "Avanzate",
     "add_to_list": "Aggiungi a un elenco",
-    "unlike": "Non mi piace più"
+    "unlike": "Non mi piace più",
+    "subtitle_failed": "Non riuscito"
   },
   "requests": {
     "title": "Richieste",
@@ -2183,6 +2184,8 @@
       "subtitle": "Configurazione della ricerca e del download automatico di sottotitoli.",
       "section_search": "Ricerca",
       "auto_search": "Ricerca automatica di sottotitoli",
+      "burn_in_covers": "Una traccia immagine conta come sottotitolo presente",
+      "burn_in_covers_hint": "Una traccia immagine (PGS, VobSub) in una lingua del profilo basta a considerare quella lingua coperta: non verrà avviato alcun download né OCR. La riproduzione passa allora dall'impressione, che impone una ricodifica completa a ogni sessione e impedisce il direct play.",
       "search_interval": "Intervallo di ricerca (minuti)",
       "search_interval_hint": "Frequenza di ricerca dei sottotitoli mancanti (predefinito: 360 = 6h).",
       "min_score": "Punteggio minimo",
@@ -2197,8 +2200,8 @@
       "encode_utf8": "Ri-codifica in UTF-8 dopo il download",
       "section_cleaning": "Pulizia",
       "remove_hi_tags": "Rimuovi i tag HI ([musica], (sospiro), ♪, ecc.)",
-      "ocr_burn_in_auto": "Converti automaticamente i sottotitoli immagine in testo (OCR) all'import",
-      "ocr_burn_in_auto_hint": "Fin dall'import, i sottotitoli immagine vengono estratti e convertiti in testo tramite OCR, poi serviti come sottotitoli normali. L'OCR è oneroso e viene eseguito in background.",
+      "ocr_burn_in_auto": "Preferire l'OCR delle tracce immagine incorporate a un download",
+      "ocr_burn_in_auto_hint": "Quando manca una lingua del profilo ed esiste una traccia immagine (PGS, VobSub) in quella lingua, viene convertita in testo tramite OCR invece di scaricare un sottotitolo. Si applica alle ricerche di sottotitoli mancanti, automatiche e manuali. L'OCR è pesante per la CPU e viene eseguito in background; se fallisce, la lingua torna ai provider.",
       "ocr_delete_source": "Elimina il sottotitolo immagine una volta estratto",
       "ocr_delete_source_hint": "Dopo una conversione OCR riuscita, elimina la traccia immagine di origine. Nota: un sottotitolo incorporato è nel container — verrà ri-rilevato alla prossima analisi del file.",
       "custom_exclusions": "Esclusioni personalizzate (regex)",
@@ -2220,7 +2223,8 @@
       "col_language": "Lingua",
       "search_one": "Cerca questo sottotitolo",
       "search_one_ok": "Sottotitolo {{lang}} scaricato per « {{title}} »",
-      "search_one_none": "Nessun sottotitolo {{lang}} trovato con un punteggio sufficiente"
+      "search_one_none": "Nessun sottotitolo {{lang}} trovato con un punteggio sufficiente",
+      "forced": "Forzato"
     },
     "plugins": {
       "title": "Plugins",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1122,7 +1122,8 @@
     "metadata_group": "Metadados",
     "advanced_group": "Avançado",
     "add_to_list": "Adicionar a uma lista",
-    "unlike": "Já não gosto"
+    "unlike": "Já não gosto",
+    "subtitle_failed": "Falhou"
   },
   "requests": {
     "title": "Pedidos",
@@ -2183,6 +2184,8 @@
       "subtitle": "Configuração da pesquisa e da transferência automática de legendas.",
       "section_search": "Pesquisa",
       "auto_search": "Pesquisa automática de legendas",
+      "burn_in_covers": "Uma faixa de imagem conta como legenda presente",
+      "burn_in_covers_hint": "Uma faixa de imagem (PGS, VobSub) num idioma do perfil basta para considerar esse idioma coberto: não será iniciada qualquer transferência nem OCR. A reprodução passa então pela gravação, que impõe uma recodificação completa em cada sessão e impede o direct play.",
       "search_interval": "Intervalo de pesquisa (minutos)",
       "search_interval_hint": "Frequência de pesquisa das legendas em falta (predefinição: 360 = 6h).",
       "min_score": "Pontuação mínima",
@@ -2197,8 +2200,8 @@
       "encode_utf8": "Recodificar em UTF-8 após a transferência",
       "section_cleaning": "Limpeza",
       "remove_hi_tags": "Remover as tags HI ([música], (suspiro), ♪, etc.)",
-      "ocr_burn_in_auto": "Converter automaticamente as legendas de imagem em texto (OCR) na importação",
-      "ocr_burn_in_auto_hint": "Logo na importação, as legendas de imagem são extraídas e convertidas em texto por OCR, e depois servidas como legendas normais. O OCR é exigente e é executado em segundo plano.",
+      "ocr_burn_in_auto": "Preferir o OCR das faixas de imagem incorporadas a uma transferência",
+      "ocr_burn_in_auto_hint": "Quando falta um idioma do perfil e existe uma faixa de imagem (PGS, VobSub) nesse idioma, ela é convertida em texto por OCR em vez de transferir uma legenda. Aplica-se às pesquisas de legendas em falta, automáticas e manuais. O OCR consome muita CPU e corre em segundo plano; se falhar, o idioma volta aos fornecedores.",
       "ocr_delete_source": "Eliminar a legenda de imagem depois de extraída",
       "ocr_delete_source_hint": "Após uma conversão OCR bem-sucedida, elimina a faixa de imagem de origem. Nota: uma legenda embutida está no contentor — será redetetada na próxima análise do ficheiro.",
       "custom_exclusions": "Exclusões personalizadas (regex)",
@@ -2220,7 +2223,8 @@
       "col_language": "Idioma",
       "search_one": "Procurar esta legenda",
       "search_one_ok": "Legenda {{lang}} transferida para «{{title}}»",
-      "search_one_none": "Nenhuma legenda {{lang}} encontrada com pontuação suficiente"
+      "search_one_none": "Nenhuma legenda {{lang}} encontrada com pontuação suficiente",
+      "forced": "Forçado"
     },
     "plugins": {
       "title": "Plugins",

--- a/client/src/app/core/services/api/subtitles-api.service.ts
+++ b/client/src/app/core/services/api/subtitles-api.service.ts
@@ -318,4 +318,5 @@ export interface MissingSubtitleEntry {
   episodeId: number | null;
   episodeLabel: string | null;
   language: string;
+  forced: boolean;
 }

--- a/client/src/app/core/services/cast.service.ts
+++ b/client/src/app/core/services/cast.service.ts
@@ -69,11 +69,25 @@ interface NativeCastLoadOpts {
   currentTime: number;
   subtitles: { url: string; language: string; label: string }[];
   activeSubtitleTrackId: number;
+  autoplay: boolean;
   customData?: Record<string, unknown>;
   /** Optional — when present, native plugin builds the platform's
    *  text-track-style equivalent (TextTrackStyle on Android, GCKMedia-
    *  TextTrackStyle on iOS) and attaches to MediaInformation. */
   textTrackStyle?: CastSubtitleStyle;
+  /** The same styling already in Cast wire form. The desktop bridge talks the
+   *  protocol directly and has no platform type to map the presets onto. */
+  castTextTrackStyle?: CastTextTrackStyle;
+}
+
+/** `TextTrackStyle` as the Cast protocol carries it. */
+export interface CastTextTrackStyle {
+  fontGenericFamily: string;
+  fontScale: number;
+  foregroundColor: string;
+  backgroundColor: string;
+  edgeType: string;
+  edgeColor: string;
 }
 
 interface NativeCastPlugin {
@@ -107,7 +121,18 @@ export interface CastDevice {
   connected?: boolean;
 }
 
-const NativeCast = registerPlugin<NativeCastPlugin>('NativeCast');
+/** The Electron main process exposes the very same surface as the Capacitor
+ *  plugin (see `desktop/src/shared/contract.ts`), plus an event subscription:
+ *  contextIsolation keeps preload-world objects out of the page, so the desktop
+ *  events arrive here and get re-dispatched as the window events the plugin
+ *  fires natively. */
+interface DesktopCastBridge extends NativeCastPlugin {
+  on(handler: (event: { name: string; detail: unknown }) => void): () => void;
+}
+
+const DesktopCast = (globalThis as { fliksCast?: DesktopCastBridge }).fliksCast;
+const CastBridge: NativeCastPlugin =
+  DesktopCast ?? registerPlugin<NativeCastPlugin>('NativeCast');
 const CAST_APP_ID = environment.castAppId;
 /** Ceiling on a connect attempt: a cold receiver launch is ~2 s on a Chromecast. */
 const CONNECT_TIMEOUT_MS = 30_000;
@@ -167,7 +192,15 @@ export class CastService implements OnDestroy {
    *  custom error message; consumed by CastPlayerService to reload. */
   readonly playbackError$ = new Subject<{ position?: number }>();
 
-  private readonly isNative = Capacitor.isNativePlatform();
+  /** Whether a native-process Cast sender backs this client — the Capacitor
+   *  plugin on mobile, the Electron main process on desktop. Without one we are
+   *  in a browser and drive the Cast Web SDK instead. */
+  private readonly hasCastBridge = Capacitor.isNativePlatform() || !!DesktopCast;
+
+  /** True when the backing sender enumerates devices itself, so the picker
+   *  lists them instead of offering the single row that opens the browser's
+   *  own Cast dialog. */
+  readonly enumerates = this.hasCastBridge;
   private readonly castSettings = inject(CastSettingsService);
   private readonly toast = inject(ToastService);
   private readonly translate = inject(TranslateService);
@@ -182,7 +215,10 @@ export class CastService implements OnDestroy {
   private remotePlayerController: any = null;
 
   constructor() {
-    if (this.isNative) {
+    DesktopCast?.on((event) =>
+      window.dispatchEvent(new CustomEvent(event.name, { detail: event.detail })),
+    );
+    if (this.hasCastBridge) {
       this.initNative();
     } else {
       this.initWeb();
@@ -205,7 +241,7 @@ export class CastService implements OnDestroy {
 
   private async initNative() {
     try {
-      const { available } = await NativeCast.initialize({ appId: CAST_APP_ID });
+      const { available } = await CastBridge.initialize({ appId: CAST_APP_ID });
       this.isAvailable.set(available);
       if (available) void this.getCastDevices();
 
@@ -251,7 +287,7 @@ export class CastService implements OnDestroy {
       // castAvailabilityChanged whenever the route list moves.
       window.addEventListener('castDevicesChanged', () => void this.getCastDevices());
     } catch (e) {
-      console.warn('NativeCast.initialize failed', e);
+      console.warn('CastBridge.initialize failed', e);
       this.isAvailable.set(false);
     }
   }
@@ -428,9 +464,9 @@ export class CastService implements OnDestroy {
 
   requestSession() {
     this.beginConnecting();
-    if (this.isNative) {
+    if (this.hasCastBridge) {
       // The plugin resolves immediately; castStateChanged fires on connect OR dismiss.
-      NativeCast.requestSession().catch(() => this.endConnecting());
+      CastBridge.requestSession().catch(() => this.endConnecting());
     } else {
       cast.framework.CastContext.getInstance().requestSession().catch(() => this.endConnecting());
     }
@@ -459,13 +495,13 @@ export class CastService implements OnDestroy {
    *  API, so this always resolves empty: the picker shows a single row that
    *  falls back to `requestSession()` there instead. */
   async getCastDevices(): Promise<CastDevice[]> {
-    if (!this.isNative) return [];
+    if (!this.hasCastBridge) return [];
     try {
-      const { devices } = await NativeCast.getCastDevices();
+      const { devices } = await CastBridge.getCastDevices();
       this.castDevices.set(devices);
       return devices;
     } catch (err) {
-      console.warn('NativeCast.getCastDevices failed', err);
+      console.warn('CastBridge.getCastDevices failed', err);
       this.castDevices.set([]);
       return [];
     }
@@ -477,7 +513,7 @@ export class CastService implements OnDestroy {
   async selectCastDevice(id: string): Promise<void> {
     this.beginConnecting();
     try {
-      await NativeCast.selectCastDevice({ id });
+      await CastBridge.selectCastDevice({ id });
     } catch (err) {
       this.endConnecting();
       throw err;
@@ -502,9 +538,9 @@ export class CastService implements OnDestroy {
 
     const subtitleStyle = this.castSettings.get().subtitleStyle;
 
-    if (this.isNative) {
+    if (this.hasCastBridge) {
       try {
-        await NativeCast.loadMedia({
+        await CastBridge.loadMedia({
           url: info.url,
           contentType: info.contentType,
           title: info.title,
@@ -513,11 +549,13 @@ export class CastService implements OnDestroy {
           currentTime: info.currentTime ?? 0,
           subtitles: info.subtitles ?? [],
           activeSubtitleTrackId: info.activeSubtitleTrackId ?? 0,
+          autoplay: info.autoplay ?? true,
           customData,
           textTrackStyle: subtitleStyle,
+          castTextTrackStyle: buildCastTextTrackStyle(subtitleStyle),
         });
       } catch (err) {
-        console.error('NativeCast.loadMedia failed:', err);
+        console.error('CastBridge.loadMedia failed:', err);
       }
       this.isPaused.set(false);
       this.mediaTitle.set(info.title);
@@ -575,21 +613,21 @@ export class CastService implements OnDestroy {
   }
 
   play() {
-    if (this.isNative) { NativeCast.play(); this.isPaused.set(false); return; }
+    if (this.hasCastBridge) { CastBridge.play(); this.isPaused.set(false); return; }
     if (!this.remotePlayerController) return;
     this.isPaused.set(false);
     if (this.remotePlayer?.isPaused) this.remotePlayerController.playOrPause();
   }
 
   pause() {
-    if (this.isNative) { NativeCast.pause(); this.isPaused.set(true); return; }
+    if (this.hasCastBridge) { CastBridge.pause(); this.isPaused.set(true); return; }
     if (!this.remotePlayerController) return;
     this.isPaused.set(true);
     if (!this.remotePlayer?.isPaused) this.remotePlayerController.playOrPause();
   }
 
   togglePlayPause() {
-    if (this.isNative) {
+    if (this.hasCastBridge) {
       if (this.isPaused()) this.play(); else this.pause();
       return;
     }
@@ -605,7 +643,7 @@ export class CastService implements OnDestroy {
     const v = Math.min(1, Math.max(0, level));
     this.volume.set(v);
     if (v > 0 && this.muted()) this.setMuted(false);
-    if (this.isNative) { NativeCast.setVolume({ level: v }).catch(() => {}); return; }
+    if (this.hasCastBridge) { CastBridge.setVolume({ level: v }).catch(() => {}); return; }
     if (!this.remotePlayer || !this.remotePlayerController) return;
     this.remotePlayer.volumeLevel = v;
     this.remotePlayerController.setVolumeLevel();
@@ -613,7 +651,7 @@ export class CastService implements OnDestroy {
 
   setMuted(muted: boolean) {
     this.muted.set(muted);
-    if (this.isNative) { NativeCast.setMuted({ muted }).catch(() => {}); return; }
+    if (this.hasCastBridge) { CastBridge.setMuted({ muted }).catch(() => {}); return; }
     if (!this.remotePlayer || !this.remotePlayerController) return;
     // muteOrUnmute() toggles receiver-side, so only fire it when the receiver's
     // current state differs from the target — avoids a double-toggle no-op.
@@ -668,7 +706,7 @@ export class CastService implements OnDestroy {
   private dispatchSeek(time: number) {
     this.lastDispatchedSeekTarget = time;
     this.seekSettleUntil = Date.now() + CAST_SEEK_SETTLE_MS;
-    if (this.isNative) { NativeCast.seek({ time }); return; }
+    if (this.hasCastBridge) { CastBridge.seek({ time }); return; }
     if (!this.remotePlayer) return;
     this.remotePlayer.currentTime = time;
     this.remotePlayerController?.seek();
@@ -699,12 +737,12 @@ export class CastService implements OnDestroy {
   }
 
   stop() {
-    if (this.isNative) { NativeCast.stop(); return; }
+    if (this.hasCastBridge) { CastBridge.stop(); return; }
     this.remotePlayerController?.stop();
   }
 
   disconnect() {
-    if (this.isNative) { NativeCast.disconnect(); }
+    if (this.hasCastBridge) { CastBridge.disconnect(); }
     else { cast.framework.CastContext.getInstance().endCurrentSession(true); }
     this.isConnected.set(false);
     this.session = null;
@@ -713,8 +751,8 @@ export class CastService implements OnDestroy {
   }
 
   setActiveSubtitle(trackId: number) {
-    if (this.isNative) {
-      NativeCast.setActiveSubtitle({ trackId });
+    if (this.hasCastBridge) {
+      CastBridge.setActiveSubtitle({ trackId });
       return;
     }
     this.applyActiveTracks({ textId: trackId > 0 ? trackId : null });
@@ -731,9 +769,9 @@ export class CastService implements OnDestroy {
    * to a full ffmpeg-restart reload in that case.
    */
   async setActiveAudioLanguage(language: string, name: string): Promise<boolean> {
-    if (this.isNative) {
+    if (this.hasCastBridge) {
       try {
-        const { success } = await NativeCast.setActiveAudioLanguage({ language, name });
+        const { success } = await CastBridge.setActiveAudioLanguage({ language, name });
         return success;
       } catch {
         return false;
@@ -796,16 +834,26 @@ export class CastService implements OnDestroy {
    *  `TextTrackStyle`. Native plugins replicate this mapping for parity
    *  so the receiver sees identical Cast values regardless of sender. */
   private buildWebTextTrackStyle(s: CastSubtitleStyle) {
+    const wire = buildCastTextTrackStyle(s);
     const style = new chrome.cast.media.TextTrackStyle();
-    style.fontGenericFamily = chrome.cast.media.TextTrackFontGenericFamily.SANS_SERIF;
-    style.fontScale = SUB_SIZE_SCALE[s.size] ?? SUB_SIZE_SCALE['normal'];
-    style.foregroundColor = SUB_FG_COLOR[s.color] ?? SUB_FG_COLOR['white'];
-    style.backgroundColor = SUB_BG_COLOR[s.background] ?? SUB_BG_COLOR['transparent'];
-    const shadow = SUB_SHADOW[s.shadow] ?? SUB_SHADOW['drop'];
-    style.edgeType = chrome.cast.media.TextTrackEdgeType[shadow.edge];
-    style.edgeColor = shadow.color;
+    Object.assign(style, wire);
+    // The SDK's own enum member rather than its name, in case the two ever
+    // diverge; every other field is a plain string or number either way.
+    style.edgeType = chrome.cast.media.TextTrackEdgeType[wire.edgeType];
     return style;
   }
+}
+
+function buildCastTextTrackStyle(s: CastSubtitleStyle): CastTextTrackStyle {
+  const shadow = SUB_SHADOW[s.shadow] ?? SUB_SHADOW['drop'];
+  return {
+    fontGenericFamily: 'SANS_SERIF',
+    fontScale: SUB_SIZE_SCALE[s.size] ?? SUB_SIZE_SCALE['normal'],
+    foregroundColor: SUB_FG_COLOR[s.color] ?? SUB_FG_COLOR['white'],
+    backgroundColor: SUB_BG_COLOR[s.background] ?? SUB_BG_COLOR['transparent'],
+    edgeType: shadow.edge,
+    edgeColor: shadow.color,
+  };
 }
 
 // Cast Web SDK wire format mappings. The size-scale table is

--- a/client/src/app/features/settings/subtitles/subtitles-settings.html
+++ b/client/src/app/features/settings/subtitles/subtitles-settings.html
@@ -8,12 +8,25 @@
       <div class="card-body gap-5">
         <h2 class="card-title text-base">{{ 'settings.subtitles.section_search' | translate }}</h2>
 
-        <label class="label cursor-pointer justify-start gap-3 max-w-max">
-          <input type="checkbox" class="toggle toggle-sm"
-            [ngModel]="autoSearch() === 'true'"
-            (ngModelChange)="autoSearch.set($event ? 'true' : 'false')" />
-          <span class="label-text">{{ 'settings.subtitles.auto_search' | translate }}</span>
-        </label>
+        <app-toggle-field
+          [value]="autoSearch() === 'true'"
+          (valueChange)="autoSearch.set($event ? 'true' : 'false')"
+          [label]="'settings.subtitles.auto_search' | translate"
+          toggleClass="toggle-sm toggle-primary" />
+
+        <app-toggle-field
+          [value]="burnInCovers() === 'true'"
+          (valueChange)="burnInCovers.set($event ? 'true' : 'false')"
+          [label]="'settings.subtitles.burn_in_covers' | translate"
+          [hint]="'settings.subtitles.burn_in_covers_hint' | translate"
+          toggleClass="toggle-sm toggle-primary" />
+
+        <app-toggle-field
+          [value]="ocrBurnInAuto() === 'true'"
+          (valueChange)="ocrBurnInAuto.set($event ? 'true' : 'false')"
+          [label]="'settings.subtitles.ocr_burn_in_auto' | translate"
+          [hint]="'settings.subtitles.ocr_burn_in_auto_hint' | translate"
+          toggleClass="toggle-sm toggle-primary" />
 
         <label class="form-control w-full max-w-xs">
           <div class="label">
@@ -65,45 +78,33 @@
         <div class="divider my-0"></div>
         <h2 class="card-title text-base">{{ 'settings.subtitles.section_post_processing' | translate }}</h2>
 
-        <label class="label cursor-pointer justify-start gap-3 max-w-max">
-          <input type="checkbox" class="toggle toggle-sm"
-            [ngModel]="autoSync() === 'true'"
-            (ngModelChange)="autoSync.set($event ? 'true' : 'false')" />
-          <span class="label-text">{{ 'settings.subtitles.auto_sync' | translate }}</span>
-        </label>
+        <app-toggle-field
+          [value]="autoSync() === 'true'"
+          (valueChange)="autoSync.set($event ? 'true' : 'false')"
+          [label]="'settings.subtitles.auto_sync' | translate"
+          toggleClass="toggle-sm toggle-primary" />
 
-        <label class="label cursor-pointer justify-start gap-3 max-w-max">
-          <input type="checkbox" class="toggle toggle-sm"
-            [ngModel]="encodeUtf8() === 'true'"
-            (ngModelChange)="encodeUtf8.set($event ? 'true' : 'false')" />
-          <span class="label-text">{{ 'settings.subtitles.encode_utf8' | translate }}</span>
-        </label>
+        <app-toggle-field
+          [value]="encodeUtf8() === 'true'"
+          (valueChange)="encodeUtf8.set($event ? 'true' : 'false')"
+          [label]="'settings.subtitles.encode_utf8' | translate"
+          toggleClass="toggle-sm toggle-primary" />
 
         <div class="divider my-0"></div>
         <h2 class="card-title text-base">{{ 'settings.subtitles.section_cleaning' | translate }}</h2>
 
-        <label class="label cursor-pointer justify-start gap-3 max-w-max">
-          <input type="checkbox" class="toggle toggle-sm"
-            [ngModel]="removeHiTags() === 'true'"
-            (ngModelChange)="removeHiTags.set($event ? 'true' : 'false')" />
-          <span class="label-text">{{ 'settings.subtitles.remove_hi_tags' | translate }}</span>
-        </label>
+        <app-toggle-field
+          [value]="removeHiTags() === 'true'"
+          (valueChange)="removeHiTags.set($event ? 'true' : 'false')"
+          [label]="'settings.subtitles.remove_hi_tags' | translate"
+          toggleClass="toggle-sm toggle-primary" />
 
-        <label class="label cursor-pointer justify-start gap-3 max-w-max">
-          <input type="checkbox" class="toggle toggle-sm"
-            [ngModel]="ocrBurnInAuto() === 'true'"
-            (ngModelChange)="ocrBurnInAuto.set($event ? 'true' : 'false')" />
-          <span class="label-text">{{ 'settings.subtitles.ocr_burn_in_auto' | translate }}</span>
-        </label>
-        <p class="text-xs text-base-content/50 -mt-1 max-w-lg">{{ 'settings.subtitles.ocr_burn_in_auto_hint' | translate }}</p>
-
-        <label class="label cursor-pointer justify-start gap-3 max-w-max">
-          <input type="checkbox" class="toggle toggle-sm"
-            [ngModel]="deleteBurnInSource() === 'true'"
-            (ngModelChange)="deleteBurnInSource.set($event ? 'true' : 'false')" />
-          <span class="label-text">{{ 'settings.subtitles.ocr_delete_source' | translate }}</span>
-        </label>
-        <p class="text-xs text-base-content/50 -mt-1 max-w-lg">{{ 'settings.subtitles.ocr_delete_source_hint' | translate }}</p>
+        <app-toggle-field
+          [value]="deleteBurnInSource() === 'true'"
+          (valueChange)="deleteBurnInSource.set($event ? 'true' : 'false')"
+          [label]="'settings.subtitles.ocr_delete_source' | translate"
+          [hint]="'settings.subtitles.ocr_delete_source_hint' | translate"
+          toggleClass="toggle-sm toggle-primary" />
 
         <label class="form-control w-full max-w-lg">
           <div class="label">

--- a/client/src/app/features/settings/subtitles/subtitles-settings.ts
+++ b/client/src/app/features/settings/subtitles/subtitles-settings.ts
@@ -9,10 +9,11 @@ import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { SettingsApiService } from '../../../core/services/api/settings-api.service';
 import { ToastService } from '../../../core/services/toast.service';
+import { ToggleFieldComponent } from '../../../shared/components/forms/toggle-field/toggle-field';
 
 @Component({
   selector: 'app-subtitles-settings',
-  imports: [FormsModule, TranslateModule],
+  imports: [FormsModule, TranslateModule, ToggleFieldComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './subtitles-settings.html',
 })
@@ -32,6 +33,7 @@ export class SubtitlesSettingsComponent implements OnInit {
   readonly autoSync = signal('false');
   readonly encodeUtf8 = signal('true');
   readonly removeHiTags = signal('false');
+  readonly burnInCovers = signal('false');
   readonly ocrBurnInAuto = signal('false');
   readonly deleteBurnInSource = signal('false');
   readonly customExclusions = signal('');
@@ -47,6 +49,7 @@ export class SubtitlesSettingsComponent implements OnInit {
       this.autoSync.set(map['subtitle_auto_sync'] ?? 'false');
       this.encodeUtf8.set(map['subtitle_encode_utf8'] ?? 'true');
       this.removeHiTags.set(map['subtitle_remove_hi_tags'] ?? 'false');
+      this.burnInCovers.set(map['subtitle_burn_in_covers_language'] ?? 'false');
       this.ocrBurnInAuto.set(map['subtitle_ocr_burn_in_auto'] ?? 'false');
       this.deleteBurnInSource.set(map['subtitle_ocr_delete_source'] ?? 'false');
       this.customExclusions.set(map['subtitle_custom_exclusions'] ?? '');
@@ -69,6 +72,7 @@ export class SubtitlesSettingsComponent implements OnInit {
         subtitle_auto_sync: this.autoSync(),
         subtitle_encode_utf8: this.encodeUtf8(),
         subtitle_remove_hi_tags: this.removeHiTags(),
+        subtitle_burn_in_covers_language: this.burnInCovers(),
         subtitle_ocr_burn_in_auto: this.ocrBurnInAuto(),
         subtitle_ocr_delete_source: this.deleteBurnInSource(),
         subtitle_custom_exclusions: this.customExclusions(),

--- a/client/src/app/features/settings/subtitles/subtitles-stats.html
+++ b/client/src/app/features/settings/subtitles/subtitles-stats.html
@@ -62,7 +62,7 @@
               </tr>
             </thead>
             <tbody>
-              @for (row of missing(); track row.fileId + row.language) {
+              @for (row of missing(); track row.fileId + row.language + row.forced) {
                 <tr>
                   <td>
                     @if (row.episodeId) {
@@ -78,7 +78,12 @@
                     }
                   </td>
                   <td class="text-sm text-base-content/60 max-w-48 truncate" [title]="row.fileName">{{ row.fileName }}</td>
-                  <td><span class="badge badge-sm badge-outline">{{ row.language }}</span></td>
+                  <td>
+                    <span class="badge badge-sm badge-outline">{{ row.language }}</span>
+                    @if (row.forced) {
+                      <span class="badge badge-sm badge-ghost ms-1">{{ 'settings.subtitles.forced' | translate }}</span>
+                    }
+                  </td>
                   <td>
                     <button
                       type="button"

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -160,6 +160,11 @@
                           </span>
                         }
                       }
+                      @if (sub.status === 'failed') {
+                        <span class="badge badge-sm badge-error mr-1">{{
+                          'media_detail.subtitle_failed' | translate
+                        }}</span>
+                      }
                       @if (sub.forced) {
                         <span class="badge badge-sm badge-outline mr-1">F</span>
                       }

--- a/client/src/app/shared/remote-picker/remote-picker.ts
+++ b/client/src/app/shared/remote-picker/remote-picker.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, Signal, computed, inject, signal } from '@angular/core';
-import { Capacitor } from '@capacitor/core';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { RouterLink } from '@angular/router';
 import {
@@ -54,17 +53,20 @@ export class RemotePickerComponent {
   private readonly toast = inject(ToastService);
   private readonly translate = inject(TranslateService);
 
-  protected readonly isNative = Capacitor.isNativePlatform();
+  /** Whether the Cast backend lists devices itself (mobile plugin, desktop
+   *  bridge) — a browser has no enumeration API and delegates to its own
+   *  dialog through the single `cast-web` row. */
+  protected readonly enumerates = this.castService.enumerates;
 
   private readonly lastUsedId = signal<string | null>(this.readLastUsed());
 
   protected readonly castSearching = computed(
-    () => this.isNative && this.castService.isAvailable() && this.castService.castDevices().length === 0,
+    () => this.enumerates && this.castService.isAvailable() && this.castService.castDevices().length === 0,
   );
 
   protected readonly pickerRows: Signal<PickerRow[]> = computed(() => {
     const rows: PickerRow[] = [];
-    if (!this.isNative) {
+    if (!this.enumerates) {
       const connected = this.castService.isConnected();
       rows.push({
         kind: 'cast-web',
@@ -114,7 +116,7 @@ export class RemotePickerComponent {
    *  on close is harmless. */
   protected onTriggerPress(): void {
     void this.remote.refreshTargets();
-    if (this.isNative) void this.castService.getCastDevices();
+    if (this.enumerates) void this.castService.getCastDevices();
   }
 
   selectRow(row: PickerRow): void {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,6 +9,7 @@
   "main": "dist/main/index.cjs",
   "scripts": {
     "typecheck": "tsc -p tsconfig.json",
+    "test": "node --test src/main/**/*.test.ts",
     "build:main": "esbuild src/main/index.ts --bundle --platform=node --target=node20 --format=cjs --external:electron --external:electron-updater --outfile=dist/main/index.cjs",
     "build:preload": "esbuild src/preload/index.ts --bundle --platform=node --target=node20 --format=cjs --external:electron --outfile=dist/preload/index.cjs",
     "build": "npm run build:main && npm run build:preload",

--- a/desktop/src/main/cast/cast.test.ts
+++ b/desktop/src/main/cast/cast.test.ts
@@ -1,0 +1,205 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { absorb, buildQuery, collect, parseRecords, parseTxt } from './mdns.ts';
+import { decodeMessage, encodeFrame, splitFrames } from './protocol.ts';
+import { mediaStatusEvent, mergeActiveTracks, pickAudioTrack } from './status.ts';
+
+test('CastMessage survives an encode/decode round trip', () => {
+  const msg = {
+    sourceId: 'sender-abc',
+    destinationId: 'receiver-0',
+    namespace: 'urn:x-cast:com.google.cast.receiver',
+    data: JSON.stringify({ type: 'LAUNCH', appId: '66BF4DAE', requestId: 2 }),
+  };
+  const { messages, rest } = splitFrames(encodeFrame(msg));
+  assert.equal(rest.length, 0);
+  assert.equal(messages.length, 1);
+  assert.deepEqual(decodeMessage(messages[0]), msg);
+});
+
+test('splitFrames keeps a partial frame for the next chunk', () => {
+  const a = encodeFrame({ sourceId: 's', destinationId: 'd', namespace: 'n', data: '{"a":1}' });
+  const b = encodeFrame({ sourceId: 's', destinationId: 'd', namespace: 'n', data: '{"b":2}' });
+  const stream = Buffer.concat([a, b]);
+  const cut = stream.subarray(0, a.length + 3);
+  const first = splitFrames(cut);
+  assert.equal(first.messages.length, 1);
+  assert.equal(first.rest.length, 3);
+
+  const second = splitFrames(Buffer.concat([first.rest, stream.subarray(cut.length)]));
+  assert.equal(second.messages.length, 1);
+  assert.equal(decodeMessage(second.messages[0]).data, '{"b":2}');
+});
+
+test('a payload longer than 127 bytes keeps its multi-byte length prefix', () => {
+  const data = JSON.stringify({ blob: 'x'.repeat(500) });
+  const { messages } = splitFrames(
+    encodeFrame({ sourceId: 's', destinationId: 'd', namespace: 'n', data }),
+  );
+  assert.equal(decodeMessage(messages[0]).data, data);
+});
+
+// ── mDNS ──
+
+/** Assemble a response packet the way a Chromecast answers a PTR query: the
+ *  instance and host names appear once and every later reference is a
+ *  compression pointer, which is the part worth testing. */
+function buildResponse(): Buffer {
+  const parts: Buffer[] = [];
+  let length = 0;
+  const push = (buf: Buffer): number => {
+    parts.push(buf);
+    length += buf.length;
+    return length - buf.length;
+  };
+  const name = (value: string): Buffer =>
+    Buffer.concat([
+      ...value.split('.').map((l) => Buffer.concat([Buffer.from([l.length]), Buffer.from(l)])),
+      Buffer.from([0]),
+    ]);
+  const pointer = (offset: number): Buffer => Buffer.from([0xc0 | (offset >> 8), offset & 0xff]);
+  const rr = (type: number, rdata: Buffer): Buffer => {
+    const head = Buffer.alloc(10);
+    head.writeUInt16BE(type, 0);
+    head.writeUInt16BE(1, 2);
+    head.writeUInt32BE(120, 4);
+    head.writeUInt16BE(rdata.length, 8);
+    return Buffer.concat([head, rdata]);
+  };
+
+  const header = Buffer.alloc(12);
+  header.writeUInt16BE(0x8400, 2);
+  header.writeUInt16BE(1, 6); // one answer
+  header.writeUInt16BE(3, 10); // three additionals
+  push(header);
+
+  const serviceOffset = push(name('_googlecast._tcp.local'));
+  // PTR rdata is the instance name: one fresh label, then a pointer back.
+  const instanceLabel = Buffer.concat([Buffer.from([14]), Buffer.from('Chromecast-abc')]);
+  const ptrRdata = Buffer.concat([instanceLabel, pointer(serviceOffset)]);
+  const instanceOffset = push(rr(12, ptrRdata)) + 10;
+
+  const srvHead = Buffer.alloc(6);
+  srvHead.writeUInt16BE(8009, 4);
+  const srvStart = push(pointer(instanceOffset));
+  const targetOffset = srvStart + 2 + 10 + srvHead.length;
+  push(rr(33, Buffer.concat([srvHead, name('abc.local')])));
+
+  push(pointer(instanceOffset));
+  const txt = ['id=uuid-1', 'fn=Salon', 'md=Chromecast Ultra'];
+  push(
+    rr(
+      16,
+      Buffer.concat(txt.map((t) => Buffer.concat([Buffer.from([t.length]), Buffer.from(t)]))),
+    ),
+  );
+
+  push(pointer(targetOffset));
+  push(rr(1, Buffer.from([192, 168, 1, 42])));
+
+  return Buffer.concat(parts);
+}
+
+test('a Cast announcement resolves to a complete device', () => {
+  const services = new Map();
+  const addresses = new Map();
+  absorb(buildResponse(), services, addresses);
+  assert.deepEqual(collect(services, addresses), [
+    {
+      id: 'uuid-1',
+      name: 'Salon',
+      modelName: 'Chromecast Ultra',
+      host: '192.168.1.42',
+      port: 8009,
+    },
+  ]);
+});
+
+test('a foreign mDNS service on the segment is not mistaken for a Cast device', () => {
+  const services = new Map();
+  const addresses = new Map();
+  // The socket sees the whole segment; only what a googlecast PTR introduced counts.
+  absorb(buildResponse(), services, addresses);
+  const printer = buildResponse();
+  printer.write('_printerxx', printer.indexOf('_googlecast'));
+  absorb(printer, services, addresses);
+  assert.equal(collect(services, addresses).length, 1);
+});
+
+test('a device is withheld until its address record lands', () => {
+  const services = new Map([['Chromecast-abc._googlecast._tcp.local', { target: 'abc.local', port: 8009 }]]);
+  assert.deepEqual(collect(services, new Map()), []);
+});
+
+test('the PTR query is a well-formed single question', () => {
+  const query = buildQuery();
+  assert.equal(query.readUInt16BE(4), 1);
+  assert.equal(query.readUInt16BE(6), 0);
+  assert.deepEqual(parseRecords(query), []);
+  assert.equal(query.readUInt16BE(query.length - 4), 12);
+});
+
+test('TXT rdata splits on the first "=" only', () => {
+  const entry = 'fn=Salon=TV';
+  const buf = Buffer.concat([Buffer.from([entry.length]), Buffer.from(entry)]);
+  assert.deepEqual(parseTxt(buf, 0, buf.length), { fn: 'Salon=TV' });
+});
+
+// ── receiver status ──
+
+test('a playing status becomes a media update', () => {
+  const event = mediaStatusEvent(
+    { playerState: 'PLAYING', currentTime: 42.5, volume: { level: 0.6, muted: false } },
+    { duration: 3600 },
+  );
+  assert.deepEqual(event, {
+    name: 'castMediaUpdate',
+    detail: {
+      currentTime: 42.5,
+      duration: 3600,
+      isPaused: false,
+      buffering: false,
+      volume: 0.6,
+      muted: false,
+    },
+  });
+});
+
+test('IDLE/ERROR becomes a recoverable error carrying the playhead', () => {
+  const event = mediaStatusEvent(
+    { playerState: 'IDLE', idleReason: 'ERROR', currentTime: 128 },
+    { duration: 3600 },
+  );
+  assert.deepEqual(event, { name: 'castError', detail: { position: 128 } });
+});
+
+test('IDLE without an error reason is an ordinary update, not a failure', () => {
+  const event = mediaStatusEvent({ playerState: 'IDLE', idleReason: 'FINISHED' }, undefined);
+  assert.equal(event.name, 'castMediaUpdate');
+});
+
+const TRACKS = [
+  { trackId: 1, type: 'TEXT', name: 'French', language: 'fr' },
+  { trackId: 2, type: 'TEXT', name: 'English', language: 'en' },
+  { trackId: 3, type: 'AUDIO', name: 'VF', language: 'fr' },
+  { trackId: 4, type: 'AUDIO', name: 'VO', language: 'en' },
+];
+
+test('changing the subtitle keeps the active audio alive', () => {
+  assert.deepEqual(mergeActiveTracks(TRACKS, [2, 4], { textId: 1 }), [4, 1]);
+});
+
+test('changing the audio keeps the active subtitle alive', () => {
+  assert.deepEqual(mergeActiveTracks(TRACKS, [2, 4], { audioId: 3 }), [3, 2]);
+});
+
+test('a null id disables that track type and nothing else', () => {
+  assert.deepEqual(mergeActiveTracks(TRACKS, [2, 4], { textId: null }), [4]);
+});
+
+test('audio matches on name before language, for 3-letter sources', () => {
+  // Shaka rewrote the manifest's "fre" to "fr", so only the NAME still matches.
+  assert.equal(pickAudioTrack(TRACKS, 'fre', 'VF')?.trackId, 3);
+  assert.equal(pickAudioTrack(TRACKS, 'en', 'Nonexistent')?.trackId, 4);
+  assert.equal(pickAudioTrack(TRACKS, 'de', 'German'), undefined);
+});

--- a/desktop/src/main/cast/index.ts
+++ b/desktop/src/main/cast/index.ts
@@ -1,0 +1,330 @@
+import { BrowserWindow, ipcMain } from 'electron';
+import { CAST_IPC } from '../../shared/contract';
+import type {
+  DesktopCastDevice,
+  DesktopCastEvent,
+  DesktopCastLoadOptions,
+} from '../../shared/contract';
+import { CastDiscovery, type DiscoveredDevice } from './mdns';
+import {
+  mediaStatusEvent,
+  mergeActiveTracks,
+  pickAudioTrack,
+  type CastTrack,
+} from './status';
+import {
+  CastChannel,
+  NS_MEDIA,
+  NS_RECEIVER,
+  PLATFORM_RECEIVER,
+} from './protocol';
+
+/** Receiver → sender bus the Fliks CAF receiver pushes player errors on.
+ *  Kept in sync with `cast-receiver/receiver.js` and the web sender. */
+const NS_FLIKS = 'urn:x-cast:media.fliks.app';
+
+/** MEDIA_STATUS only arrives on receiver-side transitions, so the playhead is
+ *  polled to keep the renderer's seekbar moving — the same job the web SDK's
+ *  RemotePlayer does for itself. 1Hz is what a cast progress bar needs. */
+const STATUS_POLL_MS = 1_000;
+
+function broadcast(event: DesktopCastEvent): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) win.webContents.send(CAST_IPC.event, event);
+  }
+}
+
+/**
+ * Cast sender for the desktop client: mDNS discovery plus a CASTV2 session,
+ * exposing the same method surface the mobile `NativeCast` Capacitor plugin
+ * does so the Angular `CastService` drives all three senders identically.
+ */
+class CastSender {
+  private readonly discovery = new CastDiscovery((devices) => this.onDevices(devices));
+  private channel: CastChannel | null = null;
+  private devices: DiscoveredDevice[] = [];
+  private appId = '';
+  private deviceId: string | null = null;
+  private transportId = '';
+  private sessionId = '';
+  private mediaSessionId: number | null = null;
+  private tracks: CastTrack[] = [];
+  private media: Record<string, unknown> | undefined;
+  private activeTrackIds: number[] = [];
+  private poll: ReturnType<typeof setInterval> | null = null;
+
+  initialize(appId: string): { available: boolean } {
+    this.appId = appId;
+    this.discovery.start();
+    return { available: this.devices.length > 0 };
+  }
+
+  listDevices(): DesktopCastDevice[] {
+    return this.devices.map((d) => ({
+      id: d.id,
+      name: d.name,
+      modelName: d.modelName,
+      connected: d.id === this.deviceId && this.isConnected(),
+    }));
+  }
+
+  refresh(): void {
+    this.discovery.query();
+  }
+
+  isConnected(): boolean {
+    return !!this.channel?.isOpen && !!this.transportId;
+  }
+
+  private onDevices(devices: DiscoveredDevice[]): void {
+    this.devices = devices;
+    broadcast({ name: 'castAvailabilityChanged', detail: { available: devices.length > 0 } });
+    broadcast({ name: 'castDevicesChanged', detail: {} });
+  }
+
+  async select(id: string): Promise<void> {
+    const device = this.devices.find((d) => d.id === id);
+    if (!device) throw new Error(`unknown cast device: ${id}`);
+    this.teardown();
+
+    const channel = new CastChannel();
+    this.channel = channel;
+    channel.on('message', (ns: string, data: Record<string, unknown>) =>
+      this.onMessage(ns, data),
+    );
+    channel.on('close', () => {
+      if (this.channel === channel) this.teardown();
+    });
+
+    await channel.connect(device.host, device.port);
+    const status = await channel.request(NS_RECEIVER, PLATFORM_RECEIVER, {
+      type: 'LAUNCH',
+      appId: this.appId,
+    }, 30_000);
+    if (!this.adoptReceiverStatus(status)) {
+      this.teardown();
+      throw new Error('receiver did not launch the Fliks app');
+    }
+    this.deviceId = device.id;
+    channel.virtualConnect(this.transportId);
+    this.startPolling();
+    broadcast({ name: 'castStateChanged', detail: { connected: true } });
+    broadcast({ name: 'castDevicesChanged', detail: {} });
+  }
+
+  /** Pull our app's transport out of a RECEIVER_STATUS. Returns false when the
+   *  Fliks receiver isn't among the running applications. */
+  private adoptReceiverStatus(message: Record<string, unknown>): boolean {
+    const status = message['status'] as Record<string, unknown> | undefined;
+    const volume = status?.['volume'] as { level?: number; muted?: boolean } | undefined;
+    if (volume) {
+      broadcast({
+        name: 'castMediaUpdate',
+        detail: { volume: volume.level, muted: volume.muted },
+      });
+    }
+    const apps = (status?.['applications'] ?? []) as Record<string, unknown>[];
+    const app = apps.find((a) => a['appId'] === this.appId);
+    if (!app) return false;
+    this.transportId = String(app['transportId'] ?? '');
+    this.sessionId = String(app['sessionId'] ?? '');
+    return !!this.transportId;
+  }
+
+  private onMessage(ns: string, data: Record<string, unknown>): void {
+    if (ns === NS_RECEIVER && data['type'] === 'RECEIVER_STATUS') {
+      const status = data['status'] as Record<string, unknown> | undefined;
+      const apps = (status?.['applications'] ?? []) as Record<string, unknown>[];
+      // The user can stop the app from the TV or another sender; the session is
+      // over even though the TCP channel is still up.
+      if (this.transportId && !apps.some((a) => a['appId'] === this.appId)) {
+        this.teardown();
+        return;
+      }
+      this.adoptReceiverStatus(data);
+      return;
+    }
+    if (ns === NS_MEDIA && data['type'] === 'MEDIA_STATUS') {
+      this.onMediaStatus((data['status'] ?? []) as Record<string, unknown>[]);
+      return;
+    }
+    if (ns === NS_FLIKS && data['kind'] === 'player_error') {
+      broadcast({ name: 'castError', detail: { position: Number(data['at']) || undefined } });
+    }
+  }
+
+  private onMediaStatus(statuses: Record<string, unknown>[]): void {
+    const status = statuses[0];
+    if (!status) return;
+    this.mediaSessionId = Number(status['mediaSessionId']) || this.mediaSessionId;
+    if (Array.isArray(status['activeTrackIds'])) {
+      this.activeTrackIds = status['activeTrackIds'] as number[];
+    }
+    const media = status['media'] as Record<string, unknown> | undefined;
+    // `media` rides only the first status after a LOAD; later ones omit it.
+    if (Array.isArray(media?.['tracks'])) this.tracks = media['tracks'] as CastTrack[];
+    if (media) this.media = media;
+    broadcast(mediaStatusEvent(status, this.media));
+  }
+
+  private startPolling(): void {
+    if (this.poll) return;
+    this.poll = setInterval(() => {
+      if (!this.isConnected()) return;
+      this.mediaSend({ type: 'GET_STATUS' });
+    }, STATUS_POLL_MS);
+  }
+
+  private mediaSend(payload: Record<string, unknown>): void {
+    if (!this.channel || !this.transportId) return;
+    const withSession =
+      this.mediaSessionId != null ? { ...payload, mediaSessionId: this.mediaSessionId } : payload;
+    this.channel.send(NS_MEDIA, this.transportId, {
+      ...withSession,
+      requestId: Math.floor(Math.random() * 1e6),
+    });
+  }
+
+  load(opts: DesktopCastLoadOptions): void {
+    if (!this.channel || !this.transportId) return;
+    const tracks = opts.subtitles.map((sub, i) => ({
+      trackId: i + 1,
+      type: 'TEXT',
+      trackContentId: sub.url,
+      trackContentType: 'text/vtt',
+      subtype: 'SUBTITLES',
+      name: sub.label,
+      language: sub.language,
+    }));
+    // A fresh LOAD invalidates the previous session's tracks and id; the
+    // MEDIA_STATUS that answers this one repopulates them.
+    this.mediaSessionId = null;
+    this.tracks = [];
+    this.activeTrackIds = [];
+    this.media = undefined;
+    this.channel.send(NS_MEDIA, this.transportId, {
+      type: 'LOAD',
+      requestId: Math.floor(Math.random() * 1e6),
+      sessionId: this.sessionId,
+      autoplay: opts.autoplay,
+      currentTime: opts.currentTime,
+      activeTrackIds: opts.activeSubtitleTrackId ? [opts.activeSubtitleTrackId] : [],
+      media: {
+        contentId: opts.url,
+        contentType: opts.contentType,
+        streamType: 'BUFFERED',
+        metadata: {
+          metadataType: 0,
+          title: opts.title,
+          subtitle: opts.subtitle,
+          images: opts.posterUrl ? [{ url: opts.posterUrl }] : [],
+        },
+        tracks,
+        textTrackStyle: opts.castTextTrackStyle,
+        customData: opts.customData,
+      },
+    });
+  }
+
+  play(): void { this.mediaSend({ type: 'PLAY' }); }
+  pause(): void { this.mediaSend({ type: 'PAUSE' }); }
+  seek(time: number): void { this.mediaSend({ type: 'SEEK', currentTime: time }); }
+  stop(): void { this.mediaSend({ type: 'STOP' }); }
+
+  setVolume(level: number): void {
+    this.channel?.send(NS_RECEIVER, PLATFORM_RECEIVER, {
+      type: 'SET_VOLUME',
+      requestId: Math.floor(Math.random() * 1e6),
+      volume: { level },
+    });
+  }
+
+  setMuted(muted: boolean): void {
+    this.channel?.send(NS_RECEIVER, PLATFORM_RECEIVER, {
+      type: 'SET_VOLUME',
+      requestId: Math.floor(Math.random() * 1e6),
+      volume: { muted },
+    });
+  }
+
+  setActiveSubtitle(trackId: number): void {
+    this.editTracks({ textId: trackId > 0 ? trackId : null });
+  }
+
+  /** Match the audio rendition by name first: Shaka rewrites HLS LANGUAGE from
+   *  ISO 639-2 to 639-1, so language equality misses 3-letter sources. */
+  setActiveAudioLanguage(language: string, name: string): boolean {
+    const target = pickAudioTrack(this.tracks, language, name);
+    if (!target) return false;
+    return this.editTracks({ audioId: target.trackId });
+  }
+
+  private editTracks(update: { audioId?: number | null; textId?: number | null }): boolean {
+    if (!this.channel || !this.transportId || this.mediaSessionId == null) return false;
+    const activeTrackIds = mergeActiveTracks(this.tracks, this.activeTrackIds, update);
+    this.mediaSend({ type: 'EDIT_TRACKS_INFO', activeTrackIds });
+    this.activeTrackIds = activeTrackIds;
+    return true;
+  }
+
+  disconnect(): void {
+    if (this.channel && this.transportId) {
+      this.channel.send(NS_RECEIVER, PLATFORM_RECEIVER, {
+        type: 'STOP',
+        requestId: Math.floor(Math.random() * 1e6),
+        sessionId: this.sessionId,
+      });
+    }
+    this.teardown();
+  }
+
+  private teardown(): void {
+    const wasConnected = this.isConnected();
+    if (this.poll) clearInterval(this.poll);
+    this.poll = null;
+    this.channel?.removeAllListeners();
+    this.channel?.close();
+    this.channel = null;
+    this.deviceId = null;
+    this.transportId = '';
+    this.sessionId = '';
+    this.mediaSessionId = null;
+    this.tracks = [];
+    this.activeTrackIds = [];
+    this.media = undefined;
+    if (wasConnected) {
+      broadcast({ name: 'castStateChanged', detail: { connected: false } });
+      broadcast({ name: 'castDevicesChanged', detail: {} });
+    }
+  }
+}
+
+export function registerCastIpc(): void {
+  const sender = new CastSender();
+  ipcMain.handle(CAST_IPC.initialize, (_e, appId: string) => sender.initialize(appId));
+  ipcMain.handle(CAST_IPC.isConnected, () => ({ connected: sender.isConnected() }));
+  ipcMain.handle(CAST_IPC.getDevices, () => {
+    sender.refresh();
+    return sender.listDevices();
+  });
+  ipcMain.handle(CAST_IPC.selectDevice, (_e, id: string) => sender.select(id));
+  // Desktop has no OS-level route picker to open — the app's own picker lists
+  // the discovered devices — so end the caller's "connecting" state at once.
+  ipcMain.handle(CAST_IPC.requestSession, () =>
+    broadcast({ name: 'castPickerDismissed', detail: {} }),
+  );
+  ipcMain.handle(CAST_IPC.load, (_e, opts: DesktopCastLoadOptions) => sender.load(opts));
+  ipcMain.handle(CAST_IPC.play, () => sender.play());
+  ipcMain.handle(CAST_IPC.pause, () => sender.pause());
+  ipcMain.handle(CAST_IPC.seek, (_e, time: number) => sender.seek(time));
+  ipcMain.handle(CAST_IPC.stop, () => sender.stop());
+  ipcMain.handle(CAST_IPC.disconnect, () => sender.disconnect());
+  ipcMain.handle(CAST_IPC.setVolume, (_e, level: number) => sender.setVolume(level));
+  ipcMain.handle(CAST_IPC.setMuted, (_e, muted: boolean) => sender.setMuted(muted));
+  ipcMain.handle(CAST_IPC.setActiveSubtitle, (_e, trackId: number) =>
+    sender.setActiveSubtitle(trackId),
+  );
+  ipcMain.handle(CAST_IPC.setActiveAudioLanguage, (_e, language: string, name: string) => ({
+    success: sender.setActiveAudioLanguage(language, name),
+  }));
+}

--- a/desktop/src/main/cast/mdns.ts
+++ b/desktop/src/main/cast/mdns.ts
@@ -1,0 +1,246 @@
+import dgram from 'node:dgram';
+
+/** Minimal mDNS browser for `_googlecast._tcp.local`, enough to feed the Cast
+ *  picker: PTR → instance, SRV → host + port, TXT → id / friendly name / model.
+ *  Node has no stdlib mDNS and the protocol surface we need is one query type,
+ *  so the packets are built and parsed here rather than pulling a resolver in. */
+
+const MDNS_ADDR = '224.0.0.251';
+const MDNS_PORT = 5353;
+const SERVICE = '_googlecast._tcp.local';
+
+const TYPE_A = 1;
+const TYPE_PTR = 12;
+const TYPE_TXT = 16;
+const TYPE_SRV = 33;
+
+export interface DiscoveredDevice {
+  id: string;
+  name: string;
+  modelName?: string;
+  host: string;
+  port: number;
+}
+
+interface Rr {
+  name: string;
+  type: number;
+  start: number;
+  length: number;
+}
+
+/** Read a DNS name at `offset`, following compression pointers. Returns the
+ *  name and the offset just past the name *in the record stream* — a pointer
+ *  consumes 2 bytes there however far it jumps. */
+function readName(buf: Buffer, offset: number): [string, number] {
+  const labels: string[] = [];
+  let pos = offset;
+  let next = offset;
+  let jumped = false;
+  // A malformed packet can point a name at itself; cap the walk.
+  for (let guard = 0; guard < 128; guard++) {
+    if (pos >= buf.length) break;
+    const len = buf[pos];
+    if (len === 0) {
+      if (!jumped) next = pos + 1;
+      break;
+    }
+    if ((len & 0xc0) === 0xc0) {
+      if (pos + 1 >= buf.length) break;
+      const ptr = ((len & 0x3f) << 8) | buf[pos + 1];
+      if (!jumped) next = pos + 2;
+      jumped = true;
+      pos = ptr;
+      continue;
+    }
+    labels.push(buf.toString('utf8', pos + 1, pos + 1 + len));
+    pos += 1 + len;
+    if (!jumped) next = pos;
+  }
+  return [labels.join('.'), next];
+}
+
+export function parseRecords(buf: Buffer): Rr[] {
+  if (buf.length < 12) return [];
+  const qd = buf.readUInt16BE(4);
+  const rrCount = buf.readUInt16BE(6) + buf.readUInt16BE(8) + buf.readUInt16BE(10);
+  let pos = 12;
+  for (let i = 0; i < qd; i++) {
+    [, pos] = readName(buf, pos);
+    pos += 4;
+  }
+  const out: Rr[] = [];
+  for (let i = 0; i < rrCount && pos + 10 <= buf.length; i++) {
+    let name: string;
+    [name, pos] = readName(buf, pos);
+    if (pos + 10 > buf.length) break;
+    const type = buf.readUInt16BE(pos);
+    const length = buf.readUInt16BE(pos + 8);
+    pos += 10;
+    out.push({ name, type, start: pos, length });
+    pos += length;
+  }
+  return out;
+}
+
+/** TXT rdata is a run of length-prefixed `key=value` strings. */
+export function parseTxt(buf: Buffer, start: number, length: number): Record<string, string> {
+  const out: Record<string, string> = {};
+  let pos = start;
+  const end = Math.min(start + length, buf.length);
+  while (pos < end) {
+    const len = buf[pos];
+    const text = buf.toString('utf8', pos + 1, Math.min(pos + 1 + len, end));
+    const eq = text.indexOf('=');
+    if (eq > 0) out[text.slice(0, eq)] = text.slice(eq + 1);
+    pos += 1 + len;
+  }
+  return out;
+}
+
+export function buildQuery(): Buffer {
+  const labels = SERVICE.split('.');
+  const nameLen = labels.reduce((n, l) => n + 1 + l.length, 0) + 1;
+  const buf = Buffer.alloc(12 + nameLen + 4);
+  buf.writeUInt16BE(1, 4); // one question, everything else stays zero
+  let pos = 12;
+  for (const label of labels) {
+    buf.writeUInt8(label.length, pos++);
+    pos += buf.write(label, pos, 'utf8');
+  }
+  buf.writeUInt8(0, pos++);
+  buf.writeUInt16BE(TYPE_PTR, pos);
+  buf.writeUInt16BE(1, pos + 2);
+  return buf;
+}
+
+interface Partial {
+  host?: string;
+  port?: number;
+  target?: string;
+  txt?: Record<string, string>;
+}
+
+/** Fold one response packet into the instance → partial-record map. Exported
+ *  for the codec test: a device is only complete once SRV, TXT and A have all
+ *  landed, which can take several packets. */
+export function absorb(
+  buf: Buffer,
+  services: Map<string, Partial>,
+  addresses: Map<string, string>,
+): void {
+  for (const rr of parseRecords(buf)) {
+    if (rr.type === TYPE_PTR && rr.name === SERVICE) {
+      const [instance] = readName(buf, rr.start);
+      if (!services.has(instance)) services.set(instance, {});
+    } else if (rr.type === TYPE_SRV) {
+      // Only ever fill in an instance a googlecast PTR introduced: the socket
+      // sees every mDNS conversation on the segment, and a printer's SRV would
+      // otherwise register as a Cast device.
+      const entry = services.get(rr.name);
+      if (entry) {
+        entry.port = buf.readUInt16BE(rr.start + 4);
+        [entry.target] = readName(buf, rr.start + 6);
+      }
+    } else if (rr.type === TYPE_TXT) {
+      const entry = services.get(rr.name);
+      if (entry) entry.txt = parseTxt(buf, rr.start, rr.length);
+    } else if (rr.type === TYPE_A && rr.length === 4) {
+      addresses.set(rr.name, Array.from(buf.subarray(rr.start, rr.start + 4)).join('.'));
+    }
+  }
+}
+
+export function collect(
+  services: Map<string, Partial>,
+  addresses: Map<string, string>,
+): DiscoveredDevice[] {
+  const out: DiscoveredDevice[] = [];
+  for (const [instance, entry] of services) {
+    const host = entry.target ? addresses.get(entry.target) : undefined;
+    if (!host || !entry.port) continue;
+    const txt = entry.txt ?? {};
+    out.push({
+      // `id` is the device UUID, stable across reboots; the instance label is
+      // the only fallback when a TXT record hasn't arrived yet.
+      id: txt['id'] || instance,
+      name: txt['fn'] || instance.split('.')[0],
+      modelName: txt['md'],
+      host,
+      port: entry.port,
+    });
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export class CastDiscovery {
+  private socket: dgram.Socket | null = null;
+  private readonly services = new Map<string, Partial>();
+  private readonly addresses = new Map<string, string>();
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  private readonly onChange: (devices: DiscoveredDevice[]) => void;
+
+  constructor(onChange: (devices: DiscoveredDevice[]) => void) {
+    this.onChange = onChange;
+  }
+
+  start(): void {
+    if (this.socket) return;
+    // reuseAddr is what lets us share 5353 with the OS responder (mDNSResponder,
+    // avahi); without it the bind fails on any machine already running one.
+    const socket = dgram.createSocket({ type: 'udp4', reuseAddr: true });
+    this.socket = socket;
+    socket.on('message', (msg) => {
+      const before = this.snapshot();
+      absorb(msg, this.services, this.addresses);
+      const after = this.snapshot();
+      if (before !== after) this.onChange(this.devices());
+    });
+    socket.on('error', (err) => {
+      console.warn('[cast] mdns socket error', err.message);
+      this.stop();
+    });
+    socket.bind(MDNS_PORT, () => {
+      try {
+        socket.addMembership(MDNS_ADDR);
+      } catch (err) {
+        console.warn('[cast] mdns membership failed', (err as Error).message);
+      }
+      this.query();
+      // Chromecasts answer a query once; they don't heartbeat their presence at
+      // a useful cadence, so re-ask to notice devices that appear or vanish.
+      this.timer = setInterval(() => this.query(), 30_000);
+    });
+  }
+
+  /** Re-send the PTR query. Called on every picker open so a device powered on
+   *  since the last sweep shows up without waiting for the 30s tick. */
+  query(): void {
+    if (!this.socket) return;
+    // ponytail: default multicast interface only; enumerate os.networkInterfaces()
+    // and send per-interface if multi-homed hosts turn out to miss devices.
+    this.socket.send(buildQuery(), MDNS_PORT, MDNS_ADDR, (err) => {
+      if (err) console.warn('[cast] mdns query failed', err.message);
+    });
+  }
+
+  devices(): DiscoveredDevice[] {
+    return collect(this.services, this.addresses);
+  }
+
+  private snapshot(): string {
+    return this.devices().map((d) => `${d.id}@${d.host}:${d.port}/${d.name}`).join('|');
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+    try {
+      this.socket?.close();
+    } catch {
+      /* already closed */
+    }
+    this.socket = null;
+  }
+}

--- a/desktop/src/main/cast/protocol.ts
+++ b/desktop/src/main/cast/protocol.ts
@@ -1,0 +1,243 @@
+import { EventEmitter } from 'node:events';
+import tls from 'node:tls';
+
+/** CASTV2 wire protocol: length-prefixed `CastMessage` protobuf frames over
+ *  TLS/8009. The message has seven scalar fields, so it is encoded by hand
+ *  rather than dragging a protobuf runtime into the bundle. */
+
+export const NS_CONNECTION = 'urn:x-cast:com.google.cast.tp.connection';
+export const NS_HEARTBEAT = 'urn:x-cast:com.google.cast.tp.heartbeat';
+export const NS_RECEIVER = 'urn:x-cast:com.google.cast.receiver';
+export const NS_MEDIA = 'urn:x-cast:com.google.cast.media';
+
+export const PLATFORM_RECEIVER = 'receiver-0';
+
+const HEARTBEAT_MS = 5_000;
+/** Two missed PINGs: the device is gone (unplugged, off the network). */
+const HEARTBEAT_TIMEOUT_MS = 15_000;
+
+export interface CastMessage {
+  sourceId: string;
+  destinationId: string;
+  namespace: string;
+  data: string;
+}
+
+function writeVarint(value: number): Buffer {
+  const bytes: number[] = [];
+  let v = value;
+  do {
+    let byte = v & 0x7f;
+    v >>>= 7;
+    if (v) byte |= 0x80;
+    bytes.push(byte);
+  } while (v);
+  return Buffer.from(bytes);
+}
+
+function readVarint(buf: Buffer, offset: number): [number, number] {
+  let value = 0;
+  let shift = 0;
+  let pos = offset;
+  while (pos < buf.length) {
+    const byte = buf[pos++];
+    value |= (byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) break;
+    shift += 7;
+  }
+  return [value >>> 0, pos];
+}
+
+function stringField(tag: number, value: string): Buffer {
+  const body = Buffer.from(value, 'utf8');
+  return Buffer.concat([Buffer.from([tag]), writeVarint(body.length), body]);
+}
+
+/** Encode a CastMessage into a complete frame (4-byte big-endian length + body). */
+export function encodeFrame(msg: CastMessage): Buffer {
+  const body = Buffer.concat([
+    Buffer.from([0x08, 0x00]), // protocol_version = CASTV2_1_0
+    stringField(0x12, msg.sourceId),
+    stringField(0x1a, msg.destinationId),
+    stringField(0x22, msg.namespace),
+    Buffer.from([0x28, 0x00]), // payload_type = STRING
+    stringField(0x32, msg.data),
+  ]);
+  const frame = Buffer.alloc(4 + body.length);
+  frame.writeUInt32BE(body.length, 0);
+  body.copy(frame, 4);
+  return frame;
+}
+
+/** Decode a CastMessage body (the frame without its length prefix). */
+export function decodeMessage(body: Buffer): CastMessage {
+  const msg: CastMessage = { sourceId: '', destinationId: '', namespace: '', data: '' };
+  let pos = 0;
+  while (pos < body.length) {
+    const [tag, afterTag] = readVarint(body, pos);
+    pos = afterTag;
+    const wire = tag & 7;
+    if (wire === 0) {
+      [, pos] = readVarint(body, pos);
+      continue;
+    }
+    if (wire !== 2) break; // castv2 uses varint + length-delimited only
+    const [size, afterSize] = readVarint(body, pos);
+    pos = afterSize;
+    const value = body.subarray(pos, pos + size);
+    pos += size;
+    switch (tag >>> 3) {
+      case 2: msg.sourceId = value.toString('utf8'); break;
+      case 3: msg.destinationId = value.toString('utf8'); break;
+      case 4: msg.namespace = value.toString('utf8'); break;
+      case 6: msg.data = value.toString('utf8'); break;
+    }
+  }
+  return msg;
+}
+
+/** Split a byte stream into CastMessage bodies, keeping any partial tail. */
+export function splitFrames(buffer: Buffer): { messages: Buffer[]; rest: Buffer } {
+  const messages: Buffer[] = [];
+  let pos = 0;
+  while (buffer.length - pos >= 4) {
+    const size = buffer.readUInt32BE(pos);
+    if (buffer.length - pos - 4 < size) break;
+    messages.push(buffer.subarray(pos + 4, pos + 4 + size));
+    pos += 4 + size;
+  }
+  return { messages, rest: buffer.subarray(pos) };
+}
+
+/**
+ * One TLS connection to a Cast device. Owns the framing, the virtual
+ * connection handshake and the heartbeat; everything above it (launching an
+ * app, media control) speaks in JSON payloads on a namespace.
+ *
+ * Events: `message` (namespace, payload, sourceId), `close`.
+ */
+export class CastChannel extends EventEmitter {
+  private socket: tls.TLSSocket | null = null;
+  private buffer: Buffer = Buffer.alloc(0);
+  private heartbeat: ReturnType<typeof setInterval> | null = null;
+  private lastPong = 0;
+  private readonly connected = new Set<string>();
+  private requestId = 1;
+
+  readonly sourceId = `sender-${Math.random().toString(36).slice(2, 10)}`;
+
+  connect(host: string, port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      // Cast devices present a self-signed cert chained to a Google device CA
+      // that no trust store carries; the LAN pairing is the trust boundary.
+      const socket = tls.connect({ host, port, rejectUnauthorized: false }, () => {
+        this.lastPong = Date.now();
+        this.virtualConnect(PLATFORM_RECEIVER);
+        this.startHeartbeat();
+        resolve();
+      });
+      socket.setNoDelay(true);
+      socket.on('data', (chunk: Buffer) => this.onData(chunk));
+      socket.on('error', (err) => {
+        reject(err);
+        this.close();
+      });
+      socket.on('close', () => this.close());
+      this.socket = socket;
+    });
+  }
+
+  /** Open a virtual connection to a destination — required before that
+   *  destination will accept anything, the app transport included. */
+  virtualConnect(destinationId: string): void {
+    if (this.connected.has(destinationId)) return;
+    this.connected.add(destinationId);
+    this.send(NS_CONNECTION, destinationId, { type: 'CONNECT' });
+  }
+
+  send(namespace: string, destinationId: string, payload: Record<string, unknown>): void {
+    if (!this.socket || this.socket.destroyed) return;
+    this.socket.write(
+      encodeFrame({
+        sourceId: this.sourceId,
+        destinationId,
+        namespace,
+        data: JSON.stringify(payload),
+      }),
+    );
+  }
+
+  /** Send a request and resolve with the reply carrying the same requestId.
+   *  Rejects on timeout so a caller never hangs on a receiver that went away. */
+  request(
+    namespace: string,
+    destinationId: string,
+    payload: Record<string, unknown>,
+    timeoutMs = 10_000,
+  ): Promise<Record<string, unknown>> {
+    const requestId = ++this.requestId;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.off('message', listener);
+        reject(new Error(`cast request timed out: ${String(payload['type'])}`));
+      }, timeoutMs);
+      const listener = (_ns: string, data: Record<string, unknown>) => {
+        if (data['requestId'] !== requestId) return;
+        clearTimeout(timer);
+        this.off('message', listener);
+        resolve(data);
+      };
+      this.on('message', listener);
+      this.send(namespace, destinationId, { ...payload, requestId });
+    });
+  }
+
+  private onData(chunk: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    const { messages, rest } = splitFrames(this.buffer);
+    this.buffer = rest;
+    for (const body of messages) {
+      const msg = decodeMessage(body);
+      let data: Record<string, unknown>;
+      try {
+        data = JSON.parse(msg.data) as Record<string, unknown>;
+      } catch {
+        continue; // binary payloads are not part of the surface we use
+      }
+      if (msg.namespace === NS_HEARTBEAT) {
+        if (data['type'] === 'PONG') this.lastPong = Date.now();
+        else if (data['type'] === 'PING') this.send(NS_HEARTBEAT, msg.sourceId, { type: 'PONG' });
+        continue;
+      }
+      this.emit('message', msg.namespace, data, msg.sourceId);
+    }
+  }
+
+  private startHeartbeat(): void {
+    this.heartbeat = setInterval(() => {
+      if (Date.now() - this.lastPong > HEARTBEAT_TIMEOUT_MS) {
+        console.warn('[cast] heartbeat lost, dropping the channel');
+        this.close();
+        return;
+      }
+      this.send(NS_HEARTBEAT, PLATFORM_RECEIVER, { type: 'PING' });
+    }, HEARTBEAT_MS);
+  }
+
+  close(): void {
+    if (this.heartbeat) clearInterval(this.heartbeat);
+    this.heartbeat = null;
+    const socket = this.socket;
+    this.socket = null;
+    this.connected.clear();
+    if (socket) {
+      socket.removeAllListeners('close');
+      socket.destroy();
+      this.emit('close');
+    }
+  }
+
+  get isOpen(): boolean {
+    return !!this.socket && !this.socket.destroyed;
+  }
+}

--- a/desktop/src/main/cast/status.ts
+++ b/desktop/src/main/cast/status.ts
@@ -1,0 +1,71 @@
+import type { DesktopCastEvent } from '../../shared/contract';
+
+/** Pure mapping of the receiver's media bus onto the events the renderer
+ *  consumes. Kept apart from the sender so it stays free of Electron and can
+ *  be exercised directly. */
+
+export interface CastTrack {
+  trackId: number;
+  type?: string;
+  name?: string;
+  language?: string;
+}
+
+/** Translate one MEDIA_STATUS entry. `duration` rides the `media` block, which
+ *  the receiver only sends on the first status after a LOAD, so the caller
+ *  keeps the last one it saw. */
+export function mediaStatusEvent(
+  status: Record<string, unknown>,
+  media: Record<string, unknown> | undefined,
+): DesktopCastEvent {
+  const playerState = String(status['playerState'] ?? '');
+  if (playerState === 'IDLE' && status['idleReason'] === 'ERROR') {
+    return {
+      name: 'castError',
+      detail: { position: Number(status['currentTime']) || undefined },
+    };
+  }
+  const volume = status['volume'] as { level?: number; muted?: boolean } | undefined;
+  return {
+    name: 'castMediaUpdate',
+    detail: {
+      currentTime: Number(status['currentTime']) || 0,
+      duration: Number(media?.['duration']) || undefined,
+      isPaused: playerState === 'PAUSED',
+      buffering: playerState === 'BUFFERING',
+      volume: volume?.level,
+      muted: volume?.muted,
+    },
+  };
+}
+
+/**
+ * Build the activeTrackIds for an EDIT_TRACKS_INFO. CAF replaces the whole
+ * active set in one shot, so the track type left unspecified has to be re-sent
+ * from the current selection or it goes silent.
+ *   undefined → keep whatever is active for that type
+ *   null      → disable that type
+ *   number    → make it the active track of that type
+ */
+export function mergeActiveTracks(
+  tracks: CastTrack[],
+  active: number[],
+  update: { audioId?: number | null; textId?: number | null },
+): number[] {
+  const activeOfType = (type: string) =>
+    active.find((id) => tracks.some((t) => t.trackId === id && t.type === type));
+  const audioId = update.audioId === undefined ? activeOfType('AUDIO') : update.audioId;
+  const textId = update.textId === undefined ? activeOfType('TEXT') : update.textId;
+  return [audioId, textId].filter((id): id is number => id != null);
+}
+
+/** Match an audio rendition by name first: Shaka rewrites HLS LANGUAGE from
+ *  ISO 639-2 to 639-1, so plain language equality misses 3-letter sources. */
+export function pickAudioTrack(
+  tracks: CastTrack[],
+  language: string,
+  name: string,
+): CastTrack | undefined {
+  const audio = tracks.filter((t) => t.type === 'AUDIO');
+  return audio.find((t) => t.name === name) ?? audio.find((t) => t.language === language);
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -9,6 +9,7 @@ import { installCorsBypass } from './cors';
 import { appendLog, redactQuery } from './log-file';
 import { setupUpdater } from './updater';
 import { registerDownloadIpc } from './download';
+import { registerCastIpc } from './cast';
 import { setPlaybackKeepAwake, keepAwakeForState } from './power';
 import { IPC, type DesktopEvent, type DesktopSubtitleStyle } from '../shared/contract';
 import { mpvSubtitleProps } from './mpv/subtitle-style';
@@ -258,6 +259,11 @@ app.whenReady().then(async () => {
   // Offline downloads (renderer→main fetch-to-disk). Registered on every
   // platform path so the desktop download UI works regardless of playback backend.
   registerDownloadIpc();
+
+  // Chromecast sender (mDNS discovery + CASTV2). Electron carries no Cast SDK —
+  // the web sender's cast_sender.js needs Chrome's media router — so the
+  // protocol is spoken from the main process. Registered on every platform path.
+  registerCastIpc();
 
   const dir = webDir();
   const haveApp = fs.existsSync(path.join(dir, 'index.html'));

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -3,6 +3,7 @@ import {
   IPC,
   UPDATE_IPC,
   DOWNLOAD_IPC,
+  CAST_IPC,
   type DesktopDownloadRequest,
   type DesktopDownloadStatus,
   type DesktopEvent,
@@ -12,6 +13,9 @@ import {
   type DesktopUpdateStatus,
   type FliksDesktopApi,
   type FliksDownloaderApi,
+  type DesktopCastEvent,
+  type DesktopCastLoadOptions,
+  type FliksCastApi,
   type FliksUpdaterApi,
 } from '../shared/contract';
 
@@ -86,3 +90,35 @@ const downloader: FliksDownloaderApi = {
 };
 
 contextBridge.exposeInMainWorld('fliksDownloader', downloader);
+
+// Exposes the Chromecast sender on `window.fliksCast`. The Angular CastService
+// consumes this exactly as it consumes the Capacitor NativeCast plugin: it
+// re-dispatches each forwarded event as the window CustomEvent the plugin
+// emits. contextIsolation keeps preload-world objects out of the page, so the
+// events travel through contextBridge rather than a window dispatch here.
+const cast: FliksCastApi = {
+  initialize: (opts: { appId: string }) => ipcRenderer.invoke(CAST_IPC.initialize, opts.appId),
+  isConnected: () => ipcRenderer.invoke(CAST_IPC.isConnected),
+  requestSession: () => ipcRenderer.invoke(CAST_IPC.requestSession),
+  getCastDevices: async () => ({ devices: await ipcRenderer.invoke(CAST_IPC.getDevices) }),
+  selectCastDevice: (opts: { id: string }) => ipcRenderer.invoke(CAST_IPC.selectDevice, opts.id),
+  loadMedia: (opts: DesktopCastLoadOptions) => ipcRenderer.invoke(CAST_IPC.load, opts),
+  play: () => ipcRenderer.invoke(CAST_IPC.play),
+  pause: () => ipcRenderer.invoke(CAST_IPC.pause),
+  seek: (opts: { time: number }) => ipcRenderer.invoke(CAST_IPC.seek, opts.time),
+  stop: () => ipcRenderer.invoke(CAST_IPC.stop),
+  disconnect: () => ipcRenderer.invoke(CAST_IPC.disconnect),
+  setVolume: (opts: { level: number }) => ipcRenderer.invoke(CAST_IPC.setVolume, opts.level),
+  setMuted: (opts: { muted: boolean }) => ipcRenderer.invoke(CAST_IPC.setMuted, opts.muted),
+  setActiveSubtitle: (opts: { trackId: number }) =>
+    ipcRenderer.invoke(CAST_IPC.setActiveSubtitle, opts.trackId),
+  setActiveAudioLanguage: (opts: { language: string; name: string }) =>
+    ipcRenderer.invoke(CAST_IPC.setActiveAudioLanguage, opts.language, opts.name),
+  on: (handler: (event: DesktopCastEvent) => void) => {
+    const listener = (_e: unknown, event: DesktopCastEvent) => handler(event);
+    ipcRenderer.on(CAST_IPC.event, listener);
+    return () => ipcRenderer.removeListener(CAST_IPC.event, listener);
+  },
+};
+
+contextBridge.exposeInMainWorld('fliksCast', cast);

--- a/desktop/src/shared/contract.ts
+++ b/desktop/src/shared/contract.ts
@@ -245,3 +245,112 @@ export interface FliksDesktopApi {
   getSystemInfo(): Promise<DesktopSystemInfo>;
   on(handler: (event: DesktopEvent) => void): () => void;
 }
+
+// ── Chromecast ──
+// App-level like downloads. The method surface mirrors the mobile `NativeCast`
+// Capacitor plugin so the Angular `CastService` treats this bridge as one more
+// native sender; the preload re-emits the events under the same window event
+// names the plugin uses.
+
+export interface DesktopCastDevice {
+  id: string;
+  name: string;
+  modelName?: string;
+  /** True for the device this sender is casting to, so the picker offers to leave it. */
+  connected?: boolean;
+}
+
+/** Cast wire format for subtitle styling — built client-side from the user's
+ *  presets and forwarded to the receiver verbatim. */
+export interface DesktopCastTextTrackStyle {
+  fontGenericFamily: string;
+  fontScale: number;
+  foregroundColor: string;
+  backgroundColor: string;
+  edgeType: string;
+  edgeColor: string;
+}
+
+export interface DesktopCastLoadOptions {
+  url: string;
+  contentType: string;
+  title: string;
+  subtitle: string;
+  posterUrl: string;
+  currentTime: number;
+  autoplay: boolean;
+  subtitles: { url: string; language: string; label: string }[];
+  activeSubtitleTrackId: number;
+  /** Forwarded to the Fliks receiver; must stay free of secrets — the CAF debug
+   *  overlay logs it in plain text. */
+  customData?: Record<string, unknown>;
+  castTextTrackStyle?: DesktopCastTextTrackStyle;
+}
+
+export interface DesktopCastMediaUpdate {
+  currentTime?: number;
+  duration?: number;
+  isPaused?: boolean;
+  buffering?: boolean;
+  volume?: number;
+  muted?: boolean;
+}
+
+/** main → renderer, sent on the single CAST_IPC.event channel. `name` and
+ *  `detail` are the window CustomEvent the mobile NativeCast plugin emits, so
+ *  the client re-dispatches them verbatim and shares one listener set.
+ *  `castError` carries the playhead a recovery reload resumes from. */
+export interface DesktopCastEvent {
+  name:
+    | 'castAvailabilityChanged'
+    | 'castDevicesChanged'
+    | 'castStateChanged'
+    | 'castPickerDismissed'
+    | 'castMediaUpdate'
+    | 'castError';
+  detail: DesktopCastMediaUpdate & {
+    available?: boolean;
+    connected?: boolean;
+    position?: number;
+  };
+}
+
+export const CAST_IPC = {
+  initialize: 'cast:initialize',
+  isConnected: 'cast:isConnected',
+  requestSession: 'cast:requestSession',
+  getDevices: 'cast:getDevices',
+  selectDevice: 'cast:selectDevice',
+  load: 'cast:load',
+  play: 'cast:play',
+  pause: 'cast:pause',
+  seek: 'cast:seek',
+  stop: 'cast:stop',
+  disconnect: 'cast:disconnect',
+  setVolume: 'cast:setVolume',
+  setMuted: 'cast:setMuted',
+  setActiveSubtitle: 'cast:setActiveSubtitle',
+  setActiveAudioLanguage: 'cast:setActiveAudioLanguage',
+  /** main → renderer (discriminated by DesktopCastEvent.type). */
+  event: 'cast:event',
+} as const;
+
+/** Exposed on `window.fliksCast` by the preload bridge. */
+export interface FliksCastApi {
+  initialize(opts: { appId: string }): Promise<{ available: boolean }>;
+  isConnected(): Promise<{ connected: boolean }>;
+  requestSession(): Promise<void>;
+  getCastDevices(): Promise<{ devices: DesktopCastDevice[] }>;
+  selectCastDevice(opts: { id: string }): Promise<void>;
+  loadMedia(opts: DesktopCastLoadOptions): Promise<void>;
+  play(): Promise<void>;
+  pause(): Promise<void>;
+  seek(opts: { time: number }): Promise<void>;
+  stop(): Promise<void>;
+  disconnect(): Promise<void>;
+  setActiveSubtitle(opts: { trackId: number }): Promise<void>;
+  setActiveAudioLanguage(opts: { language: string; name: string }): Promise<{ success: boolean }>;
+  setVolume(opts: { level: number }): Promise<void>;
+  setMuted(opts: { muted: boolean }): Promise<void>;
+  on(handler: (event: DesktopCastEvent) => void): () => void;
+}

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    // node --test strips types in place, so the test imports carry .ts paths.
+    "allowImportingTsExtensions": true,
     "lib": ["ES2022", "DOM"],
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Why

A subtitle's identity is its language **and** its flags, but most of the acquisition chain compared the language alone. A forced track carries only foreign dialogue (~40 lines), so treating it as the full subtitle is never right, and once one was stored it counted as servable and closed the language for good.

Six sites shared the defect:

| Site | Was compared | Failure |
|---|---|---|
| coverage gate | language + codec + status | a `Movie.fr.forced.srt` closed `fr` forever |
| `/subtitles/missing` SQL | mirrors the gate | the file vanished from the missing list |
| provider search | language + HI, never `forced` | a `foreign_parts_only` hit scoring 100 was downloaded as the main subtitle |
| upgrade guard | `isoCode` only | **deleted the full `.fr.srt` from disk** and replaced it with a forced one |
| ffprobe | disposition only, while the *language* was inferred from the title | a track titled `Français (Forced)` entered the library as full |
| companion rename | one trailing flag | `Movie.en.hi.forced.srt` → `.hi.forced.srt`, re-read as Hindi |

## What

One predicate in `common/constants/subtitle-flags.ts`, used by all of them.

- `forced` is exact in **both** directions when the request states it, and unstated when a human drives the search, so the manual modal still sees every candidate.
- Coverage deliberately **ignores** the HI mode. The mode selects what to fetch; `subtitle_remove_hi_tags` clears the very flag a `require` profile asks for, so enforcing it at coverage re-downloaded the same file every sweep into `.fr-1.srt`, `-2`, …
- The plain shapes of a profile language item moved next to the predicate so it stays importable without dragging TypeORM into unit code. The entity re-exports them, so no import site changed.

### Same blast radius

- **A failed OCR deleted its own row**, so the next sweep re-ran the same 30-minute job and never reached the providers. The row now stays `FAILED`, the rescan no longer reaps `PROCESSING`/`FAILED` rows, an interrupted run is swept at boot, and the source track stays visible when the run failed (deleting the row re-arms the retry).
- Bitmap extraction was capped at 120s against 15min for the same read elsewhere — a NAS timeout became a permanent refusal.
- A `.sup` sidecar was stored with no codec and counted as servable text.
- The upgrade veto keeps language granularity on purpose: a flag no provider can supply would otherwise freeze a whole file's upgrades.

### Settings

`subtitle_ocr_burn_in_auto` never ran outside a missing-subtitle search, yet it sat under *Cleaning* labelled "convert on import". Moved under *Search*, renamed to say it **replaces** a download rather than adding to it.

New `subtitle_burn_in_covers_language` (off by default): an image track closes its language for those who accept burn-in. Checked **after** the OCR path, so a convertible track is still converted to text and direct play is preserved. Its hint states the cost — burn-in forces a full re-encode every session and rules out direct play.

The page's six toggles now use the shared `app-toggle-field` component instead of raw checkboxes.

## Verification

- `tsc --noEmit` clean, backend and client
- **183 suites / 2025 tests** green
- `ng build --configuration production` green
- The `/subtitles/missing` query replayed against the real dev database inside a rolled-back transaction: a profile asking for non-forced `fr` and one asking for forced `fr` select different files, as intended

New tests cover the predicate, the title parsing (including `Non-Forced` and `Hindi` non-regressions), the OCR candidate choice, the failed-OCR fallback, the upgrade guard, filename parsing, and the companion rename.

## Not in this PR

The review that preceded it surfaced three confirmed pre-existing security issues, out of scope here and worth their own change: path traversal in `writeSidecar` (the file is written before the root check), SSRF in four provider `download()` implementations, and IDOR on every `/:id/subtitles/:subtitleId/*` endpoint.