### PR TITLE
fix(client): render nothing for unknown years and untitled episodes

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -990,7 +990,6 @@
     "col_ep": "F.",
     "col_title": "Titel",
     "col_airdate": "Ausstrahlung",
-    "ep_no_title": "Ohne Titel",
     "episode_video_label": "Video: ",
     "ep_search_releases": "Releases",
     "ep_releases_title": "Releases der Folge",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -995,7 +995,6 @@
     "col_ep": "Ep.",
     "col_title": "Title",
     "col_airdate": "Air date",
-    "ep_no_title": "Untitled",
     "episode_video_label": "Video: ",
     "ep_search_releases": "Releases",
     "ep_releases_title": "Episode releases",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -990,7 +990,6 @@
     "col_ep": "Ep.",
     "col_title": "Título",
     "col_airdate": "Emisión",
-    "ep_no_title": "Sin título",
     "episode_video_label": "Vídeo: ",
     "ep_search_releases": "Releases",
     "ep_releases_title": "Releases del episodio",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -995,7 +995,6 @@
     "col_ep": "Ep.",
     "col_title": "Titre",
     "col_airdate": "Diffusion",
-    "ep_no_title": "Sans titre",
     "episode_video_label": "Vidéo : ",
     "ep_search_releases": "Releases",
     "ep_releases_title": "Releases de l'épisode",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -990,7 +990,6 @@
     "col_ep": "Ep.",
     "col_title": "Titolo",
     "col_airdate": "Trasmissione",
-    "ep_no_title": "Senza titolo",
     "episode_video_label": "Video: ",
     "ep_search_releases": "Release",
     "ep_releases_title": "Release dell'episodio",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -990,7 +990,6 @@
     "col_ep": "Ep.",
     "col_title": "Título",
     "col_airdate": "Emissão",
-    "ep_no_title": "Sem título",
     "episode_video_label": "Vídeo: ",
     "ep_search_releases": "Releases",
     "ep_releases_title": "Releases do episódio",

--- a/client/src/app/core/services/spoiler.service.ts
+++ b/client/src/app/core/services/spoiler.service.ts
@@ -24,11 +24,11 @@ export class SpoilerService {
     return this.on(watched) && (this.auth.user()?.spoilerHideOverviews ?? true);
   }
 
-  /** Episode name, swapped for `Episode 3` while it would spoil. */
+  /** Episode name, swapped for `Episode 3` while it would spoil or when the episode has none. */
   title(watched: boolean, number: string, title: string | null): string {
     if (this.on(watched) && (this.auth.user()?.spoilerHideTitles ?? true)) {
       return this.translate.instant('spoilers.episode_title', { number });
     }
-    return title ?? this.translate.instant('media_detail.ep_no_title');
+    return title || this.translate.instant('spoilers.episode_title', { number });
   }
 }

--- a/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.html
@@ -130,9 +130,9 @@
                   </div>
                   <span class="text-sm leading-tight line-clamp-2">{{ r.title }}</span>
                   <span class="text-xs text-base-content/50">
-                    {{ r.year ?? '—' }}
+                    @if (r.year) { {{ r.year }} }
                     @if (isTaken(r)) {
-                      · {{ 'media_detail.identify_already_in_library' | translate }}
+                      @if (r.year) { · } {{ 'media_detail.identify_already_in_library' | translate }}
                     }
                   </span>
                 </button>

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -269,7 +269,7 @@ export class MediaDetailSeasonsComponent {
    * locale pipe stays in the template and keeps re-running on a language switch.
    */
   episodeCardSubtitle(formattedDate: string, runtime?: number | null): string {
-    const parts = [formattedDate || '—'];
+    const parts = formattedDate ? [formattedDate] : [];
     if (runtime) parts.push(`${runtime} ${this.translate.instant('common.min')}`);
     return parts.join(' · ');
   }

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -472,12 +472,14 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       ep.endEpisodeNumber != null && ep.endEpisodeNumber > ep.episodeNumber
         ? `E${start}-E${String(ep.endEpisodeNumber).padStart(2, '0')}`
         : `E${start}`;
+    const code = `S${sn}:${epPart}`;
+    if (!ep.title) return code;
     const title = this.spoilers.title(
       this.watchedEpisodeIds().has(ep.id),
       episodeBadgeLabel(ep),
-      ep.title ?? '',
+      ep.title,
     );
-    return `S${sn}:${epPart} - ${title}`;
+    return `${code} - ${title}`;
   });
 
   readonly episodeDateLabel = computed(() => {
@@ -681,7 +683,8 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     if (!ctx) return null;
     const sn = String(ctx.season.seasonNumber).padStart(2, '0');
     const en = String(ctx.episode.episodeNumber).padStart(2, '0');
-    return `S${sn}:E${en} - ${ctx.episode.title ?? ''}`;
+    const code = `S${sn}:E${en}`;
+    return ctx.episode.title ? `${code} - ${ctx.episode.title}` : code;
   });
 
   readonly nextPlayEpisodeId = computed(() => this.nextPlayEpisode()?.episode.id);
@@ -1186,7 +1189,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     const sn = String(foundSeason!.seasonNumber).padStart(2, '0');
     const en = String(foundEpisode.episodeNumber).padStart(2, '0');
     this.navbarService.enterHeroPage(
-      `${m.title} — S${sn}:E${en} — ${foundEpisode.title ?? ''}`,
+      [m.title, `S${sn}:E${en}`, foundEpisode.title].filter(Boolean).join(' — '),
       m.logoUrl,
     );
   }

--- a/client/src/app/features/settings/libraries/library-detail/library-media.html
+++ b/client/src/app/features/settings/libraries/library-detail/library-media.html
@@ -79,7 +79,7 @@
                   }
                 </td>
                 <td class="text-lg font-semibold">{{ item.title }}</td>
-                <td class="text-base">{{ item.year || '—' }}</td>
+                <td class="text-base">{{ item.year || '' }}</td>
                 <td class="text-base">
                   @if (item.type === 'movie') {
                     {{ 'settings.libraries.media_type_movie' | translate }}

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
@@ -150,7 +150,7 @@
                             }
                           </div>
                           <div class="text-xs text-base-content/50">
-                            {{ r.year || '—' }} · {{ r.provider | uppercase }}
+                            @if (r.year) { {{ r.year }} · } {{ r.provider | uppercase }}
                             @if (r.existingMediaId) {
                               · <span class="text-warning">{{ 'settings.libraries.scan_already' | translate }}</span>
                             }


### PR DESCRIPTION
## Why

Titles created from the file alone (#1264) have no year, no episode titles and no air dates. The UI showed that as a dash placeholder in the library table and the match lists, "Untitled" on episode cards with a dash under it, and `S01:E02 - ` with a trailing separator in the episode header.

## What

- Unknown year renders nothing: library Media tab table, orphan-scan match rows, Identify-modal match rows (the `·` separator only appears when there is a year).
- Episode header and resume label: `S01:E02` alone when the episode has no title; the hero title joins only the parts that exist.
- Episode cards: subtitle is the date and/or runtime, or empty; an episode without a title shows "Episode N" (the string the spoiler mask already uses), so `media_detail.ep_no_title` is removed from the six locales.

## Verification

`ng build --configuration development` clean; `ng test` on media-detail, seasons, spoiler, orphan-scan-panel specs: 8 files, 49 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
