### PR TITLE
fix(player): start playback on desktop instead of via stall recovery

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1523,7 +1523,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         await this.engine!.unload();
         const startPos = resumeTime ?? this.engine!.currentTime;
         await this.startCastFromPlayer(startPos);
-      } else if (!this.isNativeEngine()) {
+      } else if (!this.isNativeEngine() || this.isDesktopNative) {
         this.engine!.play().catch(() => {
           // No user gesture on a device started remotely: the browser refuses
           // autoplay. Reported, not just logged: a controller otherwise shows a


### PR DESCRIPTION
## The bug

The autoplay call after load is skipped for native engines:

```ts
} else if (!this.isNativeEngine()) {
  this.engine!.play().catch(...)
```

That holds for ExoPlayer (`playWhenReady`) and AVPlayer, which start on their own. But `wireNativePlayerEngine` — "Shared wiring for the transparent-overlay native engines (Capacitor ExoPlayer/AVPlayer **and Electron mpv**)" — sets `isNativeEngine` for the desktop engine too, and mpv does **not** autoplay: it loads paused and waits for `pause=no`.

So on desktop nothing ever called `play()` on the initial load. The chain that followed:

1. Load completes, `firstFrame` fires, mpv sits paused — no `play` IPC is ever sent.
2. The playhead never advances, so `checkStall` sees a frozen position and after `stallTimeoutMs` (15 s) treats it as a wedged player.
3. It calls `recoverFromLostSession()`, which mints a fresh `sid` and reloads the whole stream — a second cold transcode spawn.
4. That recovery path restores the pre-reload play state (`wasPaused ? pause() : play()` in `refreshSidAndReload`), which is what finally starts playback.

Desktop playback only ever started through the error-recovery path. The user-visible symptom is a long black screen after the loading spinner — the 15 s stall plus the second load.

## Evidence

Driven through the real UI (home → episode → resume), timestamped Electron stdout.

**Before:**
```
17.015  [ipc] load  #1
21.219  [player] state: paused
26.049  [player] firstFrame          <- no [ipc] play
41.160  [ipc] load  #2               <- +15.1 s, from recoverFromLostSession
49.650  [player] firstFrame
49.652  [ipc] play
49.657  [player] state: playing
```

Stack captured at the second load:

```
at DesktopEngine.load
at _PlayerComponent.refreshSidAndReload
at async _PlayerComponent.recoverFromLostSession
```

**After:**
```
18.387  [ipc] load  #1
27.225  [player] firstFrame
27.231  [ipc] play
27.446  [player] state: playing      <- one load, no reload for the next 45 s
```

| | before | after |
|---|---|---|
| click → playing | **32.6 s** | **9.1 s** |
| stream loads | 2 (two cold transcode spawns) | 1 |
| black screen | ~15 s stall + reload | none |

Instrumenting the heartbeat showed `sessionLost=false` on every beat, with the sid matching the one from playback-info — no session was ever actually lost. The recovery path was being used as an accidental start mechanism.

## Scope

One line. Mobile native engines keep their current behaviour: the new condition only adds the desktop shell, which is the one "native" engine that does not self-start.

`npx tsc -p tsconfig.json --noEmit` passes. Verified end to end on the desktop client after removing all debug instrumentation.

The ~9 s that remain are the 4K transcode spawn, tracked separately in #1250 and #1255 — a title that DirectPlays should start near-instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
