### PR TITLE
fix(player): negotiate the quality rung once instead of guessing it twice

### DIFF
--- a/backend/src/modules/streaming/dto/playback-info.dto.ts
+++ b/backend/src/modules/streaming/dto/playback-info.dto.ts
@@ -103,6 +103,11 @@ export interface PlaybackInfoResponse {
   /** Output container format */
   outputContainer: string;
 
+  /** Rung this session locked in, as one of the {@link qualities} ids —
+   *  `'original'` on the copy paths, `'auto'` when nothing is pinned. The
+   *  player adopts it so its selector always names what is actually served. */
+  quality: string;
+
   /** Hardware acceleration type used for transcoding */
   hwAccel: string;
 

--- a/backend/src/modules/streaming/negotiated-quality.spec.ts
+++ b/backend/src/modules/streaming/negotiated-quality.spec.ts
@@ -1,0 +1,98 @@
+import { StreamBuilderService } from './stream-builder.service';
+import type { DeviceProfileDto } from './dto/device-profile.dto';
+
+const svc = () =>
+  new StreamBuilderService(
+    { getDetectedHwAccel: () => 'none' } as never,
+    { getAutoCropEnabled: () => false, getTonemapAlgo: () => 'auto' } as never,
+  );
+
+const client: DeviceProfileDto = {
+  directPlayProfiles: [
+    { containers: ['mkv'], videoCodecs: ['hevc'], audioCodecs: ['aac'] },
+  ],
+  codecConditions: [
+    {
+      codec: 'hevc',
+      profiles: ['main', 'main 10'],
+      maxBitDepth: 10,
+      maxWidth: 3840,
+      maxHeight: 2160,
+      maxLevel: 180,
+    },
+  ],
+  supportsHdr: false,
+  supportsDirectPlay: true,
+  maxAudioChannels: 6,
+} as never;
+
+/** Same client, but it tone-maps HDR itself — so an HDR source puts the
+ *  session on the HDR ladder, where the rung ids carry a `-hdr` suffix. */
+const localTonemapClient: DeviceProfileDto = {
+  ...client,
+  tonemapsHdrLocally: true,
+};
+
+const resolved = (hdr: boolean) =>
+  ({
+    ext: '.mkv',
+    contentType: 'video/x-matroska',
+    absolutePath: '/m/in.mkv',
+    relativePath: 'in.mkv',
+    size: 1,
+    media: { title: 'X', type: 'movie' },
+    mediaFile: {
+      id: 1,
+      streamInfo: {
+        video: [
+          {
+            codec: 'hevc',
+            width: 1920,
+            height: 1080,
+            bitDepth: hdr ? 10 : 8,
+            profile: hdr ? 'Main 10' : 'Main',
+            level: 120,
+            bitRate: 8_000_000,
+            frameRate: '24',
+            hdrFormat: hdr ? 'HDR10' : undefined,
+            colorTransfer: hdr ? 'smpte2084' : undefined,
+            colorPrimaries: hdr ? 'bt2020' : undefined,
+          },
+        ],
+        audio: [{ codec: 'aac', channels: 2, bitRate: 128_000 }],
+        durationSeconds: 100,
+      },
+    },
+  }) as never;
+
+describe('StreamBuilderService — negotiated quality', () => {
+  it('reports the source rung on a copy path', () => {
+    const r = svc().evaluate(resolved(false), client, 'tok');
+    expect(r.response.playMethod).toBe('DirectPlay');
+    expect(r.response.quality).toBe('original');
+  });
+
+  it('reports the eco rung it locked in', () => {
+    const r = svc().evaluate(resolved(false), client, 'tok', undefined, 'eco-1080p');
+    expect(r.response.playMethod).toBe('Transcode');
+    expect(r.response.quality).toBe('eco-1080p');
+  });
+
+  it('keeps an eco request on the eco rung of the HDR ladder', () => {
+    const r = svc().evaluate(
+      resolved(true),
+      localTonemapClient,
+      'tok',
+      undefined,
+      'eco-1080p',
+    );
+    expect(r.response.playMethod).toBe('Transcode');
+    expect(r.response.quality).toBe('eco-1080p-hdr');
+  });
+
+  it('reports auto when nothing is pinned', () => {
+    const r = svc().evaluate(resolved(false), client, 'tok', undefined, 'auto', 'abr');
+    expect(r.response.playMethod).toBe('Transcode');
+    expect(r.response.quality).toBe('auto');
+  });
+});

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -15,6 +15,7 @@ import {
   getHdrLadderForDevice,
   getLadderForDevice,
   isEcoProfile,
+  resolveLadderRung,
   parseBitrateToBps,
   profileFitsSource,
   resolveSourceVideoBitrateBps,
@@ -342,7 +343,11 @@ export class StreamBuilderService {
     // to the ladder.
     const explicitRung = wantsSourceRung
       ? undefined
-      : qualityLadder.find((p) => p.name === requestedQuality);
+      : resolveLadderRung(requestedQuality as string, qualityLadder);
+    // Rung this session locks in, in `qualities` ids. The client mirrors its
+    // selector on it instead of re-deriving one from the stored preference,
+    // which cannot see which ladder the backend ended up on.
+    const negotiatedQuality = explicitRung?.name ?? 'auto';
     const explicitDownscale =
       !!explicitRung &&
       (bucketResolutionHeight(explicitRung.maxWidth, explicitRung.maxHeight) <
@@ -414,6 +419,7 @@ export class StreamBuilderService {
         outputAudioCodec: sourceAudioCodec,
         audioPlan: { mode: 'copy', codec: sourceAudioCodec },
         outputContainer: sourceContainer,
+        quality: 'original',
         hwAccel: 'none',
         tonemapping: false,
         clientTonemap,
@@ -507,6 +513,7 @@ export class StreamBuilderService {
               bitrateBps: parseBitrateToBps(ladder[0]?.audioBitrate ?? '192k'),
             },
         outputContainer: 'hls',
+        quality: 'original',
         // Report the backend's detected hwAccel even on the remux path:
         // the stats overlay binds this to the active *quality* (remux →
         // "Direct playback" / transcode rung → "Transcoding (<HW>)"). A
@@ -645,6 +652,7 @@ export class StreamBuilderService {
             bitrateBps: outputAudioBitrateBps,
           },
       outputContainer: 'hls',
+      quality: negotiatedQuality,
       hwAccel: effectiveHwAccel,
       tonemapping: transcodeTonemaps,
       clientTonemap,

--- a/backend/src/modules/streaming/transcoding/index.ts
+++ b/backend/src/modules/streaming/transcoding/index.ts
@@ -14,6 +14,7 @@ export {
   parseBitrateToBps,
   profileFitsSource,
   profileResolution,
+  resolveLadderRung,
   resolveSourceVideoBitrateBps,
 } from './profiles';
 export { cappedRungVideoBitrateBps } from './quality-ladder';

--- a/backend/src/modules/streaming/transcoding/ladder-rung.spec.ts
+++ b/backend/src/modules/streaming/transcoding/ladder-rung.spec.ts
@@ -1,0 +1,41 @@
+import {
+  getHdrLadderForDevice,
+  getLadderForDevice,
+  resolveLadderRung,
+} from './profiles';
+
+const sdr = getLadderForDevice('desktop');
+const hdr = getHdrLadderForDevice('desktop');
+
+describe('resolveLadderRung', () => {
+  it('matches an exact name', () => {
+    expect(resolveLadderRung('eco-1080p', sdr)?.name).toBe('eco-1080p');
+  });
+
+  it('keeps the low-consumption tier across ladders', () => {
+    expect(resolveLadderRung('eco-1080p', hdr)?.name).toBe('eco-1080p-hdr');
+    expect(resolveLadderRung('eco-1080p-hdr', sdr)?.name).toBe('eco-1080p');
+  });
+
+  it('never promotes an eco rung to its full-quality sibling', () => {
+    // The HDR eco tier stops at 1080p, so a 720p eco request lands on the
+    // smallest eco rung there — still low-consumption, never the full rung.
+    expect(resolveLadderRung('eco-720p', hdr)?.name).toBe('eco-1080p-hdr');
+  });
+
+  it('steps down, never up, when the tier is missing', () => {
+    expect(resolveLadderRung('1440p', sdr)?.name).toBe('1080p');
+  });
+
+  it('maps a full rung onto the same tier of the other ladder', () => {
+    expect(resolveLadderRung('1080p', hdr)?.name).toBe('1080p-hdr');
+  });
+
+  it('falls to the smallest rung of its class below the whole ladder', () => {
+    expect(resolveLadderRung('144p', hdr)?.name).toBe('480p-hdr');
+  });
+
+  it('returns undefined for a name carrying no tier', () => {
+    expect(resolveLadderRung('nonsense', sdr)).toBeUndefined();
+  });
+});

--- a/backend/src/modules/streaming/transcoding/profiles.ts
+++ b/backend/src/modules/streaming/transcoding/profiles.ts
@@ -219,6 +219,28 @@ export function isEcoProfile(name: string): boolean {
   return name.startsWith('eco-');
 }
 
+/** Resolve a requested rung name against a ladder. A name minted on another
+ *  ladder (`eco-1080p` where this one carries `eco-1080p-hdr`) resolves to the
+ *  nearest rung of the same class — full vs `eco-` — that doesn't step UP, so
+ *  honouring a stale id never raises the bitrate the user asked to cut. */
+export function resolveLadderRung(
+  name: string,
+  ladder: TranscodeProfile[],
+): TranscodeProfile | undefined {
+  const exact = ladder.find((p) => p.name === name);
+  if (exact) return exact;
+  const tier = Number(/(\d+)p/.exec(name)?.[1] ?? 0);
+  if (!tier) return undefined;
+  const eco = isEcoProfile(name);
+  const sameClass = ladder
+    .filter((p) => isEcoProfile(p.name) === eco)
+    .sort((a, b) => b.maxHeight - a.maxHeight);
+  return (
+    sameClass.find((p) => p.maxHeight <= tier) ??
+    sameClass[sameClass.length - 1]
+  );
+}
+
 /** Unified ladder for every device: the full-quality rungs plus the
  *  low-consumption `eco-*` rungs. Desktop and mobile expose the same menu;
  *  data-conscious clients pick an eco rung (or default to it via the player

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -51,6 +51,9 @@ export interface PlaybackInfoResponse {
   >;
   /** BANDWIDTH variante remux (DirectStream HLS), aligné serveur / manifeste */
   remuxMasterBandwidthBps?: number;
+  /** Rung the session locked in, as one of the `qualities` ids. Optional: an
+   *  older backend doesn't send it, and the selector then keeps its own id. */
+  quality?: string;
   /** Server-authoritative quality list (device-aware ladder + Original rule). */
   qualities?: {
     id: string;

--- a/client/src/app/core/services/quality-manager.service.ts
+++ b/client/src/app/core/services/quality-manager.service.ts
@@ -117,49 +117,24 @@ export class QualityManagerService {
     return highestRungId(this.availableQualities());
   }
 
-  /** Default quality id for the current visible list: `auto` when present,
-   *  else the first (top) visible rung. */
-  private defaultQualityId(): string {
-    const opts = this.availableQualities();
-    return opts.some((q) => q.id === 'auto') ? 'auto' : (opts[0]?.id ?? 'auto');
+  /**
+   * Restore the persisted rung BEFORE negotiating playback, so the id we send
+   * is the id the session is created with. Applied verbatim: the backend owns
+   * the ladder and resolves a rung minted on another one
+   * (`eco-1080p` → `eco-1080p-hdr`), which no client-side guess can do.
+   */
+  restorePreference(): void {
+    this.activeQualityId.set(this.readFromStorage() ?? 'auto');
   }
 
   /**
-   * Read persisted quality preference from localStorage and apply it if valid.
-   * IDs differ across media (`'original'` for the source-rung remux/DirectPlay
-   * vs `'1080p'` for a transcode rung) — when an exact id match fails, fall
-   * back to height matching so a "1080p" saved on one show maps cleanly to
-   * the equivalent rung on another (which may carry a different id).
+   * Adopt the rung the backend reports for the session just negotiated. The
+   * selector then always names what is actually served — a request the backend
+   * could not honour never lingers as a phantom active rung, which used to
+   * swallow the next click on the rung it claimed to be on.
    */
-  applySavedPreference(): void {
-    const saved = this.readFromStorage();
-    if (!saved) {
-      this.activeQualityId.set(this.defaultQualityId());
-      return;
-    }
-    const opts = this.availableQualities();
-    const direct = opts.find((q) => q.id === saved.id);
-    if (direct) {
-      this.activeQualityId.set(direct.id);
-      return;
-    }
-    if (saved.height > 0) {
-      const exactHeight = opts.find((q) => q.height === saved.height);
-      if (exactHeight) {
-        this.activeQualityId.set(exactHeight.id);
-        return;
-      }
-      // No exact-height match — pick the largest rung still ≤ saved height
-      // (don't auto-upgrade beyond the user's intent).
-      const below = opts
-        .filter((q) => q.height > 0 && q.height <= saved.height)
-        .sort((a, b) => b.height - a.height);
-      if (below.length) {
-        this.activeQualityId.set(below[0].id);
-        return;
-      }
-    }
-    this.activeQualityId.set(this.defaultQualityId());
+  adoptNegotiatedQuality(id: string | undefined): void {
+    if (id) this.activeQualityId.set(id);
   }
 
   /**
@@ -278,7 +253,8 @@ export class QualityManagerService {
   }
 
   /**
-   * After buildQualityOptions + applySavedPreference: restore last choice with force=true.
+   * After buildQualityOptions + adoptNegotiatedQuality: re-apply the active
+   * rung to the engine with force=true.
    */
   applyQualityPreferenceAfterLoad(
     engine: PlaybackEngine | null,
@@ -291,16 +267,13 @@ export class QualityManagerService {
     this.selectQuality(option, engine, playbackMode, true);
   }
 
-  /**
-   * Persist quality preference to localStorage. Stores both id and height
-   * so a follow-up media with different id naming (e.g. `'original'` instead
-   * of `'1080p'` for the same resolution) can still match by height.
-   */
+  /** Persist the chosen rung id. Re-sent on the next negotiation, where the
+   *  backend maps it onto the ladder it serves. */
   persistPreference(option: QualityOption): void {
     try {
       localStorage.setItem(
         PLAYER_QUALITY_STORAGE_KEY,
-        JSON.stringify({ id: option.id, height: option.height }),
+        JSON.stringify({ id: option.id }),
       );
     } catch {
       /* private mode / quota */
@@ -335,13 +308,12 @@ export class QualityManagerService {
 
   // ── Private helpers ──
 
-  private readFromStorage(): { id: string; height: number } | null {
+  private readFromStorage(): string | null {
     try {
       const raw = localStorage.getItem(PLAYER_QUALITY_STORAGE_KEY);
       if (!raw) return null;
-      const parsed = JSON.parse(raw) as { id?: string; height?: number };
-      if (typeof parsed.id !== 'string') return null;
-      return { id: parsed.id, height: parsed.height ?? 0 };
+      const parsed = JSON.parse(raw) as { id?: string };
+      return typeof parsed.id === 'string' ? parsed.id : null;
     } catch {
       return null;
     }

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1148,6 +1148,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       // (instead of waiting for master.m3u8), overlapping encoder init with
       // the ~100–300ms gap before the player fetches the playlist.
       const deviceProfile = this.deviceProfileService.getProfile();
+      // The service is app-scoped: without this the request would carry the
+      // previous media's rung instead of the user's saved one.
+      this.qualityManager.restorePreference();
       const prewarmQuality = this.resolveStartQuality();
       const prewarmStartAt = resumeTime;
       const playbackInfoPromise = this.isOfflinePlayback
@@ -1280,9 +1283,9 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         }
         this.state.hwAccel.set(pi.hwAccel);
 
-        // Build quality options and apply saved preference BEFORE load
+        // Options + the rung the backend locked in, BEFORE load
         this.qualityManager.buildQualityOptions(pi);
-        this.qualityManager.applySavedPreference();
+        this.qualityManager.adoptNegotiatedQuality(pi.quality);
 
         const mode = this.playbackMode();
 
@@ -2615,6 +2618,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       );
       this.state.hwAccel.set(pi.hwAccel);
       this.qualityManager.buildQualityOptions(pi);
+      this.qualityManager.adoptNegotiatedQuality(pi.quality);
 
       const { url, mimeType } = this.buildPlayUrl({ startTime });
       await this.engine.load(url, startTime, mimeType);
@@ -4559,6 +4563,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       }
       this.state.hwAccel.set(pi.hwAccel);
       this.qualityManager.buildQualityOptions(pi);
+      this.qualityManager.adoptNegotiatedQuality(pi.quality);
 
       const mode = this.playbackMode();
       // Refresh the near-expiry stream token before rebuilding the play URL:


### PR DESCRIPTION
Fixes the swallowed quality click reported on the Windows desktop client: playing on **4K basse conso**, clicking **4K normal** did nothing; clicking eco again reloaded, and every switch afterwards worked.

## Root cause

Two different pieces of code decided "the active rung", and they could disagree:

1. The playback-info request is fired from `activeQualityId` — an **app-scoped** signal that still holds the *previous* media's rung. That is what the session is created with.
2. After the response, `applySavedPreference()` overwrote that same signal from localStorage, matching by **height** when the exact id was missing. Eco and full rungs share a height (2160), so the UI could settle on `2160p` while the session was really serving `eco-2160p`.

`onSelectQualityById` then short-circuits on `id === activeQualityId()` — so the click on the rung the UI *claimed* to be on was dropped, and only a click on a third rung forced the reload that re-synchronised everything.

A second, quieter half of the same bug: an id the backend's ladder does not carry was silently ignored (`ladder.find(p => p.name === requested)` → `undefined` → source rung). A user who picked a low-consumption rung got the **full-bitrate** source instead. #1253 made this reachable in normal use, since an HDR session renames every rung (`eco-1080p` → `eco-1080p-hdr`).

## The change

- `PlaybackInfoResponse.quality` — the rung the session locked in, as one of the `qualities` ids (`'original'` on the copy paths, `'auto'` when nothing is pinned).
- Client: `restorePreference()` before the request (so the id we send is the id the session is built with) and `adoptNegotiatedQuality(pi.quality)` after it (so the selector always names what is actually served). The ~50 lines of height matching are deleted along with the bug class they caused.
- `resolveLadderRung(name, ladder)` gives the backend the tolerance the height fallback was reaching for, but where the ladders actually live: an id from another ladder resolves to the nearest rung of the same class (full vs `eco-`), **never stepping up**.

Net: **-53 lines of logic**, one owner for the decision.

## Tests

- `ladder-rung.spec.ts` (7): exact match, eco preserved across SDR↔HDR ladders, never promoted to its full-quality sibling, steps down and never up, no tier → undefined.
- `negotiated-quality.spec.ts` (4): `'original'` on a copy path, the eco rung reported back, an `eco-1080p` request landing on `eco-1080p-hdr` for an HDR-ladder session, `'auto'` when nothing is pinned.
- Backend suite 535 green, client suite 784 green, both typechecks clean.