### PR TITLE
feat(imports): read nfo fields and sibling artwork for unidentified titles

### DIFF
--- a/backend/src/modules/images/image.service.spec.ts
+++ b/backend/src/modules/images/image.service.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, promises as fsp } from 'fs';
+import { mkdtempSync, rmSync, promises as fsp, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, extname } from 'path';
 import { createHash } from 'crypto';
@@ -115,5 +115,70 @@ describe('ImageService.downloadAndStore caching', () => {
     const hash = createHash('sha1').update(bytesOnDisk).digest('hex').slice(0, 8);
     expect(meta.hash).toBe(hash);
     expect([urlA, urlB]).toContain(meta.url);
+  });
+});
+
+describe('ImageService.storeFromDisk', () => {
+  let dir: string;
+  let srcDir: string;
+  let service: ImageService;
+  let fixturePath: string;
+
+  beforeAll(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'fliks-image-disk-test-'));
+    srcDir = mkdtempSync(join(tmpdir(), 'fliks-image-disk-src-'));
+    process.env.FLIKS_DATA_DIR = dir;
+    service = new ImageService();
+
+    const fixture = await sharp({
+      create: { width: 10, height: 10, channels: 3, background: { r: 0, g: 255, b: 0 } },
+    })
+      .jpeg()
+      .toBuffer();
+    fixturePath = join(srcDir, 'poster.jpg');
+    writeFileSync(fixturePath, fixture);
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(srcDir, { recursive: true, force: true });
+  });
+
+  it('writes the full image, its resized variants and the sidecar', async () => {
+    const result = await service.storeFromDisk(fixturePath, 'media', 10, 'poster');
+    expect(result).toMatch(/^\/api\/images\/media\/10\/poster\?v=[0-9a-f]{8}$/);
+
+    await fsp.access(service.getDiskPath('media', 10, 'poster', 'full'));
+    await fsp.access(service.getDiskPath('media', 10, 'poster', 'thumb'));
+    await fsp.access(service.getDiskPath('media', 10, 'poster', 'medium'));
+  });
+
+  it('is a cache hit on a second call with an unchanged file', async () => {
+    const spy = jest.spyOn(sharp.prototype as never, 'toBuffer' as never);
+    const first = await service.storeFromDisk(fixturePath, 'media', 11, 'poster');
+    spy.mockClear();
+    const second = await service.storeFromDisk(fixturePath, 'media', 11, 'poster');
+
+    expect(second).toBe(first);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('returns null for a path that cannot be read', async () => {
+    const result = await service.storeFromDisk(
+      join(srcDir, 'missing.jpg'),
+      'media',
+      12,
+      'poster',
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a file sharp cannot decode as an image', async () => {
+    const badPath = join(srcDir, 'not-an-image.jpg');
+    writeFileSync(badPath, 'this is not image bytes');
+
+    const result = await service.storeFromDisk(badPath, 'media', 13, 'poster');
+    expect(result).toBeNull();
   });
 });

--- a/backend/src/modules/images/image.service.ts
+++ b/backend/src/modules/images/image.service.ts
@@ -158,12 +158,7 @@ export class ImageService {
 
     const fullDest = this.getDiskPath(type, id, variant, 'full');
     const srcPath = this.getSrcPath(type, id, variant);
-    const targets = (Object.entries(sizes) as [ImageSize, string][])
-      .map(([size, token]) => ({ size, width: sizeTokenWidth(token) }))
-      .filter(
-        (t): t is { size: ImageSize; width: number } =>
-          t.size !== 'full' && t.width != null,
-      );
+    const targets = this.sizeTargets(sizes);
 
     const cached = await this.readCacheHit(
       remoteUrl,
@@ -178,8 +173,6 @@ export class ImageService {
 
     const release = await downloadSemaphore.acquire();
     try {
-      await fs.promises.mkdir(path.dirname(fullDest), { recursive: true });
-
       let buffer: Buffer;
       try {
         const fullUrl =
@@ -191,48 +184,153 @@ export class ImageService {
           timeout: 15000,
         });
         buffer = Buffer.from(res.data);
-        await this.writeFileAtomic(fullDest, buffer);
       } catch (err) {
         this.logger.warn(`Failed to download image ${remoteUrl}: ${err.message}`);
         return null;
       }
+      return await this.storeBuffer(buffer, type, id, variant, remoteUrl);
+    } finally {
+      release();
+    }
+  }
 
-      // Derive the smaller variants by resizing the downloaded full locally, so
-      // every provider yields the full size pipeline, not just TMDB, whose CDN
-      // exposes per-size URLs. Best-effort per variant: the full is already saved.
-      const asPng = variant === 'logo';
-      await Promise.all(
-        targets.map(async ({ size, width }) => {
-          try {
-            const resized = sharp(buffer).resize({
-              width,
-              withoutEnlargement: true,
-            });
-            const out = await (
-              asPng ? resized.png() : resized.jpeg({ quality: 90 })
-            ).toBuffer();
-            await this.writeFileAtomic(
-              this.getDiskPath(type, id, variant, size),
-              out,
-            );
-          } catch (err) {
-            this.logger.warn(
-              `Failed to resize ${size} variant for ${type}/${id}: ${err.message}`,
-            );
-          }
-        }),
+  /** Width targets to resize the full image down to, keyed by our logical size. */
+  private sizeTargets(
+    sizes: Partial<Record<ImageSize, string>>,
+  ): { size: ImageSize; width: number }[] {
+    return (Object.entries(sizes) as [ImageSize, string][])
+      .map(([size, token]) => ({ size, width: sizeTokenWidth(token) }))
+      .filter(
+        (t): t is { size: ImageSize; width: number } =>
+          t.size !== 'full' && t.width != null,
       );
+  }
 
-      // The path is stable across re-downloads, so a client that cached the old
-      // bytes for `max-age` would keep showing them after a re-identification.
-      // Stamping the content makes the URL move exactly when the image does.
-      const hash = createHash('sha1').update(buffer).digest('hex').slice(0, 8);
-      // Holds the hash so a later cache hit returns the same `?v=` without the bytes.
-      await this.writeFileAtomic(
-        srcPath,
-        JSON.stringify({ url: remoteUrl, hash }),
-      );
-      return `${this.getApiPath(type, id, variant)}?v=${hash}`;
+  /**
+   * Write the full image plus its resized variants and the cache sidecar for
+   * (type, id, variant), and return the local API path. Shared by the download
+   * path (`sourceKey` = the remote URL) and {@link storeFromDisk} (`sourceKey`
+   * carries the source file's path + mtime instead, since there is no URL).
+   */
+  private async storeBuffer(
+    buffer: Buffer,
+    type: ImageType,
+    id: number | string,
+    variant: MediaImageVariant | undefined,
+    sourceKey: string,
+  ): Promise<string | null> {
+    const sizes = TMDB_SIZE_MAP[sizeMapKey(type, variant)] ?? {
+      full: 'original',
+    };
+    const targets = this.sizeTargets(sizes);
+    const fullDest = this.getDiskPath(type, id, variant, 'full');
+    const srcPath = this.getSrcPath(type, id, variant);
+
+    await fs.promises.mkdir(path.dirname(fullDest), { recursive: true });
+    await this.writeFileAtomic(fullDest, buffer);
+
+    // Derive the smaller variants by resizing the full locally, so every
+    // source yields the full size pipeline. Best-effort per variant: the
+    // full is already saved.
+    const asPng = variant === 'logo';
+    await Promise.all(
+      targets.map(async ({ size, width }) => {
+        try {
+          const resized = sharp(buffer).resize({
+            width,
+            withoutEnlargement: true,
+          });
+          const out = await (
+            asPng ? resized.png() : resized.jpeg({ quality: 90 })
+          ).toBuffer();
+          await this.writeFileAtomic(
+            this.getDiskPath(type, id, variant, size),
+            out,
+          );
+        } catch (err) {
+          this.logger.warn(
+            `Failed to resize ${size} variant for ${type}/${id}: ${err.message}`,
+          );
+        }
+      }),
+    );
+
+    // The path is stable across re-stores, so a client that cached the old
+    // bytes for `max-age` would keep showing them after a re-identification.
+    // Stamping the content makes the URL move exactly when the image does.
+    const hash = createHash('sha1').update(buffer).digest('hex').slice(0, 8);
+    // Holds the hash so a later cache hit returns the same `?v=` without the bytes.
+    await this.writeFileAtomic(
+      srcPath,
+      JSON.stringify({ url: sourceKey, hash }),
+    );
+    return `${this.getApiPath(type, id, variant)}?v=${hash}`;
+  }
+
+  /**
+   * Store an image already on disk (sibling artwork found next to a media
+   * file) instead of downloading it. `sourceKey` embeds the file's mtime so
+   * an unchanged file is a cache hit and a replaced one is re-stored.
+   * Returns null (with a `warn`) when the file can't be read or decoded.
+   */
+  async storeFromDisk(
+    absPath: string,
+    type: ImageType,
+    id: number | string,
+    variant?: MediaImageVariant,
+  ): Promise<string | null> {
+    const key = `${type}/${id}/${variant ?? 'default'}`;
+    const existing = this.inflight.get(key);
+    if (existing) return existing;
+    const promise = this.doStoreFromDisk(absPath, type, id, variant).finally(
+      () => {
+        if (this.inflight.get(key) === promise) this.inflight.delete(key);
+      },
+    );
+    this.inflight.set(key, promise);
+    return promise;
+  }
+
+  private async doStoreFromDisk(
+    absPath: string,
+    type: ImageType,
+    id: number | string,
+    variant?: MediaImageVariant,
+  ): Promise<string | null> {
+    let stat: fs.Stats;
+    let buffer: Buffer;
+    try {
+      stat = await fs.promises.stat(absPath);
+      buffer = await fs.promises.readFile(absPath);
+    } catch (err) {
+      this.logger.warn(`Failed to read local artwork ${absPath}: ${err.message}`);
+      return null;
+    }
+    const sourceKey = `file://${absPath}@${stat.mtimeMs}`;
+
+    const sizes = TMDB_SIZE_MAP[sizeMapKey(type, variant)] ?? {
+      full: 'original',
+    };
+    const cached = await this.readCacheHit(
+      sourceKey,
+      this.getSrcPath(type, id, variant),
+      this.getDiskPath(type, id, variant, 'full'),
+      this.sizeTargets(sizes),
+      type,
+      id,
+      variant,
+    );
+    if (cached) return cached;
+
+    const release = await downloadSemaphore.acquire();
+    try {
+      try {
+        await sharp(buffer).metadata();
+      } catch (err) {
+        this.logger.warn(`Local artwork is not a decodable image ${absPath}: ${err.message}`);
+        return null;
+      }
+      return await this.storeBuffer(buffer, type, id, variant, sourceKey);
     } finally {
       release();
     }

--- a/backend/src/modules/images/image.service.ts
+++ b/backend/src/modules/images/image.service.ts
@@ -46,10 +46,8 @@ export type ImageType =
   | 'season'
   | 'request'
   | 'user';
-/** Variant of a media image. `fanart-${N}` (N≥1) addresses the extra
- *  fanarts kept for randomised page backgrounds — they share `fanart`'s
- *  size pipeline (thumb / medium / full) so frontends can request any
- *  size without an extra round-trip to the source provider. */
+/** Variant of a media image. `fanart-${N}` (N>=1) addresses the extra
+ *  fanarts kept for randomised page backgrounds, sharing `fanart`'s size pipeline. */
 export type MediaImageVariant =
   | 'poster'
   | 'fanart'
@@ -206,12 +204,9 @@ export class ImageService {
       );
   }
 
-  /**
-   * Write the full image plus its resized variants and the cache sidecar for
-   * (type, id, variant), and return the local API path. Shared by the download
-   * path (`sourceKey` = the remote URL) and {@link storeFromDisk} (`sourceKey`
-   * carries the source file's path + mtime instead, since there is no URL).
-   */
+  /** Write the full image, its resized variants and the cache sidecar for (type, id,
+   *  variant); returns the local API path. `sourceKey` is the remote URL or, from
+   *  {@link storeFromDisk}, the source file's path + mtime. */
   private async storeBuffer(
     buffer: Buffer,
     type: ImageType,
@@ -226,8 +221,13 @@ export class ImageService {
     const fullDest = this.getDiskPath(type, id, variant, 'full');
     const srcPath = this.getSrcPath(type, id, variant);
 
-    await fs.promises.mkdir(path.dirname(fullDest), { recursive: true });
-    await this.writeFileAtomic(fullDest, buffer);
+    try {
+      await fs.promises.mkdir(path.dirname(fullDest), { recursive: true });
+      await this.writeFileAtomic(fullDest, buffer);
+    } catch (err) {
+      this.logger.warn(`Failed to write image ${type}/${id}: ${err.message}`);
+      return null;
+    }
 
     // Derive the smaller variants by resizing the full locally, so every
     // source yields the full size pipeline. Best-effort per variant: the
@@ -267,12 +267,8 @@ export class ImageService {
     return `${this.getApiPath(type, id, variant)}?v=${hash}`;
   }
 
-  /**
-   * Store an image already on disk (sibling artwork found next to a media
-   * file) instead of downloading it. `sourceKey` embeds the file's mtime so
-   * an unchanged file is a cache hit and a replaced one is re-stored.
-   * Returns null (with a `warn`) when the file can't be read or decoded.
-   */
+  /** Store an image already on disk (sibling artwork) instead of downloading it.
+   *  Returns null (with a `warn`) when the file can't be read or decoded. */
   async storeFromDisk(
     absPath: string,
     type: ImageType,
@@ -298,10 +294,8 @@ export class ImageService {
     variant?: MediaImageVariant,
   ): Promise<string | null> {
     let stat: fs.Stats;
-    let buffer: Buffer;
     try {
       stat = await fs.promises.stat(absPath);
-      buffer = await fs.promises.readFile(absPath);
     } catch (err) {
       this.logger.warn(`Failed to read local artwork ${absPath}: ${err.message}`);
       return null;
@@ -324,6 +318,13 @@ export class ImageService {
 
     const release = await downloadSemaphore.acquire();
     try {
+      let buffer: Buffer;
+      try {
+        buffer = await fs.promises.readFile(absPath);
+      } catch (err) {
+        this.logger.warn(`Failed to read local artwork ${absPath}: ${err.message}`);
+        return null;
+      }
       try {
         await sharp(buffer).metadata();
       } catch (err) {

--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -639,11 +639,27 @@ export class DiskImportService {
     if (existing) return { media: existing, created: false };
 
     const sample = path.resolve(dto.files[0].filePath);
-    const nfo = await this.nfo.readForVideoFile(sample);
     const artworkDir =
       dto.type === MediaType.SERIES
         ? path.join(library.path!, dto.folderName)
         : path.dirname(sample);
+    // Checked independently: a crafted folderName must not escape the root even
+    // when the sample file itself is a valid path under it.
+    const libraryRoot = path.resolve(library.path!);
+    const resolvedArtworkDir = path.resolve(artworkDir);
+    if (
+      relativePathUnderMediaRoot(library.path, sample) == null ||
+      (resolvedArtworkDir !== libraryRoot &&
+        !resolvedArtworkDir.startsWith(libraryRoot + path.sep))
+    ) {
+      throw new BadRequestException('File outside the library root');
+    }
+
+    const nfo =
+      dto.type === MediaType.SERIES
+        ? (await this.nfo.readNfoFile(path.join(artworkDir, 'tvshow.nfo'))) ??
+          (await this.nfo.readForVideoFile(sample))
+        : await this.nfo.readForVideoFile(sample);
     const artworkBasename =
       dto.type === MediaType.SERIES
         ? undefined

--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -30,6 +30,7 @@ import {
   RelinkResult,
 } from './dto/orphan-scan.dto';
 import { NfoMetadataService } from './nfo-metadata.service';
+import { findLocalArtwork } from './local-artwork.util';
 import { EventsService } from '../scheduler/events.service';
 import { ActivityRegistryService } from '../scheduler/activity-registry.service';
 import { mapWithConcurrency } from '../../common/utils/concurrency';
@@ -637,6 +638,18 @@ export class DiskImportService {
     });
     if (existing) return { media: existing, created: false };
 
+    const sample = path.resolve(dto.files[0].filePath);
+    const nfo = await this.nfo.readForVideoFile(sample);
+    const artworkDir =
+      dto.type === MediaType.SERIES
+        ? path.join(library.path!, dto.folderName)
+        : path.dirname(sample);
+    const artworkBasename =
+      dto.type === MediaType.SERIES
+        ? undefined
+        : path.basename(sample, path.extname(sample));
+    const artwork = await findLocalArtwork(artworkDir, artworkBasename);
+
     const created = await this.mediaService.createUnmatched(
       {
         title: dto.title?.trim() || dto.folderName,
@@ -646,6 +659,8 @@ export class DiskImportService {
         folderName: dto.folderName,
         qualityProfileId: dto.qualityProfileId,
         languageProfileId: dto.languageProfileId,
+        nfo: nfo ?? undefined,
+        artwork,
       },
       addedByUserId,
     );

--- a/backend/src/modules/imports/disk-import.unmatched.spec.ts
+++ b/backend/src/modules/imports/disk-import.unmatched.spec.ts
@@ -2,6 +2,10 @@ import { BadRequestException } from '@nestjs/common';
 import { DiskImportService } from './disk-import.service';
 import { RelinkOrphansDto } from './dto/relink-orphans.dto';
 import { MediaType } from '../../common/enums';
+import { findLocalArtwork } from './local-artwork.util';
+
+jest.mock('./local-artwork.util');
+const mockedFindLocalArtwork = jest.mocked(findLocalArtwork);
 
 const library = {
   id: 1,
@@ -33,6 +37,8 @@ function makeService() {
   const metadata = { refreshSeriesEpisodes: jest.fn() };
   const events = { emit: jest.fn(), emitDomain: jest.fn() };
   const postImportQueue = { enqueue: jest.fn() };
+  const nfo = { readForVideoFile: jest.fn().mockResolvedValue(null) };
+  mockedFindLocalArtwork.mockResolvedValue({});
   const service = new DiskImportService(
     mediaRepo as never,
     null as never, // fileRepo
@@ -42,14 +48,14 @@ function makeService() {
     null as never, // naming
     libraries as never,
     metadata as never,
-    null as never, // nfo
+    nfo as never,
     null as never, // libraryIngest
     postImportQueue as never,
     null as never, // mediaServers
     events as never,
     { upsertPending: jest.fn(), upsertRunning: jest.fn(), remove: jest.fn() } as never,
   );
-  return { service, mediaRepo, mediaService, libraries, metadata, events, postImportQueue };
+  return { service, mediaRepo, mediaService, libraries, metadata, events, postImportQueue, nfo };
 }
 
 const unmatchedRow = (id: number, folderName: string, type = MediaType.MOVIE) => ({
@@ -64,11 +70,17 @@ const unmatchedRow = (id: number, folderName: string, type = MediaType.MOVIE) =>
 });
 
 describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
+  beforeEach(() => {
+    mockedFindLocalArtwork.mockClear();
+  });
+
   it('creates an unmatched media from the guessed title and links the files in place', async () => {
-    const { service, mediaRepo, mediaService } = makeService();
+    const { service, mediaRepo, mediaService, nfo } = makeService();
     mediaRepo.findOne
       .mockResolvedValueOnce(null) // no existing unmatched row for this folder
       .mockResolvedValueOnce(unmatchedRow(42, 'Quiet Harbour (2009)')); // reload
+    nfo.readForVideoFile.mockResolvedValue({ plot: 'A harbour tale.' });
+    mockedFindLocalArtwork.mockResolvedValue({ poster: '/media/Quiet Harbour (2009)/poster.jpg' });
     mediaService.createUnmatched.mockResolvedValue({ id: 42 });
     mediaService.linkExistingFileInPlace.mockResolvedValue({
       fileId: 1,
@@ -78,6 +90,13 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
 
     const res = await service.relinkOrphans(dto(), null);
 
+    expect(nfo.readForVideoFile).toHaveBeenCalledWith(
+      '/media/Quiet Harbour (2009)/Quiet.Harbour.2009.1080p.mkv',
+    );
+    expect(mockedFindLocalArtwork).toHaveBeenCalledWith(
+      '/media/Quiet Harbour (2009)',
+      'Quiet.Harbour.2009.1080p',
+    );
     expect(mediaService.createUnmatched).toHaveBeenCalledWith(
       expect.objectContaining({
         title: 'Quiet Harbour',
@@ -85,6 +104,8 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
         type: MediaType.MOVIE,
         libraryId: 1,
         folderName: 'Quiet Harbour (2009)',
+        nfo: { plot: 'A harbour tale.' },
+        artwork: { poster: '/media/Quiet Harbour (2009)/poster.jpg' },
       }),
       null,
     );
@@ -93,8 +114,40 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     expect(res.mediaId).toBe(42);
   });
 
-  it('reuses the unmatched row already pinned to the same folder on a second scan', async () => {
+  it('reads a series folder for artwork with no filename basename', async () => {
     const { service, mediaRepo, mediaService } = makeService();
+    const seriesDto = dto({
+      type: MediaType.SERIES,
+      folderName: 'Northern Lights',
+      title: 'Northern Lights',
+      files: [
+        {
+          filePath: '/media/Northern Lights/Season 01/Northern.Lights.S01E01.mkv',
+          seasonNumber: 1,
+          episodeNumber: 1,
+        },
+      ],
+    });
+    mediaRepo.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(unmatchedRow(8, 'Northern Lights', MediaType.SERIES));
+    mediaService.createUnmatched.mockResolvedValue({ id: 8 });
+    mediaService.linkExistingFileInPlace.mockResolvedValue({
+      fileId: 1,
+      episodeId: 1,
+      created: false,
+    });
+
+    await service.relinkOrphans(seriesDto, null);
+
+    expect(mockedFindLocalArtwork).toHaveBeenCalledWith(
+      '/media/Northern Lights',
+      undefined,
+    );
+  });
+
+  it('reuses the unmatched row already pinned to the same folder on a second scan', async () => {
+    const { service, mediaRepo, mediaService, nfo } = makeService();
     mediaRepo.findOne.mockResolvedValueOnce(
       unmatchedRow(42, 'Quiet Harbour (2009)'),
     );
@@ -107,6 +160,8 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     const res = await service.relinkOrphans(dto(), null);
 
     expect(mediaService.createUnmatched).not.toHaveBeenCalled();
+    expect(nfo.readForVideoFile).not.toHaveBeenCalled();
+    expect(mockedFindLocalArtwork).not.toHaveBeenCalled();
     expect(res.created).toBe(false);
     expect(res.mediaId).toBe(42);
   });

--- a/backend/src/modules/imports/disk-import.unmatched.spec.ts
+++ b/backend/src/modules/imports/disk-import.unmatched.spec.ts
@@ -37,7 +37,10 @@ function makeService() {
   const metadata = { refreshSeriesEpisodes: jest.fn() };
   const events = { emit: jest.fn(), emitDomain: jest.fn() };
   const postImportQueue = { enqueue: jest.fn() };
-  const nfo = { readForVideoFile: jest.fn().mockResolvedValue(null) };
+  const nfo = {
+    readForVideoFile: jest.fn().mockResolvedValue(null),
+    readNfoFile: jest.fn().mockResolvedValue(null),
+  };
   mockedFindLocalArtwork.mockResolvedValue({});
   const service = new DiskImportService(
     mediaRepo as never,
@@ -144,6 +147,110 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
       '/media/Northern Lights',
       undefined,
     );
+  });
+
+  it("reads a series' tvshow.nfo instead of the episode's own nfo", async () => {
+    const { service, mediaRepo, mediaService, nfo } = makeService();
+    const seriesDto = dto({
+      type: MediaType.SERIES,
+      folderName: 'Northern Lights',
+      title: 'Northern Lights',
+      files: [
+        {
+          filePath: '/media/Northern Lights/Season 01/Northern.Lights.S01E01.mkv',
+          seasonNumber: 1,
+          episodeNumber: 1,
+        },
+      ],
+    });
+    mediaRepo.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(unmatchedRow(9, 'Northern Lights', MediaType.SERIES));
+    nfo.readNfoFile.mockResolvedValue({ title: 'Northern Lights Show' });
+    mediaService.createUnmatched.mockResolvedValue({ id: 9 });
+    mediaService.linkExistingFileInPlace.mockResolvedValue({
+      fileId: 1,
+      episodeId: 1,
+      created: false,
+    });
+
+    await service.relinkOrphans(seriesDto, null);
+
+    expect(nfo.readNfoFile).toHaveBeenCalledWith('/media/Northern Lights/tvshow.nfo');
+    expect(nfo.readForVideoFile).not.toHaveBeenCalled();
+    expect(mediaService.createUnmatched).toHaveBeenCalledWith(
+      expect.objectContaining({ nfo: { title: 'Northern Lights Show' } }),
+      null,
+    );
+  });
+
+  it('falls back to the episode nfo when the series has no tvshow.nfo', async () => {
+    const { service, mediaRepo, mediaService, nfo } = makeService();
+    const seriesDto = dto({
+      type: MediaType.SERIES,
+      folderName: 'Northern Lights',
+      title: 'Northern Lights',
+      files: [
+        {
+          filePath: '/media/Northern Lights/Season 01/Northern.Lights.S01E01.mkv',
+          seasonNumber: 1,
+          episodeNumber: 1,
+        },
+      ],
+    });
+    mediaRepo.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(unmatchedRow(9, 'Northern Lights', MediaType.SERIES));
+    nfo.readNfoFile.mockResolvedValue(null);
+    nfo.readForVideoFile.mockResolvedValue({ title: 'Episode-derived title' });
+    mediaService.createUnmatched.mockResolvedValue({ id: 9 });
+    mediaService.linkExistingFileInPlace.mockResolvedValue({
+      fileId: 1,
+      episodeId: 1,
+      created: false,
+    });
+
+    await service.relinkOrphans(seriesDto, null);
+
+    expect(nfo.readForVideoFile).toHaveBeenCalledWith(
+      '/media/Northern Lights/Season 01/Northern.Lights.S01E01.mkv',
+    );
+    expect(mediaService.createUnmatched).toHaveBeenCalledWith(
+      expect.objectContaining({ nfo: { title: 'Episode-derived title' } }),
+      null,
+    );
+  });
+
+  it('rejects a file outside the library root before creating anything', async () => {
+    const { service, mediaRepo, mediaService } = makeService();
+    mediaRepo.findOne.mockResolvedValueOnce(null);
+    const outsideDto = dto({
+      files: [{ filePath: '/etc/Quiet.Harbour.2009.1080p.mkv' }],
+    });
+
+    await expect(service.relinkOrphans(outsideDto, null)).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(mediaService.createUnmatched).not.toHaveBeenCalled();
+  });
+
+  it('rejects a series folderName that escapes the library root before creating anything', async () => {
+    const { service, mediaRepo, mediaService } = makeService();
+    mediaRepo.findOne.mockResolvedValueOnce(null);
+    // The sample file itself is a valid path under the root; only the
+    // folderName-derived artwork dir tries to escape it.
+    const escapingDto = dto({
+      type: MediaType.SERIES,
+      folderName: '../../etc',
+      files: [
+        { filePath: '/media/Northern Lights/Season 01/Escape.S01E01.mkv' },
+      ],
+    });
+
+    await expect(service.relinkOrphans(escapingDto, null)).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(mediaService.createUnmatched).not.toHaveBeenCalled();
   });
 
   it('reuses the unmatched row already pinned to the same folder on a second scan', async () => {

--- a/backend/src/modules/imports/dto/orphan-scan.dto.ts
+++ b/backend/src/modules/imports/dto/orphan-scan.dto.ts
@@ -1,5 +1,5 @@
 import { MediaType } from '../../../common/enums';
-import { NfoIds } from '../nfo-metadata.service';
+import { NfoData } from '../nfo-metadata.service';
 
 /** One orphan video file found under a library root, with cheap hints. */
 export interface OrphanFileEntry {
@@ -24,7 +24,7 @@ export interface OrphanGroup {
   folderName: string;
   guessTitle: string | null;
   guessYear: number | null;
-  nfo: NfoIds | null;
+  nfo: NfoData | null;
   suggestedProvider: string;
   files: OrphanFileEntry[];
 }

--- a/backend/src/modules/imports/dto/relink-orphans.dto.ts
+++ b/backend/src/modules/imports/dto/relink-orphans.dto.ts
@@ -1,4 +1,5 @@
 import {
+  ArrayMinSize,
   IsArray,
   IsBoolean,
   IsEnum,
@@ -91,6 +92,7 @@ export class RelinkOrphansDto {
   reorganize?: boolean;
 
   @IsArray()
+  @ArrayMinSize(1)
   @ValidateNested({ each: true })
   @Type(() => RelinkFileDto)
   files: RelinkFileDto[];

--- a/backend/src/modules/imports/local-artwork.util.spec.ts
+++ b/backend/src/modules/imports/local-artwork.util.spec.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { findLocalArtwork } from './local-artwork.util';
+
+describe('findLocalArtwork', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'fliks-artwork-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('prefers the basename-prefixed poster over a generic one', async () => {
+    writeFileSync(join(dir, 'Quiet Harbour-poster.jpg'), '');
+    writeFileSync(join(dir, 'poster.jpg'), '');
+
+    const out = await findLocalArtwork(dir, 'Quiet Harbour');
+    expect(out.poster).toBe(join(dir, 'Quiet Harbour-poster.jpg'));
+  });
+
+  it('falls back through folder, cover, movie in order', async () => {
+    writeFileSync(join(dir, 'cover.png'), '');
+    writeFileSync(join(dir, 'movie.jpg'), '');
+
+    const out = await findLocalArtwork(dir);
+    expect(out.poster).toBe(join(dir, 'cover.png'));
+  });
+
+  it('matches case-insensitively', async () => {
+    writeFileSync(join(dir, 'Poster.JPG'), '');
+    const out = await findLocalArtwork(dir);
+    expect(out.poster).toBe(join(dir, 'Poster.JPG'));
+  });
+
+  it('finds fanart and logo alongside a poster', async () => {
+    writeFileSync(join(dir, 'poster.jpg'), '');
+    writeFileSync(join(dir, 'backdrop.webp'), '');
+    writeFileSync(join(dir, 'clearlogo.png'), '');
+
+    const out = await findLocalArtwork(dir);
+    expect(out.poster).toBe(join(dir, 'poster.jpg'));
+    expect(out.fanart).toBe(join(dir, 'backdrop.webp'));
+    expect(out.logo).toBe(join(dir, 'clearlogo.png'));
+  });
+
+  it('finds series folder artwork with no basename', async () => {
+    writeFileSync(join(dir, 'folder.jpg'), '');
+    writeFileSync(join(dir, 'fanart.jpg'), '');
+
+    const out = await findLocalArtwork(dir);
+    expect(out.poster).toBe(join(dir, 'folder.jpg'));
+    expect(out.fanart).toBe(join(dir, 'fanart.jpg'));
+  });
+
+  it('returns an empty object when nothing matches', async () => {
+    writeFileSync(join(dir, 'random.txt'), '');
+    expect(await findLocalArtwork(dir)).toEqual({});
+  });
+
+  it('returns an empty object when the directory does not exist', async () => {
+    expect(await findLocalArtwork(join(dir, 'missing'))).toEqual({});
+  });
+
+  it('does not descend into subdirectories', async () => {
+    mkdirSync(join(dir, 'sub'));
+    writeFileSync(join(dir, 'sub', 'poster.jpg'), '');
+    expect(await findLocalArtwork(dir)).toEqual({});
+  });
+});

--- a/backend/src/modules/imports/local-artwork.util.ts
+++ b/backend/src/modules/imports/local-artwork.util.ts
@@ -1,0 +1,65 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+const EXTS = ['jpg', 'jpeg', 'png', 'webp'];
+
+/** Candidate basenames (without extension), in precedence order. */
+function candidateNames(kind: 'poster' | 'fanart' | 'logo', basename?: string): string[] {
+  switch (kind) {
+    case 'poster':
+      return [
+        ...(basename ? [`${basename}-poster`] : []),
+        'poster',
+        'folder',
+        'cover',
+        'movie',
+      ];
+    case 'fanart':
+      return [...(basename ? [`${basename}-fanart`] : []), 'fanart', 'backdrop'];
+    case 'logo':
+      return ['clearlogo', 'logo'];
+  }
+}
+
+export interface LocalArtwork {
+  poster?: string;
+  fanart?: string;
+  logo?: string;
+}
+
+/**
+ * Finds the usual media-center sidecar artwork next to a video file (movie,
+ * `basename` given) or in a series folder (`basename` omitted). One `readdir`
+ * per call, case-insensitive matching so `Poster.JPG` is found.
+ */
+export async function findLocalArtwork(
+  dir: string,
+  basename?: string,
+): Promise<LocalArtwork> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch {
+    return {};
+  }
+  const byLower = new Map(entries.map((e) => [e.toLowerCase(), e]));
+
+  const firstMatch = (kind: 'poster' | 'fanart' | 'logo'): string | undefined => {
+    for (const name of candidateNames(kind, basename)) {
+      for (const ext of EXTS) {
+        const hit = byLower.get(`${name}.${ext}`.toLowerCase());
+        if (hit) return path.join(dir, hit);
+      }
+    }
+    return undefined;
+  };
+
+  const out: LocalArtwork = {};
+  const poster = firstMatch('poster');
+  if (poster) out.poster = poster;
+  const fanart = firstMatch('fanart');
+  if (fanart) out.fanart = fanart;
+  const logo = firstMatch('logo');
+  if (logo) out.logo = logo;
+  return out;
+}

--- a/backend/src/modules/imports/local-artwork.util.ts
+++ b/backend/src/modules/imports/local-artwork.util.ts
@@ -27,11 +27,8 @@ export interface LocalArtwork {
   logo?: string;
 }
 
-/**
- * Finds the usual media-center sidecar artwork next to a video file (movie,
- * `basename` given) or in a series folder (`basename` omitted). One `readdir`
- * per call, case-insensitive matching so `Poster.JPG` is found.
- */
+/** Finds the usual sidecar artwork next to a video file (movie, `basename` given) or
+ *  in a series folder (omitted). One `readdir`, case-insensitive matching. */
 export async function findLocalArtwork(
   dir: string,
   basename?: string,

--- a/backend/src/modules/imports/nfo-metadata.service.spec.ts
+++ b/backend/src/modules/imports/nfo-metadata.service.spec.ts
@@ -89,6 +89,16 @@ describe('NfoMetadataService.parse', () => {
     expect(out.premiered).toBe('2012-01-09');
   });
 
+  it('accepts a decimal comma in a rating value', () => {
+    const xml = '<movie><rating>7,3</rating></movie>';
+    expect(service.parse(xml).rating).toBe(7.3);
+  });
+
+  it('drops a <premiered> value that is not a real calendar date', () => {
+    const xml = '<movie><premiered>2012-13-40</premiered></movie>';
+    expect(service.parse(xml).premiered).toBeUndefined();
+  });
+
   it('returns an empty object for malformed input instead of throwing', () => {
     expect(service.parse('not xml at all, just plain text')).toEqual({});
     expect(service.parse('<<<>>>garbage&&&')).toEqual({});

--- a/backend/src/modules/imports/nfo-metadata.service.spec.ts
+++ b/backend/src/modules/imports/nfo-metadata.service.spec.ts
@@ -1,0 +1,100 @@
+import { NfoMetadataService } from './nfo-metadata.service';
+
+describe('NfoMetadataService.parse', () => {
+  const service = new NfoMetadataService();
+
+  it('reads every field from a full Kodi movie NFO', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<movie>
+  <title>Quiet Harbour</title>
+  <originaltitle>Quiet Harbour Original</originaltitle>
+  <year>2009</year>
+  <plot>A long plot about a harbour.</plot>
+  <outline>Short outline.</outline>
+  <genre>Drama</genre>
+  <genre>Mystery</genre>
+  <genre>Drama</genre>
+  <runtime>118</runtime>
+  <ratings>
+    <rating name="imdb" default="true">
+      <value>7.6</value>
+      <votes>1200</votes>
+    </rating>
+    <rating name="tmdb">
+      <value>7.2</value>
+    </rating>
+  </ratings>
+  <premiered>2009-05-14</premiered>
+  <uniqueid type="tmdb">1234</uniqueid>
+  <uniqueid type="imdb">tt0001234</uniqueid>
+</movie>`;
+
+    const out = service.parse(xml);
+
+    expect(out).toMatchObject({
+      title: 'Quiet Harbour',
+      originalTitle: 'Quiet Harbour Original',
+      year: 2009,
+      plot: 'A long plot about a harbour.',
+      genres: ['Drama', 'Mystery'],
+      runtime: 118,
+      rating: 7.6,
+      premiered: '2009-05-14',
+      tmdbId: 1234,
+      imdbId: 'tt0001234',
+    });
+  });
+
+  it('falls back to <outline> when <plot> is absent', () => {
+    const out = service.parse('<movie><outline>Only an outline.</outline></movie>');
+    expect(out.plot).toBe('Only an outline.');
+  });
+
+  it('reads a tvshow.nfo with showtitle and an <id> tvdb id', () => {
+    const xml = `<tvshow>
+  <showtitle>Salt Meadow</showtitle>
+  <year>2015</year>
+  <genre>Comedy</genre>
+  <id>556677</id>
+</tvshow>`;
+
+    const out = service.parse(xml);
+    expect(out).toMatchObject({
+      title: 'Salt Meadow',
+      year: 2015,
+      genres: ['Comedy'],
+      tvdbId: 556677,
+    });
+  });
+
+  it('falls back to any <ratings><rating><value> when no default is marked', () => {
+    const xml = `<movie><ratings><rating name="tmdb"><value>5.5</value></rating></ratings></movie>`;
+    expect(service.parse(xml).rating).toBe(5.5);
+  });
+
+  it('falls back to a flat <rating> tag when there is no <ratings> block', () => {
+    const xml = '<movie><rating>8.1</rating></movie>';
+    expect(service.parse(xml).rating).toBe(8.1);
+  });
+
+  it('drops a rating outside the 0-10 range', () => {
+    const xml = '<movie><rating>42</rating></movie>';
+    expect(service.parse(xml).rating).toBeUndefined();
+  });
+
+  it('derives the year from <premiered> when <year> is absent', () => {
+    const xml = '<movie><premiered>2012-01-09</premiered></movie>';
+    const out = service.parse(xml);
+    expect(out.year).toBe(2012);
+    expect(out.premiered).toBe('2012-01-09');
+  });
+
+  it('returns an empty object for malformed input instead of throwing', () => {
+    expect(service.parse('not xml at all, just plain text')).toEqual({});
+    expect(service.parse('<<<>>>garbage&&&')).toEqual({});
+  });
+
+  it('returns an empty object for a completely empty document', () => {
+    expect(service.parse('')).toEqual({});
+  });
+});

--- a/backend/src/modules/imports/nfo-metadata.service.ts
+++ b/backend/src/modules/imports/nfo-metadata.service.ts
@@ -136,7 +136,7 @@ export class NfoMetadataService {
         $('premiered').first().text() || $('aired').first().text()
       ).trim();
       const isoDate = /^(\d{4}-\d{2}-\d{2})/.exec(premieredRaw)?.[1];
-      if (isoDate) out.premiered = isoDate;
+      if (isoDate && !Number.isNaN(Date.parse(isoDate))) out.premiered = isoDate;
 
       const year = toInt($('year').first().text());
       if (year) out.year = year;
@@ -162,6 +162,6 @@ function toInt(value: string): number | undefined {
 }
 
 function toRating(value: string): number | undefined {
-  const n = parseFloat((value ?? '').trim());
+  const n = parseFloat((value ?? '').trim().replace(',', '.'));
   return Number.isFinite(n) && n >= 0 && n <= 10 ? n : undefined;
 }

--- a/backend/src/modules/imports/nfo-metadata.service.ts
+++ b/backend/src/modules/imports/nfo-metadata.service.ts
@@ -3,12 +3,19 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as cheerio from 'cheerio';
 
-export interface NfoIds {
+export interface NfoData {
   tmdbId?: number;
   imdbId?: string;
   tvdbId?: number;
   title?: string;
+  originalTitle?: string;
   year?: number;
+  plot?: string;
+  genres?: string[];
+  runtime?: number;
+  rating?: number;
+  /** ISO `YYYY-MM-DD`. */
+  premiered?: string;
 }
 
 /**
@@ -26,7 +33,7 @@ export class NfoMetadataService {
    * same folder, then `tvshow.nfo` in the same folder and one level up (the
    * usual series layout: `Show/tvshow.nfo` + `Show/Season 01/<ep>.nfo`).
    */
-  async readForVideoFile(videoAbsPath: string): Promise<NfoIds | null> {
+  async readForVideoFile(videoAbsPath: string): Promise<NfoData | null> {
     const dir = path.dirname(videoAbsPath);
     const base = path.basename(videoAbsPath, path.extname(videoAbsPath));
     const candidates = [
@@ -36,7 +43,7 @@ export class NfoMetadataService {
       path.join(path.dirname(dir), 'tvshow.nfo'),
     ];
 
-    const merged: NfoIds = {};
+    const merged: NfoData = {};
     let found = false;
     for (const candidate of candidates) {
       const ids = await this.readNfoFile(candidate);
@@ -45,11 +52,11 @@ export class NfoMetadataService {
       // The most specific sidecar is read first; only fill keys still empty so
       // it keeps the title/episode hint while show-level files backfill ids.
       for (const [key, value] of Object.entries(ids) as [
-        keyof NfoIds,
-        NfoIds[keyof NfoIds],
+        keyof NfoData,
+        NfoData[keyof NfoData],
       ][]) {
         if (merged[key] == null && value != null) {
-          (merged[key] as NfoIds[keyof NfoIds]) = value;
+          (merged[key] as NfoData[keyof NfoData]) = value;
         }
       }
       if (merged.tmdbId || merged.tvdbId || merged.imdbId) break;
@@ -57,7 +64,7 @@ export class NfoMetadataService {
     return found ? merged : null;
   }
 
-  async readNfoFile(nfoAbsPath: string): Promise<NfoIds | null> {
+  async readNfoFile(nfoAbsPath: string): Promise<NfoData | null> {
     let xml: string;
     try {
       xml = await fs.readFile(nfoAbsPath, 'utf8');
@@ -67,9 +74,9 @@ export class NfoMetadataService {
     return this.parse(xml);
   }
 
-  /** Pure XML → ids extraction. */
-  parse(xml: string): NfoIds {
-    const out: NfoIds = {};
+  /** Pure XML → data extraction. */
+  parse(xml: string): NfoData {
+    const out: NfoData = {};
     try {
       const $ = cheerio.load(xml, { xml: true });
 
@@ -101,13 +108,40 @@ export class NfoMetadataService {
         $('title').first().text().trim();
       if (title) out.title = title;
 
+      const originalTitle = $('originaltitle').first().text().trim();
+      if (originalTitle) out.originalTitle = originalTitle;
+
+      const plot =
+        $('plot').first().text().trim() || $('outline').first().text().trim();
+      if (plot) out.plot = plot;
+
+      const genres = new Set<string>();
+      $('genre').each((_, el) => {
+        const g = $(el).text().trim();
+        if (g) genres.add(g);
+      });
+      if (genres.size) out.genres = [...genres];
+
+      const runtime = toInt($('runtime').first().text());
+      if (runtime) out.runtime = runtime;
+
+      const rating = toRating(
+        $('ratings rating[default="true"] value').first().text() ||
+          $('ratings rating value').first().text() ||
+          $('rating').first().text(),
+      );
+      if (rating != null) out.rating = rating;
+
+      const premieredRaw = (
+        $('premiered').first().text() || $('aired').first().text()
+      ).trim();
+      const isoDate = /^(\d{4}-\d{2}-\d{2})/.exec(premieredRaw)?.[1];
+      if (isoDate) out.premiered = isoDate;
+
       const year = toInt($('year').first().text());
       if (year) out.year = year;
       else {
-        const premiered = (
-          $('premiered').first().text() || $('aired').first().text()
-        ).trim();
-        const y = toInt(premiered.slice(0, 4));
+        const y = toInt(premieredRaw.slice(0, 4));
         if (y) out.year = y;
       }
     } catch (err) {
@@ -125,4 +159,9 @@ export class NfoMetadataService {
 function toInt(value: string): number | undefined {
   const n = parseInt((value ?? '').trim(), 10);
   return Number.isFinite(n) ? n : undefined;
+}
+
+function toRating(value: string): number | undefined {
+  const n = parseFloat((value ?? '').trim());
+  return Number.isFinite(n) && n >= 0 && n <= 10 ? n : undefined;
 }

--- a/backend/src/modules/media/media-service/media-import.createunmatched.spec.ts
+++ b/backend/src/modules/media/media-service/media-import.createunmatched.spec.ts
@@ -2,13 +2,17 @@ import { MediaImportService } from './media-import.service';
 import { MediaType, MediaStatus } from '../../../common/enums';
 
 describe('MediaImportService.createUnmatched', () => {
-  function makeService() {
+  function makeService(imageService: Record<string, jest.Mock> = {}) {
     const saved: Record<string, unknown>[] = [];
+    const updates: Record<string, unknown>[] = [];
     const mediaRepo = {
       create: jest.fn((m: any) => m),
       save: jest.fn(async (m: any) => {
         saved.push(m);
         return { id: 1, ...m };
+      }),
+      update: jest.fn(async (id: number, m: any) => {
+        updates.push({ id, ...m });
       }),
       findOne: jest.fn().mockResolvedValue({ id: 1, title: 'Quiet Harbour' }),
     };
@@ -31,8 +35,9 @@ describe('MediaImportService.createUnmatched', () => {
       { updateSearchVector: jest.fn().mockResolvedValue(undefined) } as any,
       {} as any, // requestLifecycle
       { emitDomain } as any,
+      { storeFromDisk: jest.fn(), ...imageService } as any,
     );
-    return { svc, mediaRepo, saved, emitDomain };
+    return { svc, mediaRepo, saved, updates, emitDomain };
   }
 
   it('creates an unmonitored, released title with no provider id', async () => {
@@ -62,5 +67,100 @@ describe('MediaImportService.createUnmatched', () => {
       }),
     );
     expect(media.id).toBe(1);
+  });
+
+  it('fills empty fields from the nfo but never overrides a real title', async () => {
+    const { svc, saved } = makeService();
+    await svc.createUnmatched({
+      title: 'Salt Meadow',
+      type: MediaType.MOVIE,
+      libraryId: 3,
+      folderName: 'Salt Meadow (2011)',
+      nfo: {
+        title: 'Salt Meadow Extended',
+        originalTitle: 'Salt Meadow Original',
+        year: 2011,
+        plot: 'A tale of a meadow.',
+        genres: ['Drama'],
+        runtime: 100,
+        rating: 7.4,
+        premiered: '2011-03-02',
+      },
+    });
+
+    expect(saved[0]).toMatchObject({
+      title: 'Salt Meadow',
+      originalTitle: 'Salt Meadow Original',
+      year: 2011,
+      overview: 'A tale of a meadow.',
+      genres: ['Drama'],
+      runtime: 100,
+      rating: 7.4,
+      releaseDate: '2011-03-02',
+    });
+  });
+
+  it('uses the nfo title when the guess is just the folder name', async () => {
+    const { svc, saved } = makeService();
+    await svc.createUnmatched({
+      title: 'Salt Meadow (2011)',
+      type: MediaType.MOVIE,
+      libraryId: 3,
+      folderName: 'Salt Meadow (2011)',
+      nfo: { title: 'Salt Meadow' },
+    });
+
+    expect(saved[0].title).toBe('Salt Meadow');
+    expect(saved[0].originalTitle).toBe('Salt Meadow');
+  });
+
+  it('stores sibling artwork and writes the local image urls', async () => {
+    const storeFromDisk = jest
+      .fn()
+      .mockImplementation((_p: string, _t: string, _id: number, variant: string) =>
+        Promise.resolve(`/api/images/media/1/${variant}?v=abcdef12`),
+      );
+    const { svc, updates } = makeService({ storeFromDisk });
+    await svc.createUnmatched({
+      title: 'Quiet Harbour',
+      type: MediaType.MOVIE,
+      libraryId: 3,
+      folderName: 'Quiet Harbour (2009)',
+      artwork: { poster: '/media/Quiet Harbour (2009)/poster.jpg', fanart: '/media/Quiet Harbour (2009)/fanart.jpg' },
+    });
+
+    expect(storeFromDisk).toHaveBeenCalledWith(
+      '/media/Quiet Harbour (2009)/poster.jpg',
+      'media',
+      1,
+      'poster',
+    );
+    expect(storeFromDisk).toHaveBeenCalledWith(
+      '/media/Quiet Harbour (2009)/fanart.jpg',
+      'media',
+      1,
+      'fanart',
+    );
+    expect(updates[0]).toMatchObject({
+      id: 1,
+      posterUrl: '/api/images/media/1/poster?v=abcdef12',
+      fanartUrl: '/api/images/media/1/fanart?v=abcdef12',
+    });
+  });
+
+  it('does not fail the import when storing artwork throws', async () => {
+    const storeFromDisk = jest.fn().mockRejectedValue(new Error('disk error'));
+    const { svc, saved } = makeService({ storeFromDisk });
+
+    await expect(
+      svc.createUnmatched({
+        title: 'Quiet Harbour',
+        type: MediaType.MOVIE,
+        libraryId: 3,
+        folderName: 'Quiet Harbour (2009)',
+        artwork: { poster: '/media/Quiet Harbour (2009)/poster.jpg' },
+      }),
+    ).resolves.toBeDefined();
+    expect(saved).toHaveLength(1);
   });
 });

--- a/backend/src/modules/media/media-service/media-import.service.ts
+++ b/backend/src/modules/media/media-service/media-import.service.ts
@@ -35,6 +35,8 @@ import { NamingService } from '../../scheduler/naming.service';
 import { EventsService } from '../../scheduler/events.service';
 import { buildMediaFieldsFromTmdb } from './tmdb-mapping.util';
 import { MediaMetadataService } from './media-metadata.service';
+import { ImageService, MediaImageVariant } from '../../images/image.service';
+import type { NfoData } from '../../imports/nfo-metadata.service';
 
 @Injectable()
 export class MediaImportService {
@@ -60,6 +62,7 @@ export class MediaImportService {
     @Inject(forwardRef(() => RequestLifecycleService))
     private readonly requestLifecycle: RequestLifecycleService,
     private readonly events: EventsService,
+    private readonly imageService: ImageService,
   ) {}
 
   async importFromTmdb(
@@ -379,7 +382,8 @@ export class MediaImportService {
 
   /**
    * Create a title no metadata provider matched, straight from the orphan scan's guessed title.
-   * No provider call, no images, no cast: an Identify later fills those in.
+   * No provider call, no cast: an Identify later fills those in. `nfo`/`artwork` (both
+   * optional) fill in whatever the file itself already carries.
    */
   async createUnmatched(
     dto: {
@@ -390,6 +394,8 @@ export class MediaImportService {
       folderName: string;
       qualityProfileId?: number;
       languageProfileId?: number;
+      nfo?: NfoData;
+      artwork?: { poster?: string; fanart?: string; logo?: string };
     },
     addedByUserId: number | null = null,
   ): Promise<Media> {
@@ -402,15 +408,27 @@ export class MediaImportService {
         dto.languageProfileId,
       );
 
+    const nfo = dto.nfo;
+    // The caller already falls back to the folder name when it has no guessed
+    // title; only let the NFO title win over that guess, never over a real one.
+    const title =
+      (!dto.title || dto.title === dto.folderName) && nfo?.title
+        ? nfo.title
+        : dto.title;
+
     const row = this.mediaRepo.create({
-      title: dto.title,
-      originalTitle: dto.title,
-      year: dto.year ?? undefined,
+      title,
+      originalTitle: nfo?.originalTitle || title,
+      year: dto.year ?? nfo?.year ?? undefined,
       type: dto.type,
       status: MediaStatus.RELEASED,
       monitored: false,
       alternativeTitles: [],
-      genres: [],
+      overview: nfo?.plot,
+      genres: nfo?.genres ?? [],
+      runtime: nfo?.runtime,
+      rating: nfo?.rating,
+      releaseDate: nfo?.premiered,
       library: { id: dto.libraryId } as Library,
       folderName: dto.folderName,
       ...(qualityProfileId != null
@@ -423,6 +441,7 @@ export class MediaImportService {
     });
     const saved = await this.mediaRepo.save(row);
     await this.metadata.updateSearchVector(saved.id);
+    await this.storeLocalArtwork(saved.id, dto.artwork);
     this.events.emitDomain({
       type: 'media.imported',
       mediaId: saved.id,
@@ -433,11 +452,46 @@ export class MediaImportService {
     });
     const year = dto.year ? ` (${dto.year})` : '';
     this.log.log(
-      `Library: added unidentified ${dto.type} "${dto.title}"${year}, id=${saved.id}`,
+      `Library: added unidentified ${dto.type} "${title}"${year}, id=${saved.id}`,
     );
     const reloaded = await this.mediaRepo.findOne({ where: { id: saved.id } });
     if (!reloaded) throw new Error(`Media #${saved.id} not found after save`);
     return reloaded;
+  }
+
+  /** Best-effort: a bad or unreadable sibling image never fails the import. */
+  private async storeLocalArtwork(
+    mediaId: number,
+    artwork?: { poster?: string; fanart?: string; logo?: string },
+  ): Promise<void> {
+    if (!artwork) return;
+    const slots: [MediaImageVariant, string | undefined, keyof Media][] = [
+      ['poster', artwork.poster, 'posterUrl'],
+      ['fanart', artwork.fanart, 'fanartUrl'],
+      ['logo', artwork.logo, 'logoUrl'],
+    ];
+    const updates: Partial<Media> = {};
+    for (const [variant, absPath, field] of slots) {
+      if (!absPath) continue;
+      try {
+        const url = await this.imageService.storeFromDisk(
+          absPath,
+          'media',
+          mediaId,
+          variant,
+        );
+        if (url) (updates as Record<string, string>)[field] = url;
+      } catch (e) {
+        this.log.warn(
+          `media #${mediaId}: failed to store local ${variant}: ${
+            e instanceof Error ? e.message : e
+          }`,
+        );
+      }
+    }
+    if (Object.keys(updates).length) {
+      await this.mediaRepo.update(mediaId, updates);
+    }
   }
 
   async create(dto: CreateMediaDto): Promise<Media> {


### PR DESCRIPTION
## Why

A title created from the orphan scan with no provider match (#1264) shows a placeholder and a filename-derived title. Most such folders carry what a media center left behind: a Kodi-style `.nfo` and `poster.jpg` / `fanart.jpg` next to the file. Reading them fills the page without any provider call. Phase 4 of `plan/local-media-without-metadata.md`; applies only to titles with no provider id, and only to fields still empty.

## What

- `NfoMetadataService.parse` returns `NfoData`: besides the ids, `plot` (fallback `outline`), `genres`, `runtime`, `rating` (`<ratings><rating default>` first, then any `<rating>`), `premiered` (validated ISO date), `originalTitle`. Never throws. For a series the show-level `tvshow.nfo` is read first so the episode's own `.nfo` does not leak into the show row.
- `local-artwork.util.ts` `findLocalArtwork(dir, basename?)`: one `readdir`, case-insensitive, first hit in the usual sidecar precedence (`<name>-poster`, `poster`, `folder`, `cover`, `movie`; `<name>-fanart`, `fanart`, `backdrop`; `clearlogo`, `logo`; `jpg|jpeg|png|webp`).
- `ImageService.storeFromDisk(absPath, type, id, variant)`: same output as a download (full + resized variants, sidecar, `?v=<hash>`), keyed on `file://<path>@<mtime>` so an unchanged file is a cache hit. `doDownloadAndStore` is split into fetch + `storeBuffer`; the download path keeps its paths, hash and error handling.
- `DiskImportService.findOrCreateUnmatched` (create branch only) reads the `.nfo` and the sibling artwork and hands them to `MediaImportService.createUnmatched`, which fills `overview`, `genres`, `runtime`, `rating`, `releaseDate`, `originalTitle` (and the title when the guess was just the folder name), then stores poster / fanart / logo and writes the URLs. Artwork failures are a `warn`, never a failed import.
- Guards: the sample file and the artwork folder must resolve under the library root before any disk read (400 otherwise); `files` needs at least one entry.

## Verification

- `tsc -p tsconfig.build.json --noEmit` clean; `jest src/modules/imports src/modules/images src/modules/media`: 22 suites, 118 tests green. New specs: `nfo-metadata.service.spec.ts`, `local-artwork.util.spec.ts`, `storeFromDisk` cases in `image.service.spec.ts`, nfo/artwork forwarding, series `tvshow.nfo`, path containment in `disk-import.unmatched.spec.ts`, fill-only-when-empty in `media-import.createunmatched.spec.ts`.
- Dev stack smoke test on a folder with `movie.nfo` + `poster.jpg` + `fanart.jpg`: see the PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
