### PR TITLE
fix(player): keep a multi-panel dropdown on the dismiss stack

### DIFF
--- a/client/src/app/core/services/dismissable-stack.service.spec.ts
+++ b/client/src/app/core/services/dismissable-stack.service.spec.ts
@@ -1,0 +1,33 @@
+import { DismissableStackService } from './dismissable-stack.service';
+
+describe('DismissableStackService', () => {
+  it('keeps a layer registered while its callback returns true', () => {
+    const svc = new DismissableStackService();
+    let step = 0;
+    // A multi-panel dropdown: first Back steps to the parent panel, second closes.
+    svc.push(() => (++step === 1 ? true : undefined));
+
+    expect(svc.dismissTop()).toBe(true);
+    expect(svc.hasAny()).toBe(true);
+    expect(svc.dismissTop()).toBe(true);
+    expect(svc.hasAny()).toBe(false);
+    expect(svc.dismissTop()).toBe(false);
+    expect(step).toBe(2);
+  });
+
+  it('pops the top layer and leaves the ones below', () => {
+    const svc = new DismissableStackService();
+    const order: string[] = [];
+    svc.push(() => {
+      order.push('bottom');
+    });
+    svc.push(() => {
+      order.push('top');
+    });
+
+    svc.dismissTop();
+    svc.dismissTop();
+    expect(order).toEqual(['top', 'bottom']);
+    expect(svc.hasAny()).toBe(false);
+  });
+});

--- a/client/src/app/core/services/dismissable-stack.service.ts
+++ b/client/src/app/core/services/dismissable-stack.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, computed, signal } from '@angular/core';
 
