### PR TITLE
fix(metadata): guard subtitle search, refresh jobs and request gates for titles with no provider id

### DIFF
--- a/backend/src/modules/media/media-identity.util.ts
+++ b/backend/src/modules/media/media-identity.util.ts
@@ -1,0 +1,8 @@
+import { Media } from './entities/media.entity';
+
+/** True when at least one metadata-provider id is set; false for a title built from the file alone. */
+export function hasProviderId(
+  m: Pick<Media, 'tmdbId' | 'tvdbId' | 'imdbId'>,
+): boolean {
+  return m.tmdbId != null || m.tvdbId != null || !!m.imdbId;
+}

--- a/backend/src/modules/media/media-service/media-metadata.resolve-provider.spec.ts
+++ b/backend/src/modules/media/media-service/media-metadata.resolve-provider.spec.ts
@@ -1,12 +1,9 @@
 import { MediaMetadataService } from './media-metadata.service';
 
-/**
- * resolveProviderForMedia's fallback step (no season/media/library override,
- * no direct tmdbId/tvdbId): an imdb-only media passes hasProviderId() but
- * used to fall straight to the "no provider ID" throw. It must first try the
- * TMDB imdb cross-reference, same as the tvdb/tmdb direct-match paths above it.
- */
-describe('MediaMetadataService.resolveProviderForMedia — imdb-only fallback', () => {
+/** resolveProviderForMedia's fallback step: an imdb-only media passes
+ *  hasProviderId() so it must resolve through the TMDB imdb cross-reference
+ *  instead of throwing, same as the tvdb/tmdb direct-match paths above it. */
+describe('MediaMetadataService.resolveProviderForMedia, imdb-only fallback', () => {
   function harness() {
     const mediaRepo = { update: jest.fn(() => Promise.resolve({})) };
     const tmdb = {

--- a/backend/src/modules/media/media-service/media-metadata.resolve-provider.spec.ts
+++ b/backend/src/modules/media/media-service/media-metadata.resolve-provider.spec.ts
@@ -1,0 +1,55 @@
+import { MediaMetadataService } from './media-metadata.service';
+
+/**
+ * resolveProviderForMedia's fallback step (no season/media/library override,
+ * no direct tmdbId/tvdbId): an imdb-only media passes hasProviderId() but
+ * used to fall straight to the "no provider ID" throw. It must first try the
+ * TMDB imdb cross-reference, same as the tvdb/tmdb direct-match paths above it.
+ */
+describe('MediaMetadataService.resolveProviderForMedia — imdb-only fallback', () => {
+  function harness() {
+    const mediaRepo = { update: jest.fn(() => Promise.resolve({})) };
+    const tmdb = {
+      findByExternalId: jest.fn(() =>
+        Promise.resolve({ id: '603', mediaType: 'movie' as const }),
+      ),
+    };
+    const providerRegistry = {
+      isAvailable: jest.fn(() => true),
+      get: jest.fn(),
+    };
+
+    const service = Object.create(MediaMetadataService.prototype) as MediaMetadataService;
+    Object.assign(service, {
+      mediaRepo,
+      tmdb,
+      providerRegistry,
+      log: { log: jest.fn(), warn: jest.fn() },
+      loadLibraryOverride: jest.fn(() => Promise.resolve(undefined)),
+    });
+    return { service, mediaRepo, tmdb };
+  }
+
+  it('cross-references imdbId to a tmdbId instead of throwing', async () => {
+    const { service, mediaRepo, tmdb } = harness();
+    const media = {
+      id: 5,
+      title: 'Quiet Harbour',
+      tmdbId: null,
+      tvdbId: null,
+      imdbId: 'tt1234567',
+      libraryId: null,
+      preferredProvider: null,
+    };
+
+    const result = await (
+      service as unknown as {
+        resolveProviderForMedia: (m: unknown) => Promise<{ provider: unknown; externalId: string }>;
+      }
+    ).resolveProviderForMedia(media);
+
+    expect(tmdb.findByExternalId).toHaveBeenCalledWith('imdb', 'tt1234567', undefined);
+    expect(result).toEqual({ provider: tmdb, externalId: '603' });
+    expect(mediaRepo.update).toHaveBeenCalledWith(5, { tmdbId: 603 });
+  });
+});

--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -698,6 +698,15 @@ export class MediaMetadataService {
       );
       return { provider: this.tmdb, externalId: String(media.tmdbId) };
     }
+    // imdb-only media (no tmdbId/tvdbId): cross-reference through TMDB before giving up.
+    if (media.imdbId && this.providerRegistry.isAvailable('tmdb')) {
+      const externalId = await this.resolveExternalIdForProvider(
+        media,
+        this.tmdb,
+        'tmdb',
+      );
+      if (externalId) return { provider: this.tmdb, externalId };
+    }
     throw new BadRequestException('No provider ID available for this media');
   }
 

--- a/backend/src/modules/scheduler/scheduler.service.spec.ts
+++ b/backend/src/modules/scheduler/scheduler.service.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 import { SchedulerService } from './scheduler.service';
 import { PluginJobsService } from '../plugins/plugin-jobs.service';
 import { ScheduledJobRegistry } from './scheduled-job-registry.service';
+import { MediaType, MediaStatus } from '../../common/enums';
 
 function fakePluginJobs(overrides: Partial<Record<'listDeclared' | 'trigger', jest.Mock>> = {}) {
   return {
@@ -71,5 +72,97 @@ describe('SchedulerService.triggerCommand', () => {
 
     await expect(service.triggerCommand('NoSuchJob')).rejects.toThrow(BadRequestException);
     expect(pluginJobs.trigger).not.toHaveBeenCalled();
+  });
+});
+
+/** Builds a service where only `mediaRepo`/`mediaService`/`config` drive the refresh
+ *  jobs — `eventsService`/`activityRegistry` are jest.fn() stubs, everything else unused. */
+function makeMetadataService(
+  mediaRepo: { find: jest.Mock },
+  mediaService: { refreshMetadata: jest.Mock },
+  config: { get: jest.Mock },
+) {
+  const unused = {} as never;
+  const eventsService = { emit: jest.fn() };
+  const activityRegistry = {
+    upsertRunning: jest.fn(),
+    upsertPending: jest.fn(),
+    remove: jest.fn(),
+  };
+  return new SchedulerService(
+    unused,
+    mediaRepo as never,
+    unused,
+    unused,
+    mediaService as never,
+    config as never,
+    eventsService as never,
+    unused,
+    unused,
+    unused,
+    unused,
+    fakePluginJobs() as unknown as PluginJobsService,
+    { list: jest.fn().mockReturnValue([]) } as unknown as ScheduledJobRegistry,
+    unused,
+    unused,
+    unused,
+    activityRegistry as never,
+  );
+}
+
+function unidentifiedMedia(id: number) {
+  return {
+    id,
+    title: 'Unnamed Reel',
+    type: MediaType.MOVIE,
+    status: MediaStatus.RELEASED,
+    tmdbId: null,
+    tvdbId: null,
+    imdbId: null,
+    metadataRefreshedAt: null,
+    year: 2020,
+    releaseDate: null,
+    posterUrl: null,
+    overview: null,
+  };
+}
+
+function identifiedMedia(id: number) {
+  return {
+    ...unidentifiedMedia(id),
+    title: 'Quiet Harbour',
+    tmdbId: 42,
+  };
+}
+
+describe('SchedulerService metadata refresh jobs skip unidentified titles', () => {
+  it('doRefreshMetadata never refreshes or fails a media with no provider id', async () => {
+    const mediaRepo = {
+      find: jest.fn().mockResolvedValue([identifiedMedia(1), unidentifiedMedia(2)]),
+    };
+    const mediaService = { refreshMetadata: jest.fn().mockResolvedValue(undefined) };
+    const config = { get: jest.fn().mockReturnValue('a-key') };
+    const service = makeMetadataService(mediaRepo, mediaService, config);
+
+    await (service as unknown as { doRefreshMetadata: () => Promise<void> }).doRefreshMetadata();
+
+    expect(mediaService.refreshMetadata).toHaveBeenCalledTimes(1);
+    expect(mediaService.refreshMetadata).toHaveBeenCalledWith(1);
+  });
+
+  it('doRefreshMissingMetadata never refreshes or fails a media with no provider id', async () => {
+    const mediaRepo = {
+      find: jest.fn().mockResolvedValue([identifiedMedia(1), unidentifiedMedia(2)]),
+    };
+    const mediaService = { refreshMetadata: jest.fn().mockResolvedValue(undefined) };
+    const config = { get: jest.fn().mockReturnValue('a-key') };
+    const service = makeMetadataService(mediaRepo, mediaService, config);
+
+    await (
+      service as unknown as { doRefreshMissingMetadata: () => Promise<void> }
+    ).doRefreshMissingMetadata();
+
+    expect(mediaService.refreshMetadata).toHaveBeenCalledTimes(1);
+    expect(mediaService.refreshMetadata).toHaveBeenCalledWith(1);
   });
 });

--- a/backend/src/modules/scheduler/scheduler.service.spec.ts
+++ b/backend/src/modules/scheduler/scheduler.service.spec.ts
@@ -75,8 +75,6 @@ describe('SchedulerService.triggerCommand', () => {
   });
 });
 
-/** Builds a service where only `mediaRepo`/`mediaService`/`config` drive the refresh
- *  jobs — `eventsService`/`activityRegistry` are jest.fn() stubs, everything else unused. */
 function makeMetadataService(
   mediaRepo: { find: jest.Mock },
   mediaService: { refreshMetadata: jest.Mock },

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -13,6 +13,7 @@ import { Repository } from 'typeorm';
 import { CronExpressionParser } from 'cron-parser';
 import { Command } from './entities/command.entity';
 import { Media } from '../media/entities/media.entity';
+import { hasProviderId } from '../media/media-identity.util';
 import { Episode } from '../media/entities/episode.entity';
 import { TmdbProvider } from '../metadata-providers/providers/tmdb.provider';
 import { MediaService } from '../media/media.service';
@@ -369,11 +370,13 @@ export class SchedulerService implements OnModuleInit {
     }
 
     const allMedia = await this.mediaRepo.find();
+    const identified = allMedia.filter((m) => hasProviderId(m));
+    const unidentifiedSkipped = allMedia.length - identified.length;
     const now = new Date();
-    const dueMedia = allMedia.filter((m) => this.isMetadataDue(m, now));
-    const skipped = allMedia.length - dueMedia.length;
+    const dueMedia = identified.filter((m) => this.isMetadataDue(m, now));
+    const skipped = identified.length - dueMedia.length;
     this.log.log(
-      `RefreshMetadata: starting refresh for ${dueMedia.length}/${allMedia.length} media (${skipped} settled title(s) skipped)`,
+      `RefreshMetadata: starting refresh for ${dueMedia.length}/${allMedia.length} media (${skipped} settled title(s) skipped, ${unidentifiedSkipped} unidentified title(s) skipped)`,
     );
     let updated = 0;
 
@@ -748,6 +751,8 @@ export class SchedulerService implements OnModuleInit {
     const allMedia = await this.mediaRepo.find({
       relations: ['seasons'],
     });
+    const identified = allMedia.filter((m) => hasProviderId(m));
+    const unidentifiedSkipped = allMedia.length - identified.length;
 
     const isIncomplete = (m: (typeof allMedia)[0]) =>
       !m.posterUrl ||
@@ -757,7 +762,7 @@ export class SchedulerService implements OnModuleInit {
     const isStaleOrNever = (m: (typeof allMedia)[0]) =>
       m.metadataRefreshedAt == null || m.metadataRefreshedAt < staleBefore;
 
-    const candidates = allMedia.filter(
+    const candidates = identified.filter(
       (m) => isIncomplete(m) || isStaleOrNever(m),
     );
 
@@ -805,7 +810,7 @@ export class SchedulerService implements OnModuleInit {
     }
 
     this.log.log(
-      `RefreshMissingMetadata: refreshed ${updated}/${candidates.length} titles (from ${allMedia.length} total)`,
+      `RefreshMissingMetadata: refreshed ${updated}/${candidates.length} titles (from ${allMedia.length} total, ${unidentifiedSkipped} unidentified title(s) skipped)`,
     );
   }
 

--- a/backend/src/modules/subtitles/providers/opensubtitles.provider.spec.ts
+++ b/backend/src/modules/subtitles/providers/opensubtitles.provider.spec.ts
@@ -1,0 +1,41 @@
+import { OpenSubtitlesProvider } from './opensubtitles.provider';
+import { rateLimitedFetch } from './rate-limiter';
+
+jest.mock('./rate-limiter', () => ({
+  isRateLimited: jest.fn().mockReturnValue(false),
+  rateLimitedFetch: jest.fn(),
+  markRateLimited: jest.fn(),
+}));
+
+const mockedFetch = rateLimitedFetch as jest.Mock;
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, json: () => Promise.resolve(body) } as unknown as Response;
+}
+
+function provider() {
+  return new OpenSubtitlesProvider({ username: '', password: '' });
+}
+
+describe('OpenSubtitlesProvider.search', () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+    mockedFetch.mockResolvedValue(jsonResponse({ data: [] }));
+  });
+
+  it('sends the title as a free-text query when hash and ids are absent', async () => {
+    await provider().search({ title: 'Quiet Harbour', year: 2020, language: 'en' });
+
+    const url = new URL(mockedFetch.mock.calls[0][1] as string);
+    expect(url.searchParams.get('query')).toBe('Quiet Harbour');
+    expect(url.searchParams.get('year')).toBe('2020');
+  });
+
+  it('does not send the title when a tmdbId is present', async () => {
+    await provider().search({ title: 'Quiet Harbour', tmdbId: 42, language: 'en' });
+
+    const url = new URL(mockedFetch.mock.calls[0][1] as string);
+    expect(url.searchParams.has('query')).toBe(false);
+    expect(url.searchParams.get('tmdb_id')).toBe('42');
+  });
+});

