### PR TITLE
feat(streaming): keep HDR through a forced transcode for clients that tonemap locally

### DIFF
--- a/backend/src/modules/streaming/hdr-local-tonemap.spec.ts
+++ b/backend/src/modules/streaming/hdr-local-tonemap.spec.ts
@@ -1,10 +1,13 @@
 import { StreamBuilderService } from './stream-builder.service';
 import type { DeviceProfileDto } from './dto/device-profile.dto';
 
-const svc = () =>
+const svc = (autoCrop = false) =>
   new StreamBuilderService(
     { getDetectedHwAccel: () => 'none' } as never,
-    { getAutoCropEnabled: () => false, getTonemapAlgo: () => 'auto' } as never,
+    {
+      getAutoCropEnabled: () => autoCrop,
+      getTonemapAlgo: () => 'auto',
+    } as never,
   );
 
 // Desktop shell on an SDR panel: decodes HEVC Main 10, no HDR display.
@@ -56,6 +59,7 @@ const resolved = () =>
             hdrFormat: 'HDR10',
             colorTransfer: 'smpte2084',
             colorPrimaries: 'bt2020',
+            crop: '1920:800:0:140',
           },
         ],
         audio: [{ codec: 'aac', channels: 2, bitRate: 128_000 }],
@@ -80,8 +84,24 @@ describe('StreamBuilderService — client-side HDR tone-mapping', () => {
     expect(r.response.clientTonemap).toBe(true);
   });
 
-  it('keeps the transcode ladder SDR when a lower rung forces a re-encode', () => {
-    const r = svc().evaluate(resolved(), localTonemapClient, 'tok', undefined, '720p');
+  it('keeps HDR through a lower rung instead of tone-mapping server-side', () => {
+    const r = svc().evaluate(resolved(), localTonemapClient, 'tok', undefined, '720p-hdr');
+    expect(r.response.playMethod).toBe('Transcode');
+    expect(r.videoVariant?.hdr).toBe('HDR10');
+    expect(r.response.tonemapping).toBe(false);
+    expect(r.response.clientTonemap).toBe(true);
+  });
+
+  it('keeps HDR through a crop-forced transcode', () => {
+    const r = svc(true).evaluate(resolved(), localTonemapClient, 'tok');
+    expect(r.response.playMethod).toBe('Transcode');
+    expect(r.videoVariant?.hdr).toBe('HDR10');
+    expect(r.response.tonemapping).toBe(false);
+    expect(r.response.clientTonemap).toBe(true);
+  });
+
+  it('still tone-maps a crop-forced transcode for a plain SDR client', () => {
+    const r = svc(true).evaluate(resolved(), sdrClient, 'tok');
     expect(r.response.playMethod).toBe('Transcode');
     expect(r.videoVariant?.hdr).toBeNull();
     expect(r.response.tonemapping).toBe(true);

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -264,9 +264,11 @@ export class StreamBuilderService {
       directPlayResult.videoConditionsMet;
     const clientCanPresentDynamicRange =
       clientCanPresentHdr || clientCanPresentDv;
-    // Copy path taken only because the client tone-maps on its own: the stats
-    // overlay and the admin dashboard would otherwise show no HDR step at all.
-    const clientTonemap = clientCanPresentHdr && !clientSupportsHdr;
+    // HDR reaches an SDR client that tone-maps on its own — copied through, or
+    // re-encoded on the HDR ladder. Surfaced in the stats overlay and the admin
+    // dashboard, which would otherwise show no HDR step at all.
+    const clientTonemap =
+      (clientCanPresentHdr || useHdrLadder) && !clientSupportsHdr;
 
     // HDR/DV the client can't present as-is forces a transcode. Flag the
     // tone-map only when the re-encode is actually SDR — when the HDR ladder
@@ -645,6 +647,7 @@ export class StreamBuilderService {
       outputContainer: 'hls',
       hwAccel: effectiveHwAccel,
       tonemapping: transcodeTonemaps,
+      clientTonemap,
       transcodeBitrateByQuality,
       qualities: this.buildQualityList(source, 'Transcode', sourceCopyable, qualityLadder, selectedVariant.codec),
       audioTracks: this.buildAudioTracks(audioStreams, profile, 'Transcode'),

--- a/backend/src/modules/streaming/transcoding/codec/selector.ts
+++ b/backend/src/modules/streaming/transcoding/codec/selector.ts
@@ -60,13 +60,17 @@ export function pickVariants(
       ? [source.codec, ...efficiencyOrder.filter((c) => c !== source.codec)]
       : efficiencyOrder;
 
-  // HDR path — only meaningful when source is HDR AND client supports
-  // an HDR display (browser caps + display gamut probe). H.264 is
+  // HDR path — only meaningful when source is HDR AND the client either has
+  // an HDR display (browser caps + gamut probe) or tone-maps HDR itself, which
+  // is cheaper and better than a tonemap filter on the encode. H.264 is
   // skipped (8-bit only). Two passes: the HW pass picks the first
   // codec with a HW HDR encoder; the CPU pass runs only when no
   // candidate codec has a HW HDR encoder — that's the CPU
   // libx265/libsvtav1 HDR path on boxes without QSV/VAAPI/NVENC.
-  if (source.hdr && profile.supportsHdr === true) {
+  if (
+    source.hdr &&
+    (profile.supportsHdr === true || profile.tonemapsHdrLocally === true)
+  ) {
     const beforeHdr = candidates.length;
     for (const codec of codecOrder) {
       if (codec === 'h264') continue;


### PR DESCRIPTION
Follow-up to #1251 / #1252.

## Why

#1251 only unlocked the **copy** paths. As soon as anything else forced a re-encode — auto-crop, an explicit lower rung, ABR, subtitle burn-in — the session fell back to the SDR ladder and ran a tone-map filter that the client was ready to do for free. On a machine with auto-crop enabled that is *every* HDR title, which is why the tone-map never disappeared from the stats.

## What

One condition in the codec selector: the HDR variant path now opens for a client that declared `tonemapsHdrLocally`, exactly as it does for a real HDR display. `clientTonemap` (#1252) is reported on the transcode path too, so both views keep saying who tone-maps.

Consequences:
- The server skips the tone-map pass (VAAPI/OpenCL/CPU) on those sessions.
- mpv's own tone-mapping is generally better than a static ffmpeg filter (dynamic peak detection).
- **Bitrate does not go up below 4K**: the HDR rungs are HEVC Main10 — 1080p-hdr is 5500k vs 8M for 1080p SDR, 720p-hdr 2800k vs 4M. Only 2160p-hdr is higher (28M vs 20M), and that rung is the source rung on a 4K title.
- The quality menu offers the `*-hdr` rung names to that client, since that is what the backend now serves.
- Dolby Vision P5 is unchanged: it still forces a server-side tone-map unless the client declares DV.
- When no HDR encoder is probed-OK for a client-supported codec, the selector returns an SDR variant and the server tone-maps exactly as before.

## Tests

`hdr-local-tonemap.spec.ts` extended to 5 cases: HDR survives a lower rung and a crop-forced transcode with `tonemapping: false` / `clientTonemap: true`, while a plain SDR client still gets the server tone-map in the same situations. Full streaming suite green (524 tests), backend typecheck clean.