+/** Return true to stay on the stack: the layer handled the gesture (stepped
+ *  back one panel) but is still open. */
+export type DismissCallback = () => boolean | void;
+
 /**
  * Stack of dismissable layers (bottom sheets, modals, dropdowns…) so that
  * a hardware/gesture back gesture closes the topmost one before falling
@@ -12,27 +16,28 @@ import { Injectable, computed, signal } from '@angular/core';
  */
 @Injectable({ providedIn: 'root' })
 export class DismissableStackService {
-  private readonly stack = signal<Array<() => void>>([]);
+  private readonly stack = signal<Array<DismissCallback>>([]);
 
   readonly hasAny = computed(() => this.stack().length > 0);
 
-  push(close: () => void): void {
+  push(close: DismissCallback): void {
     this.stack.update((s) => [...s, close]);
   }
 
-  remove(close: () => void): void {
+  remove(close: DismissCallback): void {
     this.stack.update((s) => s.filter((fn) => fn !== close));
   }
 
-  /** Pop and invoke the top close callback. Returns true if a layer was
-   *  dismissed; false when the stack was empty (caller should fall through
-   *  to route-level back). */
+  /** Invoke the top close callback. Returns true if a layer handled the
+   *  gesture; false when the stack was empty (caller should fall through to
+   *  route-level back). The layer is popped unless its callback returns true,
+   *  which means it consumed the gesture and is still open — a multi-step
+   *  panel stepping back to its parent. */
   dismissTop(): boolean {
     const s = this.stack();
     if (!s.length) return false;
     const top = s[s.length - 1];
-    this.stack.update((cur) => cur.slice(0, -1));
-    top();
+    if (top() !== true) this.remove(top);
     return true;
   }
 }

--- a/client/src/app/core/services/focusable.constants.ts
+++ b/client/src/app/core/services/focusable.constants.ts
@@ -50,6 +50,14 @@ export function restoreOpenerFocus(opener: HTMLElement | null | undefined): void
   if (document.activeElement === opener) opener.blur();
 }
 
+/** Focus an overlay entry and reveal it inside its own scroller: the entry is
+ *  usually the current selection, which in a long list sits below the fold. */
+export function focusOverlayEntry(el: HTMLElement | null | undefined): void {
+  if (!el) return;
+  el.focus({ preventScroll: true });
+  el.scrollIntoView({ block: 'nearest', behavior: 'instant' as ScrollBehavior });
+}
+
 export function initialOverlayFocus(root: ParentNode | null | undefined): HTMLElement | null {
   if (!root) return null;
   for (const marker of ['[autofocus]', '[aria-current="true"]', '[aria-disabled="true"]']) {

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -34,7 +34,7 @@ import { BottomSheetComponent } from '../../../shared/components/bottom-sheet';
 import { TranslateModule } from '@ngx-translate/core';
 import { AppSettingsService } from '../../../core/services/app-settings.service';
 import { formatTime, SpriteMetadata } from '../../../core/utils/player.utils';
-import { initialOverlayFocus } from '../../../core/services/focusable.constants';
+import { focusOverlayEntry, initialOverlayFocus } from '../../../core/services/focusable.constants';
 import { SeekbarComponent } from '../../../shared/components/seekbar/seekbar';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import { CachedSrcDirective } from '../../../shared/directives/cached-src.directive';
@@ -546,18 +546,21 @@ export class PlayerControlsComponent {
   }
 
   /** One step back inside the open dropdown: a sub-panel returns to its parent,
-   *  the root panel closes the menu and hands focus back to its trigger. */
-  private dropdownBack() {
+   *  the root panel closes the menu and hands focus back to its trigger.
+   *  Returns true while the dropdown stays open, so the dismissable stack keeps
+   *  it registered for the next Back/Escape. */
+  private dropdownBack(): boolean {
     if (this.openDropdown() === 'settings' && this.settingsPanel() !== 'main') {
       this.openSettingsPanel('main');
-      return;
+      return true;
     }
     if (this.openDropdown() === 'subtitles' && this.subtitlesPanel() !== 'tracks') {
       this.openSubtitlesPanel(this.activeAppearanceRow() ? 'appearance' : 'tracks');
-      return;
+      return true;
     }
     this.closeDropdown();
     this.dropdownTrigger?.focus({ preventScroll: true });
+    return false;
   }
 
   readonly formatTime = formatTime;
@@ -614,7 +617,7 @@ export class PlayerControlsComponent {
         const back = fromPanel
           ? panel?.querySelector<HTMLElement>(`[data-panel-row="${fromPanel}"]`)
           : null;
-        (back ?? initialOverlayFocus(panel))?.focus({ preventScroll: true });
+        focusOverlayEntry(back ?? initialOverlayFocus(panel));
       },
       { injector: this.injector },
     );

--- a/client/src/app/shared/components/bottom-sheet.ts
+++ b/client/src/app/shared/components/bottom-sheet.ts
@@ -15,6 +15,7 @@ import { DismissableStackService } from '../../core/services/dismissable-stack.s
 import { TvService } from '../../core/services/tv.service';
 import {
   TABBABLE_SELECTOR,
+  focusOverlayEntry,
   initialOverlayFocus,
   restoreOpenerFocus,
 } from '../../core/services/focusable.constants';
@@ -179,9 +180,7 @@ export class BottomSheetComponent {
             // paint the focus halo on the wrong element first.
             queueMicrotask(() => {
               if (!this.open()) return;
-              initialOverlayFocus(this.sheet()?.nativeElement)?.focus({
-                preventScroll: true,
-              });
+              focusOverlayEntry(initialOverlayFocus(this.sheet()?.nativeElement));
             });
           }
         } else {

--- a/client/src/app/shared/components/forms/searchable-select/searchable-select.ts
+++ b/client/src/app/shared/components/forms/searchable-select/searchable-select.ts
@@ -69,7 +69,13 @@ export class SearchableSelectComponent {
     // doesn't have to click twice to start typing.
     effect(() => {
       if (this.open()) {
-        queueMicrotask(() => this.searchInput()?.nativeElement.focus());
+        queueMicrotask(() => {
+          this.searchInput()?.nativeElement.focus();
+          // Focus stays in the search box, so reveal the selection ourselves.
+          this.host.nativeElement
+            .querySelector('[aria-current="true"]')
+            ?.scrollIntoView({ block: 'nearest' });
+        });
       } else {
         this.query.set('');
       }

--- a/client/src/app/shared/components/popover-menu.ts
+++ b/client/src/app/shared/components/popover-menu.ts
@@ -16,7 +16,11 @@ import { BottomSheetComponent } from './bottom-sheet';
 import { TvService } from '../../core/services/tv.service';
 import { DeviceService } from '../../core/services/device.service';
 import { DismissableStackService } from '../../core/services/dismissable-stack.service';
-import { initialOverlayFocus, restoreOpenerFocus } from '../../core/services/focusable.constants';
+import {
+  focusOverlayEntry,
+  initialOverlayFocus,
+  restoreOpenerFocus,
+} from '../../core/services/focusable.constants';
 
 /**
  * Reusable menu chrome that picks its presentation per-platform:
@@ -190,9 +194,7 @@ export class PopoverMenuComponent {
         }
         // Land on the current selection rather than making the user scroll to
         // it; falls back to the first focusable when nothing is marked.
-        const target = initialOverlayFocus(this.host.nativeElement);
-        target?.focus({ preventScroll: false });
-        target?.scrollIntoView({ block: 'nearest', behavior: 'instant' as ScrollBehavior });
+        focusOverlayEntry(initialOverlayFocus(this.host.nativeElement));
       });
       // Register with the dismissable stack so Escape (browser) and the
       // hardware back button (Capacitor / Tizen) close the popover. Return

--- a/client/src/app/shared/directives/dropdown-toggle.directive.ts
+++ b/client/src/app/shared/directives/dropdown-toggle.directive.ts
@@ -1,6 +1,11 @@
 import { Directive, ElementRef, inject, OnDestroy } from '@angular/core';
 import { DismissableStackService } from '../../core/services/dismissable-stack.service';
-import { TABBABLE_SELECTOR, initialOverlayFocus, restoreOpenerFocus } from '../../core/services/focusable.constants';
+import {
+  TABBABLE_SELECTOR,
+  focusOverlayEntry,
+  initialOverlayFocus,
+  restoreOpenerFocus,
+} from '../../core/services/focusable.constants';
 
 /**
  * Click-driven `.dropdown-open` toggle for any DaisyUI dropdown trigger.
@@ -79,8 +84,7 @@ export class DropdownToggleDirective implements OnDestroy {
     // and keyboard users can act without an extra Tab. Standard ARIA
     // menu pattern.
     queueMicrotask(() => {
-      const first = initialOverlayFocus(content);
-      first?.focus({ preventScroll: true });
+      focusOverlayEntry(initialOverlayFocus(content));
     });
     const close = () => {
       dropdown.classList.remove('dropdown-open');


### PR DESCRIPTION
## Escape closed too much

Open the subtitles dropdown, step into its appearance panel, then press Escape twice: the
first press walked back to the track list (correct), the second hid the entire controls bar
instead of just closing the dropdown.

`DismissableStackService.dismissTop()` popped the top callback *before* invoking it. That is
fine for a one-shot layer, but the player's dropdown callback is multi-step — the first press
only returns to the parent panel and the menu stays open. By then the layer was already off
the stack, so the second press found it empty, fell through to the `/watch` branch of
`handleBackButton` and dispatched `app:playerBack`, which hides the bar.

A dismiss callback can now return `true` to mean "I handled the gesture and I am still open",
and only then does it stay registered. The four other layers (bottom sheet, popover, dropdown
directive, modal) return `void` and behave exactly as before.

Not changed: on a browser, Escape also leaves fullscreen. That is enforced by the user agent
and `preventDefault()` cannot suppress it. Desktop already peels one layer at a time, which is
the behaviour we want, so aligning them would mean degrading desktop to match a browser limit.

## The selected option stayed below the fold

Every overlay focused its initial entry with `preventScroll: true`. `initialOverlayFocus()`
deliberately targets the current selection (`aria-current` / the `aria-disabled` marker set by
`appSelectedOption`), so in a long list — subtitles, audio tracks, quality rungs — focus landed
on an item the user could not see, and the panel never scrolled to it.

New shared helper `focusOverlayEntry()`: focus without moving the page, then
`scrollIntoView({ block: 'nearest' })` to reveal the entry inside its own scroller. Applied to
the player dropdowns, `popover-menu` (which backs `multi-select`), `bottom-sheet` and the
`appDropdownToggle` directive. `popover-menu` had a local copy of this fix; it now uses the
shared one.

`searchable-select` is the exception: it focuses its search input on purpose, so it reveals the
selection without taking focus off the box. `select-field` wraps a native `<select>`, where the
browser already does this.

## Tests

- New spec for `DismissableStackService` covering the keep-open return and plain stacking.
- `tsc -p tsconfig.app.json --noEmit` clean, full client suite green (786 tests).