### PR TITLE
feat(streaming): let clients that crop at their own output keep the copy path

### DIFF
--- a/backend/src/modules/streaming/crop-local.spec.ts
+++ b/backend/src/modules/streaming/crop-local.spec.ts
@@ -1,0 +1,98 @@
+import { StreamBuilderService } from './stream-builder.service';
+import type { DeviceProfileDto } from './dto/device-profile.dto';
+
+const svc = () =>
+  new StreamBuilderService(
+    { getDetectedHwAccel: () => 'none' } as never,
+    { getAutoCropEnabled: () => true, getTonemapAlgo: () => 'auto' } as never,
+  );
+
+const client: DeviceProfileDto = {
+  directPlayProfiles: [
+    { containers: ['mkv'], videoCodecs: ['hevc'], audioCodecs: ['aac'] },
+  ],
+  codecConditions: [
+    {
+      codec: 'hevc',
+      profiles: ['main', 'main 10'],
+      maxBitDepth: 10,
+      maxWidth: 3840,
+      maxHeight: 2160,
+      maxLevel: 180,
+    },
+  ],
+  supportsHdr: false,
+  supportsDirectPlay: true,
+  maxAudioChannels: 6,
+} as never;
+
+const croppingClient: DeviceProfileDto = {
+  ...client,
+  cropsBlackBarsLocally: true,
+};
+
+/** 2160p HEVC with black bars — cropdetect found a 3840x1648 active area. */
+const resolved = () =>
+  ({
+    ext: '.mkv',
+    contentType: 'video/x-matroska',
+    absolutePath: '/m/in.mkv',
+    relativePath: 'in.mkv',
+    size: 1,
+    media: { title: 'X', type: 'movie' },
+    mediaFile: {
+      id: 1,
+      streamInfo: {
+        video: [
+          {
+            codec: 'hevc',
+            width: 3840,
+            height: 2160,
+            bitDepth: 8,
+            profile: 'Main',
+            level: 150,
+            bitRate: 20_000_000,
+            frameRate: '24',
+            crop: { width: 3840, height: 1648, x: 0, y: 256 },
+          },
+        ],
+        audio: [{ codec: 'aac', channels: 2, bitRate: 128_000 }],
+        durationSeconds: 100,
+      },
+    },
+  }) as never;
+
+const hasCropReason = (r: { response: { transcodeReasons: { flag: string }[] } }) =>
+  r.response.transcodeReasons.some((x) => x.flag === 'VideoCrop');
+
+describe('StreamBuilderService — client-side black-bar crop', () => {
+  it('re-encodes a cropped source for a client that cannot crop', () => {
+    const r = svc().evaluate(resolved(), client, 'tok');
+    expect(r.response.playMethod).toBe('Transcode');
+    expect(hasCropReason(r)).toBe(true);
+  });
+
+  it('DirectPlays it for a client that crops at its own output', () => {
+    const r = svc().evaluate(resolved(), croppingClient, 'tok');
+    expect(r.response.playMethod).toBe('DirectPlay');
+    expect(r.response.videoCopyStream).toBe(true);
+    expect(hasCropReason(r)).toBe(false);
+    // The rectangle the client applies.
+    expect(r.response.source.crop).toEqual({
+      width: 3840,
+      height: 1648,
+      x: 0,
+      y: 256,
+    });
+  });
+
+  it('leaves another transcode reason alone — the server still crops there', () => {
+    const burnIn = svc().evaluate(resolved(), croppingClient, 'tok', 7);
+    expect(burnIn.response.playMethod).toBe('Transcode');
+    expect(burnIn.response.videoCopyStream).toBe(false);
+
+    const lowerRung = svc().evaluate(resolved(), croppingClient, 'tok', undefined, '1080p');
+    expect(lowerRung.response.playMethod).toBe('Transcode');
+    expect(lowerRung.response.videoCopyStream).toBe(false);
+  });
+});

