### PR TITLE
refactor(streaming): drop the ActiveStreamTracker fallbacks and the bulk stop route

### DIFF
--- a/backend/src/modules/scheduler/system.controller.spec.ts
+++ b/backend/src/modules/scheduler/system.controller.spec.ts
@@ -51,9 +51,6 @@ describe('SystemController.activeStreams recency filter', () => {
     const liveSessions = {
       list: jest.fn().mockReturnValue(snapshots),
     };
-    const activeStreamTracker = {
-      getDeviceName: jest.fn().mockReturnValue(null),
-    };
     const playbackService = {
       getState: jest.fn().mockResolvedValue(null),
     };
@@ -71,7 +68,6 @@ describe('SystemController.activeStreams recency filter', () => {
       {} as never, // activityRegistry
       transcodingService as never,
       {} as never, // transcodeCache
-      activeStreamTracker as never,
       liveSessions as never,
       playbackService as never,
       mediaFileRepo as never,
@@ -149,7 +145,6 @@ describe('SystemController.sendPlayerCommand', () => {
       ]),
       listForJob: jest.fn().mockReturnValue([]),
     };
-    const activeStreamTracker = { unregister: jest.fn() };
     const transcodingService = {
       getActiveSessions: jest.fn().mockReturnValue([]),
       killSessionsForJob: jest.fn(),
@@ -165,7 +160,6 @@ describe('SystemController.sendPlayerCommand', () => {
       {} as never, // activityRegistry
       transcodingService as never,
       {} as never,
-      activeStreamTracker as never,
       liveSessions as never,
       {} as never,
       {} as never,
@@ -178,7 +172,6 @@ describe('SystemController.sendPlayerCommand', () => {
       controller,
       eventsService,
       liveSessions,
-      activeStreamTracker,
       transcodingService,
     };
   }
@@ -219,13 +212,12 @@ describe('SystemController.sendPlayerCommand', () => {
   });
 
   it('stops only the targeted live session and keeps sibling viewers', () => {
-    const { controller, liveSessions, activeStreamTracker, transcodingService } =
+    const { controller, liveSessions, transcodingService } =
       makeCommandController();
 
     controller.sendPlayerCommand('linux-sid', { action: 'stop' });
 
     expect(liveSessions.stop).toHaveBeenCalledWith('linux-sid');
-    expect(activeStreamTracker.unregister).not.toHaveBeenCalled();
     expect(transcodingService.killSessionsForJob).not.toHaveBeenCalled();
   });
 });
@@ -235,7 +227,6 @@ describe('SystemController.restart', () => {
 
   function makeController() {
     return new SystemController(
-      {} as never,
       {} as never,
       {} as never,
       {} as never,

--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -43,7 +43,6 @@ import {
   getHdrLadderForDevice,
   parseBitrateToBps,
 } from '../streaming/transcoding';
-import { ActiveStreamTracker } from '../streaming/active-stream-tracker.service';
 import {
   type LiveSessionSnapshot,
   LiveSessionRegistry,
@@ -209,7 +208,6 @@ export class SystemController {
     private readonly activityRegistry: ActivityRegistryService,
     private readonly transcodingService: TranscodingService,
     private readonly transcodeCache: TranscodeCacheService,
-    private readonly activeStreamTracker: ActiveStreamTracker,
     private readonly liveSessions: LiveSessionRegistry,
     private readonly playbackService: PlaybackService,
     @InjectRepository(MediaFile)
@@ -494,14 +492,7 @@ export class SystemController {
         hwAccelVal,
         startedAt: session.startedAt.toISOString(),
         lastActivity: session.lastBeat.toISOString(),
-        deviceLabel:
-          session.deviceLabel ??
-          (session.userId != null
-            ? this.activeStreamTracker.getDeviceName(
-                session.userId,
-                session.mediaFileId,
-              )
-            : null),
+        deviceLabel: session.deviceLabel,
         systemName: session.systemName,
         appVersion: session.appVersion,
         transcodeSession: ts,
@@ -771,19 +762,7 @@ export class SystemController {
 
     if (body.action === 'stop') {
       this.liveSessions.stop(sessionId);
-      if (target.isDirectPlay) {
-        const remainingForFile = [...this.liveSessions.list()].filter(
-          (s) =>
-            s.userId === target.userId &&
-            s.mediaFileId === target.mediaFileId,
-        );
-        if (remainingForFile.length === 0) {
-          this.activeStreamTracker.unregister(
-            target.userId,
-            target.mediaFileId,
-          );
-        }
-      } else if (target.profileHash) {
+      if (!target.isDirectPlay && target.profileHash) {
         const remaining = this.liveSessions.listForJob(
           target.userId,
           target.mediaFileId,

--- a/backend/src/modules/streaming/active-stream-tracker.service.ts
+++ b/backend/src/modules/streaming/active-stream-tracker.service.ts
@@ -3,42 +3,11 @@ import type { TonemapAlgo } from './transcoding';
 import { DEFAULT_SEGMENT_DURATION } from './transcoding/constants';
 
 /**
- * Cross-cutting bookkeeping for streaming. Per-playback session state lives on
- * {@link LiveSession} — including DirectPlay presence, which the admin "now
- * watching" view reads straight off the registry (`kind === 'directplay'`).
- * This service holds only the bits that don't vary per playback session:
- *
- *  - Human-readable device name per (user, file) — a dashboard fallback for
- *    when the LiveSession carries no raw User-Agent label
- *  - Intrinsic file dimensions (identical across users, kept here for cheap
- *    reads in HLS routes)
- *  - Global admin settings (segment duration, QSV options, tonemap algo)
+ * Global admin streaming settings forwarded to transcode sessions. Everything
+ * that varies per playback lives on {@link LiveSession}.
  */
 @Injectable()
 export class ActiveStreamTracker {
-  /** Human-readable client device captured at playback-info ("Chrome — macOS",
-   *  "iPhone", "Chromecast — Living Room"). Keyed per (user, file) so two users
-   *  watching the same file from different devices don't collide. Shown on the
-   *  admin streams dashboard as a fallback when the LiveSession has no raw
-   *  User-Agent label. Cleared on stop ({@link unregister}); a playback that
-   *  never sends a clean stop leaves one small string entry until restart —
-   *  bounded by distinct (user, file) pairs and overwritten per key. */
-  private readonly deviceNameCache = new Map<string, string>();
-
-  setDeviceName(userId: number, mediaFileId: number, name: string) {
-    if (name) this.deviceNameCache.set(`${userId}-${mediaFileId}`, name);
-  }
-
-  getDeviceName(userId: number, mediaFileId: number): string | null {
-    return this.deviceNameCache.get(`${userId}-${mediaFileId}`) ?? null;
-  }
-
-  /** Release a (user, file)'s cached device name when its playback stops. */
-  unregister(userId: number, mediaFileId: number) {
-    this.deviceNameCache.delete(`${userId}-${mediaFileId}`);
-  }
-
-  // ── Global admin streaming settings forwarded to transcode sessions ──
   private qsvLowPowerCache = false;
 
   /** QSV advanced options are global (driven by admin streaming settings). */
@@ -79,21 +48,5 @@ export class ActiveStreamTracker {
   }
   getAutoCropEnabled(): boolean {
     return this.autoCropEnabledCache;
-  }
-
-  // Source dimensions describe the underlying file — identical across
-  // users, kept here for cheap lookups in HLS routes.
-  private readonly sourceWidthCache = new Map<number, number>();
-  private readonly sourceHeightCache = new Map<number, number>();
-
-  setSourceDimensions(mediaFileId: number, width: number, height: number) {
-    this.sourceWidthCache.set(mediaFileId, width);
-    this.sourceHeightCache.set(mediaFileId, height);
-  }
-  getSourceWidth(mediaFileId: number): number {
-    return this.sourceWidthCache.get(mediaFileId) ?? 0;
-  }
-  getSourceHeight(mediaFileId: number): number {
-    return this.sourceHeightCache.get(mediaFileId) ?? 0;
   }
 }

--- a/backend/src/modules/streaming/streaming.controller.spec.ts
+++ b/backend/src/modules/streaming/streaming.controller.spec.ts
@@ -111,9 +111,6 @@ describe('StreamingController.stopLiveSession', () => {
       list: jest.fn().mockReturnValue([]),
       listForJob: jest.fn().mockReturnValue([]),
     };
-    const activeStreamTracker = {
-      unregister: jest.fn(),
-    };
     const transcodingService = {
       killSessionsForJob: jest.fn(),
     };
@@ -132,7 +129,7 @@ describe('StreamingController.stopLiveSession', () => {
       {} as never, // subtitleStreamService
       transcodingService as never,
       {} as never, // streamBuilder
-      activeStreamTracker as never,
+      {} as never, // activeStreamTracker
       {} as never, // subtitleBurnIn
       {} as never, // thumbnailService
       {} as never, // playbackService
@@ -150,7 +147,6 @@ describe('StreamingController.stopLiveSession', () => {
     return {
       controller,
       liveSessions,
-      activeStreamTracker,
       transcodingService,
       events,
       caslAbilityFactory,
@@ -171,28 +167,22 @@ describe('StreamingController.stopLiveSession', () => {
     };
   }
 
-  it('unregisters the now-watching row for a DirectPlay sid (null profileHash)', () => {
+  it('stops a DirectPlay sid (null profileHash) without touching ffmpeg', () => {
     const live = makeLive({ profileHash: null, userId: 7, mediaFileId: 42 });
-    const { controller, liveSessions, activeStreamTracker, transcodingService } =
-      makeController(live);
+    const { controller, liveSessions, transcodingService } = makeController(live);
 
     controller.stopLiveSession('sid-1', owner);
 
     expect(liveSessions.stop).toHaveBeenCalledWith('sid-1');
-    // DirectPlay has no profileHash, so the ffmpeg-kill path is skipped —
-    // the tracker row must still be cleared immediately.
-    expect(activeStreamTracker.unregister).toHaveBeenCalledWith(7, 42);
     expect(transcodingService.killSessionsForJob).not.toHaveBeenCalled();
   });
 
-  it('also unregisters for a transcode sid, then walks the ffmpeg-kill path', () => {
+  it('walks the ffmpeg-kill path for a transcode sid', () => {
     const live = makeLive({ profileHash: 'abc123', userId: 7, mediaFileId: 42 });
-    const { controller, activeStreamTracker, liveSessions, transcodingService } =
-      makeController(live);
+    const { controller, liveSessions, transcodingService } = makeController(live);
 
     controller.stopLiveSession('sid-1', owner);
 
-    expect(activeStreamTracker.unregister).toHaveBeenCalledWith(7, 42);
     expect(liveSessions.listForJob).toHaveBeenCalledWith(7, 42, 'abc123');
     // No other live session references the job → reap every ffmpeg variant.
     expect(transcodingService.killSessionsForJob).toHaveBeenCalledWith(
@@ -203,36 +193,13 @@ describe('StreamingController.stopLiveSession', () => {
   });
 
   it('is a no-op on an unknown sid', () => {
-    const { controller, activeStreamTracker, liveSessions, events } =
-      makeController(null);
+    const { controller, liveSessions, events } = makeController(null);
 
     controller.stopLiveSession('missing', owner);
 
     expect(liveSessions.stop).toHaveBeenCalledWith('missing');
-    expect(activeStreamTracker.unregister).not.toHaveBeenCalled();
     // Nobody to notify: there's no live entry to read a userId off.
     expect(events.emitToUser).not.toHaveBeenCalled();
-  });
-
-  it('skips unregister when another live session remains on the same file', () => {
-    const live = makeLive({ profileHash: null, userId: 7, mediaFileId: 42 });
-    const { controller, liveSessions, activeStreamTracker } = makeController(live);
-    liveSessions.list.mockReturnValue([
-      { sessionId: 'sid-2', userId: 7, mediaFileId: 42 },
-    ]);
-
-    controller.stopLiveSession('sid-1', owner);
-
-    expect(activeStreamTracker.unregister).not.toHaveBeenCalled();
-  });
-
-  it('does not unregister when the session has no userId', () => {
-    const live = makeLive({ profileHash: null, userId: null, mediaFileId: 42 });
-    const { controller, activeStreamTracker } = makeController(live);
-
-    controller.stopLiveSession('sid-1', owner);
-
-    expect(activeStreamTracker.unregister).not.toHaveBeenCalled();
   });
 
   it('lets the owner stop their own session and notifies their other devices', () => {

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -768,8 +768,6 @@ export class StreamingController {
       pickAudioLayout(sourceAudioCount, effectiveUseTs ? 'ts' : 'fmp4') ===
       'var-stream-map';
 
-    // File-scoped + global tracker state (kept in the tracker because
-    // these don't vary per playback session).
     this.activeStreamTracker.setSegmentDuration(ss.segmentDuration);
     this.activeStreamTracker.setQsvOptions({ lowPower: ss.qsvLowPower });
     this.activeStreamTracker.setTonemapAlgo(ss.tonemapAlgo);
@@ -777,17 +775,6 @@ export class StreamingController {
     // Pin HW transcoding to the admin-selected GPU (multi-GPU hosts); 'auto'
     // clears the override and falls back to the env / detected default.
     setSelectedRenderNode(ss.gpuRenderNode);
-    this.activeStreamTracker.setDeviceName(
-      userId,
-      mediaFileId,
-      deviceProfile.deviceName ?? '',
-    );
-    const sv = resolved.mediaFile.streamInfo?.video?.[0];
-    this.activeStreamTracker.setSourceDimensions(
-      mediaFileId,
-      sv?.width ?? 0,
-      sv?.height ?? 0,
-    );
 
     // Different device profiles (codec / mux / audio layout) hash to
     // different session-map keys, so multi-device playback of the same
@@ -1127,16 +1114,6 @@ export class StreamingController {
     }
 
     this.liveSessions.stop(sessionId);
-    // Release this (user, file)'s cached device name only when no sibling
-    // session remains — multi-device viewers share the same user+file pair.
-    if (live?.userId != null) {
-      const remainingForFile = [...this.liveSessions.list()].filter(
-        (s) => s.userId === live.userId && s.mediaFileId === live.mediaFileId,
-      );
-      if (remainingForFile.length === 0) {
-        this.activeStreamTracker.unregister(live.userId, live.mediaFileId);
-      }
-    }
     if (!live || !live.profileHash) return;
     // Only kill the underlying ffmpeg job(s) when no other live
     // session is still referencing this (user, file, profileHash) —
@@ -1754,10 +1731,9 @@ export class StreamingController {
       ctx.spawnReason = 'seg-race';
       const live = this.sessionRouter.findRequestSession(req, mediaFileId);
       const deviceType = live?.deviceType ?? 'desktop';
-      const sourceW =
-        this.activeStreamTracker.getSourceWidth(mediaFileId) || 1920;
-      const sourceH =
-        this.activeStreamTracker.getSourceHeight(mediaFileId) || 1080;
+      const sv = resolved.mediaFile.streamInfo?.video?.[0];
+      const sourceW = sv?.width || 1920;
+      const sourceH = sv?.height || 1080;
       const profiles = this.transcodingService.getAvailableProfiles(
         sourceW,
         sourceH,
@@ -2384,43 +2360,6 @@ export class StreamingController {
         skipTimelineRewrite: quality === 'remux',
       },
     );
-  }
-
-  // ---------------------------------------------------------------------------
-  // Session cleanup
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Deprecated bulk stop: tears down every session this user has on a
-   * media file. Superseded by the sid-scoped `DELETE /sessions/:sid`,
-   * which stops exactly the device that asked. Kept only for clients
-   * that predate sid routing; the warning log lets us confirm zero hits
-   * before removal.
-   */
-  @Delete(':mediaFileId/sessions')
-  async stopSessions(
-    @Param('mediaFileId', ParseIntPipe) mediaFileId: number,
-    @Req() req: Request,
-  ) {
-    const user = req.user;
-    this.log.warn(
-      `[deprecated] DELETE /:mediaFileId/sessions called (mediaFileId=${mediaFileId}, userId=${user?.id ?? 'anon'}); use sid-scoped DELETE /sessions/:sid`,
-    );
-    await this.transcodingService.killSession(mediaFileId, user?.id);
-    if (user) {
-      this.activeStreamTracker.unregister(user.id, mediaFileId);
-    }
-    // Drop any live-session entries for this (user, file) so the
-    // dashboard stops surfacing the row immediately instead of waiting
-    // for the heartbeat ttl. Multi-device clean-up: we only touch
-    // sessions that match `user.id`, leaving other devices alive.
-    const userId = user?.id ?? null;
-    for (const s of this.liveSessions.list()) {
-      if (s.mediaFileId === mediaFileId && s.userId === userId) {
-        this.liveSessions.stop(s.sessionId);
-      }
-    }
-    return { ok: true };
   }
 
   // ---------------------------------------------------------------------------

--- a/backend/src/modules/streaming/transcoding/transcoding.service.ts
+++ b/backend/src/modules/streaming/transcoding/transcoding.service.ts
@@ -1218,22 +1218,6 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
     return session;
   }
 
-  /** Stop every ffmpeg job for this `(file, user)` pair across all
-   *  profile variants. The on-disk cache **stays** — `TranscodeCacheService`
-   *  owns its lifecycle and will evict on TTL / LRU. A subsequent fresh
-   *  play (same profile) reattaches to the existing segments instead of
-   *  retranscoding from scratch. */
-  async killSession(mediaFileId: number, userId?: number) {
-    const sessions = this.getSessionsForFileUser(mediaFileId, userId);
-    if (sessions.length === 0) return;
-    for (const s of sessions) {
-      this.log.log(`Kill session [${s.id}] (quality: ${s.quality})`);
-      this.sessions.delete(s.id);
-      s.intentionallyKilled = true;
-    }
-    await Promise.all(sessions.map((s) => this.killProcess(s.process)));
-  }
-
   /** Stop every ffmpeg variant (main / early / remux / per-audio) of one
    *  client job — the sessions sharing `baseProfileHash` for this (file,
    *  user). Scoped by hash so a second device on the same file with a
@@ -1588,7 +1572,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
    * Uses SIGKILL by default (instant) for seek restarts — ffmpeg's graceful
    * SIGTERM shutdown (write trailer, close files) is wasted work when we're
    * about to overwrite the output. SIGTERM is only used when the caller
-   * explicitly needs a clean shutdown (e.g. stopSessions on player close).
+   * explicitly needs a clean shutdown (e.g. stopSession on player close).
    */
   private killProcess(proc: ChildProcess, graceful = false): Promise<void> {
     if (proc.exitCode !== null) return Promise.resolve();
@@ -1614,7 +1598,7 @@ export class TranscodingService implements OnModuleInit, OnModuleDestroy {
    *
    *  Skips the rm when a replacement session is already registered with the
    *  same id — avoids wiping a freshly-spawned session's cache dir during a
-   *  quick close+replay cycle (stopSessions ↔ playback-info race). */
+   *  quick close+replay cycle (stopSession ↔ playback-info race). */
   private async killAndClean(
     proc: ChildProcess,
     dirPath: string,

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -109,7 +109,7 @@ export interface PlaybackInfoResponse {
   preRoll?: PreRollItem[];
   /** Server-issued live-session identifier. The client embeds it in every
    *  subsequent `PUT /api/playback/media/:id/state` (heartbeat) and on
-   *  the `DELETE /api/stream/:mediaFileId/sessions` unload signal so the
+   *  the `DELETE /api/stream/sessions/:sid` unload signal so the
    *  backend can match the client back to its in-memory session record. */
   sessionId?: string;
   /** Profile hash this session's transcode cache is keyed under, or
@@ -457,36 +457,19 @@ export class StreamingApiService {
     );
   }
 
-  /** Build the URL for stopping sessions (used with fetch(keepalive) on unload).
-   *  Prefer the sid-scoped variant when a sessionId is available — the
-   *  bulk path kills every profile for the (user, file) pair, which
-   *  would tear down other devices watching the same title. */
-  getStopSessionsUrl(mediaFileId: number, sessionId?: string): string {
-    if (sessionId) {
-      const path = `/api/stream/sessions/${encodeURIComponent(sessionId)}`;
-      const base = this.serverConfig.isNative
-        ? this.serverConfig.resolveUrl(path)
-        : path;
-      const token = this.playbackToken;
-      return token ? `${base}?token=${encodeURIComponent(token)}` : base;
-    }
+  /** URL for stopping one session (used with fetch(keepalive) on unload). */
+  getStopSessionUrl(sessionId: string): string {
+    const path = `/api/stream/sessions/${encodeURIComponent(sessionId)}`;
     const base = this.serverConfig.isNative
-      ? this.serverConfig.resolveUrl(`/api/stream/${mediaFileId}/sessions`)
-      : `/api/stream/${mediaFileId}/sessions`;
+      ? this.serverConfig.resolveUrl(path)
+      : path;
     const token = this.playbackToken;
     return token ? `${base}?token=${encodeURIComponent(token)}` : base;
   }
 
-  stopSessions(mediaFileId: number, sessionId?: string) {
-    if (sessionId) {
-      return firstValueFrom(
-        this.http.delete(
-          `/api/stream/sessions/${encodeURIComponent(sessionId)}`,
-        ),
-      );
-    }
+  stopSession(sessionId: string) {
     return firstValueFrom(
-      this.http.delete(`/api/stream/${mediaFileId}/sessions`),
+      this.http.delete(`/api/stream/sessions/${encodeURIComponent(sessionId)}`),
     );
   }
 

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -375,15 +375,12 @@ export class CastPlayerService {
       clearTimeout(this.disconnectGrace);
       this.disconnectGrace = null;
     }
-    const mfId = this.mediaFileId();
     const castSid = this.liveSessionId();
     this.saveCastPosition(); // Save final position before clearing
     this.stopPositionSaving();
-    if (mfId) {
-      // Sid-scoped kill so a sender that's still watching locally on a
-      // different profile isn't torn down by the cast stop.
-      this.streamingApi.stopSessions(mfId, castSid ?? undefined).catch(() => {});
-    }
+    // Sid-scoped kill so a sender that's still watching locally on a
+    // different profile isn't torn down by the cast stop.
+    if (castSid) this.streamingApi.stopSession(castSid).catch(() => {});
     this.liveSessionId.set(null);
     this.hasMedia.set(false);
     this.expanded.set(false);
@@ -466,7 +463,8 @@ export class CastPlayerService {
 
     // Scope the stop to the Cast session's own sid so a concurrent local
     // session on the same file (another profile/device) is not torn down too.
-    await this.streamingApi.stopSessions(mfId, this.liveSessionId() ?? undefined).catch(() => {});
+    const castSid = this.liveSessionId();
+    if (castSid) await this.streamingApi.stopSession(castSid).catch(() => {});
 
     const currentPos = positionOverride ?? this.cast.currentTime();
     const audioIdx = this.activeAudioStreamIndex

--- a/client/src/app/features/player/player.spec.ts
+++ b/client/src/app/features/player/player.spec.ts
@@ -125,7 +125,7 @@ function createHarness(opts: {
     return buildPi(mediaFileId);
   });
   const getPlaybackState = vi.fn(async () => null);
-  const stopSessions = vi.fn(async () => ({}));
+  const stopSession = vi.fn(async () => ({}));
   const updatePlaybackState = vi.fn(async () => ({}));
   const getStreamUrl = vi.fn((id: number, sid?: string) => `stream://${id}?sid=${sid}`);
   const getHlsUrl = vi.fn(
@@ -136,11 +136,11 @@ function createHarness(opts: {
   const streamingApi = {
     getPlaybackInfo,
     getPlaybackState,
-    stopSessions,
+    stopSession,
     updatePlaybackState,
     getStreamUrl,
     getHlsUrl,
-    getStopSessionsUrl: vi.fn(() => 'stop://x'),
+    getStopSessionUrl: vi.fn(() => 'stop://x'),
     getThumbnailMetadataUrl: vi.fn(() => ''),
     getThumbnailSpriteUrl: vi.fn(() => ''),
     getSubtitleUrl: vi.fn(() => ''),
@@ -307,7 +307,7 @@ describe('PlayerComponent pre-roll', () => {
 
     expect(h.component.preRollActive()).toBe(true);
     expect(h.component.mediaFileId).toBe(TRAILER_FILE_ID);
-    expect(h.streamingApi.stopSessions).toHaveBeenCalledWith(MAIN_FILE_ID, `sid-${MAIN_FILE_ID}`);
+    expect(h.streamingApi.stopSession).toHaveBeenCalledWith(`sid-${MAIN_FILE_ID}`);
 
     // preRollAdvanceEffect is what calls advancePreRoll() once state.ended()
     // latches — exercised directly here because Angular's only TestBed hook
@@ -342,7 +342,7 @@ describe('PlayerComponent pre-roll', () => {
 
     expect(h.component.preRollActive()).toBe(false);
     expect(h.component.mediaFileId).toBe(MAIN_FILE_ID);
-    expect(h.streamingApi.stopSessions).not.toHaveBeenCalled();
+    expect(h.streamingApi.stopSession).not.toHaveBeenCalled();
   });
 
   /** Closing before the seek to the resume point lands must not write the

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1723,7 +1723,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       if (!info) continue; // this candidate failed to negotiate — try the next
       // Only stop the main session once a pre-roll item is committed: if every
       // candidate fails, the launch is byte-identical to a plugin-free one.
-      await this.streamingApi.stopSessions(mainFileId, mainSid).catch(() => {});
+      if (mainSid) await this.streamingApi.stopSession(mainSid).catch(() => {});
       this.preRollMainFileId = mainFileId;
       this.preRollRest = rest;
       this.preRollCurrent.set(item);
@@ -2535,7 +2535,6 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     if (!this.engine || this.reloadingStream || mediaFileId === this.mediaFileId) return;
     this.reloadingStream = true;
     this.engine.resetRecoveryGuard();
-    const previousFileId = this.mediaFileId;
     const previousSessionId = this.playbackInfo?.sessionId;
     try {
       // Surface the loading backdrop (set to the new episode's still below)
@@ -2549,9 +2548,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       // Native engines must be stopped before a fresh load to avoid a freeze;
       // release the outgoing file's session (other devices on it stay alive).
       if (this.isNativeEngine()) await NativePlayer.stop().catch(() => {});
-      await this.streamingApi
-        .stopSessions(previousFileId, previousSessionId)
-        .catch(() => {});
+      if (previousSessionId) {
+        await this.streamingApi.stopSession(previousSessionId).catch(() => {});
+      }
 
       this.mediaFileId = mediaFileId;
       this.episodeId = episodeId;
@@ -3280,9 +3279,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       // treat the re-mint as a concurrent sibling and split it onto a cold job.
       const prevSid = this.playbackInfo?.sessionId;
       if (prevSid) {
-        await this.streamingApi
-          .stopSessions(this.mediaFileId, prevSid)
-          .catch(() => {});
+        await this.streamingApi.stopSession(prevSid).catch(() => {});
       }
       if (opts.unmute) this.engine.muted = false;
       const wasPaused = opts.preservePause ? this.paused() : false;
@@ -4534,9 +4531,10 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
 
       // Stop only this device's session — multi-device viewers on the
       // same file with a different profile should stay alive.
-      await this.streamingApi
-        .stopSessions(this.mediaFileId, this.playbackInfo?.sessionId)
-        .catch(() => {});
+      const currentSid = this.playbackInfo?.sessionId;
+      if (currentSid) {
+        await this.streamingApi.stopSession(currentSid).catch(() => {});
+      }
 
       const deviceProfile = this.deviceProfileService.getProfile();
       // Pass the requested rung so the backend re-decides DirectPlay vs the
@@ -4593,11 +4591,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     // Release this device's session on exit — DirectPlay included, so its
     // "now watching" dashboard row clears at once instead of lingering until
     // the backend idle reap (transcode/remux paths also stop their ffmpeg).
-    if (!this.mediaFileId) return;
-    const url = this.streamingApi.getStopSessionsUrl(
-      this.mediaFileId,
-      this.activeSessionId(),
-    );
+    const sid = this.activeSessionId();
+    if (!sid) return;
+    const url = this.streamingApi.getStopSessionUrl(sid);
     fetch(url, { method: 'DELETE', keepalive: true }).catch(() => {});
   }
 


### PR DESCRIPTION
## Summary
- `ActiveStreamTracker` loses `deviceNameCache` (`setDeviceName`/`getDeviceName`/`unregister`) and the source-dimension caches. It is now only the global admin streaming settings.
- The dashboard reads `session.deviceLabel` directly; the admin stop command and `stopLiveSession` no longer maintain a tracker row.
- The audio seg-race branch reads width/height from `resolved.mediaFile.streamInfo` instead of the tracker.
- The deprecated bulk `DELETE /api/stream/:mediaFileId/sessions` is removed, along with the now-dead `TranscodingService.killSession`.
- Client: `stopSessions(mediaFileId, sid?)` / `getStopSessionsUrl` become `stopSession(sid)` / `getStopSessionUrl(sid)`. Every caller skips the stop when it has no sid instead of falling back to the bulk route.

## Kept on purpose
- `DeviceProfileDto.deviceName` stays. The global `ValidationPipe` runs with `forbidNonWhitelisted`, so removing the field would reject every shipped client that still sends it.

## Validation
- Prod logs: zero `[deprecated] DELETE` hits over the monitoring window.
- backend: `tsc` clean, `jest src/modules/streaming src/modules/scheduler/system.controller.spec.ts` 54 suites / 528 tests green.
- client: `tsc -p tsconfig.app.json` clean, `ng test --include player.spec.ts` 32 tests green.

Closes #301