### PR TITLE
fix(subtitles): close path traversal, SSRF and IDOR on the subtitle endpoints

### DIFF
--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -75,6 +75,17 @@ export class MediaController {
     await this.mediaService.assertAccessible(id, accessible);
   }
 
+  /** The media guard above only clears `:id`. Every subtitle service method
+   *  loads its row by id alone, so the two ids have to be bound as well. */
+  private async assertSubtitleAccessible(
+    mediaId: number,
+    subtitleId: number,
+    user: User,
+  ): Promise<void> {
+    await this.assertMediaAccessible(mediaId, user);
+    await this.subtitlesService.assertBelongsToMedia(subtitleId, mediaId);
+  }
+
   @Post('import/tmdb')
   @CheckPolicies((ability) => ability.can(Action.Create, Media))
   importFromTmdb(@Body() dto: ImportTmdbDto, @CurrentUser() user: User) {
@@ -568,7 +579,7 @@ export class MediaController {
     @CurrentUser() user: User,
     @Body() body: { language?: string },
   ) {
-    await this.assertMediaAccessible(id, user);
+    await this.assertSubtitleAccessible(id, subtitleId, user);
     return this.subtitleOcr.ocrSubtitle(subtitleId, body.language);
   }
 
@@ -580,7 +591,7 @@ export class MediaController {
     @CurrentUser() user: User,
     @Body() body: { targetLanguage: string; providerId?: number },
   ) {
-    await this.assertMediaAccessible(id, user);
+    await this.assertSubtitleAccessible(id, subtitleId, user);
     return this.subtitleTranslation.translateSubtitle(
       subtitleId,
       body.targetLanguage,
@@ -596,7 +607,7 @@ export class MediaController {
     @CurrentUser() user: User,
     @Body() body: { language: string },
   ) {
-    await this.assertMediaAccessible(id, user);
+    await this.assertSubtitleAccessible(id, subtitleId, user);
     return this.subtitlesService.setLanguage(subtitleId, body.language);
   }
 
@@ -607,7 +618,7 @@ export class MediaController {
     @Param('subtitleId', ParseIntPipe) subtitleId: number,
     @CurrentUser() user: User,
   ) {
-    await this.assertMediaAccessible(id, user);
+    await this.assertSubtitleAccessible(id, subtitleId, user);
     return this.subtitlesService.validateSubtitle(subtitleId);
   }
 
@@ -664,7 +675,7 @@ export class MediaController {
     @Param('subtitleId', ParseIntPipe) subtitleId: number,
     @CurrentUser() user: User,
   ) {
-    await this.assertMediaAccessible(id, user);
+    await this.assertSubtitleAccessible(id, subtitleId, user);
     return this.subtitlesService.deleteSubtitle(subtitleId);
   }
 
@@ -682,7 +693,7 @@ export class MediaController {
       goldenSectionSearch?: boolean;
     },
   ) {
-    await this.assertMediaAccessible(id, user);
+    await this.assertSubtitleAccessible(id, subtitleId, user);
     return this.subtitleSync.enqueueSyncSubtitle(subtitleId, body ?? {});
   }
 
@@ -717,7 +728,7 @@ export class MediaController {
     @CurrentUser() user: User,
     @Body() body: { action: string; params?: Record<string, unknown> },
   ) {
-    await this.assertMediaAccessible(id, user);
+    await this.assertSubtitleAccessible(id, subtitleId, user);
     return this.subtitlesService.applyPostProcessing(
       subtitleId,
       body.action,
@@ -733,7 +744,7 @@ export class MediaController {
     @CurrentUser() user: User,
     @Body() body: { searchResult: any },
   ) {
-    await this.assertMediaAccessible(id, user);
+    await this.assertSubtitleAccessible(id, subtitleId, user);
     return this.subtitlesService.upgradeSubtitle(subtitleId, body.searchResult);
   }
 

--- a/backend/src/modules/subtitles/providers/gestdown.provider.ts
+++ b/backend/src/modules/subtitles/providers/gestdown.provider.ts
@@ -7,6 +7,7 @@ import {
   testResultFromResponse,
 } from './subtitle-provider.interface';
 import { isRateLimited, rateLimitedFetch } from './rate-limiter';
+import { providerUrl } from './provider-url';
 
 const PROVIDER_TYPE = 'gestdown';
 const BASE_URL = 'https://api.gestdown.info';
@@ -115,7 +116,7 @@ export class GestdownProvider implements SubtitleProviderInterface {
     if (isRateLimited(PROVIDER_TYPE)) {
       throw new Error('Gestdown is rate-limited, try again later');
     }
-    const url = `${BASE_URL}${result.providerFileId}`;
+    const url = providerUrl(BASE_URL, result.providerFileId);
     const res = await rateLimitedFetch(
       PROVIDER_TYPE,
       url,

--- a/backend/src/modules/subtitles/providers/provider-url.spec.ts
+++ b/backend/src/modules/subtitles/providers/provider-url.spec.ts
@@ -1,0 +1,27 @@
+import { providerUrl } from './provider-url';
+
+const BASE = 'https://dl.subdl.com';
+
+describe('providerUrl', () => {
+  it('VERDICT: a userinfo-style path can no longer move the request off-host', () => {
+    // `${BASE}${id}` produced https://dl.subdl.com@attacker.tld/x — the host
+    // was attacker.tld. Resolving keeps it a path on the provider instead.
+    const url = providerUrl(BASE, '@attacker.tld/x');
+
+    expect(new URL(url).origin).toBe(BASE);
+  });
+
+  it('refuses an absolute URL pointing elsewhere', () => {
+    expect(() => providerUrl(BASE, 'https://attacker.tld/x')).toThrow(/attacker\.tld/);
+    expect(() => providerUrl(BASE, '//attacker.tld/x')).toThrow(/attacker\.tld/);
+    expect(() => providerUrl(BASE, 'file:///etc/passwd')).toThrow();
+  });
+
+  it('keeps an absolute URL on the provider itself', () => {
+    expect(providerUrl(BASE, `${BASE}/a/b.zip`)).toBe(`${BASE}/a/b.zip`);
+  });
+
+  it('resolves the ordinary relative path unchanged', () => {
+    expect(providerUrl(BASE, '/subtitle/123.zip')).toBe(`${BASE}/subtitle/123.zip`);
+  });
+});

--- a/backend/src/modules/subtitles/providers/provider-url.ts
+++ b/backend/src/modules/subtitles/providers/provider-url.ts
@@ -1,0 +1,22 @@
+/**
+ * Resolve a provider download target against that provider's own base.
+ *
+ * `providerFileId` travels from the search response through the API client and
+ * back, so it is caller-controlled. Building a URL by concatenation lets a
+ * value like `@attacker.tld/x` move the request to another host, whose body is
+ * then written into the media library as a sidecar. `new URL(rel, base)`
+ * resolves instead of concatenating, and the origin check rejects anything
+ * absolute that points elsewhere.
+ */
+export function providerUrl(base: string, candidate: string): string {
+  let resolved: URL;
+  try {
+    resolved = new URL(candidate, base);
+  } catch {
+    throw new Error(`Invalid download path: ${candidate}`);
+  }
+  if (resolved.origin !== new URL(base).origin) {
+    throw new Error(`Refusing to download from ${resolved.origin}`);
+  }
+  return resolved.toString();
+}

--- a/backend/src/modules/subtitles/providers/subdl.provider.ts
+++ b/backend/src/modules/subtitles/providers/subdl.provider.ts
@@ -8,6 +8,7 @@ import {
 } from './subtitle-provider.interface';
 import { isRateLimited, rateLimitedFetch } from './rate-limiter';
 import { extractSubtitleFromZip } from './zip-utils';
+import { providerUrl } from './provider-url';
 
 const PROVIDER_TYPE = 'subdl';
 
@@ -91,8 +92,7 @@ export class SubdlProvider implements SubtitleProviderInterface {
       throw new Error('Subdl is rate-limited, try again later');
     }
 
-    // providerFileId contains the relative URL path from search results
-    const dlUrl = `https://dl.subdl.com${result.providerFileId}`;
+    const dlUrl = providerUrl('https://dl.subdl.com', result.providerFileId);
     const res = await rateLimitedFetch(PROVIDER_TYPE, dlUrl, {
       headers: { 'User-Agent': 'Fliks/1.0' },
     });

--- a/backend/src/modules/subtitles/providers/subsynchro.provider.ts
+++ b/backend/src/modules/subtitles/providers/subsynchro.provider.ts
@@ -7,6 +7,7 @@ import {
   testResultFromResponse,
 } from './subtitle-provider.interface';
 import { isRateLimited, rateLimitedFetch } from './rate-limiter';
+import { providerUrl } from './provider-url';
 
 const PROVIDER_TYPE = 'subsynchro';
 const BASE_URL = 'https://www.subsynchro.com';
@@ -95,11 +96,7 @@ export class SubsynchroProvider implements SubtitleProviderInterface {
    * The download may return a ZIP archive — if so, extract the first subtitle file.
    */
   async download(result: SubtitleSearchResult): Promise<Buffer> {
-    const downloadUrl = result.providerFileId;
-    // Resolve relative URLs
-    const url = downloadUrl.startsWith('http')
-      ? downloadUrl
-      : `${BASE_URL}${downloadUrl.startsWith('/') ? '' : '/'}${downloadUrl}`;
+    const url = providerUrl(BASE_URL, result.providerFileId);
 
     if (isRateLimited(PROVIDER_TYPE)) {
       throw new Error('Subsynchro is rate-limited, try again later');

--- a/backend/src/modules/subtitles/providers/supersubtitles.provider.ts
+++ b/backend/src/modules/subtitles/providers/supersubtitles.provider.ts
@@ -69,7 +69,7 @@ export class SupersubtitlesProvider implements SubtitleProviderInterface {
     if (isRateLimited(PROVIDER_TYPE)) {
       throw new Error('Supersubtitles is rate-limited, try again later');
     }
-    const url = `${BASE_URL}/index.php?action=letolt&felirat=${result.providerFileId}`;
+    const url = `${BASE_URL}/index.php?action=letolt&felirat=${encodeURIComponent(result.providerFileId)}`;
     const res = await rateLimitedFetch(PROVIDER_TYPE, url, {
       headers: this.headers,
     });

--- a/backend/src/modules/subtitles/providers/yify.provider.ts
+++ b/backend/src/modules/subtitles/providers/yify.provider.ts
@@ -8,6 +8,7 @@ import {
 } from './subtitle-provider.interface';
 import { extractSubtitleFromZip } from './zip-utils';
 import { isRateLimited, rateLimitedFetch } from './rate-limiter';
+import { providerUrl } from './provider-url';
 
 const PROVIDER_TYPE = 'yify';
 const BASE_URL = 'https://yifysubtitles.ch';
@@ -83,7 +84,7 @@ export class YifyProvider implements SubtitleProviderInterface {
       throw new Error('YIFY is rate-limited, try again later');
     }
     // providerFileId stores the subtitle page path (e.g. /subtitles/...)
-    const pageUrl = `${BASE_URL}${result.providerFileId}`;
+    const pageUrl = providerUrl(BASE_URL, result.providerFileId);
     const pageRes = await rateLimitedFetch(PROVIDER_TYPE, pageUrl, {
       headers: { 'User-Agent': USER_AGENT },
     });
@@ -97,7 +98,8 @@ export class YifyProvider implements SubtitleProviderInterface {
     if (!dlMatch)
       throw new Error('YIFY: download link not found on subtitle page');
 
-    const dlUrl = `${BASE_URL}${dlMatch[1]}`;
+    // scraped out of the page body, so it gets the same treatment
+    const dlUrl = providerUrl(BASE_URL, dlMatch[1]);
     const dlRes = await rateLimitedFetch(PROVIDER_TYPE, dlUrl, {
       headers: { 'User-Agent': USER_AGENT },
     });

--- a/backend/src/modules/subtitles/subtitle-lang-suffix.spec.ts
+++ b/backend/src/modules/subtitles/subtitle-lang-suffix.spec.ts
@@ -1,0 +1,19 @@
+import { assertSafeLangSuffix } from './subtitle-path.util';
+
+/**
+ * The suffix is built from a provider- or client-supplied language, and
+ * `normalizeLanguageCode` returns an unrecognised tag unchanged.
+ */
+describe('assertSafeLangSuffix', () => {
+  it('VERDICT: refuses a language that would escape the media folder', () => {
+    expect(() => assertSafeLangSuffix('x/../../../../tmp/pwn')).toThrow();
+    expect(() => assertSafeLangSuffix('../../etc/cron.d/x')).toThrow();
+    expect(() => assertSafeLangSuffix('fr/../..')).toThrow();
+  });
+
+  it('accepts every suffix the writers actually build', () => {
+    for (const ok of ['fr', 'en', 'und', 'fr.forced', 'en.hi']) {
+      expect(() => assertSafeLangSuffix(ok)).not.toThrow();
+    }
+  });
+});

--- a/backend/src/modules/subtitles/subtitle-ocr.service.ts
+++ b/backend/src/modules/subtitles/subtitle-ocr.service.ts
@@ -18,6 +18,7 @@ import { SettingsService } from '../settings/settings.service';
 import { EventsService } from '../scheduler/events.service';
 import { cleanSubtitle } from './subtitle-cleaner';
 import { relativePathUnderMediaRoot } from '../../common/utils/media-path.util';
+import { assertSafeLangSuffix } from './subtitle-path.util';
 import {
   isImageBasedSubtitleCodec,
   isOcrSupportedSubtitleCodec,
@@ -235,6 +236,7 @@ export class SubtitleOcrService implements OnModuleInit {
         : hearingImpaired
           ? `${source.language}.hi`
           : source.language;
+      assertSafeLangSuffix(langSuffix);
       let outPath = path.join(parsed.dir, `${parsed.name}.${langSuffix}.ocr.srt`);
       let counter = 0;
       while (await this.exists(outPath)) {

--- a/backend/src/modules/subtitles/subtitle-path.util.ts
+++ b/backend/src/modules/subtitles/subtitle-path.util.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common';
 import * as path from 'path';
 
 /**
@@ -23,4 +24,16 @@ export function resolveSubtitleAbsolutePath(
   }
 
   return absolute;
+}
+
+/**
+ * Guard the language part of a generated sidecar name. It is built from a
+ * provider-supplied or client-supplied language, and `normalizeLanguageCode`
+ * passes an unknown tag through unchanged, so a value like
+ * `x/../../../../tmp/pwn` would otherwise become a path.
+ */
+export function assertSafeLangSuffix(suffix: string): void {
+  if (!/^[a-z]{2,3}(\.(forced|hi))?$/.test(suffix)) {
+    throw new BadRequestException(`Invalid subtitle language "${suffix}"`);
+  }
 }

--- a/backend/src/modules/subtitles/subtitle-translation.service.ts
+++ b/backend/src/modules/subtitles/subtitle-translation.service.ts
@@ -26,6 +26,7 @@ import { TranslationProvider } from './entities/translation-provider.entity';
 import { parseSrt, serializeSrt } from './srt.util';
 import { cleanSubtitle } from './subtitle-cleaner';
 import { relativePathUnderMediaRoot } from '../../common/utils/media-path.util';
+import { assertSafeLangSuffix } from './subtitle-path.util';
 import { resolveSubtitleAbsolutePath } from './subtitle-path.util';
 import { isImageBasedSubtitleCodec } from '../../common/constants/subtitle-codecs';
 import { SubtitleProviderType, SubtitleStatus } from '../../common/enums';
@@ -257,6 +258,7 @@ export class SubtitleTranslationService {
         : hearingImpaired
           ? `${target}.hi`
           : target;
+      assertSafeLangSuffix(langSuffix);
       let outPath = path.join(parsed.dir, `${parsed.name}.${langSuffix}.srt`);
       let counter = 0;
       while (await this.exists(outPath)) {

--- a/backend/src/modules/subtitles/subtitles.service.ts
+++ b/backend/src/modules/subtitles/subtitles.service.ts
@@ -32,6 +32,7 @@ import * as postProcess from './subtitle-post-processor';
 import { SettingsService } from '../settings/settings.service';
 import { resolveSubtitleAbsolutePath } from './subtitle-path.util';
 import { relativePathUnderMediaRoot } from '../../common/utils/media-path.util';
+import { assertSafeLangSuffix } from './subtitle-path.util';
 import {
   APP_LANGUAGES,
   ISO_639_2_TO_1,
@@ -232,26 +233,9 @@ export class SubtitlesService {
     ext: string,
     buffer: Buffer,
   ): Promise<string> {
-    const parsed = path.parse(absolutePath);
-    let subtitlePath = path.join(parsed.dir, `${parsed.name}.${langSuffix}${ext}`);
-
-    let counter = 0;
-    while (
-      await fs.access(subtitlePath).then(
-        () => true,
-        () => false,
-      )
-    ) {
-      counter++;
-      subtitlePath = path.join(
-        parsed.dir,
-        `${parsed.name}.${langSuffix}-${counter}${ext}`,
-      );
-    }
-
-    await fs.mkdir(parsed.dir, { recursive: true });
-    await fs.writeFile(subtitlePath, buffer);
-    this.logger.log(`Subtitle saved: ${subtitlePath}`);
+    // Resolve and validate the target BEFORE writing: checking afterwards
+    // rejects the request but the file is already on disk.
+    assertSafeLangSuffix(langSuffix);
 
     const media = await this.mediaRepo.findOne({
       where: { id: mediaId },
@@ -262,6 +246,23 @@ export class SubtitlesService {
         'Assign a root folder to this media before adding subtitles',
       );
     }
+
+    const parsed = path.parse(absolutePath);
+    const candidate = (suffix: string) =>
+      path.join(parsed.dir, `${parsed.name}.${suffix}${ext}`);
+
+    let subtitlePath = candidate(langSuffix);
+    let counter = 0;
+    while (
+      await fs.access(subtitlePath).then(
+        () => true,
+        () => false,
+      )
+    ) {
+      counter++;
+      subtitlePath = candidate(`${langSuffix}-${counter}`);
+    }
+
     const relativePath = relativePathUnderMediaRoot(media.path, subtitlePath);
     if (!relativePath) {
       this.logger.error(
@@ -271,7 +272,24 @@ export class SubtitlesService {
         'Subtitle file would be outside the media folder; check root folder configuration',
       );
     }
+
+    await fs.mkdir(parsed.dir, { recursive: true });
+    await fs.writeFile(subtitlePath, buffer);
+    this.logger.log(`Subtitle saved: ${subtitlePath}`);
     return relativePath;
+  }
+
+  /** A subtitle row is addressed as `/media/:mediaId/subtitles/:id`, but every
+   *  service method loads it by id alone — bind the two or a user with access
+   *  to one media can act on any other's subtitles. */
+  async assertBelongsToMedia(subtitleId: number, mediaId: number): Promise<void> {
+    const sub = await this.repo.findOne({
+      where: { id: subtitleId },
+      select: { id: true, mediaId: true },
+    });
+    if (!sub || sub.mediaId !== mediaId) {
+      throw new NotFoundException(`Subtitle #${subtitleId} not found`);
+    }
   }
 
   async downloadSubtitle(


### PR DESCRIPTION
Three holes on the same trust boundary, all confirmed by reading the flow: values arriving from an API client or a provider response were used to build filesystem paths, request URLs and row lookups without being checked against the thing they were meant to stay inside.

## Path traversal in the sidecar writers

`writeSidecar` called `relativePathUnderMediaRoot` **after** `fs.writeFile`, so a rejected request still left the file on disk. `POST /media/:id/subtitles/download` takes an untyped `any` body, and `normalizeLanguageCode` returns an unrecognised tag unchanged, so a `language` of `x/../../../../tmp/pwn` wrote a provider-controlled file anywhere the process could reach. `uploadSubtitle` shares the writer; the OCR and translation writers had the same write-then-check order, and the OCR endpoint takes its language straight from the request body.

All three now call `assertSafeLangSuffix` and resolve the destination before writing.

## SSRF in four provider downloads

`providerFileId` travels from the search response through the client and back untouched. Four providers built their URL by concatenation:

```
`${BASE_URL}${result.providerFileId}`   // "@attacker.tld/x" → https://dl.subdl.com@attacker.tld/x
```

The host became `attacker.tld`, and the response body was written into the media library as a sidecar. Subsynchro was looser still, accepting any absolute `http*` URL.

They now go through `providerUrl`, which resolves with `new URL(rel, base)` instead of concatenating and rejects a foreign origin. Supersubtitles encodes its query parameter.

## IDOR on `/:id/subtitles/:subtitleId/*`

`assertMediaAccessible(id)` cleared the media, then every subtitle service method loaded its row by `subtitleId` alone. A user with access to one media could act on the subtitles of any media in a library they cannot see: `deleteSubtitle` (which unlinks the file from disk), `applyPostProcessing` (which rewrites it), `setLanguage`, `validateSubtitle`, `ocrSubtitle`, `translateSubtitle`, `enqueueSyncSubtitle`, `upgradeSubtitle`.

`subtitle-stream.service.ts` already does this correctly and names the risk in a comment. The eight endpoints taking both ids now bind them through `assertSubtitleAccessible`.

## Left alone

OpenSubtitles' `body.link` is still fetched unvalidated. It comes from their API rather than from our caller, and their CDN hosts cannot be enumerated safely, so an allowlist would break legitimate downloads. Flagging rather than guessing.

## Verification

- `tsc --noEmit` clean
- **185 suites / 2031 tests** green
- New tests assert the escape is closed rather than the fix is present: `@attacker.tld/x` now stays on the provider's origin, absolute foreign URLs and `//host` and `file://` are refused, and the traversal payloads are rejected while every suffix the writers actually build still passes