--- a/backend/src/modules/streaming/dto/device-profile.dto.ts
+++ b/backend/src/modules/streaming/dto/device-profile.dto.ts
@@ -97,6 +97,16 @@ export class DeviceProfileDto {
   tonemapsHdrLocally?: boolean;
 
   /**
+   * Client crops the detected black bars at its own video output (mpv
+   * `video-crop`, free and hwdec-safe), so a crop alone no longer demotes a
+   * copy path to a re-encode. Only the copy paths hand the rectangle over: a
+   * session that re-encodes for any other reason still crops server-side.
+   */
+  @IsBoolean()
+  @IsOptional()
+  cropsBlackBarsLocally?: boolean;
+
+  /**
    * Client can present single-layer Dolby Vision (Profile 5 / 8.x) directly:
    * both a DV decoder and a DV panel confirmed on the device. The backend then
    * DirectPlays the original container untouched so the RPU rides through.

--- a/backend/src/modules/streaming/stream-builder.service.ts
+++ b/backend/src/modules/streaming/stream-builder.service.ts
@@ -223,6 +223,11 @@ export class StreamBuilderService {
     // Cropping black bars forces a re-encode. When the admin disables auto-crop
     // (low-power servers), keep the bars and let the source Direct Play / remux.
     const needsCrop = !!source.crop;
+    // …unless the client crops at its own video output, which costs nothing and
+    // keeps the bitstream copyable. A session that re-encodes for another reason
+    // still crops server-side — fewer pixels to encode — and the client leaves
+    // it alone, keyed off `videoCopyStream`.
+    const clientCropsBlackBars = profile.cropsBlackBarsLocally === true;
 
     const reasons: TranscodeReason[] = [];
 
@@ -300,7 +305,7 @@ export class StreamBuilderService {
     }
 
     // Crop (black bar removal) forces transcode
-    if (needsCrop) {
+    if (needsCrop && !clientCropsBlackBars) {
       if (directPlayResult.canDirectPlay)
         directPlayResult.canDirectPlay = false;
       reasons.push({
@@ -364,7 +369,7 @@ export class StreamBuilderService {
       directPlayResult.videoConditionsMet &&
       ((!isSourceHdr && !dvP5) || clientCanPresentDynamicRange) &&
       !needsBurnIn &&
-      !needsCrop;
+      (!needsCrop || clientCropsBlackBars);
 
     if (profile.supportsDirectPlay === false && directPlayResult.canDirectPlay) {
       directPlayResult.canDirectPlay = false;

--- a/client/src/app/core/plugins/desktop-player.bridge.ts
+++ b/client/src/app/core/plugins/desktop-player.bridge.ts
@@ -26,6 +26,9 @@ export interface DesktopLoadOptions {
   /** Preferred audio language (mpv `alang`) so the player keeps the chosen
    *  language across seeks/reloads instead of reverting to the manifest default. */
   audioLanguage?: string;
+  /** Black-bar rectangle in mpv `video-crop` syntax (`WxH+x+y`); the VO crops
+   *  after decode, keeping hardware decoding. Absent clears any previous crop. */
+  videoCrop?: string;
 }
 
 export interface DesktopSubtitleStyle {

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -91,6 +91,9 @@ export interface DeviceProfile {
   /** mpv tone-maps HDR to this SDR display itself, so the backend copies the
    *  HDR bitstream instead of re-encoding it. Desktop shell only. */
   tonemapsHdrLocally?: boolean;
+  /** mpv crops the detected black bars at its video output, so a crop alone
+   *  no longer costs a server-side re-encode. Desktop shell only. */
+  cropsBlackBarsLocally?: boolean;
   /** Client can present single-layer Dolby Vision (P5 / 8.x) directly, so the
    *  backend DirectPlays the original container untouched instead of tonemapping
    *  P5 to SDR. iOS/Android report it from the native probe (DV HW decoder / DV
@@ -511,13 +514,17 @@ export class BrowserDeviceProfileService {
       supportsHdr = hdrDisplay && has10bitCodec;
     }
 
-    // mpv tone-maps HDR down to an SDR display on its own (Windows vo=gpu,
-    // macOS layer when the screen has no EDR headroom) — the Linux x11
-    // software VO does not, so it keeps the server-side tonemap.
-    const tonemapsHdrLocally =
-      !supportsHdr &&
-      this.device.isDesktopNative() &&
-      /Windows|Mac OS X/.test(navigator.userAgent);
+    // Backends whose mpv renders through a real video output: Windows vo=gpu
+    // and the macOS layer. The Linux shell draws through the x11 software VO,
+    // which neither tone-maps nor crops, so it stays on the server-side paths.
+    const mpvVideoOutput =
+      this.device.isDesktopNative() && /Windows|Mac OS X/.test(navigator.userAgent);
+    // mpv tone-maps HDR down to an SDR display on its own (the macOS layer does
+    // it whenever the screen has no EDR headroom).
+    const tonemapsHdrLocally = mpvVideoOutput && !supportsHdr;
+    // `video-crop` cuts the bars at the VO — free, and hwdec-safe unlike a
+    // lavfi crop.
+    const cropsBlackBarsLocally = mpvVideoOutput;
 
     // Dolby Vision passthrough capability, gated under supportsHdr (DV ⊆ HDR, so
     // it never outlives HDR and the forceDisableHdr override stays consistent).
@@ -553,6 +560,7 @@ export class BrowserDeviceProfileService {
       audioChannelsByCodec: this.nativeAudio?.channelsByCodec,
       supportsHdr,
       tonemapsHdrLocally,
+      cropsBlackBarsLocally,
       supportsDolbyVision,
       deviceType: Capacitor.isNativePlatform() ? 'mobile' : 'desktop',
       deviceName: getDeviceName(),

--- a/client/src/app/core/services/playback-engine/desktop-engine.ts
+++ b/client/src/app/core/services/playback-engine/desktop-engine.ts
@@ -59,6 +59,7 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
   /** Preferred audio language (from configure()); passed to mpv as `alang` at
    *  load so it auto-picks the matching rendition on every reconfig. */
   private _preferredAudioLanguage?: string;
+  private _videoCrop?: string;
 
   private _subtitleStyle: {
     fontScale: number;
@@ -111,6 +112,7 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
       startTime,
       headers,
       audioLanguage: this._preferredAudioLanguage,
+      videoCrop: this._videoCrop,
     });
     if (this._subtitleStyle) {
       await this.bridge.setSubtitleStyle(this._subtitleStyle);
@@ -332,6 +334,12 @@ export class DesktopEngine extends AbstractPlaybackEngine implements PlaybackEng
     // preferredAudioLanguage).
     if (config && typeof config.preferredAudioLanguage === 'string') {
       this._preferredAudioLanguage = config.preferredAudioLanguage || undefined;
+    }
+    // Black-bar crop: mpv cuts it at the VO for free, so the backend copies the
+    // bitstream instead of re-encoding. Held here and re-applied on every load,
+    // like the subtitle style and fill-screen above.
+    if (config && 'videoCrop' in config) {
+      this._videoCrop = config.videoCrop || undefined;
     }
   }
 

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1377,6 +1377,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
             if (preferredAudioLang) {
               this.engine!.configure({ preferredAudioLanguage: preferredAudioLang });
             }
+            this.applyVideoCrop();
           }
 
           // Capacitor native players preload sidecar subs into the MediaItem for
