### PR TITLE
perf(subtitles): bound the provider and sync I/O, index the hot lookups

### DIFF
--- a/backend/src/migrations/1784700000000-index-subtitle-files-media.ts
+++ b/backend/src/migrations/1784700000000-index-subtitle-files-media.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Postgres does not index foreign keys on its own, and every subtitle pass
+ * looks rows up by media file: the missing-search does one lookup per file and
+ * the `/subtitles/missing` NOT EXISTS does one per (file, language). On a real
+ * library that is a sequential scan of the whole table, thousands of times.
+ */
+export class IndexSubtitleFilesMedia1784700000000 implements MigrationInterface {
+  name = 'IndexSubtitleFilesMedia1784700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_subtitle_files_mediaFileId" ON "subtitle_files" ("mediaFileId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_subtitle_files_mediaId" ON "subtitle_files" ("mediaId")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_subtitle_files_mediaFileId"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_subtitle_files_mediaId"`);
+  }
+}

--- a/backend/src/modules/subtitles/providers/opensubtitles.provider.ts
+++ b/backend/src/modules/subtitles/providers/opensubtitles.provider.ts
@@ -22,11 +22,30 @@ interface OpenSubtitlesSettings {
   password: string;
 }
 
+/** The factory builds a provider per call, so an instance field meant a login
+ *  before every search and every download. Tokens last ~24h; keyed by the
+ *  credentials that obtained them. */
+const tokenCache = new Map<string, { token: string; expiresAt: number }>();
+const TOKEN_TTL_MS = 23 * 60 * 60 * 1000;
+
 export class OpenSubtitlesProvider implements SubtitleProviderInterface {
   private readonly logger = new Logger(OpenSubtitlesProvider.name);
-  private token: string | null = null;
 
   constructor(private readonly settings: OpenSubtitlesSettings) {}
+
+  private get tokenKey(): string {
+    return `${this.apiKey}:${this.settings.username}`;
+  }
+
+  private get token(): string | null {
+    const hit = tokenCache.get(this.tokenKey);
+    if (!hit) return null;
+    if (hit.expiresAt <= Date.now()) {
+      tokenCache.delete(this.tokenKey);
+      return null;
+    }
+    return hit.token;
+  }
 
   private get apiKey(): string {
     return this.settings.apiKey?.trim() || DEFAULT_API_KEY;
@@ -139,7 +158,15 @@ export class OpenSubtitlesProvider implements SubtitleProviderInterface {
       markRateLimited(PROVIDER_TYPE, null, 3600); // 1h backoff when quota 0
     }
 
-    const fileRes = await fetch(body.link);
+    // Their CDN hosts can't be enumerated safely, so no allowlist — but the
+    // scheme is ours to insist on, and the host is worth a log line.
+    const link = new URL(body.link);
+    if (link.protocol !== 'https:') {
+      throw new Error(`OpenSubtitles returned a non-https link (${link.protocol})`);
+    }
+    const fileRes = await fetch(link, {
+      signal: AbortSignal.timeout(60_000),
+    });
     if (!fileRes.ok)
       throw new Error(`Failed to fetch subtitle file: ${fileRes.status}`);
     return Buffer.from(await fileRes.arrayBuffer());
@@ -195,7 +222,10 @@ export class OpenSubtitlesProvider implements SubtitleProviderInterface {
 
     if (res.ok) {
       const body = (await res.json()) as { token: string };
-      this.token = body.token;
+      tokenCache.set(this.tokenKey, {
+        token: body.token,
+        expiresAt: Date.now() + TOKEN_TTL_MS,
+      });
       this.logger.log('OpenSubtitles: authenticated successfully');
     } else {
       const body = await res.text().catch(() => '');

--- a/backend/src/modules/subtitles/providers/rate-limiter.ts
+++ b/backend/src/modules/subtitles/providers/rate-limiter.ts
@@ -229,6 +229,9 @@ export function getAllCooldowns(): {
  *  - Returns null in any skip case (caller should treat as empty
  *    results — providers' contract is best-effort).
  */
+/** Undici defaults to 300s. A stalled provider must not hold a pass. */
+const PROVIDER_FETCH_TIMEOUT_MS = 30_000;
+
 export async function rateLimitedFetch(
   providerType: string,
   url: string,
@@ -243,7 +246,10 @@ export async function rateLimitedFetch(
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     let res: Response;
     try {
-      res = await fetch(url, init);
+      res = await fetch(url, {
+        signal: AbortSignal.timeout(PROVIDER_FETCH_TIMEOUT_MS),
+        ...init,
+      });
     } catch (err) {
       // Network error (DNS, TLS, ECONNRESET, timeout, …). Don't retry
       // here — let the breaker decide if subsequent calls should be

--- a/backend/src/modules/subtitles/subtitle-sync.service.ts
+++ b/backend/src/modules/subtitles/subtitle-sync.service.ts
@@ -21,6 +21,12 @@ import { MediaServersService } from '../media-servers/media-servers.service';
 import { resolveSubtitleAbsolutePath } from './subtitle-path.util';
 
 const execFileAsync = promisify(execFile);
+const SYNC_TOOL_TIMEOUT_MS = 900_000;
+const SYNC_TOOL_MAX_BUFFER = 1 << 24;
+const SYNC_EXEC_OPTS = {
+  timeout: SYNC_TOOL_TIMEOUT_MS,
+  maxBuffer: SYNC_TOOL_MAX_BUFFER,
+};
 const MAX_CONCURRENT = 2;
 
 export interface SyncOptions {
@@ -233,6 +239,7 @@ export class SubtitleSyncService {
       await execFileAsync(
         'ffsubsync',
         buildFfsubsyncArgs(refPath, refStreamIndex),
+        SYNC_EXEC_OPTS,
       );
       subtitle.synced = true;
       subtitle.status = SubtitleStatus.SYNCED;
@@ -256,6 +263,7 @@ export class SubtitleSyncService {
             await execFileAsync(
               'ffsubsync',
               buildFfsubsyncArgs(refPath, firstAudio.streamIndex),
+              SYNC_EXEC_OPTS,
             );
             subtitle.synced = true;
             subtitle.status = SubtitleStatus.SYNCED;
@@ -284,7 +292,7 @@ export class SubtitleSyncService {
 
       // Fallback to alass
       try {
-        await execFileAsync('alass', [refPath, subPath, subPath]);
+        await execFileAsync('alass', [refPath, subPath, subPath], SYNC_EXEC_OPTS);
         subtitle.synced = true;
         subtitle.status = SubtitleStatus.SYNCED;
       } catch (alassErr: any) {

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1685,14 +1685,15 @@
       "audio_languages": "Akzeptierte Audiosprachen",
       "audio_languages_hint": "Leer = alle Sprachen akzeptiert. Ankreuzen, um Releases nach Audiosprache zu filtern.",
       "subtitle_languages": "Untertitelsprachen",
-      "subtitle_languages_hint": "Automatisch herunterzuladende Untertitel. Kreuzen Sie Forced oder HI pro Sprache an.",
+      "subtitle_languages_hint": "Die Sprache für den vollständigen Untertitel ankreuzen, „Erzwungen“ für eine Spur mit fremdsprachigen Dialogen. Beide sind unabhängig: ein erzwungener Untertitel ersetzt nie den vollständigen.",
       "save": "Speichern",
       "cancel": "Abbrechen",
       "load_error": "Die Sprachprofile konnten nicht geladen werden.",
       "save_error": "Speichern nicht möglich.",
       "delete_error": "Löschen nicht möglich.",
       "empty": "Kein Sprachprofil.",
-      "name_required": "Der Profilname ist erforderlich."
+      "name_required": "Der Profilname ist erforderlich.",
+      "forced_label": "Erzwungen"
     },
     "custom_formats": {
       "title": "Benutzerdefinierte Formate",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1702,14 +1702,15 @@
       "audio_languages": "Accepted audio languages",
       "audio_languages_hint": "Empty = all languages accepted. Check to filter releases by audio language.",
       "subtitle_languages": "Subtitle languages",
-      "subtitle_languages_hint": "Subtitles to download automatically. Check Forced or HI per language.",
+      "subtitle_languages_hint": "Tick the language for the full subtitle, and “Forced” for a foreign-dialogue track. The two are independent: a forced subtitle never stands in for the full one.",
       "save": "Save",
       "cancel": "Cancel",
       "load_error": "Unable to load the language profiles.",
       "save_error": "Unable to save.",
       "delete_error": "Unable to delete.",
       "empty": "No language profile.",
-      "name_required": "The profile name is required."
+      "name_required": "The profile name is required.",
+      "forced_label": "Forced"
     },
     "custom_formats": {
       "title": "Custom formats",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1685,14 +1685,15 @@
       "audio_languages": "Idiomas de audio aceptados",
       "audio_languages_hint": "Vacío = todos los idiomas aceptados. Marque para filtrar las releases por idioma de audio.",
       "subtitle_languages": "Idiomas de subtítulos",
-      "subtitle_languages_hint": "Subtítulos a descargar automáticamente. Marque Forced o HI por idioma.",
+      "subtitle_languages_hint": "Marque el idioma para el subtítulo completo y «Forzado» para una pista de diálogos extranjeros. Son independientes: un subtítulo forzado nunca sustituye al completo.",
       "save": "Guardar",
       "cancel": "Cancelar",
       "load_error": "No se pueden cargar los perfiles de idioma.",
       "save_error": "No se puede guardar.",
       "delete_error": "No se puede eliminar.",
       "empty": "No hay perfiles de idioma.",
-      "name_required": "El nombre del perfil es obligatorio."
+      "name_required": "El nombre del perfil es obligatorio.",
+      "forced_label": "Forzado"
     },
     "custom_formats": {
       "title": "Formatos personalizados",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1702,14 +1702,15 @@
       "audio_languages": "Langues audio acceptées",
       "audio_languages_hint": "Vide = toutes les langues acceptées. Cochez pour filtrer les releases par langue audio.",
       "subtitle_languages": "Langues de sous-titres",
-      "subtitle_languages_hint": "Sous-titres à télécharger automatiquement. Cochez Forced ou HI par langue.",
+      "subtitle_languages_hint": "Cochez la langue pour le sous-titre complet, et « Forcé » pour une piste de dialogues étrangers. Les deux sont indépendants : un sous-titre forcé ne remplace jamais le complet.",
       "save": "Enregistrer",
       "cancel": "Annuler",
       "load_error": "Impossible de charger les profils de langue.",
       "save_error": "Enregistrement impossible.",
       "delete_error": "Suppression impossible.",
       "empty": "Aucun profil de langue.",
-      "name_required": "Le nom du profil est obligatoire."
+      "name_required": "Le nom du profil est obligatoire.",
+      "forced_label": "Forcé"
     },
     "custom_formats": {
       "title": "Formats personnalisés",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1685,14 +1685,15 @@
       "audio_languages": "Lingue audio accettate",
       "audio_languages_hint": "Vuoto = tutte le lingue accettate. Seleziona per filtrare le release per lingua audio.",
       "subtitle_languages": "Lingue dei sottotitoli",
-      "subtitle_languages_hint": "Sottotitoli da scaricare automaticamente. Seleziona Forced o HI per lingua.",
+      "subtitle_languages_hint": "Spunta la lingua per il sottotitolo completo e «Forzato» per una traccia di dialoghi stranieri. Sono indipendenti: un sottotitolo forzato non sostituisce mai quello completo.",
       "save": "Salva",
       "cancel": "Annulla",
       "load_error": "Impossibile caricare i profili di lingua.",
       "save_error": "Salvataggio non riuscito.",
       "delete_error": "Eliminazione non riuscita.",
       "empty": "Nessun profilo di lingua.",
-      "name_required": "Il nome del profilo è obbligatorio."
+      "name_required": "Il nome del profilo è obbligatorio.",
+      "forced_label": "Forzato"
     },
     "custom_formats": {
       "title": "Formati personalizzati",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1685,14 +1685,15 @@
       "audio_languages": "Idiomas de áudio aceites",
       "audio_languages_hint": "Vazio = todos os idiomas aceites. Marque para filtrar as releases por idioma de áudio.",
       "subtitle_languages": "Idiomas de legendas",
-      "subtitle_languages_hint": "Legendas a transferir automaticamente. Marque Forced ou HI por idioma.",
+      "subtitle_languages_hint": "Marque o idioma para a legenda completa e “Forçado” para uma faixa de diálogos estrangeiros. São independentes: uma legenda forçada nunca substitui a completa.",
       "save": "Guardar",
       "cancel": "Cancelar",
       "load_error": "Não foi possível carregar os perfis de idioma.",
       "save_error": "Não foi possível guardar.",
       "delete_error": "Não foi possível eliminar.",
       "empty": "Nenhum perfil de idioma.",
-      "name_required": "O nome do perfil é obrigatório."
+      "name_required": "O nome do perfil é obrigatório.",
+      "forced_label": "Forçado"
     },
     "custom_formats": {
       "title": "Formatos personalizados",

--- a/client/src/app/features/settings/language-profiles/language-profiles.html
+++ b/client/src/app/features/settings/language-profiles/language-profiles.html
@@ -133,16 +133,16 @@
                 />
                 <span class="text-sm flex-1">{{ l.name }}</span>
                 <span class="text-sm text-base-content/50 font-mono mr-2">{{ l.isoCode }}</span>
+                <label class="flex items-center gap-1 text-xs">
+                  <input
+                    type="checkbox"
+                    class="checkbox checkbox-xs"
+                    [checked]="isSubForced(l.isoCode)"
+                    (change)="toggleSubForced(l.isoCode, $event)"
+                  />
+                  {{ 'settings.language_profiles.forced_label' | translate }}
+                </label>
                 @if (isSubtitleSelected(l.isoCode)) {
-                  <label class="flex items-center gap-1 text-xs">
-                    <input
-                      type="checkbox"
-                      class="checkbox checkbox-xs"
-                      [checked]="isSubForced(l.isoCode)"
-                      (change)="toggleSubForced(l.isoCode, $event)"
-                    />
-                    Forced
-                  </label>
                   <label class="flex items-center gap-1 text-xs">
                     <span>{{ 'settings.language_profiles.hi_label' | translate }}</span>
                     <select

--- a/client/src/app/features/settings/language-profiles/language-profiles.ts
+++ b/client/src/app/features/settings/language-profiles/language-profiles.ts
@@ -36,6 +36,10 @@ interface SubEntry {
 
 const HI_MODES: HearingImpairedMode[] = ['prefer', 'avoid', 'require', 'forbid'];
 
+/** A language is requested twice at most: once full, once forced. */
+const subKey = (isoCode: string, forced: boolean) =>
+  `${isoCode}|${forced ? 'forced' : 'full'}`;
+
 @Component({
   selector: 'app-language-profiles',
   imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslateModule],
@@ -107,7 +111,7 @@ export class LanguageProfilesComponent implements OnInit {
     this.audioIsoCodes.set(new Set(p.audioLanguages.map((l) => l.isoCode)));
     const subs = new Map<string, SubEntry>();
     for (const s of p.subtitleLanguages) {
-      subs.set(s.isoCode, {
+      subs.set(subKey(s.isoCode, s.forced), {
         forced: s.forced,
         hi: s.hi,
         hearingImpaired: s.hearingImpaired ?? (s.hi ? 'prefer' : 'avoid'),
@@ -134,42 +138,52 @@ export class LanguageProfilesComponent implements OnInit {
   }
 
   isSubtitleSelected(isoCode: string): boolean {
-    return this.subtitleEntries().has(isoCode);
+    return this.subtitleEntries().has(subKey(isoCode, false));
   }
 
   toggleSubtitle(isoCode: string, ev: Event) {
-    const checked = (ev.target as HTMLInputElement).checked;
-    const next = new Map(this.subtitleEntries());
-    if (checked) next.set(isoCode, { forced: false, hi: false, hearingImpaired: 'avoid' });
-    else next.delete(isoCode);
-    this.subtitleEntries.set(next);
+    this.setSubEntry(isoCode, false, (ev.target as HTMLInputElement).checked);
   }
 
+  /** Independent of the full one: a forced track only carries foreign dialogue
+   *  and never stands in for the complete subtitle. */
   isSubForced(isoCode: string): boolean {
-    return this.subtitleEntries().get(isoCode)?.forced ?? false;
-  }
-
-  subHiMode(isoCode: string): HearingImpairedMode {
-    return this.subtitleEntries().get(isoCode)?.hearingImpaired ?? 'avoid';
+    return this.subtitleEntries().has(subKey(isoCode, true));
   }
 
   toggleSubForced(isoCode: string, ev: Event) {
-    const checked = (ev.target as HTMLInputElement).checked;
+    this.setSubEntry(isoCode, true, (ev.target as HTMLInputElement).checked);
+  }
+
+  private setSubEntry(isoCode: string, forced: boolean, wanted: boolean) {
     const next = new Map(this.subtitleEntries());
-    const entry = next.get(isoCode);
-    if (entry) {
-      next.set(isoCode, { ...entry, forced: checked });
-      this.subtitleEntries.set(next);
+    if (wanted) {
+      next.set(subKey(isoCode, forced), {
+        forced,
+        hi: false,
+        hearingImpaired: 'avoid',
+      });
+    } else {
+      next.delete(subKey(isoCode, forced));
     }
+    this.subtitleEntries.set(next);
+  }
+
+  subHiMode(isoCode: string): HearingImpairedMode {
+    return (
+      this.subtitleEntries().get(subKey(isoCode, false))?.hearingImpaired ??
+      'avoid'
+    );
   }
 
   /** Set the HI preference; keep the compact `hi` boolean in sync too, since
    *  `resolveHearingImpairedMode` reads it as the stored form. */
   setSubHiMode(isoCode: string, mode: HearingImpairedMode) {
     const next = new Map(this.subtitleEntries());
-    const entry = next.get(isoCode);
+    const key = subKey(isoCode, false);
+    const entry = next.get(key);
     if (entry) {
-      next.set(isoCode, {
+      next.set(key, {
         ...entry,
         hearingImpaired: mode,
         hi: mode === 'prefer' || mode === 'require',
@@ -186,8 +200,8 @@ export class LanguageProfilesComponent implements OnInit {
       if (def) audioLanguages.push({ isoCode: def.isoCode, name: def.name });
     }
     const subtitleLanguages: SubtitleLanguageItem[] = [];
-    for (const [iso, opts] of this.subtitleEntries()) {
-      const def = defs.find((d) => d.isoCode === iso);
+    for (const [key, opts] of this.subtitleEntries()) {
+      const def = defs.find((d) => d.isoCode === key.split('|')[0]);
       if (def)
         subtitleLanguages.push({
           isoCode: def.isoCode,


### PR DESCRIPTION
Five items from the review that followed #1238. None changes what the feature does.

## Unbounded I/O

`rateLimitedFetch` passed no `signal`, so undici's **300s** default applied to a provider that accepts the connection and never answers — sequentially, once per file of a pass. Now 30s.

`ffsubsync` and `alass` ran with neither `timeout` nor `maxBuffer`. A hung run held one of the two sync slots permanently **and** blocked the scheduled pass, which `await`s the sync inline. Separately, ffsubsync writes a tqdm progress bar to stderr; past the 1 MiB default Node kills the child with a generic error, which reads as a crash and falls through to alass for no reason. Now 15min / 16 MiB.

## Missing indexes

Postgres does not index foreign keys. Every pass looks subtitle rows up by media file — one query per file for the missing search, one per (file, language) for the `NOT EXISTS` behind the missing list — so both were sequential scans of the whole table.

Checked on the dev database, inside a rolled-back transaction:

```
Index Scan using "IDX_subtitle_files_mediaFileId" on subtitle_files
  Index Cond: ("mediaFileId" = 45)
```

## One login per request

The OpenSubtitles token was an instance field, and the factory builds a provider **per call** — so a `POST /login` preceded every search and every download, on their most rate-limited endpoint. A pass over 500 files × 2 languages meant ~1000 logins. Moved to a module-level cache keyed by the credentials that obtained it, 23h TTL.

Their CDN `link` still can't be allowlisted (the hosts aren't enumerable and guessing would break real downloads), but it now has to be `https` and carries a timeout.

## A profile can finally ask for both

Ticking "Forced" on a language **replaced** it rather than adding to it: the editor stored one entry per iso code. Since #1238 made `forced` an exact match, that quietly emptied a library's coverage for that language — every file went to "missing" and the scheduler started fetching forced tracks for all of them.

Entries are now keyed by language **and** `forced`, so the two checkboxes are independent and either can stand alone. The label was hardcoded in English; it and the section hint are translated in the six locales, and the hint states that a forced subtitle never stands in for the full one.

## Verification

- `tsc --noEmit` clean, backend and client
- **185 suites / 2031 tests** green
- `ng build --configuration production` green
- Migration SQL and its query plan replayed against the dev database, rolled back

## Still open from that review

Two items are a new entity and a new screen rather than hardening, so they are not in here: search failures below the score threshold are still entirely silent (no row, no event — it needs a `lastSearchedAt` / `bestScoreSeen` per (file, language) to show a *why* in the missing list), and the subtitle blacklist has a working API with no client page, so an entry can be created but never seen or undone.