### PR TITLE
refactor(paths): move extracted subtitles and sprites into a cache directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,15 @@ docker volume rm fliks_images   # only once the boot log stops naming the old pa
 With a bind mount instead of a named volume, `mv` the host directory and
 update the left side of the mapping.
 
+### Cache directory
+
+`FLIKS_CACHE_DIR` sets where regenerable content lives: extracted subtitles
+and seek-preview sprites. It defaults to `cache/` inside the data directory,
+so no action is needed unless you want it elsewhere, for example to exclude it
+from backups. Everything under it is safe to delete, it is rebuilt on demand.
+On first boot after upgrading, the old `subs/` and `thumbnails*/` folders that
+used to sit directly in the data directory are removed automatically.
+
 ### Update checks
 
 Fliks asks the **public GitHub releases API** whether a newer version

--- a/backend/src/common/constants/paths.spec.ts
+++ b/backend/src/common/constants/paths.spec.ts
@@ -94,3 +94,36 @@ describe('getDataDir', () => {
     expect(load({ FLIKS_DATA_DIR: dir, FLIKS_IMAGES_DIR: path.join(cwd, 'loses') })).toBe(dir);
   });
 });
+
+describe('getCacheDir', () => {
+  const OLD_ENV = process.env;
+  let cwd: string;
+  let cwdSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetModules();
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'fliks-cachedir-'));
+    cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(cwd);
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    cwdSpy.mockRestore();
+    fs.rmSync(cwd, { recursive: true, force: true });
+    jest.resetModules();
+  });
+
+  function load(env: Record<string, string | undefined> = {}): string {
+    process.env = { ...OLD_ENV, ...env };
+    return (require('./paths') as typeof import('./paths')).getCacheDir();
+  }
+
+  it('defaults to cache/ under the data directory', () => {
+    expect(load()).toBe(path.join(cwd, 'data', 'cache'));
+  });
+
+  it('honours FLIKS_CACHE_DIR', () => {
+    const dir = path.join(cwd, 'elsewhere');
+    expect(load({ FLIKS_CACHE_DIR: dir })).toBe(dir);
+  });
+});

--- a/backend/src/common/constants/paths.ts
+++ b/backend/src/common/constants/paths.ts
@@ -43,20 +43,40 @@ function intendedDataDir(): string {
 }
 
 /**
- * Artwork, seek-preview sprites, the extracted-subtitle cache and uploaded user
- * avatars. `FLIKS_DATA_DIR` overrides; falls back to a temp dir (wiped on
- * restart) if it isn't writable at the container's uid. Probed once, on first
- * call. Not a cache: the avatars in here cannot be re-fetched.
+ * Artwork and uploaded user avatars. `FLIKS_DATA_DIR` overrides; falls back to
+ * a temp dir (wiped on restart) if it isn't writable at the container's uid.
+ * Probed once, on first call. Not a cache: the avatars in here cannot be
+ * re-fetched.
  */
 export function getDataDir(): string {
   if (cachedDataDir) return cachedDataDir;
   cachedDataDir = resolveWritableDir(
     [intendedDataDir(), path.join(os.tmpdir(), 'fliks-data')],
-    'Cannot write to the data directory — artwork, sprites and uploaded ' +
+    'Cannot write to the data directory — artwork and uploaded ' +
       'avatars will not survive a restart. Set FLIKS_DATA_DIR, or mount ' +
       '/app/data writable for this container user.',
   );
   return cachedDataDir;
+}
+
+let cachedCacheDir: string | null = null;
+
+/**
+ * Extracted-subtitle VTTs and seek-preview sprites. Everything here is
+ * regenerable and safe to delete. `FLIKS_CACHE_DIR` overrides; otherwise
+ * `<dataDir>/cache`. Probed once, on first call.
+ */
+export function getCacheDir(): string {
+  if (cachedCacheDir) return cachedCacheDir;
+  const override = process.env.FLIKS_CACHE_DIR?.trim();
+  const preferred = override || path.join(getDataDir(), 'cache');
+  cachedCacheDir = resolveWritableDir(
+    [preferred, path.join(os.tmpdir(), 'fliks-cache')],
+    'Cannot write to the cache directory, extracted subtitles and ' +
+      'seek-preview sprites will be regenerated on every restart. Set ' +
+      'FLIKS_CACHE_DIR to a writable path.',
+  );
+  return cachedCacheDir;
 }
 
 let cachedPluginsRuntimeDir: string | null = null;