@@ -2619,6 +2620,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       this.state.hwAccel.set(pi.hwAccel);
       this.qualityManager.buildQualityOptions(pi);
       this.qualityManager.adoptNegotiatedQuality(pi.quality);
+      this.applyVideoCrop();
 
       const { url, mimeType } = this.buildPlayUrl({ startTime });
       await this.engine.load(url, startTime, mimeType);
@@ -4416,6 +4418,19 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     this.statsVisible.set(false);
   }
 
+  /** Push the black-bar rectangle onto the desktop engine. The server only
+   *  crops when it re-encodes, so the client crops exactly on the copy paths —
+   *  `videoCopyStream` tells the two apart and keeps them from stacking. */
+  private applyVideoCrop(): void {
+    if (!this.isDesktopNative) return;
+    const c = this.playbackInfo?.videoCopyStream
+      ? this.playbackInfo.source?.crop
+      : undefined;
+    this.engine?.configure({
+      videoCrop: c ? `${c.width}x${c.height}+${c.x}+${c.y}` : null,
+    });
+  }
+
   async onSelectQualityById(id: string) {
     const option = this.availableQualities().find(q => q.id === id);
     if (!option) return;
@@ -4564,6 +4579,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       this.state.hwAccel.set(pi.hwAccel);
       this.qualityManager.buildQualityOptions(pi);
       this.qualityManager.adoptNegotiatedQuality(pi.quality);
+      this.applyVideoCrop();
 
       const mode = this.playbackMode();
       // Refresh the near-expiry stream token before rebuilding the play URL:

--- a/desktop/src/main/mpv/mac-mpv-player.ts
+++ b/desktop/src/main/mpv/mac-mpv-player.ts
@@ -166,6 +166,9 @@ export class MacMpvPlayer extends TypedEmitter<PlayerBackendEvents> implements P
     // timeout + the error path keep an aborted load from hanging.
     this.firstFrameResolve?.();
     this.sawFirstFrame = false;
+    // Global property, so it is always written — otherwise the previous file's
+    // rectangle would crop the next one.
+    this.addon.setProperty('video-crop', opts.videoCrop ?? '');
     this.addon.load(opts);
     await this.waitFirstFrame();
   }

