### PR TITLE
fix(subtitles): declare the subtitle_files media indexes on the entity

### DIFF
--- a/backend/src/modules/subtitles/entities/subtitle-file.entity.ts
+++ b/backend/src/modules/subtitles/entities/subtitle-file.entity.ts
@@ -1,4 +1,11 @@
-import { Entity, Column, ManyToOne, JoinColumn, RelationId } from 'typeorm';
+import {
+  Entity,
+  Column,
+  Index,
+  ManyToOne,
+  JoinColumn,
+  RelationId,
+} from 'typeorm';
 import { BaseEntity } from '../../../common/entities/base.entity';
 import { SubtitleProviderType, SubtitleStatus } from '../../../common/enums';
 import { Media } from '../../media/entities/media.entity';
@@ -8,6 +15,8 @@ import { TranslationProvider } from './translation-provider.entity';
 import { normalizeLanguageCode } from '../../../common/constants/app-languages';
 
 @Entity('subtitle_files')
+@Index('IDX_subtitle_files_mediaId', ['media'])
+@Index('IDX_subtitle_files_mediaFileId', ['mediaFile'])
 export class SubtitleFile extends BaseEntity {
   @ManyToOne(() => Media, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'mediaId' })


### PR DESCRIPTION
## Why

The DB migrations check has been red on every push to `main` since #1240. Its migration created `IDX_subtitle_files_mediaId` and `IDX_subtitle_files_mediaFileId`, but the entity never declared them, so `migration:generate` against the migrated schema emits a migration that drops both.

## What

Two class-level `@Index` decorators on `SubtitleFile`, same names as the migration, same pattern as the playlist entities.

## Verification

Replayed the CI check locally on a throwaway Postgres 17: `db:migration:run` then `migration:generate` reports "No changes in database schema were found". `tsc --noEmit` clean. The one prettier complaint on this file is on a pre-existing untouched line.