--- a/backend/src/modules/streaming/subtitle-cache-path.spec.ts
+++ b/backend/src/modules/streaming/subtitle-cache-path.spec.ts
@@ -36,10 +36,10 @@ describe('subtitle cache path', () => {
     ) as unknown as Svc;
   }
 
-  it('resolves under the images volume, not the media folder', () => {
+  it('resolves under the cache directory', () => {
     const svc = loadSvc();
     expect(svc.cachePathFor(7, 2)).toBe(
-      path.join(dir, 'subs', '7', 'emb-2.vtt'),
+      path.join(dir, 'cache', 'subs', '7', 'emb-2.vtt'),
     );
   });
 

--- a/backend/src/modules/streaming/subtitle-stream.service.ts
+++ b/backend/src/modules/streaming/subtitle-stream.service.ts
@@ -3,6 +3,7 @@ import {
   Logger,
   BadRequestException,
   NotFoundException,
+  OnModuleInit,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -28,7 +29,7 @@ import { resolveSubtitleAbsolutePath } from '../subtitles/subtitle-path.util';
 import { normalizeLanguageCode } from '../../common/constants/app-languages';
 import type { SubtitleRenditionMeta } from './transcoding/types';
 import { withFfmpegSlot } from '../../common/utils/ffmpeg-slots';
-import { getDataDir } from '../../common/constants/paths';
+import { getCacheDir, getDataDir } from '../../common/constants/paths';
 import {
   formatMediaProgressSubject,
   type MediaProgressSubject,
@@ -36,8 +37,8 @@ import {
 
 const execFileAsync = promisify(execFile);
 
-/** getDataDir() probes the filesystem on its first call — keep this lazy. */
-const subsDir = () => path.join(getDataDir(), 'subs');
+/** getCacheDir() probes the filesystem on its first call, keep this lazy. */
+const subsDir = () => path.join(getCacheDir(), 'subs');
 
 /**
  * Global cap on concurrent warmup extractions — a full library refresh can
@@ -78,7 +79,7 @@ interface WarmupBatch {
 }
 
 @Injectable()
-export class SubtitleStreamService {
+export class SubtitleStreamService implements OnModuleInit {
   private readonly log = new Logger(SubtitleStreamService.name);
   private readonly warmupQueue: WarmupTask[] = [];
   private warmupRunning = 0;
@@ -107,6 +108,15 @@ export class SubtitleStreamService {
     private readonly streamingSettings: StreamingSettingsCache,
     private readonly activityRegistry: ActivityRegistryService,
   ) {}
+
+  /** Subs used to sit directly in the data dir, next to the avatars. */
+  async onModuleInit(): Promise<void> {
+    if (getCacheDir() === getDataDir()) return;
+    const legacyDir = path.join(getDataDir(), 'subs');
+    await fs.rm(legacyDir, { recursive: true, force: true }).catch((err) => {
+      this.log.warn(`Failed to remove legacy subs dir "${legacyDir}": ${err}`);
+    });
+  }
 
   /** ACL is checked on the subtitle's OWN media, so a foreign id can't be read
    *  via another mediaFileId (IDOR); realpath blocks symlink escapes. */
@@ -640,8 +650,8 @@ export class SubtitleStreamService {
   }
 
   /**
-   * Cache path: `<imagesDir>/subs/<mediaFileId>/emb-<streamIndex>.vtt`. The
-   * managed images volume (not the library mount) survives library moves and
+   * Cache path: `<cacheDir>/subs/<mediaFileId>/emb-<streamIndex>.vtt`. The
+   * managed cache directory (not the library mount) survives library moves and
    * still works when the library is mounted read-only.
    */
   private cacheDirFor(mediaFileId: number): string {

--- a/backend/src/modules/streaming/thumbnail.service.ts
+++ b/backend/src/modules/streaming/thumbnail.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { execFile, spawn, type ChildProcess } from 'child_process';
@@ -6,7 +6,7 @@ import { promisify } from 'util';
 import { existsSync } from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
-import { getDataDir } from '../../common/constants/paths';
+import { getCacheDir, getDataDir } from '../../common/constants/paths';
 import { EventsService } from '../scheduler/events.service';
 import { ActivityRegistryService } from '../scheduler/activity-registry.service';
 import { Command } from '../scheduler/entities/command.entity';
@@ -42,8 +42,8 @@ export interface SpriteMetadata {
   count: number;
 }
 
-const baseDir = () => path.join(getDataDir(), 'thumbnails');
-const framesTmpDir = () => path.join(getDataDir(), 'thumbnails-tmp');
+const baseDir = () => path.join(getCacheDir(), 'thumbnails');
+const framesTmpDir = () => path.join(getCacheDir(), 'thumbnails-tmp');
 
 const COLUMNS = 10;
 const THUMB_WIDTH = 240;
@@ -62,7 +62,7 @@ interface QueueItem {
 }
 
 @Injectable()
-export class ThumbnailService {
+export class ThumbnailService implements OnModuleInit {
   private readonly log = new Logger(ThumbnailService.name);
   private readonly generating = new Map<
     number,
@@ -81,6 +81,17 @@ export class ThumbnailService {
     this.log.log(
       `Thumbnail extraction backends: ${describeBackends()} (FFMPEG_SLOTS=${FFMPEG_SLOTS}, SPRITE_CONCURRENCY=${SPRITE_CONCURRENCY})`,
     );
+  }
+
+  /** Sprites used to sit directly in the data dir, next to the avatars. */
+  async onModuleInit(): Promise<void> {
+    if (getCacheDir() === getDataDir()) return;
+    for (const name of ['thumbnails', 'thumbnails-tmp']) {
+      const legacyDir = path.join(getDataDir(), name);
+      await fsp.rm(legacyDir, { recursive: true, force: true }).catch((err) => {
+        this.log.warn(`Failed to remove legacy dir "${legacyDir}": ${err}`);
+      });
+    }
   }
 
   /** Pick the frame extractor, forcing the CPU path while a live transcode is

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -49,6 +49,10 @@ services:
       # Without this the segment cache lands in /tmp, which is tmpfs on many
       # hosts — and its LRU cap defaults to 20 GB.
       FLIKS_TRANSCODE_DIR: /app/transcode
+      # Extracted subtitles and seek-preview sprites. Regenerable, safe to
+      # delete. Defaults to cache/ inside /app/data; point it elsewhere to keep
+      # it out of your data backups.
+      # FLIKS_CACHE_DIR: /app/data/cache
       # TZ: Europe/Paris
 
       # ---- Access (optional) ----
@@ -90,8 +94,8 @@ services:
       - /path/to/download/folder:/downloads
       # JWT key: lose it and everyone is logged out.
       - fliks_conf:/app/conf
-      # Artwork, seek-preview sprites, extracted subtitle cache and uploaded
-      # avatars. Not disposable: the avatars can't be re-fetched.
+      # Artwork and uploaded avatars, plus the cache/ subfolder (see
+      # FLIKS_CACHE_DIR). Not disposable: the avatars can't be re-fetched.
       - fliks_data:/app/data
       # HLS segment cache, paired with FLIKS_TRANSCODE_DIR above. Drop both to
       # leave it in /tmp.


### PR DESCRIPTION
## Why

The data directory held regenerable caches (extracted subtitle VTTs, seek-preview sprites) flat next to the one thing in it that cannot be rebuilt: uploaded avatars. A user could never wipe the caches without risking the avatars, and every backup of the volume carried gigabytes of disposable output.

## What

- `getCacheDir()` in `paths.ts`: `<data>/cache` by default, `FLIKS_CACHE_DIR` overrides, same write probe and temp fallback as the other managed dirs.
- `subs/`, `thumbnails/`, `thumbnails-tmp/` move under it.
- One-time boot cleanup in `SubtitleStreamService` and `ThumbnailService` removes the old folders from the data dir.
- README section and example compose comments for `FLIKS_CACHE_DIR`.

No new volume, no compose edit needed. Existing caches are not migrated; they regenerate on demand, same trade-off as #1230.

## Verification

- `tsc --noEmit` clean.
- `paths.spec.ts`, `subtitle-cache-path.spec.ts`, `subtitle-prewarm.spec.ts`: 22 passed.

Refs: #1132