### PR TITLE
fix(streaming): tone-map HDR sources when extracting sprite tiles

### DIFF
--- a/backend/src/modules/streaming/thumbnail-extractors/cuda.extractor.spec.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/cuda.extractor.spec.ts
@@ -49,6 +49,26 @@ describe('CudaExtractor', () => {
     );
   });
 
+  it('hdr: 10-bit download then the CPU tone-map chain', () => {
+    const vf = vfOf(ext.buildArgs({ ...base, hdr: true }));
+    expect(vf).toContain('scale_cuda=w=240:h=-2:format=p010le');
+    expect(vf).toContain('hwdownload,format=p010le,zscale=w=240:h=-2:t=linear');
+    expect(vf).toContain('tonemap=tonemap=hable:desat=0');
+    expect(vf.endsWith('zscale=t=bt709:m=bt709:r=tv,format=yuv420p')).toBe(true);
+  });
+
+  it('hdr + crop: tone-map replaces the CPU scale, never follows it', () => {
+    const vf = vfOf(
+      ext.buildArgs({
+        ...base,
+        hdr: true,
+        crop: { width: 3840, height: 1632, x: 0, y: 264 },
+      }),
+    );
+    expect(vf).toContain('hwdownload,format=p010le,crop=3840:1632:0:264,zscale=w=240');
+    expect(vf).not.toContain('scale=240:-1');
+  });
+
   it('crop: full-frame hwdownload then CPU crop+scale', () => {
     const args = ext.buildArgs({
       ...base,

--- a/backend/src/modules/streaming/thumbnail-extractors/cuda.extractor.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/cuda.extractor.ts
@@ -1,8 +1,9 @@
+import { downloadPixFmt, tonemapChain } from './tonemap';
 import type { CropArea, ExtractArgs, ExtractorBackend } from './types';
 
-/** CUDA/NVDEC backend for NVIDIA Linux hosts. `scale_cuda` converts p010→nv12
- *  itself (untonemapped, like vaapi/qsv) but has no crop option, so the crop
- *  case falls back to a CPU crop+scale. */
+/** CUDA/NVDEC backend for NVIDIA Linux hosts. `scale_cuda` handles the pixel
+ *  format conversion itself but has no crop option, so the crop case falls
+ *  back to a CPU crop+scale. */
 export class CudaExtractor implements ExtractorBackend {
   readonly name = 'cuda';
 
@@ -20,11 +21,14 @@ export class CudaExtractor implements ExtractorBackend {
     outputPath,
     crop,
     thumbWidth,
+    hdr,
   }: ExtractArgs): string[] {
+    const pix = downloadPixFmt(hdr);
+    const scale = hdr ? tonemapChain(thumbWidth) : `scale=${thumbWidth}:-1`;
     const vf = crop
       ? // ponytail: full-frame download on crop; cuvid -crop/-resize if benches say so
-        `hwdownload,crop=${crop.width}:${crop.height}:${crop.x}:${crop.y},scale=${thumbWidth}:-1`
-      : `scale_cuda=w=${thumbWidth}:h=-2:format=nv12,hwdownload,format=nv12`;
+        `hwdownload${hdr ? `,format=${pix}` : ''},crop=${crop.width}:${crop.height}:${crop.x}:${crop.y},${scale}`
+      : `scale_cuda=w=${thumbWidth}:h=-2:format=${pix},hwdownload,format=${pix}${hdr ? `,${tonemapChain(thumbWidth)}` : ''}`;
     return [
       '-nostdin',
       '-hide_banner',

--- a/backend/src/modules/streaming/thumbnail-extractors/qsv.extractor.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/qsv.extractor.ts
@@ -1,3 +1,4 @@
+import { downloadPixFmt, tonemapChain } from './tonemap';
 import type { CropArea, ExtractArgs, ExtractorBackend } from './types';
 
 /**
@@ -31,6 +32,7 @@ export class QsvExtractor implements ExtractorBackend {
     outputPath,
     crop,
     thumbWidth,
+    hdr,
   }: ExtractArgs): string[] {
     if (!crop) {
       // supports() should have routed this elsewhere, but type-narrow safely.
@@ -39,6 +41,7 @@ export class QsvExtractor implements ExtractorBackend {
     // Output height preserves the crop region's aspect ratio. Rounded to
     // an even number — required by most video filters / encoders.
     const outH = Math.round((crop.height * thumbWidth) / crop.width / 2) * 2;
+    const pix = downloadPixFmt(hdr);
     return [
       '-nostdin',
       '-hide_banner',
@@ -66,7 +69,7 @@ export class QsvExtractor implements ExtractorBackend {
       // vpp_qsv crops with cw/ch/cx/cy and scales to w/h in a single pass
       // on the GPU. We hwdownload the small output tile only.
       '-vf',
-      `vpp_qsv=w=${thumbWidth}:h=${outH}:cw=${crop.width}:ch=${crop.height}:cx=${crop.x}:cy=${crop.y}:format=nv12,hwdownload,format=nv12`,
+      `vpp_qsv=w=${thumbWidth}:h=${outH}:cw=${crop.width}:ch=${crop.height}:cx=${crop.x}:cy=${crop.y}:format=${pix},hwdownload,format=${pix}${hdr ? `,${tonemapChain(thumbWidth)}` : ''}`,
       '-q:v',
       '5',
       '-y',

--- a/backend/src/modules/streaming/thumbnail-extractors/sw.extractor.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/sw.extractor.ts
@@ -1,3 +1,4 @@
+import { tonemapChain } from './tonemap';
 import type { CropArea, ExtractArgs, ExtractorBackend } from './types';
 
 /**
@@ -24,10 +25,12 @@ export class SwExtractor implements ExtractorBackend {
     outputPath,
     crop,
     thumbWidth,
+    hdr,
   }: ExtractArgs): string[] {
+    const scale = hdr ? tonemapChain(thumbWidth) : `scale=${thumbWidth}:-1`;
     const vf = crop
-      ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y},scale=${thumbWidth}:-1`
-      : `scale=${thumbWidth}:-1`;
+      ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y},${scale}`
+      : scale;
     return [
       '-nostdin',
       '-hide_banner',

--- a/backend/src/modules/streaming/thumbnail-extractors/tonemap.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/tonemap.ts
@@ -1,0 +1,13 @@
+/** HDR (PQ/HLG) → SDR BT.709 for sprite tiles. The opening zscale linearises
+ *  and downscales in one pass: `tonemap` only works on linear light — fed PQ
+ *  code values the picture collapses to washed-out grey — and the curve then
+ *  runs at tile size. `h=-2` keeps the height even, which zscale requires on
+ *  subsampled formats. Source colorimetry comes from the frame tags. */
+export const tonemapChain = (width: number): string =>
+  `zscale=w=${width}:h=-2:t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,` +
+  `tonemap=tonemap=hable:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p`;
+
+/** HW surfaces must come down 10-bit: converting to nv12 before the tone-map
+ *  clips the PQ highlights and darkens the tile. */
+export const downloadPixFmt = (hdr?: boolean): string =>
+  hdr ? 'p010le' : 'nv12';

--- a/backend/src/modules/streaming/thumbnail-extractors/types.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/types.ts
@@ -13,6 +13,8 @@ export interface ExtractArgs {
   outputPath: string;
   crop?: CropArea;
   thumbWidth: number;
+  /** Source carries a PQ / HLG transfer — the tile needs tone-mapping. */
+  hdr?: boolean;
 }
 
 /** One backend = one ffmpeg invocation strategy. The factory in `index.ts`

--- a/backend/src/modules/streaming/thumbnail-extractors/vaapi.extractor.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/vaapi.extractor.ts
@@ -1,3 +1,4 @@
+import { downloadPixFmt, tonemapChain } from './tonemap';
 import type { CropArea, ExtractArgs, ExtractorBackend } from './types';
 
 /**
@@ -28,7 +29,9 @@ export class VaapiExtractor implements ExtractorBackend {
     seekSeconds,
     outputPath,
     thumbWidth,
+    hdr,
   }: ExtractArgs): string[] {
+    const pix = downloadPixFmt(hdr);
     return [
       '-nostdin',
       '-hide_banner',
@@ -57,7 +60,7 @@ export class VaapiExtractor implements ExtractorBackend {
       '-frames:v',
       '1',
       '-vf',
-      `scale_vaapi=${thumbWidth}:-2:format=nv12,hwdownload,format=nv12`,
+      `scale_vaapi=${thumbWidth}:-2:format=${pix},hwdownload,format=${pix}${hdr ? `,${tonemapChain(thumbWidth)}` : ''}`,
       '-q:v',
       '5',
       '-y',

--- a/backend/src/modules/streaming/thumbnail-extractors/videotoolbox.extractor.ts
+++ b/backend/src/modules/streaming/thumbnail-extractors/videotoolbox.extractor.ts
@@ -1,3 +1,4 @@
+import { tonemapChain } from './tonemap';
 import type { CropArea, ExtractArgs, ExtractorBackend } from './types';
 
 /**
@@ -31,10 +32,12 @@ export class VideoToolboxExtractor implements ExtractorBackend {
     outputPath,
     crop,
     thumbWidth,
+    hdr,
   }: ExtractArgs): string[] {
+    const scale = hdr ? tonemapChain(thumbWidth) : `scale=${thumbWidth}:-1`;
     const vf = crop
-      ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y},scale=${thumbWidth}:-1`
-      : `scale=${thumbWidth}:-1`;
+      ? `crop=${crop.width}:${crop.height}:${crop.x}:${crop.y},${scale}`
+      : scale;
     return [
       '-nostdin',
       '-hide_banner',

--- a/backend/src/modules/streaming/thumbnail.service.ts
+++ b/backend/src/modules/streaming/thumbnail.service.ts
@@ -42,6 +42,12 @@ export interface SpriteMetadata {
   count: number;
 }
 
+/** PQ / HLG sources need the tone-map chain in the extractor, or the tiles
+ *  come out washed-out grey. Gated on the transfer curve alone — the primaries
+ *  can be missing or wrong and the picture is still HDR-encoded. */
+const isHdrTransfer = (colorTransfer?: string): boolean =>
+  colorTransfer === 'smpte2084' || colorTransfer === 'arib-std-b67';
+
 const baseDir = () => path.join(getCacheDir(), 'thumbnails');
 const framesTmpDir = () => path.join(getCacheDir(), 'thumbnails-tmp');
 
@@ -58,6 +64,7 @@ interface QueueItem {
   subject: MediaProgressSubject;
   skipTracking?: boolean;
   crop?: CropArea;
+  hdr?: boolean;
   resolve: (meta: SpriteMetadata | null) => void;
 }
 
@@ -117,7 +124,7 @@ export class ThumbnailService implements OnModuleInit {
       relativePath: string;
       streamInfo?: {
         durationSeconds?: number;
-        video?: { crop?: CropArea }[];
+        video?: { crop?: CropArea; colorTransfer?: string }[];
       } | null;
     },
     media: { path: string | null; title: string },
@@ -138,6 +145,7 @@ export class ThumbnailService implements OnModuleInit {
       options.force ?? false,
       options.skipTracking ?? false,
       file.streamInfo?.video?.[0]?.crop,
+      isHdrTransfer(file.streamInfo?.video?.[0]?.colorTransfer),
     );
   }
 
@@ -149,6 +157,7 @@ export class ThumbnailService implements OnModuleInit {
     force = false,
     skipTracking = false,
     crop?: CropArea,
+    hdr = false,
   ): Promise<SpriteMetadata | null> {
     const dir = path.join(baseDir(), String(mediaFileId));
     const metaPath = path.join(dir, 'sprite.json');
@@ -178,6 +187,7 @@ export class ThumbnailService implements OnModuleInit {
         subject,
         skipTracking,
         crop,
+        hdr,
         resolve,
       });
       this.processQueue();
@@ -236,6 +246,7 @@ export class ThumbnailService implements OnModuleInit {
         item.subject,
         item.skipTracking,
         item.crop,
+        item.hdr,
       )
         .then((meta) => item.resolve(meta))
         .catch((err) => {
@@ -261,6 +272,7 @@ export class ThumbnailService implements OnModuleInit {
     subject: MediaProgressSubject,
     skipTracking = false,
     crop?: CropArea,
+    hdr = false,
   ): Promise<SpriteMetadata | null> {
     const dir = path.join(baseDir(), String(mediaFileId));
     const spritePath = path.join(dir, 'sprite.jpg');
@@ -291,7 +303,7 @@ export class ThumbnailService implements OnModuleInit {
     // exactly what ffmpeg sees per frame.
     const decode = this.chooseExtractor(crop).describe();
     this.log.log(
-      `Sprite START for "${label}" (file #${mediaFileId}): ${count} thumbs @ ${interval}s interval, workers=${FFMPEG_SLOTS}, decode=${decode}, otherSprites=${otherRunning}, queued=${this.queue.length}, srcSize=${srcSizeMb ?? '?'}MB, crop=${
+      `Sprite START for "${label}" (file #${mediaFileId}): ${count} thumbs @ ${interval}s interval, workers=${FFMPEG_SLOTS}, decode=${decode}, hdr=${hdr ? 'tonemap' : 'no'}, otherSprites=${otherRunning}, queued=${this.queue.length}, srcSize=${srcSizeMb ?? '?'}MB, crop=${
         crop ? `${crop.width}x${crop.height}+${crop.x},${crop.y}` : 'none'
       }, src=${absolutePath}`,
     );
@@ -358,6 +370,7 @@ export class ThumbnailService implements OnModuleInit {
             subject,
             progressKey,
             crop,
+            hdr,
           );
           extractMs = Date.now() - tExtract;
 
@@ -480,6 +493,7 @@ export class ThumbnailService implements OnModuleInit {
     subject: MediaProgressSubject,
     progressKey: string,
     crop?: CropArea,
+    hdr = false,
   ): Promise<void> {
     let completed = 0;
     let failed = 0;
@@ -503,7 +517,7 @@ export class ThumbnailService implements OnModuleInit {
         );
         const tFrame = Date.now();
         try {
-          await this.extractFrameAt(inputPath, timestamp, outPath, crop);
+          await this.extractFrameAt(inputPath, timestamp, outPath, crop, hdr);
           frameTimings.push({ idx, ms: Date.now() - tFrame, ts: timestamp });
           completed++;
         } catch (err) {
@@ -631,6 +645,7 @@ export class ThumbnailService implements OnModuleInit {
     seekSeconds: number,
     outputPath: string,
     crop?: CropArea,
+    hdr = false,
   ): Promise<void> {
     return withFfmpegSlot(
       () =>
@@ -641,6 +656,7 @@ export class ThumbnailService implements OnModuleInit {
             outputPath,
             crop,
             thumbWidth: THUMB_WIDTH,
+            hdr,
           });
           const proc = spawnLowPriority('ffmpeg', args);
           let stderr = '';


### PR DESCRIPTION
## Problem

Seek-preview sprites generated from HDR titles come out washed-out grey.

None of the five thumbnail extractors tone-mapped: PQ / HLG code values went straight into the JPEG tiles. Read back as gamma 2.2 they collapse to low-contrast grey — the exact failure the transcode filter graph already documents at `ffmpeg-filter-graph.ts:81`.

## Fix

An `hdr` flag threaded from `streamInfo.video[0].colorTransfer` down to `buildArgs`, gated on the transfer curve alone (`smpte2084` / `arib-std-b67`) — a PQ file mis-tagged with bt709 primaries is still HDR-encoded, so `hdrFormat`, which requires bt2020, would have missed it.

Each backend then appends the CPU chain the transcode path already uses. Two details that are not cosmetic:

- The chain's opening zscale linearises **and** downscales in one pass, and it *replaces* the extractor's own scale instead of following it. `scale=240:-1` yields an odd height (135 on 16:9) and zscale rejects odd dimensions on subsampled formats — appending after the scale fails outright.
- The HW paths (`scale_vaapi` / `vpp_qsv` / `scale_cuda`) download `p010le` rather than `nv12`; converting to 8-bit before the tone-map clips the PQ highlights.

## Verification

Real source — *Furiosa*, 4K AV1 HDR10 — through the VAAPI extractor. Before / after:

| | YAVG | SATAVG |
|---|---|---|
| before | 113.4 | 10.0 |
| after | 122.7 | 25.6 |

Same picture through the QSV crop path on a synthetic 4K HEVC 10-bit PQ clip: SATAVG 26.2 → 71.6.

**Performance**, Arc A370M, QSV crop path, 20 frames at 4 workers, 3 runs:

| variant | wall |
|---|---|
| SDR clip, SDR argv (unchanged) | 3.83 / 3.76 / 3.76 s |
| HDR clip, before | 3.80 / 3.80 / 3.79 s |
| HDR clip, after | 3.83 / 3.81 / 3.79 s |

Per process (`-benchmark`): utime 0.121 → 0.157 s, rtime 0.273 → 0.284 s. The +4% is absorbed by the worker pool because the curve runs on the 240px tile, not the source frame. SDR sources build byte-identical argv — the `format=` and the chain are both conditioned on `hdr`.

## Not covered

- Sprites already on disk keep their grey tiles until regenerated.
- Dolby Vision profile 5 carries no transfer tag, so `colorTransfer` is empty and those sources are left alone. They need `apply_dovi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)