### PR TITLE
feat(media-detail): surface unidentified titles and let admins filter them

### DIFF
--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -26,6 +26,8 @@ export type WhenPredicateName =
   | 'isMonitored'
   | 'hasQualityProfile'
   | 'isEpisode'
+  /** False when the title has no metadata-provider id (tmdbId/tvdbId/imdbId all null). */
+  | 'identified'
   | 'isTv'
   | 'isTouch'
   /** Which menu is being built. The card menu and the media detail menu read the

--- a/backend/src/modules/media/dto/search-media.dto.ts
+++ b/backend/src/modules/media/dto/search-media.dto.ts
@@ -121,6 +121,11 @@ export class SearchMediaDto {
   @Transform(({ value }) => value === 'true' || value === true)
   cutoffUnmet?: boolean;
 
+  @IsBoolean()
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  unidentified?: boolean;
+
   @IsString()
   @IsOptional()
   letter?: string;

--- a/backend/src/modules/media/media-service/media-query.applyfilters.spec.ts
+++ b/backend/src/modules/media/media-service/media-query.applyfilters.spec.ts
@@ -104,6 +104,28 @@ describe('MediaQueryService.applyFilters', () => {
     expect(clauses(qb)).not.toContain('media.genres @> :genres');
   });
 
+  it('emits the tmdbId/tvdbId/imdbId null clause when unidentified is true', () => {
+    const qb = fakeQueryBuilder();
+
+    (service as any).applyFilters(qb, {
+      unidentified: true,
+    } as SearchMediaDto);
+
+    expect(clauses(qb)).toContain(
+      'media."tmdbId" IS NULL AND media."tvdbId" IS NULL AND media."imdbId" IS NULL',
+    );
+  });
+
+  it('omits the unidentified clause when unidentified is not set', () => {
+    const qb = fakeQueryBuilder();
+
+    (service as any).applyFilters(qb, {} as SearchMediaDto);
+
+    expect(clauses(qb)).not.toContain(
+      'media."tmdbId" IS NULL AND media."tvdbId" IS NULL AND media."imdbId" IS NULL',
+    );
+  });
+
   it('keeps the single-genre and exact-year branches for other callers', () => {
     const qb = fakeQueryBuilder();
 

--- a/backend/src/modules/media/media-service/media-query.service.ts
+++ b/backend/src/modules/media/media-service/media-query.service.ts
@@ -1059,6 +1059,11 @@ export class MediaQueryService {
     } else if (query.missing === false) {
       qb.andWhere('files.id IS NOT NULL');
     }
+    if (query.unidentified === true) {
+      qb.andWhere(
+        'media."tmdbId" IS NULL AND media."tvdbId" IS NULL AND media."imdbId" IS NULL',
+      );
+    }
     if (query.letter) {
       const letter = query.letter.toUpperCase();
       if (letter === '#') {

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1123,7 +1123,8 @@
     "advanced_group": "Erweitert",
     "add_to_list": "Zu Liste hinzufügen",
     "unlike": "Gefällt mir nicht mehr",
-    "subtitle_failed": "Fehlgeschlagen"
+    "subtitle_failed": "Fehlgeschlagen",
+    "unidentified_callout": "Dieser Titel ist nicht identifiziert. Die angezeigten Informationen stammen aus der Datei."
   },
   "requests": {
     "title": "Anfragen",
@@ -1971,7 +1972,8 @@
       "scan_unmatched_option": "Keine Übereinstimmung: unverändert hinzufügen",
       "scan_reorganize_needs_match": "Verschieben/Umbenennen gilt nur für identifizierte Titel",
       "scan_queued_unmatched": "{{count}} Titel ohne Metadaten hinzugefügt, identifizieren Sie sie im Tab Medien",
-      "scan_search_failed_count": "{{count}} Ordner nicht analysiert (Suche fehlgeschlagen), starten Sie den Scan im Tab Medien erneut"
+      "scan_search_failed_count": "{{count}} Ordner nicht analysiert (Suche fehlgeschlagen), starten Sie den Scan im Tab Medien erneut",
+      "media_filter_unidentified": "Nicht identifiziert"
     },
     "users": {
       "title": "Benutzer",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1131,7 +1131,8 @@
     "advanced_group": "Advanced",
     "add_to_list": "Add to list",
     "unlike": "Unlike",
-    "subtitle_failed": "Failed"
+    "subtitle_failed": "Failed",
+    "unidentified_callout": "This title isn't identified. The information shown comes from the file."
   },
   "requests": {
     "title": "Requests",
@@ -1988,7 +1989,8 @@
       "scan_unmatched_option": "No match: add as is",
       "scan_reorganize_needs_match": "Move/rename only applies to identified titles",
       "scan_queued_unmatched": "{{count}} title(s) added without metadata, identify them from the Media tab",
-      "scan_search_failed_count": "{{count}} folder(s) not scanned (search failed), relaunch the scan from the Media tab"
+      "scan_search_failed_count": "{{count}} folder(s) not scanned (search failed), relaunch the scan from the Media tab",
+      "media_filter_unidentified": "Unidentified"
     },
     "users": {
       "title": "Users",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1123,7 +1123,8 @@
     "advanced_group": "Avanzado",
     "add_to_list": "Añadir a una lista",
     "unlike": "Ya no me gusta",
-    "subtitle_failed": "Error"
+    "subtitle_failed": "Error",
+    "unidentified_callout": "Este título no está identificado. La información mostrada proviene del archivo."
   },
   "requests": {
     "title": "Solicitudes",
@@ -1971,7 +1972,8 @@
       "scan_unmatched_option": "Sin coincidencia: añadir tal cual",
       "scan_reorganize_needs_match": "Mover/renombrar solo se aplica a títulos identificados",
       "scan_queued_unmatched": "{{count}} título(s) añadido(s) sin metadatos, identifíquelos desde la pestaña Medios",
-      "scan_search_failed_count": "{{count}} carpeta(s) no analizada(s) (búsqueda fallida), vuelva a lanzar el análisis desde la pestaña Medios"
+      "scan_search_failed_count": "{{count}} carpeta(s) no analizada(s) (búsqueda fallida), vuelva a lanzar el análisis desde la pestaña Medios",
+      "media_filter_unidentified": "No identificados"
     },
     "users": {
       "title": "Usuarios",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1131,7 +1131,8 @@
     "advanced_group": "Avancé",
     "add_to_list": "Ajouter à une liste",
     "unlike": "Je n’aime plus",
-    "subtitle_failed": "Échec"
+    "subtitle_failed": "Échec",
+    "unidentified_callout": "Ce titre n'est pas identifié. Les informations affichées viennent du fichier."
   },
   "requests": {
     "title": "Demandes",
@@ -1988,7 +1989,8 @@
       "scan_unmatched_option": "Aucune correspondance : ajouter tel quel",
       "scan_reorganize_needs_match": "Le déplacement/renommage ne s'applique qu'aux titres identifiés",
       "scan_queued_unmatched": "{{count}} titre(s) ajouté(s) sans métadonnées, identifiez-les depuis l'onglet Médias",
-      "scan_search_failed_count": "{{count}} dossier(s) non analysé(s) (recherche en erreur), relancez l'analyse depuis l'onglet Médias"
+      "scan_search_failed_count": "{{count}} dossier(s) non analysé(s) (recherche en erreur), relancez l'analyse depuis l'onglet Médias",
+      "media_filter_unidentified": "Non identifiés"
     },
     "users": {
       "title": "Utilisateurs",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1123,7 +1123,8 @@
     "advanced_group": "Avanzate",
     "add_to_list": "Aggiungi a un elenco",
     "unlike": "Non mi piace più",
-    "subtitle_failed": "Non riuscito"
+    "subtitle_failed": "Non riuscito",
+    "unidentified_callout": "Questo titolo non è identificato. Le informazioni mostrate provengono dal file."
   },
   "requests": {
     "title": "Richieste",
@@ -1971,7 +1972,8 @@
       "scan_unmatched_option": "Nessuna corrispondenza: aggiungi così com'è",
       "scan_reorganize_needs_match": "Sposta/rinomina si applica solo ai titoli identificati",
       "scan_queued_unmatched": "{{count}} titolo/i aggiunto/i senza metadati, identificali dalla scheda Media",
-      "scan_search_failed_count": "{{count}} cartella/e non analizzata/e (ricerca fallita), rilancia la scansione dalla scheda Media"
+      "scan_search_failed_count": "{{count}} cartella/e non analizzata/e (ricerca fallita), rilancia la scansione dalla scheda Media",
+      "media_filter_unidentified": "Non identificati"
     },
     "users": {
       "title": "Utenti",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1123,7 +1123,8 @@
     "advanced_group": "Avançado",
     "add_to_list": "Adicionar a uma lista",
     "unlike": "Já não gosto",
-    "subtitle_failed": "Falhou"
+    "subtitle_failed": "Falhou",
+    "unidentified_callout": "Este título não está identificado. As informações exibidas vêm do arquivo."
   },
   "requests": {
     "title": "Pedidos",
@@ -1971,7 +1972,8 @@
       "scan_unmatched_option": "Sem correspondência: adicionar tal como está",
       "scan_reorganize_needs_match": "Mover/renomear aplica-se apenas a títulos identificados",
       "scan_queued_unmatched": "{{count}} título(s) adicionado(s) sem metadados, identifique-os no separador Media",
-      "scan_search_failed_count": "{{count}} pasta(s) não analisada(s) (pesquisa falhou), reinicie a análise no separador Media"
+      "scan_search_failed_count": "{{count}} pasta(s) não analisada(s) (pesquisa falhou), reinicie a análise no separador Media",
+      "media_filter_unidentified": "Não identificados"
     },
     "users": {
       "title": "Utilizadores",

--- a/client/src/app/core/plugin-ui/when-evaluator.spec.ts
+++ b/client/src/app/core/plugin-ui/when-evaluator.spec.ts
@@ -41,6 +41,14 @@ describe('evaluateWhen', () => {
     expect(evaluateWhen(['isEpisode'], ctx())).toBe(false);
   });
 
+  // `identified` defaults to true (unlike the other optional flags) so a
+  // surface that never sets it keeps showing the refresh-metadata row.
+  it('defaults identified to true when the context omits it, false when set', () => {
+    expect(evaluateWhen(['identified'], ctx())).toBe(true);
+    expect(evaluateWhen(['identified'], ctx({ identified: false }))).toBe(false);
+    expect(evaluateWhen(['!identified'], ctx({ identified: false }))).toBe(true);
+  });
+
   it('negates a known predicate with a leading "!"', () => {
     expect(evaluateWhen(['!isAdmin'], ctx({ isAdmin: false }))).toBe(true);
     expect(evaluateWhen(['!isAdmin'], ctx({ isAdmin: true }))).toBe(false);

--- a/client/src/app/core/plugin-ui/when-evaluator.ts
+++ b/client/src/app/core/plugin-ui/when-evaluator.ts
@@ -12,6 +12,8 @@ export interface WhenContext {
   isMonitored?: boolean;
   hasQualityProfile?: boolean;
   isEpisode?: boolean;
+  /** False when the title has no metadata-provider id: a refresh has nothing to refresh from. */
+  identified?: boolean;
   isTv: boolean;
   isTouch: boolean;
   /** Which menu is being built. Both surfaces read the same contribution
@@ -32,6 +34,7 @@ function evaluateKnown(predicate: string, ctx: WhenContext): boolean | null {
   if (predicate === 'isMonitored') return ctx.isMonitored ?? false;
   if (predicate === 'hasQualityProfile') return ctx.hasQualityProfile ?? false;
   if (predicate === 'isEpisode') return ctx.isEpisode ?? false;
+  if (predicate === 'identified') return ctx.identified ?? true;
   if (predicate === 'isTv') return ctx.isTv;
   if (predicate === 'isTouch') return ctx.isTouch;
   if (predicate === 'surface:card') return ctx.surface === 'card';

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -229,6 +229,7 @@ export interface SearchParams {
   limit?: number;
   missing?: boolean;
   cutoffUnmet?: boolean;
+  unidentified?: boolean;
   letter?: string;
   excludeWatched?: boolean;
   onlyWatched?: boolean;

--- a/client/src/app/core/utils/media-identity.ts
+++ b/client/src/app/core/utils/media-identity.ts
@@ -1,0 +1,4 @@
+/** True when at least one metadata-provider id is set; false for a title built from the file alone. */
+export function hasProviderId(m: { tmdbId?: number | null; tvdbId?: number | null; imdbId?: string | null }): boolean {
+  return m.tmdbId != null || m.tvdbId != null || !!m.imdbId;
+}

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -74,6 +74,7 @@
           [userHasOpenWholeRequest]="hasBlockingRequest()"
           [releasesLoading]="epReleasesLoading()"
           [grabBusy]="epHeaderGrabBusy()"
