### PR TITLE
feat(streaming): direct play HDR on desktop clients that tonemap locally

### DIFF
--- a/backend/src/modules/streaming/dto/device-profile.dto.ts
+++ b/backend/src/modules/streaming/dto/device-profile.dto.ts
@@ -88,6 +88,15 @@ export class DeviceProfileDto {
   supportsHdr?: boolean;
 
   /**
+   * Client decodes HDR and tone-maps it to its SDR display itself (desktop mpv),
+   * so the HDR bitstream is copied instead of re-encoded. {@link supportsHdr}
+   * stays false: any transcode the session still needs outputs SDR.
+   */
+  @IsBoolean()
+  @IsOptional()
+  tonemapsHdrLocally?: boolean;
+
+  /**
    * Client can present single-layer Dolby Vision (Profile 5 / 8.x) directly:
    * both a DV decoder and a DV panel confirmed on the device. The backend then
    * DirectPlays the original container untouched so the RPU rides through.

--- a/backend/src/modules/streaming/hdr-local-tonemap.spec.ts
+++ b/backend/src/modules/streaming/hdr-local-tonemap.spec.ts
@@ -1,0 +1,87 @@
+import { StreamBuilderService } from './stream-builder.service';
+import type { DeviceProfileDto } from './dto/device-profile.dto';
+
+const svc = () =>
+  new StreamBuilderService(
+    { getDetectedHwAccel: () => 'none' } as never,
+    { getAutoCropEnabled: () => false, getTonemapAlgo: () => 'auto' } as never,
+  );
+
+// Desktop shell on an SDR panel: decodes HEVC Main 10, no HDR display.
+const sdrClient: DeviceProfileDto = {
+  directPlayProfiles: [
+    { containers: ['mkv'], videoCodecs: ['hevc'], audioCodecs: ['aac'] },
+  ],
+  codecConditions: [
+    {
+      codec: 'hevc',
+      profiles: ['main', 'main 10'],
+      maxBitDepth: 10,
+      maxWidth: 3840,
+      maxHeight: 2160,
+      maxLevel: 180,
+    },
+  ],
+  supportsHdr: false,
+  supportsDirectPlay: true,
+  maxAudioChannels: 6,
+} as never;
+
+const localTonemapClient: DeviceProfileDto = {
+  ...sdrClient,
+  tonemapsHdrLocally: true,
+};
+
+const resolved = () =>
+  ({
+    ext: '.mkv',
+    contentType: 'video/x-matroska',
+    absolutePath: '/m/in.mkv',
+    relativePath: 'in.mkv',
+    size: 1,
+    media: { title: 'X', type: 'movie' },
+    mediaFile: {
+      id: 1,
+      streamInfo: {
+        video: [
+          {
+            codec: 'hevc',
+            width: 1920,
+            height: 1080,
+            bitDepth: 10,
+            profile: 'Main 10',
+            level: 120,
+            bitRate: 8_000_000,
+            frameRate: '24',
+            hdrFormat: 'HDR10',
+            colorTransfer: 'smpte2084',
+            colorPrimaries: 'bt2020',
+          },
+        ],
+        audio: [{ codec: 'aac', channels: 2, bitRate: 128_000 }],
+        durationSeconds: 100,
+      },
+    },
+  }) as never;
+
+describe('StreamBuilderService — client-side HDR tone-mapping', () => {
+  it('tonemaps server-side for an SDR client without the flag', () => {
+    const r = svc().evaluate(resolved(), sdrClient, 'tok');
+    expect(r.response.playMethod).toBe('Transcode');
+    expect(r.response.tonemapping).toBe(true);
+  });
+
+  it('DirectPlays HDR for a client that tone-maps locally', () => {
+    const r = svc().evaluate(resolved(), localTonemapClient, 'tok');
+    expect(r.response.playMethod).toBe('DirectPlay');
+    expect(r.response.videoCopyStream).toBe(true);
+    expect(r.response.tonemapping).toBe(false);
+  });
+
+  it('keeps the transcode ladder SDR when a lower rung forces a re-encode', () => {
+    const r = svc().evaluate(resolved(), localTonemapClient, 'tok', undefined, '720p');
+    expect(r.response.playMethod).toBe('Transcode');
+    expect(r.videoVariant?.hdr).toBeNull();
+    expect(r.response.tonemapping).toBe(true);
+  });
+});

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -245,10 +245,12 @@ export class StreamBuilderService {
     // depth, which tryDirectPlay already validated via codecConditions
     // (videoConditionsMet covers the per-codec maxBitDepth). Decoupled from
     // the source codec on purpose: AV1, VP9 and HEVC 10-bit HDR all qualify.
+    // A client that tone-maps HDR itself (desktop mpv on an SDR display) also
+    // takes the bitstream verbatim — it just renders it in SDR.
     const clientCanPresentHdr =
       isSourceHdr &&
       !dvP5 &&
-      clientSupportsHdr &&
+      (clientSupportsHdr || profile.tonemapsHdrLocally === true) &&
       directPlayResult.videoSupported &&
       directPlayResult.videoConditionsMet;
 

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -88,6 +88,9 @@ export interface DeviceProfile {
    *  Falls back to maxAudioChannels per codec on the backend. */
   audioChannelsByCodec?: Record<string, number>;
   supportsHdr: boolean;
+  /** mpv tone-maps HDR to this SDR display itself, so the backend copies the
+   *  HDR bitstream instead of re-encoding it. Desktop shell only. */
+  tonemapsHdrLocally?: boolean;
   /** Client can present single-layer Dolby Vision (P5 / 8.x) directly, so the
    *  backend DirectPlays the original container untouched instead of tonemapping
    *  P5 to SDR. iOS/Android report it from the native probe (DV HW decoder / DV
@@ -508,6 +511,14 @@ export class BrowserDeviceProfileService {
       supportsHdr = hdrDisplay && has10bitCodec;
     }
 
+    // mpv tone-maps HDR down to an SDR display on its own (Windows vo=gpu,
+    // macOS layer when the screen has no EDR headroom) — the Linux x11
+    // software VO does not, so it keeps the server-side tonemap.
+    const tonemapsHdrLocally =
+      !supportsHdr &&
+      this.device.isDesktopNative() &&
+      /Windows|Mac OS X/.test(navigator.userAgent);
+
     // Dolby Vision passthrough capability, gated under supportsHdr (DV ⊆ HDR, so
     // it never outlives HDR and the forceDisableHdr override stays consistent).
     // iOS/Android report it from the native probe (DV HW decoder / DV panel
@@ -541,6 +552,7 @@ export class BrowserDeviceProfileService {
       maxAudioChannels,
       audioChannelsByCodec: this.nativeAudio?.channelsByCodec,
       supportsHdr,
+      tonemapsHdrLocally,
       supportsDolbyVision,
       deviceType: Capacitor.isNativePlatform() ? 'mobile' : 'desktop',
       deviceName: getDeviceName(),


### PR DESCRIPTION
## Why

On a Windows PC whose display is not HDR (`Use HDR: not supported`), the desktop shell reports `supportsHdr: false`, so **every HDR source was fully re-encoded server-side** just to tone-map it to SDR. mpv already tone-maps HDR down to an SDR display on its own — Windows `--vo=gpu`, and the macOS layer falls back to the SDR tone-map pair when the screen has no EDR headroom. The transcode was pure waste.

## What

- New optional device-profile flag `tonemapsHdrLocally`, deliberately separate from `supportsHdr`.
- `stream-builder` lets it unlock only the **copy** paths (DirectPlay / remux): an HDR bitstream is served verbatim and the client renders it in SDR.
- `supportsHdr` stays false, so any transcode the session still needs (lower quality rung, crop, subtitle burn-in) keeps producing an SDR ladder — no HDR rungs offered to a display that cannot show them.
- Dolby Vision P5 is untouched: it still transcodes unless the client declares `supportsDolbyVision`.
- Client sets the flag on the Electron shell only, and only on Windows/macOS. The Linux desktop backend renders through the x11 software VO, which does not tone-map, so it keeps the server-side tonemap.

## Tests

`backend/src/modules/streaming/hdr-local-tonemap.spec.ts` — SDR client without the flag still tonemaps server-side; with the flag it DirectPlays with `videoCopyStream`; and an explicit 720p rung still transcodes to an SDR variant.

Backend + client typecheck clean, existing Dolby Vision play-method specs still green.

## Validation

Server-side behaviour is covered by the specs. Actual on-screen rendering on a Windows SDR panel is still to be confirmed on the device.