### PR TITLE
feat(streaming): surface client-side HDR tone-mapping in the stats and admin views

### DIFF
--- a/backend/src/modules/scheduler/system.controller.ts
+++ b/backend/src/modules/scheduler/system.controller.ts
@@ -114,6 +114,8 @@ export interface ActiveStreamDto {
   audioMode: 'direct' | 'copy' | 'transcode';
   /** Transcode buffer progress (0-100), null for direct play */
   transcodePercent: number | null;
+  /** HDR served untouched to a client that tone-maps it to its SDR display. */
+  clientTonemap: boolean;
   /** Reasons why transcoding is needed, split by category */
   videoReasons: string[];
   audioReasons: string[];
@@ -452,6 +454,7 @@ export class SystemController {
       systemName: string | null;
       appVersion: string | null;
       transcodeSession: TranscodeSession | undefined;
+      clientTonemap: boolean;
       audioPlan: LiveSessionSnapshot['audioPlan'];
       position: number;
       episodeId: number | null;
@@ -496,6 +499,7 @@ export class SystemController {
         systemName: session.systemName,
         appVersion: session.appVersion,
         transcodeSession: ts,
+        clientTonemap: session.clientTonemap,
         audioPlan: session.audioPlan,
         // The LiveSession keeps the playhead fresh on every heartbeat — read
         // it straight from memory instead of a per-row playback_states query.
@@ -585,6 +589,7 @@ export class SystemController {
         audioOutputBitrateBps,
         audioMode,
         transcodePercent: null as number | null, // filled below for transcode sessions
+        clientTonemap: s.clientTonemap,
         videoReasons: [] as string[],
         audioReasons: [] as string[],
         containerReasons: [] as string[],

--- a/backend/src/modules/streaming/dto/playback-info.dto.ts
+++ b/backend/src/modules/streaming/dto/playback-info.dto.ts
@@ -109,6 +109,10 @@ export interface PlaybackInfoResponse {
   /** Whether HDR→SDR tone mapping is being applied */
   tonemapping: boolean;
 
+  /** The HDR stream is copied and the SDR client tone-maps it itself (desktop
+   *  mpv), so no server-side tone-map ran. */
+  clientTonemap?: boolean;
+
   /** Tone-map mechanism the session actually runs. `'vaapi'` / `'opencl'`
    *  / `'qsv'` for QSV/VAAPI encoders (after `auto` resolution + boot
    *  probe); `'videotoolbox'` for the macOS `scale_vt` Metal path; `'cpu'`

--- a/backend/src/modules/streaming/hdr-local-tonemap.spec.ts
+++ b/backend/src/modules/streaming/hdr-local-tonemap.spec.ts
@@ -69,6 +69,7 @@ describe('StreamBuilderService — client-side HDR tone-mapping', () => {
     const r = svc().evaluate(resolved(), sdrClient, 'tok');
     expect(r.response.playMethod).toBe('Transcode');
     expect(r.response.tonemapping).toBe(true);
+    expect(r.response.clientTonemap).toBeFalsy();
   });
 
   it('DirectPlays HDR for a client that tone-maps locally', () => {
@@ -76,6 +77,7 @@ describe('StreamBuilderService — client-side HDR tone-mapping', () => {
     expect(r.response.playMethod).toBe('DirectPlay');
     expect(r.response.videoCopyStream).toBe(true);
     expect(r.response.tonemapping).toBe(false);
+    expect(r.response.clientTonemap).toBe(true);
   });
 
   it('keeps the transcode ladder SDR when a lower rung forces a re-encode', () => {

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -128,6 +128,8 @@ export interface LiveSession {
   supportsAbr: boolean;
   videoVariant: CodecVariant | null;
   tonemapping: boolean;
+  /** HDR copied through to a client that tone-maps it locally. */
+  clientTonemap: boolean;
   transcodeReasons: TranscodeReason[];
   burnIn: BurnInSubtitle | null;
   encoderPreset: string;
@@ -185,6 +187,7 @@ export interface CreateLiveSessionInput {
   supportsAbr?: boolean;
   videoVariant?: CodecVariant | null;
   tonemapping?: boolean;
+  clientTonemap?: boolean;
   transcodeReasons?: TranscodeReason[];
   burnIn?: BurnInSubtitle | null;
   encoderPreset?: string;
@@ -300,6 +303,7 @@ export function buildLiveSession(
       supportsAbr: input.supportsAbr ?? true,
       videoVariant: input.videoVariant ?? null,
       tonemapping: input.tonemapping ?? false,
+      clientTonemap: input.clientTonemap ?? false,
       transcodeReasons: input.transcodeReasons ?? [],
       burnIn: input.burnIn ?? null,
       encoderPreset: input.encoderPreset ?? 'faster',

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -264,6 +264,9 @@ export class StreamBuilderService {
       directPlayResult.videoConditionsMet;
     const clientCanPresentDynamicRange =
       clientCanPresentHdr || clientCanPresentDv;
+    // Copy path taken only because the client tone-maps on its own: the stats
+    // overlay and the admin dashboard would otherwise show no HDR step at all.
+    const clientTonemap = clientCanPresentHdr && !clientSupportsHdr;
 
     // HDR/DV the client can't present as-is forces a transcode. Flag the
     // tone-map only when the re-encode is actually SDR — when the HDR ladder
@@ -272,6 +275,9 @@ export class StreamBuilderService {
     if ((isSourceHdr || dvP5) && !clientCanPresentDynamicRange) {
       if (directPlayResult.canDirectPlay)
         directPlayResult.canDirectPlay = false;
+      this.log.log(
+        `hdrDecision[file=${resolved.mediaFile.id}] ${dvP5 ? 'Dolby Vision P5' : source.hdrFormat} → SDR: supportsHdr=${clientSupportsHdr}, tonemapsHdrLocally=${profile.tonemapsHdrLocally === true}, supportsDolbyVision=${profile.supportsDolbyVision === true}, videoSupported=${directPlayResult.videoSupported}, videoConditionsMet=${directPlayResult.videoConditionsMet}`,
+      );
       if (transcodeTonemaps) {
         reasons.push({
           flag: 'VideoHdrNotSupported',
@@ -408,6 +414,7 @@ export class StreamBuilderService {
         outputContainer: sourceContainer,
         hwAccel: 'none',
         tonemapping: false,
+        clientTonemap,
         qualities: this.buildQualityList(source, 'DirectPlay', sourceCopyable, qualityLadder, selectedVariant.codec),
         audioTracks: this.buildAudioTracks(audioStreams, profile, 'DirectPlay'),
         source,
@@ -506,6 +513,7 @@ export class StreamBuilderService {
         // hevc_qsv main10), since the field is stale for the new session.
         hwAccel: this.transcodingService.getDetectedHwAccel(),
         tonemapping: false,
+        clientTonemap,
         remuxMasterBandwidthBps: remuxBw > 0 ? remuxBw : undefined,
         transcodeBitrateByQuality,
         qualities: this.buildQualityList(source, 'DirectStream', sourceCopyable, qualityLadder, selectedVariant.codec),

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -1002,6 +1002,7 @@ export class StreamingController {
       supportsAbr: deviceProfile.supportsAbr,
       videoVariant,
       tonemapping: response.tonemapping,
+      clientTonemap: response.clientTonemap ?? false,
       transcodeReasons: response.transcodeReasons,
       burnIn,
       encoderPreset: ss.qsvPreset,

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -107,6 +107,7 @@
     "stats_dropped_frames": "Verworfene Bilder:",
     "stats_crop": "Zuschnitt:",
     "stats_tonemapping": "Tone-Mapping:",
+    "stats_tonemapping_client": "Lokal (Client)",
     "stats_reasons": "Gründe:",
     "stats_sample_rate": "Abtastrate",
     "transcode_reason": {
@@ -1246,6 +1247,7 @@
     "streams_audio_transcode": "Transkodierung ({{codec}})",
     "streams_audio_transcode_with_bitrate": "Transkodierung ({{codec}}, {{kbps}} kbps)",
     "streams_video_direct": "Direktwiedergabe",
+    "streams_video_client_tonemap": "HDR → SDR (Tone-Mapping clientseitig)",
     "streams_video_transcode": "Transkodierung ({{hw}})",
     "stream_message_btn": "Nachricht senden",
     "stream_message_title": "Nachricht senden",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -112,6 +112,7 @@
     "stats_dropped_frames": "Dropped frames:",
     "stats_crop": "Crop:",
     "stats_tonemapping": "Tone mapping:",
+    "stats_tonemapping_client": "Local (client)",
     "stats_reasons": "Reasons:",
     "stats_sample_rate": "Sample rate",
     "transcode_reason": {
@@ -1254,6 +1255,7 @@
     "streams_audio_transcode": "Transcoding ({{codec}})",
     "streams_audio_transcode_with_bitrate": "Transcoding ({{codec}}, {{kbps}} kbps)",
     "streams_video_direct": "Direct Play",
+    "streams_video_client_tonemap": "HDR → SDR (client-side tone mapping)",
     "streams_video_transcode": "Transcoding ({{hw}})",
     "stream_message_btn": "Send a message",
     "stream_message_title": "Send a message",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -107,6 +107,7 @@
     "stats_dropped_frames": "Imágenes perdidas:",
     "stats_crop": "Recorte:",
     "stats_tonemapping": "Mapeo tonal:",
+    "stats_tonemapping_client": "Local (cliente)",
     "stats_reasons": "Motivos:",
     "stats_sample_rate": "Frecuencia de muestreo",
     "transcode_reason": {
@@ -1246,6 +1247,7 @@
     "streams_audio_transcode": "Transcodificación ({{codec}})",
     "streams_audio_transcode_with_bitrate": "Transcodificación ({{codec}}, {{kbps}} kbps)",
     "streams_video_direct": "Reproducción directa",
+    "streams_video_client_tonemap": "HDR → SDR (mapeo tonal en el cliente)",
     "streams_video_transcode": "Transcodificación ({{hw}})",
     "stream_message_btn": "Enviar un mensaje",
     "stream_message_title": "Enviar un mensaje",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -112,6 +112,7 @@
     "stats_dropped_frames": "Images perdues :",
     "stats_crop": "Recadrage :",
     "stats_tonemapping": "Mappage tonal :",
+    "stats_tonemapping_client": "Local (client)",
     "stats_reasons": "Raisons :",
     "stats_sample_rate": "Fréquence d'échantillonnage",
     "transcode_reason": {
@@ -1254,6 +1255,7 @@
     "streams_audio_transcode": "Transcodage ({{codec}})",
     "streams_audio_transcode_with_bitrate": "Transcodage ({{codec}}, {{kbps}} kbps)",
     "streams_video_direct": "Lecture directe",
+    "streams_video_client_tonemap": "HDR → SDR (mappage tonal côté client)",
     "streams_video_transcode": "Transcodage ({{hw}})",
     "stream_message_btn": "Envoyer un message",
     "stream_message_title": "Envoyer un message",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -107,6 +107,7 @@
     "stats_dropped_frames": "Fotogrammi persi:",
     "stats_crop": "Ritaglio:",
     "stats_tonemapping": "Mappatura tonale:",
+    "stats_tonemapping_client": "Locale (client)",
     "stats_reasons": "Motivi:",
     "stats_sample_rate": "Frequenza di campionamento",
     "transcode_reason": {
@@ -1246,6 +1247,7 @@
     "streams_audio_transcode": "Transcodifica ({{codec}})",
     "streams_audio_transcode_with_bitrate": "Transcodifica ({{codec}}, {{kbps}} kbps)",
     "streams_video_direct": "Direct Play",
+    "streams_video_client_tonemap": "HDR → SDR (mappatura tonale lato client)",
     "streams_video_transcode": "Transcodifica ({{hw}})",
     "stream_message_btn": "Invia un messaggio",
     "stream_message_title": "Invia un messaggio",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -107,6 +107,7 @@
     "stats_dropped_frames": "Imagens perdidas:",
     "stats_crop": "Recorte:",
     "stats_tonemapping": "Mapeamento tonal:",
+    "stats_tonemapping_client": "Local (cliente)",
     "stats_reasons": "Motivos:",
     "stats_sample_rate": "Frequência de amostragem",
     "transcode_reason": {
@@ -1246,6 +1247,7 @@
     "streams_audio_transcode": "Transcodificação ({{codec}})",
     "streams_audio_transcode_with_bitrate": "Transcodificação ({{codec}}, {{kbps}} kbps)",
     "streams_video_direct": "Reprodução direta",
+    "streams_video_client_tonemap": "HDR → SDR (mapeamento tonal no cliente)",
     "streams_video_transcode": "Transcodificação ({{hw}})",
     "stream_message_btn": "Enviar uma mensagem",
     "stream_message_title": "Enviar uma mensagem",

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -29,6 +29,9 @@ export interface PlaybackInfoResponse {
   outputContainer: string;
   hwAccel: string;
   tonemapping: boolean;
+  /** HDR copied through and tone-mapped by this client (desktop mpv on an SDR
+   *  display), so no server-side tone-map ran. */
+  clientTonemap?: boolean;
   /** Tone-map mechanism the backend actually runs: a HW path
    *  (`'vaapi'` / `'opencl'` / `'qsv'`) on QSV/VAAPI encoders, or
    *  `'cpu'` for the CPU chain (NVENC / libx26x / VideoToolbox

--- a/client/src/app/core/services/api/streams-api.service.ts
+++ b/client/src/app/core/services/api/streams-api.service.ts
@@ -46,6 +46,8 @@ export interface ActiveStream {
    *  but audio bitstream verbatim; `'transcode'` = ffmpeg re-encoded. */
   audioMode: 'direct' | 'copy' | 'transcode';
   transcodePercent: number | null;
+  /** HDR served untouched to a client that tone-maps it to its SDR display. */
+  clientTonemap: boolean;
   videoReasons: string[];
   audioReasons: string[];
   containerReasons: string[];

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -962,12 +962,11 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     const tonemapAlgoLabel = pi?.tonemapAlgo
       ? `${tonemapLabel[pi.tonemapAlgo] ?? pi.tonemapAlgo}${curve}`
       : '';
-    const tonemapping =
-      pi?.tonemapping && tonemapAlgoLabel
-        ? tonemapAlgoLabel
-        : pi?.tonemapping
-          ? 'enabled'
-          : '';
+    const tonemapping = pi?.tonemapping
+      ? tonemapAlgoLabel || 'enabled'
+      : pi?.clientTonemap
+        ? this.translate.instant('player.stats_tonemapping_client')
+        : '';
 
     // Split transcode-reason flags by what they actually re-encode so
     // each section's "Reasons" line only shows what's relevant to it.

--- a/client/src/app/features/system/streams/streams.html
+++ b/client/src/app/features/system/streams/streams.html
@@ -115,6 +115,11 @@
                     }
                   }
                 </div>
+                @if (s.clientTonemap) {
+                  <div class="text-base-content/50 italic">
+                    {{ 'system.streams_video_client_tonemap' | translate }}
+                  </div>
+                }
                 @for (r of s.videoReasons; track r) {
                   <div class="text-warning/80 italic">{{ r }}</div>
                 }


### PR DESCRIPTION
Follow-up to #1251.

## Why

When the backend copies an HDR stream to a client that tone-maps it locally, **no view said so**: the player's "stats for nerds" hid its tone-mapping line entirely (it keys off the server-side `tonemapping` flag), and the admin video activity just showed "Direct Play". The user cannot tell HDR-on-an-SDR-screen from plain SDR.

## What

- `PlaybackInfoResponse.clientTonemap` is set on both copy paths (DirectPlay / remux) when the copy is only possible because the client declared `tonemapsHdrLocally`. Threaded onto the `LiveSession` so the admin dashboard sees it too.
- Player stats overlay: tone-mapping line reads "Local (client)".
- Admin video activity: an informational "HDR → SDR (client-side tone mapping)" line under the video mode.
- New i18n keys in all six locales.

## Diagnostics

`stream-builder` now logs the HDR decision inputs whenever an HDR source is forced onto a tonemap transcode:

```
hdrDecision[file=42] HDR10 → SDR: supportsHdr=false, tonemapsHdrLocally=false, supportsDolbyVision=false, videoSupported=true, videoConditionsMet=true
```

Until now that branch was silent, so a client that never declared the capability was indistinguishable from one whose codec conditions were rejected — the exact question #1251 raises on every deployment.

## Tests

`hdr-local-tonemap.spec.ts` extended: `clientTonemap` is true on the copy path and falsy when the server tone-maps. Full streaming suite green (522 tests), backend + client typecheck clean.