+          [identified]="!unidentified()"
           (selectedFileIdChange)="selectedFileId.set($event)"
           (openDownload)="openDownloadModal()"
           (refreshMetadata)="refreshMetadata()"

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -166,12 +166,20 @@
       <!-- ===== NORMAL MODE (movie / series) ===== -->
     } @else {
       <div class="flex flex-col">
+        @if (isAdmin() && unidentified()) {
+          <div role="alert" class="alert alert-info mb-4 flex items-center justify-between py-2">
+            <span class="text-sm">{{ 'media_detail.unidentified_callout' | translate }}</span>
+            <button class="btn btn-sm btn-ghost" (click)="openIdentifyModal()">
+              {{ 'media_detail.identify' | translate }}
+            </button>
+          </div>
+        }
         <app-media-info-header
           [title]="m.title"
           [mediaId]="m.id"
           [rating]="m.rating"
           [dateLabel]="m.year ? '' + m.year : null"
-          [runtime]="m.runtime"
+          [runtime]="displayRuntime()"
           [overview]="m.overview"
           [genres]="m.genres ?? []"
           [resumeEpisodeLabel]="resumeEpisodeLabel()"
@@ -202,6 +210,7 @@
           [grabBusy]="movieHeaderGrabBusy()"
           [monitoredLoading]="monitoredLoading()"
           [deleteLoading]="deleteLoading()"
+          [identified]="!unidentified()"
           (selectedFileIdChange)="selectedFileId.set($event)"
           (openDownload)="openDownloadModal()"
           (openProfiles)="openProfilesModal()"

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -1055,7 +1055,6 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       // by episodeFocusEffect as soon as `media` is set, so no imperative
       // call is needed here.
 
-      // Load cast/crew async — doesn't block page render
       // Provider-derived sections have nothing to fetch for an unidentified title.
       if (hasProviderId(m)) {
         this.mediaService

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -15,6 +15,7 @@ import {
 import { toSignal } from '@angular/core/rxjs-interop';
 import { NgTemplateOutlet } from '@angular/common';
 import { IdentifyModalService } from '../../core/services/identify-modal.service';
+import { hasProviderId } from '../../core/utils/media-identity';
 import { TrackingModalService } from '../../core/services/tracking-modal.service';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -395,6 +396,14 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     return m.type === 'series' ? [] : list;
   });
 
+  /** Falls back to the file's own duration when the provider never gave a runtime. */
+  readonly displayRuntime = computed(() => {
+    const m = this.media();
+    if (m?.runtime) return m.runtime;
+    const seconds = this.mediaFiles()[0]?.streamInfo?.durationSeconds;
+    return seconds ? Math.round(seconds / 60) : (m?.runtime ?? null);
+  });
+
   /**
    * For a series, true iff every downloaded episode in a non-special season
    * (seasonNumber > 0, hasFile=true) is marked as watched. Drives the series
@@ -749,6 +758,12 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   readonly canDelete = computed(() => this.auth.hasPermission('media.delete'));
   readonly isAdmin = computed(() => this.auth.hasPermission('settings.access'));
 
+  /** No metadata-provider id: title, artwork and provider-derived sections all come from the file. */
+  readonly unidentified = computed(() => {
+    const m = this.media();
+    return !!m && !hasProviderId(m);
+  });
+
   /** Anti-spoiler masks for the focused episode's hero, still and synopsis. */
   readonly episodeSpoilerImage = computed(() =>
     this.focusedEpisodeWatched() === null
@@ -1041,23 +1056,26 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
       // call is needed here.
 
       // Load cast/crew async — doesn't block page render
-      this.mediaService
-        .getCast(m.id)
-        .then((c) => this.cast.set(c))
-        .catch(() => {});
-      this.mediaService
-        .getCrew(m.id)
-        .then((c) => this.crew.set(c))
-        .catch(() => {});
-      if (m.type === 'movie') {
+      // Provider-derived sections have nothing to fetch for an unidentified title.
+      if (hasProviderId(m)) {
         this.mediaService
-          .getSimilar(m.id)
-          .then((s) => this.similar.set(s))
+          .getCast(m.id)
+          .then((c) => this.cast.set(c))
           .catch(() => {});
         this.mediaService
-          .getCollection(m.id)
-          .then((c) => this.collection.set(c))
+          .getCrew(m.id)
+          .then((c) => this.crew.set(c))
           .catch(() => {});
+        if (m.type === 'movie') {
+          this.mediaService
+            .getSimilar(m.id)
+            .then((s) => this.similar.set(s))
+            .catch(() => {});
+          this.mediaService
+            .getCollection(m.id)
+            .then((c) => this.collection.set(c))
+            .catch(() => {});
+        }
       }
       // Active requests (only for users who would ever see the Demander
       // button — admins skip the round-trip).

--- a/client/src/app/features/media-detail/media-detail.unidentified.spec.ts
+++ b/client/src/app/features/media-detail/media-detail.unidentified.spec.ts
@@ -1,0 +1,185 @@
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { provideTranslateService, TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { vi, afterEach, describe, it, expect } from 'vitest';
+import { MediaDetailComponent } from './media-detail';
+import { MediaService, Media } from '../../core/services/api/media.service';
+import { MediaDetailReleasePickerService } from './media-detail-release-picker.service';
+import { AuthService } from '../../core/services/auth.service';
+import { ProfilesService } from '../../core/services/api/profiles.service';
+import { LibrariesApiService } from '../../core/services/api/libraries-api.service';
+import { NavbarService } from '../../core/services/navbar.service';
+import { BackgroundService } from '../../core/services/background.service';
+import { StreamingApiService } from '../../core/services/api/streaming-api.service';
+import { MarkersApiService } from '../../core/services/api/markers-api.service';
+import { RequestsService } from '../../core/services/api/requests.service';
+import { ConfirmationService } from '../../core/services/confirmation.service';
+import { ToastService } from '../../core/services/toast.service';
+import { SseService } from '../../core/services/sse.service';
+import { DownloadManagerService } from '../../core/services/download-manager.service';
+import { DownloadProgressService } from '../../core/services/download-progress.service';
+import { TvService } from '../../core/services/tv.service';
+import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
+import { AddToPlaylistService } from '../../core/services/add-to-playlist.service';
+import { RecommendService } from '../../core/services/recommend.service';
+import { LikesApiService } from '../../core/services/api/likes-api.service';
+import { ServerConfigService } from '../../core/services/server-config.service';
+
+const MEDIA_ID = 42;
+const PARAMS = { get: (k: string) => (k === 'id' ? String(MEDIA_ID) : null) };
+
+const BASE_MOVIE: Media = {
+  id: MEDIA_ID,
+  title: 'Test Movie',
+  originalTitle: 'Test Movie',
+  year: 2024,
+  type: 'movie',
+  tmdbId: 1,
+  overview: '',
+  status: 'released',
+  monitored: true,
+  posterUrl: null,
+  fanartUrl: null,
+  logoUrl: null,
+  additionalFanartUrls: [],
+  rating: 0,
+  runtime: 100,
+  files: [],
+};
+
+const UNIDENTIFIED_MOVIE: Media = {
+  ...BASE_MOVIE,
+  tmdbId: null,
+  tvdbId: null,
+  imdbId: null,
+};
+
+/** Only the admin-callout markup, so the test doesn't drag in the whole page's child tree. */
+const CALLOUT_TEMPLATE = `
+  @if (isAdmin() && unidentified()) {
+    <div class="unidentified-callout">
+      {{ 'media_detail.unidentified_callout' | translate }}
+      <button (click)="openIdentifyModal()">{{ 'media_detail.identify' | translate }}</button>
+    </div>
+  }
+`;
+
+function createHarness(media: Media, isAdmin: boolean) {
+  const getSimilar = vi.fn(async () => []);
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideTranslateService({
+        lang: 'en',
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+      }),
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          paramMap: of(PARAMS),
+          snapshot: {
+            data: { kind: 'movie' },
+            paramMap: PARAMS,
+            queryParamMap: { get: () => null },
+          },
+        },
+      },
+      { provide: Router, useValue: { navigate: vi.fn(), getCurrentNavigation: () => null } },
+      {
+        provide: MediaService,
+        useValue: {
+          getOne: vi.fn(async () => media),
+          getCast: vi.fn(async () => []),
+          getCrew: vi.fn(async () => []),
+          getSimilar,
+          getCollection: vi.fn(async () => null),
+        },
+      },
+      { provide: ServerConfigService, useValue: { resolveUrl: (u: string) => u } },
+      { provide: MediaDetailReleasePickerService, useValue: {} },
+      { provide: AuthService, useValue: { hasPermission: (p: string) => isAdmin && p === 'settings.access' } },
+      { provide: ProfilesService, useValue: {} },
+      { provide: LibrariesApiService, useValue: {} },
+      { provide: NavbarService, useValue: { enterHeroPage: vi.fn(), leaveHeroPage: vi.fn(), navigatedBack: signal(false) } },
+      { provide: BackgroundService, useValue: { clear: vi.fn(), setBackgrounds: vi.fn(), setBackground: vi.fn(), url: signal(null) } },
+      { provide: ConfirmationService, useValue: {} },
+      { provide: ToastService, useValue: { success: vi.fn(), error: vi.fn() } },
+      { provide: SseService, useValue: { lastEvent: signal(null) } },
+      {
+        provide: StreamingApiService,
+        useValue: {
+          getMediaResumeInfo: vi.fn(async () => null),
+          getWatchedEpisodeIds: vi.fn(async () => []),
+          getEpisodeProgress: vi.fn(async () => ({})),
+        },
+      },
+      { provide: MarkersApiService, useValue: {} },
+      { provide: RequestsService, useValue: {} },
+      { provide: DownloadManagerService, useValue: {} },
+      { provide: DownloadProgressService, useValue: { progress: signal(new Map()) } },
+      { provide: TvService, useValue: { isTv: () => false } },
+      { provide: ScrollMemoryService, useValue: { activate: vi.fn(), deactivate: vi.fn(), restoreSticky: vi.fn() } },
+      { provide: AddToPlaylistService, useValue: {} },
+      { provide: RecommendService, useValue: {} },
+      { provide: LikesApiService, useValue: { state: vi.fn(async () => ({ media: false, seasonIds: [], episodeIds: [] })) } },
+    ],
+  });
+
+  TestBed.overrideComponent(MediaDetailComponent, {
+    set: { template: CALLOUT_TEMPLATE, imports: [TranslateModule] },
+  });
+
+  const fixture = TestBed.createComponent(MediaDetailComponent);
+  const mediaService = TestBed.inject(MediaService) as unknown as {
+    getSimilar: ReturnType<typeof vi.fn>;
+  };
+  fixture.detectChanges();
+  return { fixture, mediaService, getSimilar };
+}
+
+describe('MediaDetailComponent, unidentified title', () => {
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('shows the callout to an admin on an unidentified title', async () => {
+    const { fixture } = createHarness(UNIDENTIFIED_MOVIE, true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.unidentified-callout')).not.toBeNull();
+  });
+
+  it('hides the callout from a non-admin viewer even on an unidentified title', async () => {
+    const { fixture } = createHarness(UNIDENTIFIED_MOVIE, false);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.unidentified-callout')).toBeNull();
+  });
+
+  it('hides the callout for an admin on an identified title', async () => {
+    const { fixture } = createHarness(BASE_MOVIE, true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.unidentified-callout')).toBeNull();
+  });
+
+  it('never calls getSimilar for an unidentified title', async () => {
+    const { fixture, getSimilar } = createHarness(UNIDENTIFIED_MOVIE, true);
+    await fixture.whenStable();
+
+    expect(getSimilar).not.toHaveBeenCalled();
+  });
+
+  it('calls getSimilar for an identified movie', async () => {
+    const { fixture, getSimilar } = createHarness(BASE_MOVIE, true);
+    await fixture.whenStable();
+
+    expect(getSimilar).toHaveBeenCalledWith(MEDIA_ID);
+  });
+});

--- a/client/src/app/features/settings/libraries/library-detail/library-media.html
+++ b/client/src/app/features/settings/libraries/library-detail/library-media.html
@@ -37,6 +37,17 @@
         <button type="button" class="btn btn-outline btn-sm" (click)="openScan()">
           {{ 'settings.libraries.scan_folder' | translate }}
         </button>
+        @if (unidentifiedCount() > 0) {
+          <button
+            type="button"
+            class="btn btn-outline btn-sm"
+            [class.btn-active]="unidentifiedOnly()"
+            (click)="toggleUnidentified()"
+          >
+            {{ 'settings.libraries.media_filter_unidentified' | translate }}
+            <span class="badge badge-sm">{{ unidentifiedCount() }}</span>
+          </button>
+        }
       </div>
       <div class="relative w-full max-w-xs">
         <svg lucideSearch class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-base-content/40 pointer-events-none z-10"></svg>

--- a/client/src/app/features/settings/libraries/library-detail/library-media.html
+++ b/client/src/app/features/settings/libraries/library-detail/library-media.html
@@ -37,7 +37,7 @@
         <button type="button" class="btn btn-outline btn-sm" (click)="openScan()">
           {{ 'settings.libraries.scan_folder' | translate }}
         </button>
-        @if (unidentifiedCount() > 0) {
+        @if (unidentifiedCount() > 0 || unidentifiedOnly()) {
           <button
             type="button"
             class="btn btn-outline btn-sm"

--- a/client/src/app/features/settings/libraries/library-detail/library-media.ts
+++ b/client/src/app/features/settings/libraries/library-detail/library-media.ts
@@ -51,6 +51,8 @@ export class LibraryMediaComponent implements OnInit {
   readonly search = signal('');
   readonly loading = signal(true);
   readonly loadError = signal(false);
+  readonly unidentifiedOnly = signal(false);
+  readonly unidentifiedCount = signal(0);
 
   private searchTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -80,21 +82,32 @@ export class LibraryMediaComponent implements OnInit {
     if (!silent) this.loading.set(true);
     this.loadError.set(false);
     try {
-      const res = await this.mediaService.getAll({
-        libraryId,
-        q: this.search().trim() || undefined,
-        page: this.page(),
-        limit: PAGE_SIZE,
-        sortBy: 'title',
-        sortOrder: 'ASC',
-      });
+      const [res, unidentified] = await Promise.all([
+        this.mediaService.getAll({
+          libraryId,
+          q: this.search().trim() || undefined,
+          page: this.page(),
+          limit: PAGE_SIZE,
+          sortBy: 'title',
+          sortOrder: 'ASC',
+          unidentified: this.unidentifiedOnly() || undefined,
+        }),
+        this.mediaService.getAll({ libraryId, unidentified: true, limit: 1 }),
+      ]);
       this.items.set(res.data);
       this.total.set(res.total);
+      this.unidentifiedCount.set(unidentified.total);
     } catch {
       this.loadError.set(true);
     } finally {
       this.loading.set(false);
     }
+  }
+
+  toggleUnidentified() {
+    this.unidentifiedOnly.update((v) => !v);
+    this.page.set(1);
+    void this.load();
   }
 
   onSearch(value: string) {

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -23,6 +23,7 @@ import { PlayableMediaService } from '../../../core/services/playable-media.serv
 import { NavbarService } from '../../../core/services/navbar.service';
 import { PluginUiRegistryService } from '../../../core/plugin-ui/plugin-ui-registry.service';
 import { evaluateWhen, type WhenContext } from '../../../core/plugin-ui/when-evaluator';
+import { hasProviderId } from '../../../core/utils/media-identity';
 import type { UiContribution } from '@fliks/plugin-contract/ui';
 import { CORE_MEDIA_ACTIONS, sectionOf } from '../media-info-header/core-media-actions';
 import { resolveMenuContributions } from '../../../core/plugin-ui/resolve-menu-contributions';
@@ -438,6 +439,7 @@ export class MediaCardComponent {
     isMonitored: this.media()?.monitored,
     hasQualityProfile: !!this.media()?.qualityProfile,
     isEpisode: this.playlistEpisodeId() != null,
+    identified: !this.media() || hasProviderId(this.media()!),
     isTv: this.tv.isTv(),
     isTouch: this.device.isTouch(),
     surface: 'card',

--- a/client/src/app/shared/components/media-info-header/core-media-actions.ts
+++ b/client/src/app/shared/components/media-info-header/core-media-actions.ts
@@ -118,7 +118,7 @@ export const CORE_MEDIA_ACTIONS: readonly UiContribution[] = [
       weight: 20,
       labelKey: 'media_detail.refresh_metadata',
       icon: 'rotate-ccw',
-      when: ['isAdmin'],
+      when: ['isAdmin', 'identified'],
       action: { kind: 'action', actionId: 'media.refresh-metadata' },
     },
     ],

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -256,6 +256,9 @@ export class MediaInfoHeaderComponent {
    *  openDownloadDetail. */
   readonly badge = input<MediaInfoHeaderBadge | null>(null);
 
+  /** False when the title has no metadata-provider id; gates the refresh-metadata action. */
+  readonly identified = input(true);
+
   protected badgeLabel(b: MediaInfoHeaderBadge): string {
     return this.translate.instant(b.labelKey, b.labelParams ?? undefined);
   }
@@ -649,6 +652,7 @@ export class MediaInfoHeaderComponent {
     isMonitored: this.monitored(),
     hasQualityProfile: !!this.qualityProfileName(),
     isEpisode: !!this.episodeId(),
+    identified: this.identified(),
     isTv: this.tv.isTv(),
     isTouch: this.device.isTouch(),
     surface: 'detail',


### PR DESCRIPTION
## Why

Titles with no provider id (#1264, #1265) show up in the library like any other, but the page still behaved as if a provider had filled it: it fetched cast, similar titles and collections that cannot exist, offered "Refresh metadata" (which throws with no id), and gave an admin no quick way to find and identify these titles. Phase 3 of `plan/local-media-without-metadata.md`.

## What

- **Detail page**: admin-only callout "this title is not identified, the information comes from the file" with the existing Identify action as its button. Provider-derived loads (cast, crew, similar, collection) are skipped for such a title. Runtime falls back to the file's probed duration when the row has none.
- **Actions**: new `identified` predicate in the plugin-ui `when` evaluator (additive to the contract union, defaults to `true` for surfaces that do not set it); `core.refresh_metadata` requires it on the detail header (movie, series and episode modes) and on the card menu.
- **Library Media tab**: "Unidentified" toggle with a count badge, backed by a new `unidentified` filter on `GET /media` (`tmdbId`, `tvdbId` and `imdbId` all null).
- Viewers see the title, year, files, playback and the placeholder poster; nothing else is claimed.

## Verification

- Backend: `tsc` clean; `jest src/modules/media` 15 suites / 70 tests, incl. the `unidentified` clause in `media-query.applyfilters.spec.ts`.
- Client: `ng build` clean; media-detail, when-evaluator, media-card, orphan-scan-panel specs: 10 files / 100 tests, incl. `media-detail.unidentified.spec.ts` (callout shown for admin only, `getSimilar` not called).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
