### PR TITLE
fix(android): report HDR unsupported on ColorOS devices so the server tonemaps

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/HdrPlugin.java
+++ b/client/android/app/src/main/java/media/fliks/app/HdrPlugin.java
@@ -1,7 +1,11 @@
 package media.fliks.app;
 
 import android.os.Build;
+import android.util.Log;
 import android.view.Display;
+
+import java.util.Arrays;
+import java.util.List;
 
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
@@ -18,12 +22,22 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 @CapacitorPlugin(name = "Hdr")
 public class HdrPlugin extends Plugin {
 
+    private static final String TAG = "FliksHdr";
+
+    // ColorOS firmware gates the panel's HDR brightness boost on an OEM app whitelist,
+    // so HDR renders at SDR luminance; report SDR so the server tonemaps instead.
+    private static final List<String> HDR_INEFFECTIVE_MANUFACTURERS =
+            Arrays.asList("oneplus", "oppo", "realme");
+
     @PluginMethod()
     public void isSupported(PluginCall call) {
         boolean supported = false;
         boolean dolbyVision = false;
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (HDR_INEFFECTIVE_MANUFACTURERS.contains(Build.MANUFACTURER.toLowerCase())) {
+            Log.i(TAG, "HDR reported unsupported: " + Build.MANUFACTURER
+                    + " gates the HDR brightness boost on an app whitelist");
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             Display display = getActivity().getWindowManager().getDefaultDisplay();
             Display.HdrCapabilities hdrCaps = display.getHdrCapabilities();
             if (hdrCaps != null) {


### PR DESCRIPTION
## Summary
- `HdrPlugin.isSupported()` returns `supported=false` when `Build.MANUFACTURER` is OnePlus, OPPO or realme, with an info log explaining why.
- The device profile then reports `supportsHdr=false`, so the backend takes the existing `forceDisableHdr` path and serves the HDR->SDR tonemapped ladder instead of dark HDR10.

## Why a manufacturer denylist
ColorOS gates the panel HDR brightness boost on an OEM app whitelist; a third-party app gets PQ content composited at SDR luminance. There is no public API to detect or bypass it (`getHdrCapabilities()` says HDR, `getHdrSdrRatio()` is a constant `1.0`). The runtime `getHdrSdrRatio` probe suggested in the issue was not implemented: the ratio also sits at 1.0 on genuine HDR panels when brightness is already at max, so a persisted "HDR ineffective" verdict could permanently disable HDR on a good device, and it could not be validated here (only the OnePlus 9 is available).

## Validation (OnePlus 9, OxygenOS 14)
- logcat: `FliksHdr: HDR reported unsupported: OnePlus gates the HDR brightness boost on an app whitelist`
- backend: `Transcode for file 38: VideoResolutionNotSupported, VideoHdrNotSupported` with the `tonemap=hable` / bt709 filter chain
- device: decoder output `color-transfer = 3` (SDR), `OplusFeatureHDREnhanceBrightness: isPlayingHDR=0`; image correctly exposed.

Closes #393