### PR TITLE
fix(desktop): leave fullscreen whenever the player is torn down

### DIFF
--- a/client/src/app/core/services/playback-engine/desktop-engine.ts
+++ b/client/src/app/core/services/playback-engine/desktop-engine.ts
@@ -84,6 +84,9 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
   async destroy(): Promise<void> {
     this.dead = true;
     this._initialized = false;
+    // The compositor window is the app window: leave fullscreen with the
+    // player, whatever route change tore it down.
+    if (this._fullscreen) await this.setFullscreen(false);
     this.unsubscribe?.();
     this.unsubscribe = null;
     this._activeTrackId = null;

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -3784,12 +3784,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
   onBack() {
     this.savePosition();
-    // Desktop compositor: leaving the player drops the native (SDL) window out
-    // of fullscreen so the rest of the app isn't stuck fullscreen. Item
-    // switches route through advance(), not onBack(), so they keep it.
-    if (this.isDesktopNative && this.engine instanceof DesktopEngine && this.engine.fullscreen) {
-      this.engine.setFullscreen(false);
-    }
     // Explicit navigation rather than history.back() — nav-inside-player
     // (e.g. next-episode) leaves multiple /watch entries on the stack, and
     // router-reuse across same routes means history.back() only rewrites


### PR DESCRIPTION
## Why

On desktop (reported on macOS), enter fullscreen in the player and leave with the mouse back button: the route goes back but the app stays fullscreen.

Only `onBack()` exited the compositor fullscreen. The mouse back button goes through browser history, so the player is destroyed via `ngOnDestroy` → `engine.destroy()` without ever leaving fullscreen. The compositor window is the app window, so the whole app is stuck.

## What

`DesktopEngine.destroy()` exits fullscreen when it is on, before stopping mpv. The explicit call in `onBack()` is removed since destroy now covers it. Item switches route through `advance()` and never destroy the engine, so they keep fullscreen as before.

## Verification

`tsc` on the client is clean. Not validated on a device: needs a macOS run of enter fullscreen → mouse back.