--- a/backend/src/modules/subtitles/providers/opensubtitles.provider.ts
+++ b/backend/src/modules/subtitles/providers/opensubtitles.provider.ts
@@ -70,6 +70,10 @@ export class OpenSubtitlesProvider implements SubtitleProviderInterface {
     if (params.moviehash) query.set('moviehash', params.moviehash);
     if (params.imdbId) query.set('imdb_id', params.imdbId);
     if (params.tmdbId) query.set('tmdb_id', String(params.tmdbId));
+    if (!params.moviehash && !params.imdbId && !params.tmdbId) {
+      query.set('query', params.title);
+      if (params.year) query.set('year', String(params.year));
+    }
     query.set('languages', params.language);
     if (params.season != null)
       query.set('season_number', String(params.season));

--- a/backend/src/modules/subtitles/providers/subdl.provider.spec.ts
+++ b/backend/src/modules/subtitles/providers/subdl.provider.spec.ts
@@ -1,0 +1,40 @@
+import { SubdlProvider } from './subdl.provider';
+import { rateLimitedFetch } from './rate-limiter';
+
+jest.mock('./rate-limiter', () => ({
+  isRateLimited: jest.fn().mockReturnValue(false),
+  rateLimitedFetch: jest.fn(),
+}));
+
+const mockedFetch = rateLimitedFetch as jest.Mock;
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, json: () => Promise.resolve(body) } as unknown as Response;
+}
+
+function provider() {
+  return new SubdlProvider({ apiKey: 'test-key' });
+}
+
+describe('SubdlProvider.search', () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+    mockedFetch.mockResolvedValue(jsonResponse({ status: true, subtitles: [] }));
+  });
+
+  it('sends the title as film_name when hash and ids are absent', async () => {
+    await provider().search({ title: 'Quiet Harbour', year: 2020, language: 'en' });
+
+    const url = new URL(mockedFetch.mock.calls[0][1] as string);
+    expect(url.searchParams.get('film_name')).toBe('Quiet Harbour');
+    expect(url.searchParams.get('year')).toBe('2020');
+  });
+
+  it('does not send the title when a tmdbId is present', async () => {
+    await provider().search({ title: 'Quiet Harbour', tmdbId: 42, language: 'en' });
+
+    const url = new URL(mockedFetch.mock.calls[0][1] as string);
+    expect(url.searchParams.has('film_name')).toBe(false);
+    expect(url.searchParams.get('tmdb_id')).toBe('42');
+  });
+});

