### PR TITLE
fix(ci): import the mac signing cert into our own keychain for the desktop build

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -289,6 +289,30 @@ jobs:
           KEY_P8: ${{ secrets.APPSTORE_API_KEY_P8_BASE64 }}
         run: echo "$KEY_P8" | base64 -d > "$RUNNER_TEMP/notary-AuthKey.p8"
 
+      # macOS: import the Developer ID cert into our own keychain and hand it to
+      # electron-builder via CSC_KEYCHAIN. Its CSC_LINK path runs
+      # set-key-partition-list with the .p12 password instead of the keychain's,
+      # which macOS 26 rejects (electron-builder #10066, unreleased fix).
+      - name: Import signing certificate (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          CERT_P12_BASE64: ${{ secrets.MAC_DEVELOPER_ID_CERT_P12_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.MAC_DEVELOPER_ID_CERT_PASSWORD }}
+        run: |
+          keychain="$RUNNER_TEMP/signing.keychain-db"
+          keychain_pw="$(openssl rand -base64 32)"
+          echo "$CERT_P12_BASE64" | base64 -d > "$RUNNER_TEMP/cert.p12"
+          security create-keychain -p "$keychain_pw" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_pw" "$keychain"
+          security import "$RUNNER_TEMP/cert.p12" -k "$keychain" -P "$CERT_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_pw" "$keychain"
+          security list-keychains -d user -s "$keychain" $(security list-keychains -d user | tr -d '"')
+          rm -f "$RUNNER_TEMP/cert.p12"
+          echo "CSC_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
+
       # ── Package the installer for this OS ──
       # With the github `publish` provider configured in electron-builder.yml,
       # `--publish always` (tag builds) generates the auto-update metadata
@@ -301,13 +325,10 @@ jobs:
       - name: Build installer
         working-directory: desktop
         shell: bash
-        # macOS-only signing + notarization env. Empty strings on Linux/Windows
-        # so electron-builder doesn't try to use the mac Developer ID cert as a
-        # Windows Authenticode cert (CSC_LINK is per-platform). GH_TOKEN lets
-        # electron-builder publish to the GitHub Release on tag builds.
+        # macOS-only notarization env, empty on Linux/Windows. The signing
+        # identity comes from the CSC_KEYCHAIN exported by the import step.
+        # GH_TOKEN lets electron-builder publish to the GitHub Release on tag builds.
         env:
-          CSC_LINK: ${{ runner.os == 'macOS' && secrets.MAC_DEVELOPER_ID_CERT_P12_BASE64 || '' }}
-          CSC_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.MAC_DEVELOPER_ID_CERT_PASSWORD || '' }}
           APPLE_API_KEY: ${{ runner.os == 'macOS' && format('{0}/notary-AuthKey.p8', runner.temp) || '' }}
           APPLE_API_KEY_ID: ${{ runner.os == 'macOS' && secrets.APPSTORE_API_KEY_ID || '' }}
           APPLE_API_ISSUER: ${{ runner.os == 'macOS' && secrets.APPSTORE_API_ISSUER_ID || '' }}


### PR DESCRIPTION
## Why

Every macOS desktop build fails since the 2026-08-31 `macos-26-arm64` runner image:

```
security set-key-partition-list ... : SecKeychainUnlock: The user name or passphrase you entered is not correct.
```

electron-builder 26.15.3 passes the `.p12` import password to `set-key-partition-list -k` instead of the temporary keychain's own password (electron-userland/electron-builder#10066). Older images tolerated it on an already-unlocked keychain. The upstream fix (#10101) is merged but is not in any published 26.x release, 26.16.0 included.

## What

A macOS-only step imports the Developer ID certificate into a keychain we create, runs `set-key-partition-list` with the right password, and exports `CSC_KEYCHAIN`. `CSC_LINK` and `CSC_KEY_PASSWORD` are no longer handed to electron-builder, which only honours `CSC_KEYCHAIN` when `CSC_LINK` is empty. This is the documented CI setup and stays correct once the upstream fix ships.

## Verification

Dispatched the workflow on this branch: run 33989536721, all three jobs green, macOS job signed and notarized.