### PR TITLE
fix(desktop): flag a libmpv bump that renames the mac color enums

### DIFF
--- a/desktop/native/player_mac/addon.mm
+++ b/desktop/native/player_mac/addon.mm
@@ -39,6 +39,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <iterator>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -438,6 +439,45 @@ void ReconfigureColorForCurrentVideo() {
   dispatch_async(dispatch_get_main_queue(), ^{ ApplyLayerColorConfig(clsInt); });
 }
 
+// mpv documents the video-params enum values as subject to change, and the
+// vendored libmpv tracks whatever version Homebrew serves (vendor-libmpv-mac.sh
+// pins nothing). A rename degrades silently — an unrecognised gamma classifies as
+// CC_SDR_709, so HDR would play tone-mapped with no error — so check the names
+// ReconfigureColorForCurrentVideo compares against once at startup. mpv's own
+// choice lists come from the same tables that format video-params.
+void VerifyColorEnums() {
+  if (!g_state.mpv) return;
+  if (char* ver = M::get_property_string(g_state.mpv, "mpv-version")) {
+    fprintf(stderr, "[player-mac] libmpv version: %s\n", ver);
+    M::mpv_free(ver);
+  }
+  const struct {
+    const char* prop;
+    const char* expected[4];
+  } kChecks[] = {
+      {"option-info/target-trc/choices", {"pq", "hlg"}},
+      {"option-info/target-prim/choices", {"display-p3", "dci-p3", "bt.2020"}},
+  };
+  for (const auto& check : kChecks) {
+    char* raw = M::get_property_string(g_state.mpv, check.prop);
+    if (!raw) {
+      fprintf(stderr, "[player-mac] color: cannot read %s\n", check.prop);
+      continue;
+    }
+    const std::string csv = std::string(",") + raw + ",";
+    M::mpv_free(raw);
+    for (const char* const* name = check.expected; name < std::end(check.expected) && *name;
+         ++name) {
+      if (csv.find(std::string(",") + *name + ",") == std::string::npos) {
+        fprintf(stderr,
+                "[player-mac] color: libmpv no longer knows '%s' in %s — content "
+                "classification will fall back to SDR-709\n",
+                *name, check.prop);
+      }
+    }
+  }
+}
+
 // Emit the UI playback state from the cached pause + core-idle flags. core-idle
 // (mpv not rendering frames) distinguishes "buffering/loading" from "playing"
 // while NOT user-paused — it is the authoritative signal for the loading spinner
@@ -615,6 +655,7 @@ Napi::Value Start(const Napi::CallbackInfo& info) {
   // (MPV_STREAM_OPTIONS in src/shared/mpv-stream-options.ts) — one source of
   // truth shared with the Linux + Windows backends.
   if (M::initialize(g_state.mpv) < 0) fprintf(stderr, "[player-mac] mpv_initialize failed\n");
+  VerifyColorEnums();
   // time-pos is read on demand by the event thread's position heartbeat (see
   // EventThreadMain), so it is deliberately NOT observed — observing it would
   // wake the loop on every frame for no gain.


### PR DESCRIPTION
## Why

The macOS color pipeline classifies content by comparing `video-params/gamma` and `video-params/primaries` against literal mpv enum strings — `pq`, `hlg`, `display-p3`, `dci-p3`, `bt.2020`. mpv documents those values as subject to change, and `desktop/scripts/vendor-libmpv-mac.sh` pins no version: it takes `$(brew --prefix mpv)/lib/libmpv.dylib`, whatever Homebrew happens to serve, locally and in CI alike.

A rename would degrade silently rather than fail. An unrecognised `gamma` falls through to `CC_SDR_709`, so HDR content would play tone-mapped to SDR with no error anywhere — the exact class of bug that is hard to attribute after the fact.

Follow-up to the verification in #605.

## What

`VerifyColorEnums()` runs once after `mpv_initialize` and checks the five names against `option-info/target-trc/choices` and `option-info/target-prim/choices`. Those lists are formatted from the same name tables mpv uses to format `video-params`, so they are a faithful proxy that needs no clip to test. It also logs the vendored libmpv version, which nothing surfaced before.

Silent on a healthy vendor tree; one loud line per missing name otherwise. No behaviour change — diagnostics only, and it reuses `M::get_property_string`, already `dlsym`'d, so the dlopen surface is unchanged.

## Verification

Built on macOS arm64 (`node-gyp build`, clean).

Ran the check's logic against the vendored `libmpv.dylib` with two extra negative controls (`st2084`, `smpte2084`) spliced in:

```
[player-mac] libmpv version: mpv v0.41.0
[player-mac] color: libmpv no longer knows 'st2084' in option-info/target-trc/choices — content classification will fall back to SDR-709
[player-mac] color: libmpv no longer knows 'smpte2084' in option-info/target-trc/choices — content classification will fall back to SDR-709
```

The five real names produced no output; only the controls tripped it.

Separately confirmed that the strings the pipeline compares against are the ones this libmpv actually emits, by loading clips tagged with the matching H.273 values through the vendored dylib and reading the properties back:

| clip tags | `video-params/gamma` | `video-params/primaries` |
|---|---|---|
| smpte2084 / bt2020 | `pq` | `bt.2020` |
| arib-std-b67 / bt2020 | `hlg` | `bt.2020` |
| iec61966-2-1 / smpte432 | `srgb` | `display-p3` |
| bt709 / smpte431 | `bt.1886` | `dci-p3` |
| bt709 / bt709 | `bt.1886` | `bt.709` |

Full details in https://github.com/fliks-app/fliks/issues/605#issuecomment-5554914518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
