### PR TITLE
feat(libraries): add unidentified titles from the orphan scan instead of skipping them

### DIFF
--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -6,13 +6,14 @@ import {
   forwardRef,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { relativePathUnderMediaRoot } from '../../common/utils/media-path.util';
 import { sanitizeFsPath } from '../../common/utils/fs-path.util';
 import { Media } from '../media/entities/media.entity';
+import { hasProviderId } from '../media/media-identity.util';
 import { MediaFile } from '../media/entities/media-file.entity';
 import { Season } from '../media/entities/season.entity';
 import { Episode } from '../media/entities/episode.entity';
@@ -432,51 +433,14 @@ export class DiskImportService {
         `Library "${library.name}" does not accept ${dto.type}`,
       );
     }
-
-    const externalIdNum = Number(dto.externalId);
-    const where =
-      dto.provider === 'tvdb'
-        ? { tvdbId: externalIdNum, type: dto.type }
-        : { tmdbId: externalIdNum, type: dto.type };
-
-    let media = await this.mediaRepo.findOne({
-      where,
-      relations: ['library', 'files'],
-    });
-    let created = false;
-    if (!media) {
-      try {
-        const imported = await this.mediaService.importMedia(
-          {
-            type: dto.type,
-            externalId: dto.externalId,
-            provider: dto.provider,
-            libraryId: dto.libraryId,
-            qualityProfileId: dto.qualityProfileId,
-            languageProfileId: dto.languageProfileId,
-          },
-          addedByUserId,
-        );
-        media = await this.mediaRepo.findOne({
-          where: { id: imported.id },
-          relations: ['library', 'files'],
-        });
-        created = true;
-      } catch (e) {
-        // Two orphan files of the same title (e.g. multiple editions, or the
-        // auto-import linking siblings in parallel) can both reach the create
-        // branch before either insert lands, tripping the unique (type,tmdbId)
-        // constraint. Re-fetch and reuse the row the other request created.
-        media = await this.mediaRepo.findOne({
-          where,
-          relations: ['library', 'files'],
-        });
-        if (!media) throw e;
-      }
+    if (!dto.externalId && dto.reorganize) {
+      throw new BadRequestException('Reorganize needs an identified title');
     }
-    if (!media) {
-      throw new BadRequestException('Media not found after import');
-    }
+
+    const { media, created } = dto.externalId
+      ? await this.findOrImportIdentified(dto, addedByUserId)
+      : await this.findOrCreateUnmatched(dto, library, addedByUserId);
+
     if (media.library && media.library.id !== dto.libraryId) {
       throw new BadRequestException(
         `Media already belongs to another library ("${media.library.name}")`,
@@ -582,7 +546,8 @@ export class DiskImportService {
     }
 
     // Backfill metadata for any season/episode slot invented while linking.
-    if (media.type === MediaType.SERIES && slotCreated) {
+    // An unmatched media has no provider id to refresh from — it would just throw.
+    if (media.type === MediaType.SERIES && slotCreated && hasProviderId(media)) {
       try {
         await this.metadata.refreshSeriesEpisodes(media);
       } catch (e) {
@@ -596,6 +561,103 @@ export class DiskImportService {
       `Orphan relink — media #${media.id} created=${created} linked=${linked} errors=${errors.length}`,
     );
     return { mediaId: media.id, created, linked, errors };
+  }
+
+  /** Today's identified path: reuse the media already holding this external id, or import it. */
+  private async findOrImportIdentified(
+    dto: RelinkOrphansDto,
+    addedByUserId: number | null,
+  ): Promise<{ media: Media; created: boolean }> {
+    const externalIdNum = Number(dto.externalId);
+    const where =
+      dto.provider === 'tvdb'
+        ? { tvdbId: externalIdNum, type: dto.type }
+        : { tmdbId: externalIdNum, type: dto.type };
+
+    let media = await this.mediaRepo.findOne({
+      where,
+      relations: ['library', 'files'],
+    });
+    let created = false;
+    if (!media) {
+      try {
+        const imported = await this.mediaService.importMedia(
+          {
+            type: dto.type,
+            externalId: dto.externalId!,
+            provider: dto.provider,
+            libraryId: dto.libraryId,
+            qualityProfileId: dto.qualityProfileId,
+            languageProfileId: dto.languageProfileId,
+          },
+          addedByUserId,
+        );
+        media = await this.mediaRepo.findOne({
+          where: { id: imported.id },
+          relations: ['library', 'files'],
+        });
+        created = true;
+      } catch (e) {
+        // Two orphan files of the same title (e.g. multiple editions, or the
+        // auto-import linking siblings in parallel) can both reach the create
+        // branch before either insert lands, tripping the unique (type,tmdbId)
+        // constraint. Re-fetch and reuse the row the other request created.
+        media = await this.mediaRepo.findOne({
+          where,
+          relations: ['library', 'files'],
+        });
+        if (!media) throw e;
+      }
+    }
+    if (!media) {
+      throw new BadRequestException('Media not found after import');
+    }
+    return { media, created };
+  }
+
+  /**
+   * No external id: reuse the unmatched media already pinned to this folder
+   * (a second scan of the same title), or create one from the guessed/corrected
+   * title. Natural key is (library, type, folderName) so two scans converge.
+   */
+  private async findOrCreateUnmatched(
+    dto: RelinkOrphansDto,
+    library: Library,
+    addedByUserId: number | null,
+  ): Promise<{ media: Media; created: boolean }> {
+    const existing = await this.mediaRepo.findOne({
+      where: {
+        library: { id: library.id },
+        type: dto.type,
+        folderName: dto.folderName,
+        tmdbId: IsNull(),
+        tvdbId: IsNull(),
+        imdbId: IsNull(),
+      },
+      relations: ['library', 'files'],
+    });
+    if (existing) return { media: existing, created: false };
+
+    const created = await this.mediaService.createUnmatched(
+      {
+        title: dto.title?.trim() || dto.folderName,
+        year: dto.year,
+        type: dto.type,
+        libraryId: dto.libraryId,
+        folderName: dto.folderName,
+        qualityProfileId: dto.qualityProfileId,
+        languageProfileId: dto.languageProfileId,
+      },
+      addedByUserId,
+    );
+    const media = await this.mediaRepo.findOne({
+      where: { id: created.id },
+      relations: ['library', 'files'],
+    });
+    if (!media) {
+      throw new BadRequestException('Media not found after import');
+    }
+    return { media, created: true };
   }
 
   async scanFolder(folderPath: string): Promise<ScanCandidate[]> {

--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -546,7 +546,7 @@ export class DiskImportService {
     }
 
     // Backfill metadata for any season/episode slot invented while linking.
-    // An unmatched media has no provider id to refresh from — it would just throw.
+    // An unmatched media has no provider id to refresh from, it would just throw.
     if (media.type === MediaType.SERIES && slotCreated && hasProviderId(media)) {
       try {
         await this.metadata.refreshSeriesEpisodes(media);
@@ -563,7 +563,7 @@ export class DiskImportService {
     return { mediaId: media.id, created, linked, errors };
   }
 
-  /** Today's identified path: reuse the media already holding this external id, or import it. */
+  /** Reuse the media holding this external id, or import it. */
   private async findOrImportIdentified(
     dto: RelinkOrphansDto,
     addedByUserId: number | null,
@@ -616,9 +616,8 @@ export class DiskImportService {
   }
 
   /**
-   * No external id: reuse the unmatched media already pinned to this folder
-   * (a second scan of the same title), or create one from the guessed/corrected
-   * title. Natural key is (library, type, folderName) so two scans converge.
+   * No external id: reuse the media already pinned to this folder, or create one from the
+   * guessed/corrected title. Natural key is (library, type, folderName).
    */
   private async findOrCreateUnmatched(
     dto: RelinkOrphansDto,

--- a/backend/src/modules/imports/disk-import.unmatched.spec.ts
+++ b/backend/src/modules/imports/disk-import.unmatched.spec.ts
@@ -63,7 +63,7 @@ const unmatchedRow = (id: number, folderName: string, type = MediaType.MOVIE) =>
   imdbId: null,
 });
 
-describe('DiskImportService.relinkOrphans — creating an unmatched title', () => {
+describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
   it('creates an unmatched media from the guessed title and links the files in place', async () => {
     const { service, mediaRepo, mediaService } = makeService();
     mediaRepo.findOne

--- a/backend/src/modules/imports/disk-import.unmatched.spec.ts
+++ b/backend/src/modules/imports/disk-import.unmatched.spec.ts
@@ -1,0 +1,182 @@
+import { BadRequestException } from '@nestjs/common';
+import { DiskImportService } from './disk-import.service';
+import { RelinkOrphansDto } from './dto/relink-orphans.dto';
+import { MediaType } from '../../common/enums';
+
+const library = {
+  id: 1,
+  name: 'Movies',
+  path: '/media',
+  mediaTypes: [MediaType.MOVIE, MediaType.SERIES],
+};
+
+const dto = (overrides: Partial<RelinkOrphansDto> = {}): RelinkOrphansDto =>
+  ({
+    libraryId: 1,
+    type: MediaType.MOVIE,
+    folderName: 'Quiet Harbour (2009)',
+    title: 'Quiet Harbour',
+    year: 2009,
+    files: [{ filePath: '/media/Quiet Harbour (2009)/Quiet.Harbour.2009.1080p.mkv' }],
+    ...overrides,
+  }) as RelinkOrphansDto;
+
+function makeService() {
+  const mediaRepo = { findOne: jest.fn(), update: jest.fn() };
+  const mediaService = {
+    importMedia: jest.fn(),
+    createUnmatched: jest.fn(),
+    linkExistingFileInPlace: jest.fn(),
+    ensureSeriesEpisode: jest.fn(),
+  };
+  const libraries = { requirePathFor: jest.fn().mockResolvedValue(library) };
+  const metadata = { refreshSeriesEpisodes: jest.fn() };
+  const events = { emit: jest.fn(), emitDomain: jest.fn() };
+  const postImportQueue = { enqueue: jest.fn() };
+  const service = new DiskImportService(
+    mediaRepo as never,
+    null as never, // fileRepo
+    null as never, // seasonRepo
+    null as never, // episodeRepo
+    mediaService as never,
+    null as never, // naming
+    libraries as never,
+    metadata as never,
+    null as never, // nfo
+    null as never, // libraryIngest
+    postImportQueue as never,
+    null as never, // mediaServers
+    events as never,
+    { upsertPending: jest.fn(), upsertRunning: jest.fn(), remove: jest.fn() } as never,
+  );
+  return { service, mediaRepo, mediaService, libraries, metadata, events, postImportQueue };
+}
+
+const unmatchedRow = (id: number, folderName: string, type = MediaType.MOVIE) => ({
+  id,
+  type,
+  folderName,
+  files: [],
+  library: { id: 1 },
+  tmdbId: null,
+  tvdbId: null,
+  imdbId: null,
+});
+
+describe('DiskImportService.relinkOrphans — creating an unmatched title', () => {
+  it('creates an unmatched media from the guessed title and links the files in place', async () => {
+    const { service, mediaRepo, mediaService } = makeService();
+    mediaRepo.findOne
+      .mockResolvedValueOnce(null) // no existing unmatched row for this folder
+      .mockResolvedValueOnce(unmatchedRow(42, 'Quiet Harbour (2009)')); // reload
+    mediaService.createUnmatched.mockResolvedValue({ id: 42 });
+    mediaService.linkExistingFileInPlace.mockResolvedValue({
+      fileId: 1,
+      episodeId: null,
+      created: false,
+    });
+
+    const res = await service.relinkOrphans(dto(), null);
+
+    expect(mediaService.createUnmatched).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Quiet Harbour',
+        year: 2009,
+        type: MediaType.MOVIE,
+        libraryId: 1,
+        folderName: 'Quiet Harbour (2009)',
+      }),
+      null,
+    );
+    expect(res.created).toBe(true);
+    expect(res.linked).toBe(1);
+    expect(res.mediaId).toBe(42);
+  });
+
+  it('reuses the unmatched row already pinned to the same folder on a second scan', async () => {
+    const { service, mediaRepo, mediaService } = makeService();
+    mediaRepo.findOne.mockResolvedValueOnce(
+      unmatchedRow(42, 'Quiet Harbour (2009)'),
+    );
+    mediaService.linkExistingFileInPlace.mockResolvedValue({
+      fileId: 2,
+      episodeId: null,
+      created: false,
+    });
+
+    const res = await service.relinkOrphans(dto(), null);
+
+    expect(mediaService.createUnmatched).not.toHaveBeenCalled();
+    expect(res.created).toBe(false);
+    expect(res.mediaId).toBe(42);
+  });
+
+  it('refuses reorganize on a title with no external id', async () => {
+    const { service } = makeService();
+    await expect(
+      service.relinkOrphans(dto({ reorganize: true }), null),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('skips the series episode metadata backfill for an unmatched title', async () => {
+    const { service, mediaRepo, mediaService, metadata } = makeService();
+    const seriesDto = dto({
+      type: MediaType.SERIES,
+      folderName: 'Northern Lights',
+      title: 'Northern Lights',
+      year: 2011,
+      files: [
+        {
+          filePath: '/media/Northern Lights/Northern.Lights.S01E01.mkv',
+          seasonNumber: 1,
+          episodeNumber: 1,
+        },
+      ],
+    });
+    mediaRepo.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(unmatchedRow(7, 'Northern Lights', MediaType.SERIES));
+    mediaService.createUnmatched.mockResolvedValue({ id: 7 });
+    // A slot is invented for the file, which would normally trigger the backfill.
+    mediaService.linkExistingFileInPlace.mockResolvedValue({
+      fileId: 3,
+      episodeId: 99,
+      created: true,
+    });
+
+    const res = await service.relinkOrphans(seriesDto, null);
+
+    expect(res.linked).toBe(1);
+    expect(metadata.refreshSeriesEpisodes).not.toHaveBeenCalled();
+  });
+
+  it('leaves the identified path untouched when an externalId is given', async () => {
+    const { service, mediaRepo, mediaService } = makeService();
+    const identifiedDto = dto({ externalId: '999', provider: 'tmdb' });
+    mediaRepo.findOne
+      .mockResolvedValueOnce(null) // no media with this tmdbId yet
+      .mockResolvedValueOnce({
+        id: 55,
+        type: MediaType.MOVIE,
+        folderName: identifiedDto.folderName,
+        files: [],
+        library: { id: 1 },
+        tmdbId: 999,
+        tvdbId: null,
+        imdbId: null,
+      });
+    mediaService.importMedia.mockResolvedValue({ id: 55 });
+    mediaService.linkExistingFileInPlace.mockResolvedValue({
+      fileId: 1,
+      episodeId: null,
+      created: false,
+    });
+
+    const res = await service.relinkOrphans(identifiedDto, null);
+
+    expect(mediaService.importMedia).toHaveBeenCalled();
+    expect(mediaService.createUnmatched).not.toHaveBeenCalled();
+    expect(res.created).toBe(true);
+    expect(res.mediaId).toBe(55);
+  });
+});

--- a/backend/src/modules/imports/dto/relink-orphans.dto.ts
+++ b/backend/src/modules/imports/dto/relink-orphans.dto.ts
@@ -5,6 +5,8 @@ import {
   IsInt,
   IsOptional,
   IsString,
+  Max,
+  MaxLength,
   Min,
   ValidateNested,
 } from 'class-validator';
@@ -43,12 +45,26 @@ export class RelinkOrphansDto {
   @IsEnum(MediaType)
   type: MediaType;
 
+  @IsOptional()
   @IsString()
-  externalId: string;
+  externalId?: string;
 
   @IsOptional()
   @IsString()
   provider?: string;
+
+  /** Used only when `externalId` is absent, to create an unmatched title. */
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  title?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1888)
+  @Max(2100)
+  year?: number;
 
   @IsOptional()
   @Type(() => Number)

--- a/backend/src/modules/media/media-service/media-import.createunmatched.spec.ts
+++ b/backend/src/modules/media/media-service/media-import.createunmatched.spec.ts
@@ -1,0 +1,66 @@
+import { MediaImportService } from './media-import.service';
+import { MediaType, MediaStatus } from '../../../common/enums';
+
+describe('MediaImportService.createUnmatched', () => {
+  function makeService() {
+    const saved: Record<string, unknown>[] = [];
+    const mediaRepo = {
+      create: jest.fn((m: any) => m),
+      save: jest.fn(async (m: any) => {
+        saved.push(m);
+        return { id: 1, ...m };
+      }),
+      findOne: jest.fn().mockResolvedValue({ id: 1, title: 'Quiet Harbour' }),
+    };
+    const emitDomain = jest.fn();
+    const svc = new MediaImportService(
+      mediaRepo as any,
+      {} as any, // seasonRepo
+      {} as any, // episodeRepo
+      {} as any, // libraryRepo
+      {} as any, // dataSource
+      {} as any, // tmdb
+      {} as any, // providerRegistry
+      {} as any, // config
+      {
+        resolveQualityProfileIdForImport: jest.fn().mockResolvedValue(null),
+        resolveLanguageProfileIdForImport: jest.fn().mockResolvedValue(null),
+      } as any,
+      {} as any, // libraries
+      {} as any, // naming
+      { updateSearchVector: jest.fn().mockResolvedValue(undefined) } as any,
+      {} as any, // requestLifecycle
+      { emitDomain } as any,
+    );
+    return { svc, mediaRepo, saved, emitDomain };
+  }
+
+  it('creates an unmonitored, released title with no provider id', async () => {
+    const { svc, saved, emitDomain } = makeService();
+    const media = await svc.createUnmatched({
+      title: 'Quiet Harbour',
+      year: 2009,
+      type: MediaType.MOVIE,
+      libraryId: 3,
+      folderName: 'Quiet Harbour (2009)',
+    });
+
+    expect(saved[0]).toMatchObject({
+      title: 'Quiet Harbour',
+      originalTitle: 'Quiet Harbour',
+      monitored: false,
+      status: MediaStatus.RELEASED,
+    });
+    expect(saved[0]).not.toHaveProperty('tmdbId');
+    expect(saved[0]).not.toHaveProperty('tvdbId');
+    expect(saved[0]).not.toHaveProperty('imdbId');
+    expect(emitDomain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'media.imported',
+        tmdbId: null,
+        mediaType: MediaType.MOVIE,
+      }),
+    );
+    expect(media.id).toBe(1);
+  });
+});

--- a/backend/src/modules/media/media-service/media-import.service.ts
+++ b/backend/src/modules/media/media-service/media-import.service.ts
@@ -378,9 +378,8 @@ export class MediaImportService {
   }
 
   /**
-   * Create a title no metadata provider matched, straight from the orphan scan's
-   * guessed (or admin-corrected) title. No provider call, no images, no cast:
-   * an Identify later fills those in and this row is only a placeholder until then.
+   * Create a title no metadata provider matched, straight from the orphan scan's guessed title.
+   * No provider call, no images, no cast: an Identify later fills those in.
    */
   async createUnmatched(
     dto: {

--- a/backend/src/modules/media/media-service/media-import.service.ts
+++ b/backend/src/modules/media/media-service/media-import.service.ts
@@ -23,7 +23,7 @@ import {
   SeasonDetails,
 } from '../../metadata-providers/interfaces/metadata-provider.interface';
 import { MetadataLanguageOverride } from '../../metadata-providers/metadata-settings-cache.service';
-import { MediaType } from '../../../common/enums';
+import { MediaType, MediaStatus } from '../../../common/enums';
 import { RequestLifecycleService } from '../../requests/request-lifecycle.service';
 import { ProfilesService } from '../../profiles/profiles.service';
 import { QualityProfile } from '../../profiles/entities/quality-profile.entity';
@@ -375,6 +375,70 @@ export class MediaImportService {
       if (cross) return cross.id;
     }
     return null;
+  }
+
+  /**
+   * Create a title no metadata provider matched, straight from the orphan scan's
+   * guessed (or admin-corrected) title. No provider call, no images, no cast:
+   * an Identify later fills those in and this row is only a placeholder until then.
+   */
+  async createUnmatched(
+    dto: {
+      title: string;
+      year?: number | null;
+      type: MediaType;
+      libraryId: number;
+      folderName: string;
+      qualityProfileId?: number;
+      languageProfileId?: number;
+    },
+    addedByUserId: number | null = null,
+  ): Promise<Media> {
+    const qualityProfileId =
+      await this.profiles.resolveQualityProfileIdForImport(
+        dto.qualityProfileId,
+      );
+    const languageProfileId =
+      await this.profiles.resolveLanguageProfileIdForImport(
+        dto.languageProfileId,
+      );
+
+    const row = this.mediaRepo.create({
+      title: dto.title,
+      originalTitle: dto.title,
+      year: dto.year ?? undefined,
+      type: dto.type,
+      status: MediaStatus.RELEASED,
+      monitored: false,
+      alternativeTitles: [],
+      genres: [],
+      library: { id: dto.libraryId } as Library,
+      folderName: dto.folderName,
+      ...(qualityProfileId != null
+        ? { qualityProfile: { id: qualityProfileId } as QualityProfile }
+        : {}),
+      ...(languageProfileId != null
+        ? { languageProfile: { id: languageProfileId } as LanguageProfile }
+        : {}),
+      ...(addedByUserId ? { addedBy: { id: addedByUserId } as User } : {}),
+    });
+    const saved = await this.mediaRepo.save(row);
+    await this.metadata.updateSearchVector(saved.id);
+    this.events.emitDomain({
+      type: 'media.imported',
+      mediaId: saved.id,
+      tmdbId: null,
+      mediaType: dto.type,
+      libraryId: dto.libraryId,
+      addedByUserId: addedByUserId ?? null,
+    });
+    const year = dto.year ? ` (${dto.year})` : '';
+    this.log.log(
+      `Library: added unidentified ${dto.type} "${dto.title}"${year}, id=${saved.id}`,
+    );
+    const reloaded = await this.mediaRepo.findOne({ where: { id: saved.id } });
+    if (!reloaded) throw new Error(`Media #${saved.id} not found after save`);
+    return reloaded;
   }
 
   async create(dto: CreateMediaDto): Promise<Media> {

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -74,6 +74,13 @@ export class MediaService {
     return this.imports.create(dto);
   }
 
+  createUnmatched(
+    dto: Parameters<MediaImportService['createUnmatched']>[0],
+    addedByUserId: number | null = null,
+  ) {
+    return this.imports.createUnmatched(dto, addedByUserId);
+  }
+
   // -- Reads ------------------------------------------------------------------
 
   getCounts(accessibleLibraryIds: number[]) {

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1941,7 +1941,6 @@
       "scan_folder": "Ordner scannen",
       "scan_required": "Scannen Sie den Ordner, um die gefundenen Medien vor dem Erstellen der Bibliothek zu prüfen.",
       "scan_queued": "Import von {{count}} Medien im Hintergrund gestartet.",
-      "scan_unmatched": "{{count}} Ordner nicht erkannt: führen Sie „Ordner scannen“ im Tab Medien erneut aus, um sie zuzuordnen.",
       "scan_title": "Ordner-Scan",
       "scan_scanning": "Dateien werden gescannt…",
       "scan_progress": "{{done}}/{{total}} Dateien werden geprüft…",
@@ -1967,7 +1966,12 @@
       "scan_nothing_linked": "Keine Datei verknüpft (Duplikat bereits im Medium vorhanden).",
       "scan_error": "Scan fehlgeschlagen.",
       "scan_loose_skipped": "{{count}} Datei(en) im Stammverzeichnis übersprungen — verschieben Sie sie in einen Unterordner, um sie zu verknüpfen.",
-      "scan_files": "{{count}} Datei(en)"
+      "scan_files": "{{count}} Datei(en)",
+      "scan_add_unmatched": "Ohne Metadaten hinzufügen",
+      "scan_unmatched_badge": "Keine Metadaten",
+      "scan_unmatched_option": "Keine Übereinstimmung: unverändert hinzufügen",
+      "scan_reorganize_needs_match": "Verschieben/Umbenennen gilt nur für identifizierte Titel",
+      "scan_queued_unmatched": "{{count}} Titel ohne Metadaten hinzugefügt, identifizieren Sie sie im Tab Medien"
     },
     "users": {
       "title": "Benutzer",

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1971,7 +1971,8 @@
       "scan_unmatched_badge": "Keine Metadaten",
       "scan_unmatched_option": "Keine Übereinstimmung: unverändert hinzufügen",
       "scan_reorganize_needs_match": "Verschieben/Umbenennen gilt nur für identifizierte Titel",
-      "scan_queued_unmatched": "{{count}} Titel ohne Metadaten hinzugefügt, identifizieren Sie sie im Tab Medien"
+      "scan_queued_unmatched": "{{count}} Titel ohne Metadaten hinzugefügt, identifizieren Sie sie im Tab Medien",
+      "scan_search_failed_count": "{{count}} Ordner nicht analysiert (Suche fehlgeschlagen), starten Sie den Scan im Tab Medien erneut"
     },
     "users": {
       "title": "Benutzer",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1958,7 +1958,6 @@
       "scan_folder": "Scan the folder",
       "scan_required": "Scan the folder to review the media found before creating the library.",
       "scan_queued": "Import of {{count}} media started in the background.",
-      "scan_unmatched": "{{count}} folder(s) not recognised: run \"Scan the folder\" again from the Media tab to match them.",
       "scan_title": "Folder scan",
       "scan_scanning": "Scanning files…",
       "scan_progress": "Scanning {{done}}/{{total}} files…",
@@ -1984,7 +1983,12 @@
       "scan_nothing_linked": "No file linked (duplicate already present in the media).",
       "scan_error": "Scan failed.",
       "scan_loose_skipped": "{{count}} file(s) at the root skipped — move them into a subfolder to link them.",
-      "scan_files": "{{count}} file(s)"
+      "scan_files": "{{count}} file(s)",
+      "scan_add_unmatched": "Add without metadata",
+      "scan_unmatched_badge": "No metadata",
+      "scan_unmatched_option": "No match: add as is",
+      "scan_reorganize_needs_match": "Move/rename only applies to identified titles",
+      "scan_queued_unmatched": "{{count}} title(s) added without metadata, identify them from the Media tab"
     },
     "users": {
       "title": "Users",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1988,7 +1988,8 @@
       "scan_unmatched_badge": "No metadata",
       "scan_unmatched_option": "No match: add as is",
       "scan_reorganize_needs_match": "Move/rename only applies to identified titles",
-      "scan_queued_unmatched": "{{count}} title(s) added without metadata, identify them from the Media tab"
+      "scan_queued_unmatched": "{{count}} title(s) added without metadata, identify them from the Media tab",
+      "scan_search_failed_count": "{{count}} folder(s) not scanned (search failed), relaunch the scan from the Media tab"
     },
     "users": {
       "title": "Users",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1941,7 +1941,6 @@
       "scan_folder": "Analizar la carpeta",
       "scan_required": "Analiza la carpeta para revisar los medios encontrados antes de crear la biblioteca.",
       "scan_queued": "Importación de {{count}} medios iniciada en segundo plano.",
-      "scan_unmatched": "{{count}} carpeta(s) no reconocida(s): vuelva a ejecutar «Analizar la carpeta» desde la pestaña Medios para asociarlas.",
       "scan_title": "Análisis de la carpeta",
       "scan_scanning": "Análisis de los archivos en curso…",
       "scan_progress": "Analizando {{done}}/{{total}} archivos…",
@@ -1967,7 +1966,12 @@
       "scan_nothing_linked": "No se ha vinculado ningún archivo (duplicado ya presente en el medio).",
       "scan_error": "Error del análisis.",
       "scan_loose_skipped": "{{count}} archivo(s) en la raíz ignorado(s) — muévalos a una subcarpeta para vincularlos.",
-      "scan_files": "{{count}} archivo(s)"
+      "scan_files": "{{count}} archivo(s)",
+      "scan_add_unmatched": "Añadir sin metadatos",
+      "scan_unmatched_badge": "Sin metadatos",
+      "scan_unmatched_option": "Sin coincidencia: añadir tal cual",
+      "scan_reorganize_needs_match": "Mover/renombrar solo se aplica a títulos identificados",
+      "scan_queued_unmatched": "{{count}} título(s) añadido(s) sin metadatos, identifíquelos desde la pestaña Medios"
     },
     "users": {
       "title": "Usuarios",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1971,7 +1971,8 @@
       "scan_unmatched_badge": "Sin metadatos",
       "scan_unmatched_option": "Sin coincidencia: añadir tal cual",
       "scan_reorganize_needs_match": "Mover/renombrar solo se aplica a títulos identificados",
-      "scan_queued_unmatched": "{{count}} título(s) añadido(s) sin metadatos, identifíquelos desde la pestaña Medios"
+      "scan_queued_unmatched": "{{count}} título(s) añadido(s) sin metadatos, identifíquelos desde la pestaña Medios",
+      "scan_search_failed_count": "{{count}} carpeta(s) no analizada(s) (búsqueda fallida), vuelva a lanzar el análisis desde la pestaña Medios"
     },
     "users": {
       "title": "Usuarios",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1988,7 +1988,8 @@
       "scan_unmatched_badge": "Sans métadonnées",
       "scan_unmatched_option": "Aucune correspondance : ajouter tel quel",
       "scan_reorganize_needs_match": "Le déplacement/renommage ne s'applique qu'aux titres identifiés",
-      "scan_queued_unmatched": "{{count}} titre(s) ajouté(s) sans métadonnées, identifiez-les depuis l'onglet Médias"
+      "scan_queued_unmatched": "{{count}} titre(s) ajouté(s) sans métadonnées, identifiez-les depuis l'onglet Médias",
+      "scan_search_failed_count": "{{count}} dossier(s) non analysé(s) (recherche en erreur), relancez l'analyse depuis l'onglet Médias"
     },
     "users": {
       "title": "Utilisateurs",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1958,7 +1958,6 @@
       "scan_folder": "Analyser le dossier",
       "scan_required": "Analysez le dossier pour vérifier les médias trouvés avant de créer la bibliothèque.",
       "scan_queued": "Import de {{count}} médias lancé en arrière-plan.",
-      "scan_unmatched": "{{count}} dossier(s) non reconnu(s) : relancez « Analyser le dossier » depuis l'onglet Médias pour les associer.",
       "scan_title": "Analyse du dossier",
       "scan_scanning": "Analyse des fichiers en cours…",
       "scan_progress": "Analyse de {{done}}/{{total}} fichiers…",
@@ -1984,7 +1983,12 @@
       "scan_nothing_linked": "Aucun fichier lié (doublon déjà présent dans le média).",
       "scan_error": "Échec de l'analyse.",
       "scan_loose_skipped": "{{count}} fichier(s) à la racine ignoré(s) — déplacez-les dans un sous-dossier pour les lier.",
-      "scan_files": "{{count}} fichier(s)"
+      "scan_files": "{{count}} fichier(s)",
+      "scan_add_unmatched": "Ajouter sans métadonnées",
+      "scan_unmatched_badge": "Sans métadonnées",
+      "scan_unmatched_option": "Aucune correspondance : ajouter tel quel",
+      "scan_reorganize_needs_match": "Le déplacement/renommage ne s'applique qu'aux titres identifiés",
+      "scan_queued_unmatched": "{{count}} titre(s) ajouté(s) sans métadonnées, identifiez-les depuis l'onglet Médias"
     },
     "users": {
       "title": "Utilisateurs",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1941,7 +1941,6 @@
       "scan_folder": "Analizza la cartella",
       "scan_required": "Analizza la cartella per verificare i file multimediali trovati prima di creare la libreria.",
       "scan_queued": "Importazione di {{count}} file multimediali avviata in background.",
-      "scan_unmatched": "{{count}} cartella/e non riconosciuta/e: riesegui «Analizza la cartella» dalla scheda Media per associarle.",
       "scan_title": "Analisi della cartella",
       "scan_scanning": "Analisi dei file in corso…",
       "scan_progress": "Analisi di {{done}}/{{total}} file…",
@@ -1967,7 +1966,12 @@
       "scan_nothing_linked": "Nessun file collegato (duplicato già presente nel file multimediale).",
       "scan_error": "Analisi fallita.",
       "scan_loose_skipped": "{{count}} file nella radice ignorato/i — spostali in una sottocartella per collegarli.",
-      "scan_files": "{{count}} file"
+      "scan_files": "{{count}} file",
+      "scan_add_unmatched": "Aggiungi senza metadati",
+      "scan_unmatched_badge": "Senza metadati",
+      "scan_unmatched_option": "Nessuna corrispondenza: aggiungi così com'è",
+      "scan_reorganize_needs_match": "Sposta/rinomina si applica solo ai titoli identificati",
+      "scan_queued_unmatched": "{{count}} titolo/i aggiunto/i senza metadati, identificali dalla scheda Media"
     },
     "users": {
       "title": "Utenti",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1971,7 +1971,8 @@
       "scan_unmatched_badge": "Senza metadati",
       "scan_unmatched_option": "Nessuna corrispondenza: aggiungi così com'è",
       "scan_reorganize_needs_match": "Sposta/rinomina si applica solo ai titoli identificati",
-      "scan_queued_unmatched": "{{count}} titolo/i aggiunto/i senza metadati, identificali dalla scheda Media"
+      "scan_queued_unmatched": "{{count}} titolo/i aggiunto/i senza metadati, identificali dalla scheda Media",
+      "scan_search_failed_count": "{{count}} cartella/e non analizzata/e (ricerca fallita), rilancia la scansione dalla scheda Media"
     },
     "users": {
       "title": "Utenti",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1941,7 +1941,6 @@
       "scan_folder": "Analisar a pasta",
       "scan_required": "Analise a pasta para verificar as medias encontradas antes de criar a biblioteca.",
       "scan_queued": "Importação de {{count}} medias iniciada em segundo plano.",
-      "scan_unmatched": "{{count}} pasta(s) não reconhecida(s): volte a executar «Analisar a pasta» no separador Media para as associar.",
       "scan_title": "Análise da pasta",
       "scan_scanning": "Análise dos ficheiros em curso…",
       "scan_progress": "A analisar {{done}}/{{total}} ficheiros…",
@@ -1967,7 +1966,12 @@
       "scan_nothing_linked": "Nenhum ficheiro associado (duplicado já presente no media).",
       "scan_error": "Falha na análise.",
       "scan_loose_skipped": "{{count}} ficheiro(s) na raiz ignorado(s) — mova-os para uma subpasta para os associar.",
-      "scan_files": "{{count}} ficheiro(s)"
+      "scan_files": "{{count}} ficheiro(s)",
+      "scan_add_unmatched": "Adicionar sem metadados",
+      "scan_unmatched_badge": "Sem metadados",
+      "scan_unmatched_option": "Sem correspondência: adicionar tal como está",
+      "scan_reorganize_needs_match": "Mover/renomear aplica-se apenas a títulos identificados",
+      "scan_queued_unmatched": "{{count}} título(s) adicionado(s) sem metadados, identifique-os no separador Media"
     },
     "users": {
       "title": "Utilizadores",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1971,7 +1971,8 @@
       "scan_unmatched_badge": "Sem metadados",
       "scan_unmatched_option": "Sem correspondência: adicionar tal como está",
       "scan_reorganize_needs_match": "Mover/renomear aplica-se apenas a títulos identificados",
-      "scan_queued_unmatched": "{{count}} título(s) adicionado(s) sem metadados, identifique-os no separador Media"
+      "scan_queued_unmatched": "{{count}} título(s) adicionado(s) sem metadados, identifique-os no separador Media",
+      "scan_search_failed_count": "{{count}} pasta(s) não analisada(s) (pesquisa falhou), reinicie a análise no separador Media"
     },
     "users": {
       "title": "Utilizadores",

--- a/client/src/app/core/services/api/imports-api.service.ts
+++ b/client/src/app/core/services/api/imports-api.service.ts
@@ -57,8 +57,11 @@ export interface RelinkFile {
 export interface RelinkOrphansBody {
   libraryId: number;
   type: MediaType;
-  externalId: string;
+  externalId?: string;
   provider?: string;
+  /** Used only when `externalId` is absent, to create an unmatched title. */
+  title?: string;
+  year?: number;
   qualityProfileId?: number;
   languageProfileId?: number;
   folderName: string;

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
@@ -67,6 +67,8 @@
                 <span class="badge badge-success badge-sm">{{ 'common.saved' | translate }}</span>
               } @else if (vm.pick) {
                 <span class="badge badge-primary badge-sm truncate max-w-40">{{ vm.pick.title }}</span>
+              } @else if (vm.searched) {
+                <span class="badge badge-ghost badge-sm">{{ 'settings.libraries.scan_unmatched_badge' | translate }}</span>
               }
             </div>
             <div class="collapse-content">
@@ -102,6 +104,26 @@
                   }
 
                   <div class="flex flex-col gap-1 max-h-60 overflow-auto">
+                    @if (vm.searched) {
+                      <button type="button"
+                        class="relative flex items-center gap-3 p-2 rounded-lg text-left border-2 hover:bg-base-300/50"
+                        [class.bg-base-300]="!vm.pick"
+                        [class.border-primary]="!vm.pick"
+                        [class.border-transparent]="!!vm.pick"
+                        (click)="pickUnmatched(i)">
+                        @if (!vm.pick) {
+                          <span class="absolute top-1 right-1 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-primary-content">
+                            <svg lucideCheck class="h-3 w-3"></svg>
+                          </span>
+                        }
+                        <div class="h-14 w-9 rounded bg-base-300 shrink-0"></div>
+                        <div class="min-w-0">
+                          <span class="font-medium truncate italic text-base-content/70">
+                            {{ 'settings.libraries.scan_unmatched_option' | translate }}
+                          </span>
+                        </div>
+                      </button>
+                    }
                     @for (r of vm.results; track key(r)) {
                       <button type="button"
                         class="relative flex items-center gap-3 p-2 rounded-lg text-left border-2 hover:bg-base-300/50"
@@ -141,11 +163,14 @@
                   @if (!deferLink()) {
                     <div class="flex justify-end">
                       <button type="button" class="btn btn-sm btn-primary"
-                        (click)="link(i)" [disabled]="!vm.pick || vm.linking">
+                        [title]="(reorganize() && !vm.pick) ? ('settings.libraries.scan_reorganize_needs_match' | translate) : ''"
+                        (click)="link(i)" [disabled]="vm.linking">
                         @if (vm.linking) { <span class="loading loading-spinner loading-xs"></span> }
                         {{ (vm.pick?.existingMediaId
                           ? 'settings.libraries.scan_relink_existing'
-                          : 'settings.libraries.scan_link') | translate }}
+                          : vm.pick
+                            ? 'settings.libraries.scan_link'
+                            : 'settings.libraries.scan_add_unmatched') | translate }}
                       </button>
                     </div>
                   }

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
@@ -164,7 +164,7 @@
                     <div class="flex justify-end">
                       <button type="button" class="btn btn-sm btn-primary"
                         [title]="(reorganize() && !vm.pick) ? ('settings.libraries.scan_reorganize_needs_match' | translate) : ''"
-                        (click)="link(i)" [disabled]="vm.linking">
+                        (click)="link(i)" [disabled]="vm.linking || vm.searching">
                         @if (vm.linking) { <span class="loading loading-spinner loading-xs"></span> }
                         {{ (vm.pick?.existingMediaId
                           ? 'settings.libraries.scan_relink_existing'

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.spec.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.spec.ts
@@ -99,20 +99,26 @@ describe('OrphanScanPanelComponent.importAll', () => {
     const { panel, relinked } = setup(['Alpha', 'Beta']);
     await panel.scanPath('/medias', ['movie'], 'tmdb');
 
-    expect(await panel.importAll(7)).toEqual({ queued: 2, skipped: 0 });
+    expect(await panel.importAll(7)).toEqual({ queued: 2, unmatched: 0 });
     expect(relinked.map((b) => [b.folderName, b.externalId, b.libraryId])).toEqual([
       ['Alpha', '11', 7],
       ['Beta', '11', 7],
     ]);
   });
 
-  it('skips a group whose default pick was deselected', async () => {
+  it('adds a group whose default pick was deselected as unmatched, without dropping it', async () => {
     const { panel, relinked } = setup(['Alpha', 'Beta']);
     await panel.scanPath('/medias', ['movie'], 'tmdb');
     panel.pick(0, panel.groups()[0].pick!); // clicking the selected row clears it
 
-    expect(await panel.importAll(7)).toEqual({ queued: 1, skipped: 1 });
-    expect(relinked.map((b) => b.folderName)).toEqual(['Beta']);
+    expect(await panel.importAll(7)).toEqual({ queued: 2, unmatched: 1 });
+    const alpha = relinked.find((b) => b.folderName === 'Alpha')!;
+    expect(alpha.externalId).toBeUndefined();
+    expect(alpha.title).toBe('Alpha');
+    expect(alpha.year).toBe(2001);
+    expect(alpha.reorganize).toBe(false);
+    const beta = relinked.find((b) => b.folderName === 'Beta')!;
+    expect(beta.externalId).toBe('11');
   });
 
   it('selects the first result as soon as a group is searched', async () => {

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.spec.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.spec.ts
@@ -65,11 +65,16 @@ const scanResult = (folders: string[]): OrphanScanResult => ({
 
 function setup(folders: string[], metadataOverrides: Record<string, unknown> = {}) {
   const relinked: RelinkOrphansBody[] = [];
+  const linked: RelinkOrphansBody[] = [];
   const importsApi = {
     previewOrphans: () => Promise.resolve(scanResult(folders)),
     relinkOrphansBatch: (items: RelinkOrphansBody[]) => {
       relinked.push(...items);
       return Promise.resolve({ queued: items.length });
+    },
+    relinkOrphans: (body: RelinkOrphansBody) => {
+      linked.push(body);
+      return Promise.resolve({ mediaId: 1, created: true, linked: body.files.length, errors: [] });
     },
   };
   const metadata = {
@@ -91,7 +96,7 @@ function setup(folders: string[], metadataOverrides: Record<string, unknown> = {
     ],
   });
   const fixture = TestBed.createComponent(OrphanScanPanelComponent);
-  return { panel: fixture.componentInstance, relinked };
+  return { panel: fixture.componentInstance, relinked, linked };
 }
 
 describe('OrphanScanPanelComponent.importAll', () => {
@@ -99,7 +104,7 @@ describe('OrphanScanPanelComponent.importAll', () => {
     const { panel, relinked } = setup(['Alpha', 'Beta']);
     await panel.scanPath('/medias', ['movie'], 'tmdb');
 
-    expect(await panel.importAll(7)).toEqual({ queued: 2, unmatched: 0 });
+    expect(await panel.importAll(7)).toEqual({ queued: 2, unmatched: 0, failed: 0 });
     expect(relinked.map((b) => [b.folderName, b.externalId, b.libraryId])).toEqual([
       ['Alpha', '11', 7],
       ['Beta', '11', 7],
@@ -111,7 +116,7 @@ describe('OrphanScanPanelComponent.importAll', () => {
     await panel.scanPath('/medias', ['movie'], 'tmdb');
     panel.pick(0, panel.groups()[0].pick!); // clicking the selected row clears it
 
-    expect(await panel.importAll(7)).toEqual({ queued: 2, unmatched: 1 });
+    expect(await panel.importAll(7)).toEqual({ queued: 2, unmatched: 1, failed: 0 });
     const alpha = relinked.find((b) => b.folderName === 'Alpha')!;
     expect(alpha.externalId).toBeUndefined();
     expect(alpha.title).toBe('Alpha');
@@ -136,6 +141,54 @@ describe('OrphanScanPanelComponent.importAll', () => {
 
     await panel.importAll(7);
     expect(relinked[0].externalId).toBe('22');
+  });
+});
+
+describe('OrphanScanPanelComponent.linkAll', () => {
+  it('searches a not-yet-searched group before linking it, rather than adding it unmatched blind', async () => {
+    const folders = Array.from({ length: 25 }, (_, i) => `F${i}`);
+    const { panel, linked } = setup(folders);
+    await panel.scanPath('/medias', ['movie'], 'tmdb');
+    // Page 2 was never opened, so its groups never went through search().
+    expect(panel.groups()[24].searched).toBe(false);
+
+    await panel.linkAll();
+
+    expect(panel.groups()[24].searched).toBe(true);
+    const last = linked.find((b) => b.folderName === 'F24');
+    expect(last?.externalId).toBe('11');
+  });
+});
+
+describe('OrphanScanPanelComponent: a group whose search errored', () => {
+  const withOneFailing = (folders: string[], failing: string) =>
+    setup(folders, {
+      searchMovie: (query: string) =>
+        query === failing
+          ? Promise.reject({ status: 500, error: {} })
+          : Promise.resolve([result(11, 'First')]),
+    });
+
+  it('is not queued by importAll, and is counted as failed', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { panel, relinked } = withOneFailing(['Alpha', 'Beta'], 'Beta');
+    await panel.scanPath('/medias', ['movie'], 'tmdb');
+
+    expect(await panel.importAll(7)).toEqual({ queued: 1, unmatched: 0, failed: 1 });
+    expect(relinked.map((b) => b.folderName)).toEqual(['Alpha']);
+  });
+
+  it('is not linked unmatched by autoImportAll', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { panel, linked } = withOneFailing(['Alpha', 'Beta'], 'Beta');
+    await panel.scanPath('/medias', ['movie'], 'tmdb');
+    expect(panel.groups()[1].error).toBeTruthy();
+
+    await panel.autoImportAll();
+
+    expect(panel.groups()[1].done).toBe(false);
+    expect(linked.some((b) => b.folderName === 'Beta')).toBe(false);
+    expect(linked.some((b) => b.folderName === 'Alpha')).toBe(true);
   });
 });
 

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
@@ -197,32 +197,44 @@ export class OrphanScanPanelComponent {
     );
   }
 
-  /**
-   * Queue every detected group for import into a library that now exists.
-   * A group the admin left untouched takes the provider's first result; a
-   * group with no pick (no match, or explicitly deselected) is added unmatched.
-   * Returns once the batch is queued: the server imports in the background.
-   */
-  async importAll(libraryId: number): Promise<{ queued: number; unmatched: number }> {
-    const pending = this.groups()
-      .map((g, i) => (g.done ? -1 : i))
-      .filter((i) => i >= 0);
-    const unsearched = pending.filter((i) => !this.groups()[i].searched);
+  /** Search every listed group not yet searched, capped at SEARCH_CONCURRENCY concurrent requests. */
+  private async searchBatched(indices: number[]) {
+    const unsearched = indices.filter((i) => !this.groups()[i].searched);
     for (let s = 0; s < unsearched.length; s += SEARCH_CONCURRENCY) {
       await Promise.all(
         unsearched.slice(s, s + SEARCH_CONCURRENCY).map((i) => this.search(i)),
       );
     }
+  }
+
+  /**
+   * Queue every detected group for import into a library that now exists.
+   * A group the admin left untouched takes the provider's first result; a
+   * group with no pick (no match, or explicitly deselected) is added unmatched.
+   * A group whose search errored is left alone (still visible with its alert)
+   * rather than queued unmatched. Returns once the batch is queued: the
+   * server imports in the background.
+   */
+  async importAll(libraryId: number): Promise<{ queued: number; unmatched: number; failed: number }> {
+    const pending = this.groups()
+      .map((g, i) => (g.done ? -1 : i))
+      .filter((i) => i >= 0);
+    await this.searchBatched(pending);
 
     const items: RelinkOrphansBody[] = [];
     let unmatched = 0;
+    let failed = 0;
     for (const i of pending) {
       const vm = this.groups()[i];
+      if (vm.error) {
+        failed++;
+        continue;
+      }
       items.push(this.relinkBody(libraryId, vm, vm.pick));
       if (!vm.pick) unmatched++;
     }
     if (items.length) await this.importsApi.relinkOrphansBatch(items);
-    return { queued: items.length, unmatched };
+    return { queued: items.length, unmatched, failed };
   }
 
   private relinkBody(
@@ -372,7 +384,9 @@ export class OrphanScanPanelComponent {
       .map((g, i) => ({ g, i }))
       .filter(({ g }) => !g.done && !g.linking)
       .map(({ i }) => i);
+    await this.searchBatched(indices);
     for (const i of indices) {
+      if (this.groups()[i].error) continue;
       await this.link(i);
     }
   }
@@ -397,6 +411,7 @@ export class OrphanScanPanelComponent {
     const vm = this.groups()[index];
     if (vm.done || vm.linking) return;
     if (!vm.searched) await this.search(index);
+    if (this.groups()[index].error) return;
     // No provider match: still add it, unmatched, rather than leave it behind.
     const best = this.bestMatch(this.groups()[index]);
     this.patch(index, { pick: best });

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
@@ -94,7 +94,7 @@ export class OrphanScanPanelComponent {
   readonly reorganize = signal(true);
 
   readonly pendingGroups = computed(() =>
-    this.groups().filter((g) => !g.done && g.pick && !g.linking),
+    this.groups().filter((g) => !g.done && !g.linking),
   );
 
   readonly hasLinkable = computed(() =>
@@ -199,10 +199,11 @@ export class OrphanScanPanelComponent {
 
   /**
    * Queue every detected group for import into a library that now exists.
-   * A group the admin left untouched takes the provider's first result.
+   * A group the admin left untouched takes the provider's first result; a
+   * group with no pick (no match, or explicitly deselected) is added unmatched.
    * Returns once the batch is queued: the server imports in the background.
    */
-  async importAll(libraryId: number): Promise<{ queued: number; skipped: number }> {
+  async importAll(libraryId: number): Promise<{ queued: number; unmatched: number }> {
     const pending = this.groups()
       .map((g, i) => (g.done ? -1 : i))
       .filter((i) => i >= 0);
@@ -214,33 +215,39 @@ export class OrphanScanPanelComponent {
     }
 
     const items: RelinkOrphansBody[] = [];
-    let skipped = 0;
+    let unmatched = 0;
     for (const i of pending) {
-      // The search selects the first result, so an empty pick is a deselection:
-      // the group is skipped rather than imported against a row nobody chose.
       const vm = this.groups()[i];
-      if (vm.pick) items.push(this.relinkBody(libraryId, vm.group, vm.pick));
-      else skipped++;
+      items.push(this.relinkBody(libraryId, vm, vm.pick));
+      if (!vm.pick) unmatched++;
     }
     if (items.length) await this.importsApi.relinkOrphansBatch(items);
-    return { queued: items.length, skipped };
+    return { queued: items.length, unmatched };
   }
 
   private relinkBody(
     libraryId: number,
-    group: OrphanGroup,
-    pick: MetadataSearchResult,
+    vm: GroupVM,
+    pick: MetadataSearchResult | null,
   ): RelinkOrphansBody {
+    const group = vm.group;
     return {
       libraryId,
       type: group.mediaType,
-      externalId:
-        pick.provider === 'tvdb' && pick.tvdbId != null
-          ? String(pick.tvdbId)
-          : String(pick.tmdbId),
-      provider: pick.provider,
+      ...(pick
+        ? {
+            externalId:
+              pick.provider === 'tvdb' && pick.tvdbId != null
+                ? String(pick.tvdbId)
+                : String(pick.tmdbId),
+            provider: pick.provider,
+          }
+        : {
+            title: vm.query.trim() || group.guessTitle || group.folderName,
+            year: vm.year ?? undefined,
+          }),
       folderName: group.folderName,
-      reorganize: this.reorganize(),
+      reorganize: pick ? this.reorganize() : false,
       files: group.files.map((f) => ({
         filePath: f.filePath,
         seasonNumber: f.seasonNumber ?? undefined,
@@ -321,14 +328,18 @@ export class OrphanScanPanelComponent {
     this.patch(index, { pick: same ? null : result, fromNfo: false });
   }
 
+  /** The "add as is" pseudo-option: always sets an unmatched pick, no toggle. */
+  pickUnmatched(index: number) {
+    this.patch(index, { pick: null, fromNfo: false });
+  }
+
   async link(index: number) {
     const vm = this.groups()[index];
-    if (!vm?.pick || vm.linking || vm.done) return;
-    const pick = vm.pick;
+    if (!vm || vm.linking || vm.done) return;
     this.patch(index, { linking: true, error: '' });
     try {
       const res = await this.importsApi.relinkOrphans(
-        this.relinkBody(this.libraryId, vm.group, pick),
+        this.relinkBody(this.libraryId, vm, vm.pick),
       );
       if (res.linked > 0) {
         this.anyLinked.set(true);
@@ -359,7 +370,7 @@ export class OrphanScanPanelComponent {
   async linkAll() {
     const indices = this.groups()
       .map((g, i) => ({ g, i }))
-      .filter(({ g }) => !g.done && g.pick && !g.linking)
+      .filter(({ g }) => !g.done && !g.linking)
       .map(({ i }) => i);
     for (const i of indices) {
       await this.link(i);
@@ -386,8 +397,8 @@ export class OrphanScanPanelComponent {
     const vm = this.groups()[index];
     if (vm.done || vm.linking) return;
     if (!vm.searched) await this.search(index);
+    // No provider match: still add it, unmatched, rather than leave it behind.
     const best = this.bestMatch(this.groups()[index]);
-    if (!best) return;
     this.patch(index, { pick: best });
     await this.link(index);
   }

--- a/client/src/app/features/settings/libraries/library-wizard/library-wizard-media.ts
+++ b/client/src/app/features/settings/libraries/library-wizard/library-wizard-media.ts
@@ -49,7 +49,7 @@ export class LibraryWizardMediaComponent {
   }
 
   /** Import every detected media into the library once it exists. */
-  async importAll(libraryId: number): Promise<{ queued: number; skipped: number }> {
-    return (await this.scanPanel()?.importAll(libraryId)) ?? { queued: 0, skipped: 0 };
+  async importAll(libraryId: number): Promise<{ queued: number; unmatched: number }> {
+    return (await this.scanPanel()?.importAll(libraryId)) ?? { queued: 0, unmatched: 0 };
   }
 }

--- a/client/src/app/features/settings/libraries/library-wizard/library-wizard-media.ts
+++ b/client/src/app/features/settings/libraries/library-wizard/library-wizard-media.ts
@@ -49,7 +49,9 @@ export class LibraryWizardMediaComponent {
   }
 
   /** Import every detected media into the library once it exists. */
-  async importAll(libraryId: number): Promise<{ queued: number; unmatched: number }> {
-    return (await this.scanPanel()?.importAll(libraryId)) ?? { queued: 0, unmatched: 0 };
+  async importAll(libraryId: number): Promise<{ queued: number; unmatched: number; failed: number }> {
+    return (
+      (await this.scanPanel()?.importAll(libraryId)) ?? { queued: 0, unmatched: 0, failed: 0 }
+    );
   }
 }

--- a/client/src/app/features/settings/libraries/library-wizard/library-wizard.ts
+++ b/client/src/app/features/settings/libraries/library-wizard/library-wizard.ts
@@ -78,7 +78,7 @@ export class LibraryWizardComponent implements OnInit {
     // it. The library page reports the import over SSE.
     void media
       .importAll(id)
-      .then(({ queued, unmatched }) => {
+      .then(({ queued, unmatched, failed }) => {
         if (queued > 0) {
           this.toast.success(
             this.translate.instant('settings.libraries.scan_queued', { count: queued }),
@@ -87,6 +87,11 @@ export class LibraryWizardComponent implements OnInit {
         if (unmatched > 0) {
           this.toast.info(
             this.translate.instant('settings.libraries.scan_queued_unmatched', { count: unmatched }),
+          );
+        }
+        if (failed > 0) {
+          this.toast.warning(
+            this.translate.instant('settings.libraries.scan_search_failed_count', { count: failed }),
           );
         }
       })

--- a/client/src/app/features/settings/libraries/library-wizard/library-wizard.ts
+++ b/client/src/app/features/settings/libraries/library-wizard/library-wizard.ts
@@ -78,15 +78,15 @@ export class LibraryWizardComponent implements OnInit {
     // it. The library page reports the import over SSE.
     void media
       .importAll(id)
-      .then(({ queued, skipped }) => {
+      .then(({ queued, unmatched }) => {
         if (queued > 0) {
           this.toast.success(
             this.translate.instant('settings.libraries.scan_queued', { count: queued }),
           );
         }
-        if (skipped > 0) {
-          this.toast.warning(
-            this.translate.instant('settings.libraries.scan_unmatched', { count: skipped }),
+        if (unmatched > 0) {
+          this.toast.info(
+            this.translate.instant('settings.libraries.scan_queued_unmatched', { count: unmatched }),
           );
         }
       })


### PR DESCRIPTION
## Why

Until now a video file only entered the library once the orphan scan matched it to a TMDB/TVDB title; a group the admin could not (or did not) match was skipped and stayed invisible, and files at the library root were never offered at all. The library should show what is on disk; the provider match is an enrichment, not a gate. This is Phases 1 and 2 of `plan/local-media-without-metadata.md` (Phase 0, the guards, landed in #1263).

## What

**Backend**
- `RelinkOrphansDto.externalId` is optional; new `title` / `year` carry the admin's corrected guess when there is no match.
- `DiskImportService.relinkOrphans` branches: with an external id, the previous find-or-import path (moved verbatim to `findOrImportIdentified`); without one, `findOrCreateUnmatched` reuses the row already holding `(library, type, folderName)` with all three ids null, or creates one through the new `MediaImportService.createUnmatched`.
- `createUnmatched` writes `monitored: false`, `status: released`, null provider ids, resolves the default profiles like `importMedia`, updates the search vector and emits `media.imported` with `tmdbId: null`. It does not touch requests, images or cast.
- `reorganize` without an external id is refused (400): the naming templates would produce empty `{TMDB Id}` / `{Year}`. Linking is always in place for these titles.
- The `refreshSeriesEpisodes` backfill is skipped for a title with no provider id (it would throw). Invented seasons/episodes from `SxxEyy` stay as they are; a later Identify replaces them.

**Client**
- In the orphan scan panel a null pick now means "add without metadata" instead of "skip": explicit "add as is" row in the results, badge on the collapsed group, `Add without metadata` button label, `reorganize` forced off for such a group.
- `importAll` (wizard) and `autoImportAll` / `linkAll` (library page) send every group; unsearched groups are searched first, and a group whose search *errored* is left in the panel with its alert rather than added blind.
- Wizard toasts report how many titles were added without metadata and how many searches failed.
- i18n: five new keys in the six locale files, `scan_unmatched` removed.

## Verification

- Backend: `tsc -p tsconfig.build.json --noEmit` clean; `jest src/modules/imports src/modules/media` 18 suites / 80 tests green, including the new `disk-import.unmatched.spec.ts` (create, reuse, reorganize refused, series backfill skipped, identified path untouched) and `media-import.createunmatched.spec.ts`.
- Client: `ng build --configuration development` clean; `orphan-scan-panel.spec.ts` 12 tests green (unmatched body, `linkAll` searches first, errored group never linked or queued).
- Dev stack smoke test on a fixture library (one unmatched movie, one unmatched series, one movie with `.nfo`): see the PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