--- a/desktop/src/main/mpv/mpv-player.ts
+++ b/desktop/src/main/mpv/mpv-player.ts
@@ -483,6 +483,9 @@ export class MpvPlayer extends TypedEmitter<PlayerBackendEvents> implements Play
       'http-header-fields',
       opts.headers ? Object.entries(opts.headers).map(([k, v]) => `${k}: ${v}`) : [],
     );
+    // Always written, so a cropped file's rectangle can't survive into the next
+    // one (the property is global, not per-file).
+    await this.set('video-crop', opts.videoCrop ?? '').catch(() => {});
     if (gen !== this.loadGen) return;
     // mpv >= 0.38 loadfile signature is <url> <flags> <index> <options>; the
     // bundled mpv is recent, so pass index 0 then the options. Omit the options

--- a/desktop/src/shared/contract.ts
+++ b/desktop/src/shared/contract.ts
@@ -29,6 +29,10 @@ export interface DesktopLoadOptions {
    *  the macOS in-process backend and the Windows subprocess consume it; the
    *  Linux compositor backend does not. */
   audioLanguage?: string;
+  /** Black-bar rectangle in mpv `video-crop` syntax (`WxH+x+y`). The VO crops
+   *  after decode — free, and unlike a lavfi crop it keeps hwdec. Empty/absent
+   *  clears a previous file's crop. */
+  videoCrop?: string;
 }
 
 export interface DesktopSubtitleStyle {


### PR DESCRIPTION
Closes #1255.

> **Stacked on #1254** — its base is `fix/quality-rung-negotiation`, so merge that one first and this PR retargets `main` on its own. Only the last commit belongs to this PR.

## Why

Removing black bars was enough, on its own, to demote a 2160p HEVC title that would otherwise DirectPlay into a full re-encode — 16.98 s to first frame cold, 5.50 s warm, against effectively instant for an uncropped title. `VideoCrop` was the only remaining reason on those sessions.

mpv crops at the video output, after decode, for free — and per `mpv(1)`, `--video-crop` "works with hwdec, unlike the equivalent lavfi-crop". On a copy path the bitrate argument for a server-side crop does not apply either: the client receives the source bitstream either way.

## What

Mirrors the `tonemapsHdrLocally` waiver, in the same shape:

- `cropsBlackBarsLocally` on the device profile, set by the desktop shell. Both mpv waivers now derive from one `mpvVideoOutput` gate (Windows `vo=gpu` + the macOS layer); the Linux shell draws through the x11 software VO, which neither tone-maps nor crops, so it stays on the server-side path.
- `stream-builder` lifts the crop demotion on the **copy paths only**. A session that re-encodes for another reason still crops server-side, and the client keys its own crop off `videoCopyStream` — the two can never stack.
- The rectangle already travels in `source.crop` (the stats overlay reads it), so nothing new crosses the wire.
- `DesktopLoadOptions.videoCrop` in mpv syntax (`3840x1648+0+256`). Both backends write `video-crop` **unconditionally** on load: it is a global property, so a stale rectangle would otherwise crop the next file.
- `DesktopEngine` holds it and re-applies it on every load, like `_subtitleStyle` and `_fillScreen` already do.

## Tests

`crop-local.spec.ts` (3): a cropped source still re-encodes for a client that cannot crop; DirectPlays with the flag, no `VideoCrop` reason, rectangle intact in the response; and the issue's open question — with the flag plus a burn-in or a lower rung it stays a transcode with `videoCopyStream: false`, so the server keeps the crop.

Backend 538 green, client 784 green, backend/client/desktop typechecks clean.

## Not verified on device

That mpv applies `video-crop` through the macOS render-API path (`vo=libmpv`) as it does with `vo=gpu` on Windows. Same caveat the issue raises about per-backend verification — worth a look on the Mac before trusting it there.