--- a/backend/src/modules/subtitles/providers/subdl.provider.spec.ts
+++ b/backend/src/modules/subtitles/providers/subdl.provider.spec.ts
@@ -30,6 +30,17 @@ describe('SubdlProvider.search', () => {
     expect(url.searchParams.get('year')).toBe('2020');
   });
 
+  it('sends film_name even when a moviehash is present, Subdl has no hash search', async () => {
+    await provider().search({
+      title: 'Quiet Harbour',
+      moviehash: 'deadbeefcafebabe',
+      language: 'en',
+    });
+
+    const url = new URL(mockedFetch.mock.calls[0][1] as string);
+    expect(url.searchParams.get('film_name')).toBe('Quiet Harbour');
+  });
+
   it('does not send the title when a tmdbId is present', async () => {
     await provider().search({ title: 'Quiet Harbour', tmdbId: 42, language: 'en' });
 

--- a/backend/src/modules/subtitles/providers/subdl.provider.ts
+++ b/backend/src/modules/subtitles/providers/subdl.provider.ts
@@ -41,7 +41,7 @@ export class SubdlProvider implements SubtitleProviderInterface {
     query.set('api_key', this.settings.apiKey);
     if (params.imdbId) query.set('imdb_id', params.imdbId);
     if (params.tmdbId) query.set('tmdb_id', String(params.tmdbId));
-    if (!params.moviehash && !params.imdbId && !params.tmdbId) {
+    if (!params.imdbId && !params.tmdbId) {
       query.set('film_name', params.title);
       if (params.year) query.set('year', String(params.year));
     }

--- a/backend/src/modules/subtitles/providers/subdl.provider.ts
+++ b/backend/src/modules/subtitles/providers/subdl.provider.ts
@@ -41,6 +41,10 @@ export class SubdlProvider implements SubtitleProviderInterface {
     query.set('api_key', this.settings.apiKey);
     if (params.imdbId) query.set('imdb_id', params.imdbId);
     if (params.tmdbId) query.set('tmdb_id', String(params.tmdbId));
+    if (!params.moviehash && !params.imdbId && !params.tmdbId) {
+      query.set('film_name', params.title);
+      if (params.year) query.set('year', String(params.year));
+    }
     query.set('languages', params.language);
     query.set('type', params.season != null ? 'tv' : 'movie');
     if (params.season != null)

--- a/backend/src/modules/subtitles/subtitles.service.ts
+++ b/backend/src/modules/subtitles/subtitles.service.ts
@@ -78,6 +78,12 @@ export class SubtitlesService {
       }
     }
 
+    if (!params.moviehash && !params.imdbId && !params.tmdbId) {
+      this.logger.warn(
+        `Subtitle search for "${params.title}" has no hash and no provider id, title-only match`,
+      );
+    }
+
     const providers = await this.providerService.findEnabled();
     const allResults: SubtitleSearchResult[] = [];
 

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -62,7 +62,7 @@ export interface Media {
   originalTitle: string;
   year: number;
   type: MediaType;
-  tmdbId: number;
+  tmdbId: number | null;
   overview: string;
   status: string;
   monitored: boolean;

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -765,15 +765,22 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   });
 
   /** Regular requester (no `media.create` permission). The Demander
-   *  actions are only surfaced for them — admins use Grab/Search. */
+   *  actions are only surfaced for them — admins use Grab/Search. An
+   *  unidentified title has no tmdbId to key the request on. */
   readonly canRequest = computed(
-    () => !this.auth.hasPermission('media.create') && this.auth.hasPermission('requests.create'),
+    () =>
+      !this.auth.hasPermission('media.create') &&
+      this.auth.hasPermission('requests.create') &&
+      this.media()?.tmdbId != null,
   );
 
   /** Requester (no `media.delete`) can ask an admin to delete this library
    *  title. Admins with `media.delete` delete directly and never see it. */
   readonly canRequestDeletion = computed(
-    () => this.auth.hasPermission('requests.create') && !this.auth.hasPermission('media.delete'),
+    () =>
+      this.auth.hasPermission('requests.create') &&
+      !this.auth.hasPermission('media.delete') &&
+      this.media()?.tmdbId != null,
   );
 
   /** A deletion request on this title is already pending (submitted by the
@@ -2168,7 +2175,8 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   /** Fetch the global active-request state for this title. Run after the
    *  media loads, and again after a successful submit so the gates and the
    *  profile lock flip without a manual reload. */
-  private async loadTitleState(tmdbId: number, mediaType: MediaType) {
+  private async loadTitleState(tmdbId: number | null, mediaType: MediaType) {
+    if (tmdbId == null) return;
     try {
       this.titleState.set(await this.requestsApi.getTitleState(tmdbId, mediaType));
     } catch {
@@ -2178,7 +2186,8 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
 
   /** Seed the pending-deletion gate from the viewer's visible requests so the
    *  entry hides when a deletion request already exists on this title. */
-  private async loadDeleteRequestState(tmdbId: number, mediaType: MediaType) {
+  private async loadDeleteRequestState(tmdbId: number | null, mediaType: MediaType) {
+    if (tmdbId == null) return;
     try {
       const res = await this.requestsApi.list({ kind: 'delete', status: 'pending' });
       this.deleteRequestPending.set(
@@ -2193,7 +2202,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
    *  deletion request scoped to the whole title (movie or series). */
   protected async requestDeletion() {
     const m = this.media();
-    if (!m) return;
+    if (!m || m.tmdbId == null) return;
     if (
       !(await this.confirmation.confirm({
         title: this.translate.instant('media_detail.request_deletion_title'),
@@ -2223,7 +2232,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
    *  whole-series scope (no seasons pre-selected). */
   protected openRequestForMedia() {
     const m = this.media();
-    if (!m) return;
+    if (!m || m.tmdbId == null) return;
     const state = this.titleState();
     this.requestModal()?.open({
       title: m.title,
@@ -2241,7 +2250,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
    *  the user toggle which seasons to send. */
   protected openRequestForSeason(season: Season) {
     const m = this.media();
-    if (!m) return;
+    if (!m || m.tmdbId == null) return;
     const state = this.titleState();
     this.requestModal()?.open({
       title: m.title,

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -764,9 +764,8 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     return ep ? this.watchedEpisodeIds().has(ep.id) : null;
   });
 
-  /** Regular requester (no `media.create` permission). The Demander
-   *  actions are only surfaced for them — admins use Grab/Search. An
-   *  unidentified title has no tmdbId to key the request on. */
+  /** Regular requester (no `media.create`) with a tmdbId to request against;
+   *  an unidentified title has none, so the Demander actions stay hidden. */
   readonly canRequest = computed(
     () =>
       !this.auth.hasPermission('media.create') &&

--- a/plan/local-media-without-metadata.md
+++ b/plan/local-media-without-metadata.md
@@ -1,0 +1,429 @@
+# Plan — show every file on disk, matched to a metadata provider or not
+
+Status: **planned, not started**. Written 2026-09-06.
+
+Goal: a video file under a library root is always reachable in Fliks. A title
+that TMDB/TVDB never matched (or that the admin never bothered to match) gets a
+`Media` row anyway, with a placeholder poster and whatever the file itself can
+tell us (filename, `.nfo`, ffprobe, sibling artwork). Metadata decorates the
+library; it no longer gates it. The model is Jellyfin's: the file is the source
+of truth, the provider match is an optional enrichment the admin can apply later
+through the existing **Identify** flow.
+
+Non-goals (this plan): a periodic full-library scan à la Jellyfin, auto-matching
+after the fact, local artwork for *matched* titles, a frame-extraction poster
+(listed as optional at the end).
+
+## What the audit found
+
+Everything below is already true on `main` — the plan builds on it, nothing
+here needs to be re-verified before starting.
+
+**The data model already allows it.**
+
+- `tmdbId` / `tvdbId` / `imdbId` are nullable
+  (`backend/src/modules/media/entities/media.entity.ts`).
+- `UQ_media_type_tmdbId` is a plain unique index → NULLS DISTINCT, any number
+  of unmatched rows per type.
+- `CreateMediaDto` requires only `title` + `type`.
+- `MediaImportService.create()` and
+  `MediaRescanService.linkExistingFileInPlace()` are the two bricks needed;
+  no new entity, no migration.
+- `applyIdentity()` / `completeIdentify()` work on a media with no id at all.
+  The Identify modal is wired on the card and the detail page (admin only).
+- Playback, social, playlists, markers, streaming never read `tmdbId`.
+- `media-card.html` already renders the film-icon placeholder when
+  `posterUrl` is null.
+
+**The single blocker**: nothing creates a `Media` without an external id.
+
+- `DiskImportService.relinkOrphans` requires `dto.externalId` and goes through
+  `importMedia`, which reads the provider.
+- `OrphanScanPanelComponent.importAll` skips every group without a pick.
+- Files directly under the library root (`looseFiles`) are counted and thrown
+  away (`media.path` needs a non-empty `folderName`).
+
+**What breaks the day unmatched rows exist** (must be fixed *before* or *with*
+the creation path):
+
+1. Subtitle providers: `opensubtitles.provider.ts` and `subdl.provider.ts`
+   only send `moviehash` / `imdb_id` / `tmdb_id`; `params.title` is never sent.
+   A file with no hash and no id would query `languages=xx` alone and download
+   an unrelated subtitle.
+2. `SchedulerService.doRefreshMissingMetadata` picks `!posterUrl || !overview`
+   and `doRefreshMetadata` picks anything not "settled"; both call
+   `refreshMetadata`, which throws `No provider ID available` for every
+   unmatched title, every night.
+3. `monitored` defaults to `true`; an unmatched local title would trigger the
+   release search on a filename-derived title.
+4. Requests are keyed on `tmdbId` (NOT NULL column). `media-detail.ts` calls
+   `loadTitleState(m.tmdbId)` → `?tmdbId=undefined` → 400, and the
+   Request / Request-deletion gates read a wrong state.
+5. `findByTmdbId` is the only "already in library" check, so an unmatched
+   title is invisible to dedup (a user request for it re-downloads it).
+6. Naming templates emit empty `{TMDB Id}` / `{Year}` → "reorganize" must be
+   refused on an unmatched title.
+7. `dropSeasonsAbsentFromProvider` after an Identify sets `episodeId` to NULL
+   on files whose invented episode the provider does not list (pre-existing,
+   becomes common).
+
+## Decisions taken
+
+- **No new column.** "Unmatched" is derived: `tmdbId == null && tvdbId == null
+  && imdbId == null`. One helper each side (`isUnmatched(media)`), no
+  `metadataSource` enum, no `identifiedAt`. Re-evaluate only if a later feature
+  needs to distinguish "NFO-sourced" from "filename-sourced".
+- **Unmatched rows are created with `monitored: false`,
+  `status: RELEASED`, `metadataRefreshedAt: null`.** `RELEASED` keeps the
+  detail page from labelling a file on disk "TBA" and keeps `isMetadataDue`
+  logic sane; monitoring is the admin's explicit choice after an Identify.
+- **Natural key for an unmatched title is `(libraryId, type, folderName)`.**
+  Two scans of the same folder relink into the same row instead of creating a
+  twin. Two folders with the same guessed title stay two titles, like Jellyfin.
+- **Requests stay TMDB-keyed.** The Request / Request-deletion entries are
+  hidden on an unmatched title (the admin identifies it first). Re-keying the
+  requests table on `mediaId` is a separate project with no payoff here.
+- **"Reorganize" is refused server-side for an unmatched title** (400), and
+  the client never sends it for one. Linking is always in place.
+- **Local `.nfo` and sibling artwork are read only for unmatched titles** in
+  this plan. Applying them to matched titles (Jellyfin's "local over remote"
+  preference) is a follow-up with its own precedence rules.
+- **Files at the library root are their own PR** (Phase 5): they touch
+  `media.path`, which feeds the folder deletion path.
+
+## Phase 0 — guards (ship first, safe on its own)
+
+Nothing in this phase changes behaviour for matched titles. It closes the
+three silent-guard holes so Phase 1 can't hurt anyone.
+
+### 0.1 Subtitle providers send the title
+
+- `opensubtitles.provider.ts`: `if (!params.moviehash && !params.imdbId &&
+  !params.tmdbId) query.set('query', params.title)`. OpenSubtitles' `query`
+  parameter is the documented free-text search.
+- `subdl.provider.ts`: same shape with `film_name`.
+- `SubtitlesService.searchSubtitles`: log at `warn` when a search runs with no
+  hash and no id — the scorer already rates candidates by release name and
+  title, so the results are usable, but the log makes a bad match diagnosable.
+- Spec: one test per provider asserting the URL carries the title when ids
+  and hash are absent, and does not when an id is present.
+
+### 0.2 Schedulers skip titles with no provider id
+
+- `scheduler.service.ts`: `doRefreshMetadata` and `doRefreshMissingMetadata`
+  filter `allMedia` with `hasProviderId(m)` before building `dueMedia` /
+  `candidates`. Log the skipped count once per run
+  (`… (N unidentified title(s) skipped)`), not per title.
+- `MediaMetadataService.refreshMetadata`: keep the throw (a manual refresh on
+  an unmatched title must say why), the schedulers just stop calling it.
+- Spec: `scheduler.service.spec.ts` — an unmatched row is neither refreshed
+  nor counted as failed.
+
+### 0.3 Client request gates tolerate a missing `tmdbId`
+
+- `media-detail.ts`: `loadTitleState` / `loadDeleteRequestState` return early
+  when `m.tmdbId == null`; `canRequest()` / `canRequestDeletion()` (or the
+  template around the buttons) also require `tmdbId`.
+- Same check anywhere else `m.tmdbId` is stringified into a URL (grep
+  `tmdbId` in `client/src/app/features/media-detail/`).
+
+PR title: `fix(metadata): guard subtitle search, refresh jobs and request gates against titles with no provider id`.
+
+## Phase 1 — backend: create an unmatched title from an orphan group
+
+### 1.1 DTO
+
+`RelinkOrphansDto` (`backend/src/modules/imports/dto/relink-orphans.dto.ts`):
+
+- `externalId` → `@IsOptional()`. `provider` already optional.
+- Add `title?: string` (`@IsOptional() @IsString() @MaxLength(255)`) and
+  `year?: number` (`@IsOptional() @IsInt() @Min(1888) @Max(2100)`), used only
+  when `externalId` is absent. Both come from the panel's editable query/year
+  fields, so the admin's correction of the guessed title is what gets stored.
+- Class-level rule: `externalId` absent + `reorganize: true` → 400
+  (`Reorganize needs an identified title`). Do it in the service, not with a
+  custom validator — one `if`, one exception.
+
+### 1.2 Service branch
+
+`DiskImportService.relinkOrphans`:
+
+```ts
+let media = dto.externalId
+  ? await this.findOrImportIdentified(dto, addedByUserId)     // today's code
+  : await this.findOrCreateUnmatched(dto, library, addedByUserId);
+```
+
+`findOrCreateUnmatched`:
+
+1. `mediaRepo.findOne({ where: { library: { id }, type, folderName,
+   tmdbId: IsNull(), tvdbId: IsNull(), imdbId: IsNull() } })` → reuse.
+2. Otherwise `mediaImport.createUnmatched({ title, year, type, libraryId,
+   folderName, qualityProfileId, languageProfileId }, addedByUserId)`.
+
+`MediaImportService.createUnmatched` (next to `create()`):
+
+- Resolves profiles through `profiles.resolveQualityProfileIdForImport` /
+  `resolveLanguageProfileIdForImport` like `importMedia` does, so an Identify
+  followed by "monitor" behaves like any other title.
+- `mediaRepo.create({ title, originalTitle: title, year, type,
+  status: MediaStatus.RELEASED, monitored: false, alternativeTitles: [],
+  genres: [], library, folderName, addedBy })`.
+- `updateSearchVector(saved.id)`.
+- `events.emitDomain({ type: 'media.imported', tmdbId: null, … })` — the
+  event is already typed `tmdbId: number | null`; `RequestLifecycleService.
+  onMediaImported` already returns on `!media.tmdbId`.
+- Log: `Library: added unidentified movie "<title>" (<year>) — id=…`.
+
+Everything after that in `relinkOrphans` is unchanged: pin `folderName`,
+`linkExistingFileInPlace` per file, `postImportQueue.enqueue`, the
+`media.files.imported` domain event. For a series the existing
+`ensureSeasonAndEpisode` invents seasons/episodes from `SxxEyy`; skip the
+`refreshSeriesEpisodes` backfill when the media has no id (it would throw).
+
+### 1.3 Helper
+
+`backend/src/modules/media/media-identity.util.ts` (or inside the entity as a
+getter — pick the entity getter only if it doesn't need `@Expose`):
+
+```ts
+export const hasProviderId = (m: Pick<Media, 'tmdbId' | 'tvdbId' | 'imdbId'>) =>
+  m.tmdbId != null || m.tvdbId != null || !!m.imdbId;
+```
+
+Used by Phase 0.2, by `relinkOrphans`, and by the `unidentified` filter in
+Phase 3.
+
+### 1.4 Tests
+
+- `disk-import.unmatched.spec.ts` (same harness as
+  `disk-import.orphan-scan.spec.ts`): no `externalId` → `createUnmatched`
+  called with the guessed title/year, files linked in place, `created: true`;
+  second call on the same folder reuses the row (`created: false`);
+  `reorganize: true` without `externalId` → `BadRequestException`;
+  series group → seasons/episodes created, `refreshSeriesEpisodes` not called.
+- `media-import.service` spec: `createUnmatched` sets `monitored: false`,
+  `status: released`, emits `media.imported` with `tmdbId: null`.
+
+## Phase 2 — client: the scan panel offers "add without metadata"
+
+`client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/`.
+
+### 2.1 Group state
+
+`GroupVM` gains nothing new: "unmatched" is `pick === null`. What changes is
+what a null pick *means*: today it's "skip", after this it's "add as is".
+
+- `relinkBody(libraryId, group, pick | null)`: when `pick` is null, omit
+  `externalId`/`provider`, send `title: vm.query.trim() || group.guessTitle ||
+  group.folderName`, `year: vm.year ?? undefined`, and force
+  `reorganize: false`.
+- `link(i)`: no longer requires `vm.pick`. Button label switches between
+  `scan_link` / `scan_relink_existing` / new `scan_add_unmatched`
+  ("Ajouter sans métadonnées").
+- `importAll` (wizard path): every pending group is sent; `skipped` only
+  counts groups whose request failed to build (in practice zero). Return
+  `{ queued, unmatched }` so the wizard toast can say how many landed without
+  metadata.
+- `autoImportAll`: unchanged — it still picks the best provider match when
+  there is one; when `bestMatch` returns null it now links unmatched instead
+  of leaving the group behind.
+- `pendingGroups` / `hasLinkable`: drop the `g.pick` condition.
+
+### 2.2 Template
+
+- Collapsed header badge: `vm.pick?.title` today; when null and the group
+  has been searched, show a ghost badge `scan_unmatched_badge`
+  ("Sans métadonnées").
+- Search results list: add a first pseudo-row "Aucune correspondance : ajouter
+  tel quel" that is selected when `pick` is null. This makes the deselect
+  gesture (clicking the picked result again) discoverable instead of implicit.
+- The `reorganize` toggle stays global; the link button tooltip says it is
+  ignored for an unmatched title (`scan_reorganize_needs_match`).
+- Wizard (`library-wizard.ts`): replace the `scan_unmatched` warning toast
+  with an info toast `scan_queued_unmatched` ("{{count}} titre(s) ajouté(s)
+  sans métadonnées, identifiez-les depuis l'onglet Médias").
+
+### 2.3 i18n
+
+Add to all six `client/public/i18n/*.json` under `settings.libraries`:
+`scan_add_unmatched`, `scan_unmatched_badge`, `scan_unmatched_option`,
+`scan_reorganize_needs_match`, `scan_queued_unmatched`. Retire
+`scan_unmatched` (the "relaunch the scan" warning) once nothing reads it.
+
+### 2.4 Tests
+
+`orphan-scan-panel.spec.ts`: a group with no pick produces a body without
+`externalId` and with `title`/`year`; `importAll` queues it; `reorganize` is
+forced to `false` on that body.
+
+PR (Phases 1 + 2 together, they are useless apart):
+`feat(libraries): add unidentified titles from the orphan scan instead of skipping them`.
+
+## Phase 3 — display and admin tooling for unidentified titles
+
+### 3.1 Detail page
+
+`media-detail.ts` / `media-info-header`:
+
+- Admin-only callout above the header when `!hasProviderId(m)`:
+  "Ce titre n'est pas identifié. Les informations viennent du fichier." with
+  the existing `media.identify` action as its button. The Identify entry in
+  the actions menu stays; the callout is the discoverable path.
+- Skip `getSimilar` / `getCollection` / cast loading when unmatched (they are
+  provider-derived and would 404 or return empty).
+- Runtime fallback: `runtime ?? Math.round(files[0].streamInfo.durationSeconds
+  / 60)`; the header already takes `runtime` as an input.
+- "Refresh metadata" action: when unmatched, open Identify instead (a refresh
+  has nothing to refresh from). Gate on `hasProviderId` in
+  `core-media-actions.ts`.
+- Non-admin viewers see the title, year, file badges, playback controls and
+  the placeholder; nothing else is claimed.
+
+### 3.2 Cards and rows
+
+No change to `media-card`. Optional: a tiny "?" corner badge for admins on
+unmatched cards — skip unless the admin filter below proves insufficient.
+
+### 3.3 Admin filter
+
+- `SearchMediaDto`: `unidentified?: boolean` → `media-query.service.ts`
+  `applyFilters`: `qb.andWhere('media."tmdbId" IS NULL AND media."tvdbId" IS
+  NULL AND media."imdbId" IS NULL')`.
+- Library detail → Media tab (`library-media.ts`): a "Non identifiés" toggle
+  and a count chip, so the admin batch-identifies after a big import. The
+  card's existing Identify action does the rest.
+
+### 3.4 Tests
+
+`media-query.applyfilters.spec.ts`: the `unidentified` filter clause.
+`media-detail` spec: callout shown for admin + unmatched, hidden otherwise;
+`getSimilar` not called when unmatched.
+
+PR: `feat(media-detail): surface unidentified titles and let admins filter and identify them`.
+
+## Phase 4 — metadata from the disk (the Jellyfin part worth copying)
+
+Applied only in `createUnmatched` and only when the field is still empty.
+
+### 4.1 NFO beyond ids
+
+`NfoMetadataService.parse` already reads `title`, `year`, `uniqueid`. Extend
+`NfoIds` (rename to `NfoData`) with `plot`, `genres: string[]`, `runtime`
+(minutes), `rating` (`<ratings><rating><value>` then `<rating>`), `premiered`
+(ISO date), `originalTitle`. Kodi's schema is stable; this is ~25 lines of
+cheerio. `readForVideoFile` merges per key the same way it does today.
+
+`OrphanGroup.nfo` already flows to the client; the panel can prefill the
+query field from `nfo.title` (it does) and the backend uses the full NFO at
+create time — re-read server-side from the sample file rather than trusting
+the client copy.
+
+Spec: `nfo-metadata.service.spec.ts` (new) — a full Kodi movie NFO and a
+`tvshow.nfo`, plus malformed XML → `{}`.
+
+### 4.2 Sibling artwork
+
+`ImageService`: split `doDownloadAndStore` into "fetch bytes" and
+`storeBuffer(buffer, type, id, variant, sourceKey)` (variants, sidecar, hash).
+Add `storeFromDisk(absPath, type, id, variant)` whose sidecar `url` is
+`file://<abs>@<mtimeMs>` so the cache-hit path stays valid.
+
+`backend/src/modules/imports/local-artwork.util.ts` — pure candidate list,
+Jellyfin's conventions, first hit wins, extensions `jpg|jpeg|png|webp`:
+
+- Movie poster: `<basename>-poster`, `poster`, `folder`, `cover`, `movie`.
+- Movie fanart: `<basename>-fanart`, `fanart`, `backdrop`.
+- Series (folder-level): `poster`, `folder`, `fanart`, `backdrop`, `banner`
+  (banner ignored for now), `logo`/`clearlogo` → `logo` variant.
+
+`createUnmatched` calls the lookup for poster/fanart/logo and sets
+`posterUrl`/`fanartUrl`/`logoUrl` from `storeFromDisk`. Best-effort: a bad
+image is a `warn`, never a failed import.
+
+Spec: `local-artwork.util.spec.ts` on a temp tree; `image.service.spec.ts`
+for `storeFromDisk` (sidecar written, variants present, second call is a
+cache hit).
+
+### 4.3 Embedded tags (cheap, optional)
+
+ffprobe already returns `format.tags`. If `tags.title` exists and the
+filename-derived title is a bare release name, prefer `tags.title`. Only if
+4.1/4.2 leave real gaps in practice — flag it, do not build it now.
+
+PR: `feat(imports): read local nfo fields and sibling artwork for unidentified titles`.
+
+## Phase 5 — files directly under the library root
+
+Today: `folderName: ''` → `media.path` getter returns `null` →
+`linkExistingFileInPlace` refuses → the scan lists them as "skipped".
+
+Decision: allow `folderName = ''` for **movies only** (a series is a folder by
+definition) and make `media.path` fall back to `library.path`. Everything that
+treats `media.path` as "the folder I own" must be audited because the root is
+now a possible answer:
+
+- `MediaMutationService.resolveSafeMediaDir` — already returns `null` when
+  `resolvedDir === resolvedRoot`. Keep, add a spec asserting it.
+- `LibraryIngestService.ingest` — refuse a media whose `folderName` is empty
+  (a grab must never land loose files at the root). Today it throws on
+  `!media.path`; it must throw on `!media.folderName` instead.
+- `NamingService` rename / reorganize — refuse (already refused for
+  unmatched; a root movie can be identified later, so check `folderName` too).
+- `DiskImportService.scanLibraryOrphans` `linkedSet` — uses
+  `f.media?.path ?? library.path`, fine.
+- `doRescanMissingFiles` / `rescanMediaList` — a root movie's "folder" is the
+  whole library; the rescan must only look at its own `relativePath`, not walk
+  the root. Check `MediaRescanService.rescan` before enabling.
+- Orphan scan: loose movie files become groups with `folderName: ''` and
+  `groupKey: movie:<abs>`; `looseFiles` disappears from the result and the
+  `scan_loose_skipped` string is retired.
+- `MediaFile.relativePath` for a root movie is just the filename; the
+  `relativePathUnderMediaRoot(library.path, abs)` helper handles it.
+- Delete from the UI on a root movie: `diskPath` is `null` → only the DB row
+  goes; the file stays. Say so in the confirm dialog (`media_detail.
+  delete_no_folder`).
+
+Spec: every bullet above gets one assertion; the destructive one
+(`resolveSafeMediaDir` on a root movie) is mandatory.
+
+PR: `feat(libraries): link movie files that sit directly under the library root`.
+
+## Optional follow-ups (not planned)
+
+- **Frame-extracted poster** when no artwork and no provider: the
+  `ThumbnailService` sprite pipeline already decodes the file; a
+  `-ss <10 %> -frames:v 1` extraction stored via `storeFromDisk` as `poster`
+  is ~40 lines. Do it only if placeholders turn out to be a real complaint.
+- **Local artwork for matched titles** (Jellyfin's "prefer local").
+- **Dedup by title/year** in `findByTmdbId` callers so a request for an
+  unmatched title that is already on disk is caught.
+- **Auto-identify job** for unmatched titles (year + exact title from the
+  provider's first result). The wizard already does this at scan time; a
+  nightly retry adds risk of silent wrong matches for little gain.
+
+## Rollout order and verification
+
+| PR | Phases | Ships alone? | Verify |
+|----|--------|--------------|--------|
+| 1 | 0 | yes | unit specs; nightly job log shows the skipped count; subtitle search URL in the provider log carries `query=` |
+| 2 | 1 + 2 | after PR 1 | dev stack: library wizard on a folder with one matched, one unmatched movie and one unmatched series → three rows, playback works on all three, `monitored=false` on the two unmatched, Identify on one of them swaps in the provider data and keeps the files |
+| 3 | 3 | after PR 2 | admin sees the callout and the filter; a viewer sees title/year/placeholder and can play; Request buttons absent |
+| 4 | 4 | after PR 2 | folder with `movie.nfo` + `poster.jpg`: plot, genres, poster appear without any provider call (network off in the container to be sure) |
+| 5 | 5 | after PR 2 | `Movie (2020).mkv` at the root imports; deleting it from the UI removes the row and **not** the library folder |
+
+Backend checks use the direct binaries (`node_modules/.bin/jest`,
+`node_modules/.bin/tsc -p tsconfig.build.json`), not the `npx` wrappers. Client
+builds go to `/tmp/fliks-verify` (`dist/` is root-owned on the dev machine).
+
+## Open questions for the owner
+
+1. Wizard default: when a group has no provider match, add it unmatched
+   silently (with a count toast) or stop and ask? Plan assumes **add
+   silently** — a library that shows everything is the point.
+2. Should `autoImportAll` on the library page also link groups with *no*
+   provider result as unmatched? Plan assumes **yes** (same rule as the
+   wizard).
+3. Is `RELEASED` acceptable as the status of every unmatched title, or should
+   the detail page hide the status line entirely for them? Plan assumes
+   **RELEASED**, hidden line is a one-line change if preferred.

--- a/plan/local-media-without-metadata.md
+++ b/plan/local-media-without-metadata.md
@@ -1,4 +1,4 @@
-# Plan — show every file on disk, matched to a metadata provider or not
+# Plan: show every file on disk, matched to a metadata provider or not
 
 Status: **planned, not started**. Written 2026-09-06.
 
@@ -6,17 +6,17 @@ Goal: a video file under a library root is always reachable in Fliks. A title
 that TMDB/TVDB never matched (or that the admin never bothered to match) gets a
 `Media` row anyway, with a placeholder poster and whatever the file itself can
 tell us (filename, `.nfo`, ffprobe, sibling artwork). Metadata decorates the
-library; it no longer gates it. The model is Jellyfin's: the file is the source
-of truth, the provider match is an optional enrichment the admin can apply later
-through the existing **Identify** flow.
+library; it no longer gates it. The file is the source of truth, the provider
+match is an optional enrichment the admin can apply later through the existing
+**Identify** flow.
 
-Non-goals (this plan): a periodic full-library scan à la Jellyfin, auto-matching
+Non-goals (this plan): a periodic full-library scan, auto-matching
 after the fact, local artwork for *matched* titles, a frame-extraction poster
 (listed as optional at the end).
 
 ## What the audit found
 
-Everything below is already true on `main` — the plan builds on it, nothing
+Everything below is already true on `main`: the plan builds on it, nothing
 here needs to be re-verified before starting.
 
 **The data model already allows it.**
@@ -79,19 +79,19 @@ the creation path):
   logic sane; monitoring is the admin's explicit choice after an Identify.
 - **Natural key for an unmatched title is `(libraryId, type, folderName)`.**
   Two scans of the same folder relink into the same row instead of creating a
-  twin. Two folders with the same guessed title stay two titles, like Jellyfin.
+  twin. Two folders with the same guessed title stay two titles.
 - **Requests stay TMDB-keyed.** The Request / Request-deletion entries are
   hidden on an unmatched title (the admin identifies it first). Re-keying the
   requests table on `mediaId` is a separate project with no payoff here.
 - **"Reorganize" is refused server-side for an unmatched title** (400), and
   the client never sends it for one. Linking is always in place.
 - **Local `.nfo` and sibling artwork are read only for unmatched titles** in
-  this plan. Applying them to matched titles (Jellyfin's "local over remote"
-  preference) is a follow-up with its own precedence rules.
+  this plan. Applying a local-over-remote artwork preference to matched titles
+  is a follow-up with its own precedence rules.
 - **Files at the library root are their own PR** (Phase 5): they touch
   `media.path`, which feeds the folder deletion path.
 
-## Phase 0 — guards (ship first, safe on its own)
+## Phase 0: guards (ship first, safe on its own)
 
 Nothing in this phase changes behaviour for matched titles. It closes the
 three silent-guard holes so Phase 1 can't hurt anyone.
@@ -103,7 +103,7 @@ three silent-guard holes so Phase 1 can't hurt anyone.
   parameter is the documented free-text search.
 - `subdl.provider.ts`: same shape with `film_name`.
 - `SubtitlesService.searchSubtitles`: log at `warn` when a search runs with no
-  hash and no id — the scorer already rates candidates by release name and
+  hash and no id, the scorer already rates candidates by release name and
   title, so the results are usable, but the log makes a bad match diagnosable.
 - Spec: one test per provider asserting the URL carries the title when ids
   and hash are absent, and does not when an id is present.
@@ -116,7 +116,7 @@ three silent-guard holes so Phase 1 can't hurt anyone.
   (`… (N unidentified title(s) skipped)`), not per title.
 - `MediaMetadataService.refreshMetadata`: keep the throw (a manual refresh on
   an unmatched title must say why), the schedulers just stop calling it.
-- Spec: `scheduler.service.spec.ts` — an unmatched row is neither refreshed
+- Spec: `scheduler.service.spec.ts`: an unmatched row is neither refreshed
   nor counted as failed.
 
 ### 0.3 Client request gates tolerate a missing `tmdbId`
@@ -129,7 +129,7 @@ three silent-guard holes so Phase 1 can't hurt anyone.
 
 PR title: `fix(metadata): guard subtitle search, refresh jobs and request gates against titles with no provider id`.
 
-## Phase 1 — backend: create an unmatched title from an orphan group
+## Phase 1: backend, create an unmatched title from an orphan group
 
 ### 1.1 DTO
 
@@ -142,7 +142,7 @@ PR title: `fix(metadata): guard subtitle search, refresh jobs and request gates 
   fields, so the admin's correction of the guessed title is what gets stored.
 - Class-level rule: `externalId` absent + `reorganize: true` → 400
   (`Reorganize needs an identified title`). Do it in the service, not with a
-  custom validator — one `if`, one exception.
+  custom validator: one `if`, one exception.
 
 ### 1.2 Service branch
 
@@ -170,10 +170,10 @@ let media = dto.externalId
   status: MediaStatus.RELEASED, monitored: false, alternativeTitles: [],
   genres: [], library, folderName, addedBy })`.
 - `updateSearchVector(saved.id)`.
-- `events.emitDomain({ type: 'media.imported', tmdbId: null, … })` — the
+- `events.emitDomain({ type: 'media.imported', tmdbId: null, … })`: the
   event is already typed `tmdbId: number | null`; `RequestLifecycleService.
   onMediaImported` already returns on `!media.tmdbId`.
-- Log: `Library: added unidentified movie "<title>" (<year>) — id=…`.
+- Log: `Library: added unidentified movie "<title>" (<year>), id=…`.
 
 Everything after that in `relinkOrphans` is unchanged: pin `folderName`,
 `linkExistingFileInPlace` per file, `postImportQueue.enqueue`, the
@@ -184,7 +184,7 @@ Everything after that in `relinkOrphans` is unchanged: pin `folderName`,
 ### 1.3 Helper
 
 `backend/src/modules/media/media-identity.util.ts` (or inside the entity as a
-getter — pick the entity getter only if it doesn't need `@Expose`):
+getter, pick the entity getter only if it doesn't need `@Expose`):
 
 ```ts
 export const hasProviderId = (m: Pick<Media, 'tmdbId' | 'tvdbId' | 'imdbId'>) =>
@@ -205,7 +205,7 @@ Phase 3.
 - `media-import.service` spec: `createUnmatched` sets `monitored: false`,
   `status: released`, emits `media.imported` with `tmdbId: null`.
 
-## Phase 2 — client: the scan panel offers "add without metadata"
+## Phase 2: client, the scan panel offers "add without metadata"
 
 `client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/`.
 
@@ -225,7 +225,7 @@ what a null pick *means*: today it's "skip", after this it's "add as is".
   counts groups whose request failed to build (in practice zero). Return
   `{ queued, unmatched }` so the wizard toast can say how many landed without
   metadata.
-- `autoImportAll`: unchanged — it still picks the best provider match when
+- `autoImportAll`: unchanged, it still picks the best provider match when
   there is one; when `bestMatch` returns null it now links unmatched instead
   of leaving the group behind.
 - `pendingGroups` / `hasLinkable`: drop the `g.pick` condition.
@@ -260,7 +260,7 @@ forced to `false` on that body.
 PR (Phases 1 + 2 together, they are useless apart):
 `feat(libraries): add unidentified titles from the orphan scan instead of skipping them`.
 
-## Phase 3 — display and admin tooling for unidentified titles
+## Phase 3: display and admin tooling for unidentified titles
 
 ### 3.1 Detail page
 
@@ -283,7 +283,7 @@ PR (Phases 1 + 2 together, they are useless apart):
 ### 3.2 Cards and rows
 
 No change to `media-card`. Optional: a tiny "?" corner badge for admins on
-unmatched cards — skip unless the admin filter below proves insufficient.
+unmatched cards, skip unless the admin filter below proves insufficient.
 
 ### 3.3 Admin filter
 
@@ -302,7 +302,7 @@ unmatched cards — skip unless the admin filter below proves insufficient.
 
 PR: `feat(media-detail): surface unidentified titles and let admins filter and identify them`.
 
-## Phase 4 — metadata from the disk (the Jellyfin part worth copying)
+## Phase 4: metadata from the disk
 
 Applied only in `createUnmatched` and only when the field is still empty.
 
@@ -316,10 +316,10 @@ cheerio. `readForVideoFile` merges per key the same way it does today.
 
 `OrphanGroup.nfo` already flows to the client; the panel can prefill the
 query field from `nfo.title` (it does) and the backend uses the full NFO at
-create time — re-read server-side from the sample file rather than trusting
+create time, re-read server-side from the sample file rather than trusting
 the client copy.
 
-Spec: `nfo-metadata.service.spec.ts` (new) — a full Kodi movie NFO and a
+Spec: `nfo-metadata.service.spec.ts` (new): a full Kodi movie NFO and a
 `tvshow.nfo`, plus malformed XML → `{}`.
 
 ### 4.2 Sibling artwork
@@ -329,8 +329,9 @@ Spec: `nfo-metadata.service.spec.ts` (new) — a full Kodi movie NFO and a
 Add `storeFromDisk(absPath, type, id, variant)` whose sidecar `url` is
 `file://<abs>@<mtimeMs>` so the cache-hit path stays valid.
 
-`backend/src/modules/imports/local-artwork.util.ts` — pure candidate list,
-Jellyfin's conventions, first hit wins, extensions `jpg|jpeg|png|webp`:
+`backend/src/modules/imports/local-artwork.util.ts`: pure candidate list,
+the usual media-center sidecar conventions (Kodi-style names), first hit wins,
+extensions `jpg|jpeg|png|webp`:
 
 - Movie poster: `<basename>-poster`, `poster`, `folder`, `cover`, `movie`.
 - Movie fanart: `<basename>-fanart`, `fanart`, `backdrop`.
@@ -349,11 +350,11 @@ cache hit).
 
 ffprobe already returns `format.tags`. If `tags.title` exists and the
 filename-derived title is a bare release name, prefer `tags.title`. Only if
-4.1/4.2 leave real gaps in practice — flag it, do not build it now.
+4.1/4.2 leave real gaps in practice, flag it, do not build it now.
 
 PR: `feat(imports): read local nfo fields and sibling artwork for unidentified titles`.
 
-## Phase 5 — files directly under the library root
+## Phase 5: files directly under the library root
 
 Today: `folderName: ''` → `media.path` getter returns `null` →
 `linkExistingFileInPlace` refuses → the scan lists them as "skipped".
@@ -363,16 +364,16 @@ definition) and make `media.path` fall back to `library.path`. Everything that
 treats `media.path` as "the folder I own" must be audited because the root is
 now a possible answer:
 
-- `MediaMutationService.resolveSafeMediaDir` — already returns `null` when
+- `MediaMutationService.resolveSafeMediaDir`: already returns `null` when
   `resolvedDir === resolvedRoot`. Keep, add a spec asserting it.
-- `LibraryIngestService.ingest` — refuse a media whose `folderName` is empty
+- `LibraryIngestService.ingest`: refuse a media whose `folderName` is empty
   (a grab must never land loose files at the root). Today it throws on
   `!media.path`; it must throw on `!media.folderName` instead.
-- `NamingService` rename / reorganize — refuse (already refused for
+- `NamingService` rename / reorganize: refuse (already refused for
   unmatched; a root movie can be identified later, so check `folderName` too).
-- `DiskImportService.scanLibraryOrphans` `linkedSet` — uses
+- `DiskImportService.scanLibraryOrphans` `linkedSet`: uses
   `f.media?.path ?? library.path`, fine.
-- `doRescanMissingFiles` / `rescanMediaList` — a root movie's "folder" is the
+- `doRescanMissingFiles` / `rescanMediaList`: a root movie's "folder" is the
   whole library; the rescan must only look at its own `relativePath`, not walk
   the root. Check `MediaRescanService.rescan` before enabling.
 - Orphan scan: loose movie files become groups with `folderName: ''` and
@@ -395,7 +396,7 @@ PR: `feat(libraries): link movie files that sit directly under the library root`
   `ThumbnailService` sprite pipeline already decodes the file; a
   `-ss <10 %> -frames:v 1` extraction stored via `storeFromDisk` as `poster`
   is ~40 lines. Do it only if placeholders turn out to be a real complaint.
-- **Local artwork for matched titles** (Jellyfin's "prefer local").
+- **Local artwork for matched titles** (a local-over-remote artwork preference).
 - **Dedup by title/year** in `findByTmdbId` callers so a request for an
   unmatched title that is already on disk is caught.
 - **Auto-identify job** for unmatched titles (year + exact title from the
@@ -420,7 +421,7 @@ builds go to `/tmp/fliks-verify` (`dist/` is root-owned on the dev machine).
 
 1. Wizard default: when a group has no provider match, add it unmatched
    silently (with a count toast) or stop and ask? Plan assumes **add
-   silently** — a library that shows everything is the point.
+   silently**, a library that shows everything is the point.
 2. Should `autoImportAll` on the library page also link groups with *no*
    provider result as unmatched? Plan assumes **yes** (same rule as the
    wizard).


### PR DESCRIPTION
## Why

The library is about to hold `Media` rows with no `tmdbId`, `tvdbId` or `imdbId` (titles built from the file alone, see `plan/local-media-without-metadata.md`). Three code paths silently misbehave on such a row today; this PR closes them before any such row can exist, and changes nothing for identified titles.

## What

- **Subtitle providers send the title when they have nothing else.** OpenSubtitles only got `moviehash` / `imdb_id` / `tmdb_id`; with none of them the request was `languages=xx` alone, i.e. the provider's global feed, and the top candidate got downloaded. It now sends `query` (+ `year`) in that case. Subdl has no hash parameter at all, so it sends `film_name` (+ `year`) whenever both ids are absent. `SubtitlesService` logs a `warn` on a title-only search so a bad match is diagnosable. Parameter names checked against both providers' API docs.
- **Refresh jobs skip titles with no provider id.** `RefreshMetadata` and `RefreshMissingMetadata` filtered on `!posterUrl || !overview` and "not settled", so an unidentified row would be retried every night and fail with `No provider ID available`. Both jobs now filter with `hasProviderId()` (new `media-identity.util.ts`) and log the skipped count once per run.
- **imdb-only titles resolve through TMDB.** `resolveProviderForMedia` accepted an imdb-only identity (`applyIdentity` allows it) but threw at the end; it now cross-references imdb to tmdb before giving up.
- **Client request gates tolerate a missing `tmdbId`.** `media-detail` stringified `m.tmdbId` into `/requests/title-state?tmdbId=undefined`; the request and request-deletion gates and their loaders now require a present id. `Media.tmdbId` is typed `number | null`.
- Adds the plan document.

## Verification

- `jest src/modules/subtitles src/modules/scheduler src/modules/media`: 43 suites, 352 tests, green.
- `tsc -p tsconfig.build.json --noEmit`: clean.
- `ng build --configuration development`: clean.
- New specs: OpenSubtitles / Subdl request URL with and without ids and hash; scheduler skips an unidentified row in both jobs; `resolveProviderForMedia` on an imdb-only row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
