### PR TITLE
test: use neutral placeholder titles in specs

### DIFF
--- a/backend/src/modules/imports/disk-import.matching.spec.ts
+++ b/backend/src/modules/imports/disk-import.matching.spec.ts
@@ -10,38 +10,38 @@ describe('disk scan — matching a filename to a library title', () => {
   // Callers hand over the output of extractTitle, which has already turned
   // dots and underscores into spaces.
   it('ignores case, punctuation and repeated spaces', () => {
-    const rows = [media('The Long Voyage')];
-    expect(matchMedia('the long voyage', rows)?.title).toBe('The Long Voyage');
-    expect(matchMedia('The  Long   Voyage!', rows)?.title).toBe('The Long Voyage');
+    const rows = [media('Sample Movie')];
+    expect(matchMedia('sample movie', rows)?.title).toBe('Sample Movie');
+    expect(matchMedia('Sample  Movie!', rows)?.title).toBe('Sample Movie');
   });
 
   it('matches the original title too', () => {
-    const rows = [media('The Long Voyage', 'Le Long Voyage')];
-    expect(matchMedia('le long voyage', rows)?.title).toBe('The Long Voyage');
+    const rows = [media('Sample Movie', 'Sample Movie Original')];
+    expect(matchMedia('sample movie original', rows)?.title).toBe('Sample Movie');
   });
 
   it('accepts a filename carrying trailing noise', () => {
-    const rows = [media('The Long Voyage')];
-    expect(matchMedia('the long voyage 2011', rows)?.title).toBe('The Long Voyage');
+    const rows = [media('Sample Movie')];
+    expect(matchMedia('sample movie 2011', rows)?.title).toBe('Sample Movie');
   });
 
   it('accepts a truncated filename against a longer library title', () => {
-    expect(matchMedia('voy', [media('Voyager')])?.title).toBe('Voyager');
+    expect(matchMedia('epi', [media('Episode')])?.title).toBe('Episode');
   });
 
   it('refuses to let a two-letter library title absorb a shorter fragment', () => {
     // The length guard sits on the library title, not on the filename.
-    expect(matchMedia('v', [media('Vo')])).toBeNull();
-    expect(matchMedia('v', [media('Voy')])?.title).toBe('Voy');
+    expect(matchMedia('e', [media('Ep')])).toBeNull();
+    expect(matchMedia('e', [media('Epi')])?.title).toBe('Epi');
   });
 
   it('prefers an exact hit over a prefix one, whatever the order', () => {
-    const rows = [media('Voyager'), media('Voy')];
-    expect(matchMedia('voy', rows)?.title).toBe('Voy');
+    const rows = [media('Episode'), media('Epi')];
+    expect(matchMedia('epi', rows)?.title).toBe('Epi');
   });
 
   it('returns null on an empty target or no candidate', () => {
-    expect(matchMedia('', [media('Voyager')])).toBeNull();
-    expect(matchMedia('something else', [media('Voyager')])).toBeNull();
+    expect(matchMedia('', [media('Episode')])).toBeNull();
+    expect(matchMedia('something else', [media('Episode')])).toBeNull();
   });
 });

--- a/backend/src/modules/imports/disk-import.orphan-scan.spec.ts
+++ b/backend/src/modules/imports/disk-import.orphan-scan.spec.ts
@@ -7,27 +7,27 @@ import { NfoMetadataService } from './nfo-metadata.service';
 import { NamingService } from '../scheduler/naming.service';
 import { MediaType } from '../../common/enums';
 
-const TVSHOW_NFO = `<tvshow><title>Northern Lights</title><year>2011</year>
+const TVSHOW_NFO = `<tvshow><title>Sample Show</title><year>2011</year>
 <uniqueid type="tmdb">4242</uniqueid></tvshow>`;
 
 async function buildTree(): Promise<string> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'orphan-scan-'));
-  const show = path.join(root, 'Northern Lights');
+  const show = path.join(root, 'Sample Show');
   await fs.mkdir(path.join(show, 'Season 01'), { recursive: true });
   await fs.writeFile(path.join(show, 'tvshow.nfo'), TVSHOW_NFO);
   for (const ep of ['S01E01', 'S01E02', 'S01E03']) {
     await fs.writeFile(
-      path.join(show, 'Season 01', `Northern.Lights.${ep}.1080p.mkv`),
+      path.join(show, 'Season 01', `Sample.Show.${ep}.1080p.mkv`),
       'x',
     );
   }
   await fs.writeFile(
-    path.join(show, 'Season 01', 'Northern.Lights.Special.1080p.mkv'),
+    path.join(show, 'Season 01', 'Sample.Show.Special.1080p.mkv'),
     'x',
   );
-  const movie = path.join(root, 'Quiet Harbour (2009)');
+  const movie = path.join(root, 'Sample Movie (2009)');
   await fs.mkdir(movie, { recursive: true });
-  await fs.writeFile(path.join(movie, 'Quiet.Harbour.2009.1080p.mkv'), 'x');
+  await fs.writeFile(path.join(movie, 'Sample.Movie.2009.1080p.mkv'), 'x');
   await fs.writeFile(path.join(root, 'stray.mkv'), 'x');
   return root;
 }
@@ -77,11 +77,11 @@ describe('orphan scan', () => {
     expect(res.looseFiles.map((f) => f.filename)).toEqual(['stray.mkv']);
 
     const series = res.groups.find((g) => g.mediaType === MediaType.SERIES);
-    expect(series?.folderName).toBe('Northern Lights');
+    expect(series?.folderName).toBe('Sample Show');
     // The special has no SxxEyy but is still a file of this show.
     expect(series?.files).toHaveLength(4);
     // Show-level .nfo wins over the filename guess for the whole group.
-    expect(series?.guessTitle).toBe('Northern Lights');
+    expect(series?.guessTitle).toBe('Sample Show');
     expect(series?.nfo?.tmdbId).toBe(4242);
 
     const movie = res.groups.find((g) => g.mediaType === MediaType.MOVIE);

--- a/backend/src/modules/imports/disk-import.unmatched.spec.ts
+++ b/backend/src/modules/imports/disk-import.unmatched.spec.ts
@@ -18,10 +18,10 @@ const dto = (overrides: Partial<RelinkOrphansDto> = {}): RelinkOrphansDto =>
   ({
     libraryId: 1,
     type: MediaType.MOVIE,
-    folderName: 'Quiet Harbour (2009)',
-    title: 'Quiet Harbour',
+    folderName: 'Sample Movie (2009)',
+    title: 'Sample Movie',
     year: 2009,
-    files: [{ filePath: '/media/Quiet Harbour (2009)/Quiet.Harbour.2009.1080p.mkv' }],
+    files: [{ filePath: '/media/Sample Movie (2009)/Sample.Movie.2009.1080p.mkv' }],
     ...overrides,
   }) as RelinkOrphansDto;
 
@@ -81,9 +81,9 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     const { service, mediaRepo, mediaService, nfo } = makeService();
     mediaRepo.findOne
       .mockResolvedValueOnce(null) // no existing unmatched row for this folder
-      .mockResolvedValueOnce(unmatchedRow(42, 'Quiet Harbour (2009)')); // reload
+      .mockResolvedValueOnce(unmatchedRow(42, 'Sample Movie (2009)')); // reload
     nfo.readForVideoFile.mockResolvedValue({ plot: 'A harbour tale.' });
-    mockedFindLocalArtwork.mockResolvedValue({ poster: '/media/Quiet Harbour (2009)/poster.jpg' });
+    mockedFindLocalArtwork.mockResolvedValue({ poster: '/media/Sample Movie (2009)/poster.jpg' });
     mediaService.createUnmatched.mockResolvedValue({ id: 42 });
     mediaService.linkExistingFileInPlace.mockResolvedValue({
       fileId: 1,
@@ -94,21 +94,21 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     const res = await service.relinkOrphans(dto(), null);
 
     expect(nfo.readForVideoFile).toHaveBeenCalledWith(
-      '/media/Quiet Harbour (2009)/Quiet.Harbour.2009.1080p.mkv',
+      '/media/Sample Movie (2009)/Sample.Movie.2009.1080p.mkv',
     );
     expect(mockedFindLocalArtwork).toHaveBeenCalledWith(
-      '/media/Quiet Harbour (2009)',
-      'Quiet.Harbour.2009.1080p',
+      '/media/Sample Movie (2009)',
+      'Sample.Movie.2009.1080p',
     );
     expect(mediaService.createUnmatched).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: 'Quiet Harbour',
+        title: 'Sample Movie',
         year: 2009,
         type: MediaType.MOVIE,
         libraryId: 1,
-        folderName: 'Quiet Harbour (2009)',
+        folderName: 'Sample Movie (2009)',
         nfo: { plot: 'A harbour tale.' },
-        artwork: { poster: '/media/Quiet Harbour (2009)/poster.jpg' },
+        artwork: { poster: '/media/Sample Movie (2009)/poster.jpg' },
       }),
       null,
     );
@@ -121,11 +121,11 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     const { service, mediaRepo, mediaService } = makeService();
     const seriesDto = dto({
       type: MediaType.SERIES,
-      folderName: 'Northern Lights',
-      title: 'Northern Lights',
+      folderName: 'Sample Show',
+      title: 'Sample Show',
       files: [
         {
-          filePath: '/media/Northern Lights/Season 01/Northern.Lights.S01E01.mkv',
+          filePath: '/media/Sample Show/Season 01/Sample.Show.S01E01.mkv',
           seasonNumber: 1,
           episodeNumber: 1,
         },
@@ -133,7 +133,7 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     });
     mediaRepo.findOne
       .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(unmatchedRow(8, 'Northern Lights', MediaType.SERIES));
+      .mockResolvedValueOnce(unmatchedRow(8, 'Sample Show', MediaType.SERIES));
     mediaService.createUnmatched.mockResolvedValue({ id: 8 });
     mediaService.linkExistingFileInPlace.mockResolvedValue({
       fileId: 1,
@@ -144,7 +144,7 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     await service.relinkOrphans(seriesDto, null);
 
     expect(mockedFindLocalArtwork).toHaveBeenCalledWith(
-      '/media/Northern Lights',
+      '/media/Sample Show',
       undefined,
     );
   });
@@ -153,11 +153,11 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     const { service, mediaRepo, mediaService, nfo } = makeService();
     const seriesDto = dto({
       type: MediaType.SERIES,
-      folderName: 'Northern Lights',
-      title: 'Northern Lights',
+      folderName: 'Sample Show',
+      title: 'Sample Show',
       files: [
         {
-          filePath: '/media/Northern Lights/Season 01/Northern.Lights.S01E01.mkv',
+          filePath: '/media/Sample Show/Season 01/Sample.Show.S01E01.mkv',
           seasonNumber: 1,
           episodeNumber: 1,
         },
@@ -165,8 +165,8 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     });
     mediaRepo.findOne
       .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(unmatchedRow(9, 'Northern Lights', MediaType.SERIES));
-    nfo.readNfoFile.mockResolvedValue({ title: 'Northern Lights Show' });
+      .mockResolvedValueOnce(unmatchedRow(9, 'Sample Show', MediaType.SERIES));
+    nfo.readNfoFile.mockResolvedValue({ title: 'Sample Show Extended' });
     mediaService.createUnmatched.mockResolvedValue({ id: 9 });
     mediaService.linkExistingFileInPlace.mockResolvedValue({
       fileId: 1,
@@ -176,10 +176,10 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
 
     await service.relinkOrphans(seriesDto, null);
 
-    expect(nfo.readNfoFile).toHaveBeenCalledWith('/media/Northern Lights/tvshow.nfo');
+    expect(nfo.readNfoFile).toHaveBeenCalledWith('/media/Sample Show/tvshow.nfo');
     expect(nfo.readForVideoFile).not.toHaveBeenCalled();
     expect(mediaService.createUnmatched).toHaveBeenCalledWith(
-      expect.objectContaining({ nfo: { title: 'Northern Lights Show' } }),
+      expect.objectContaining({ nfo: { title: 'Sample Show Extended' } }),
       null,
     );
   });
@@ -188,11 +188,11 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     const { service, mediaRepo, mediaService, nfo } = makeService();
     const seriesDto = dto({
       type: MediaType.SERIES,
-      folderName: 'Northern Lights',
-      title: 'Northern Lights',
+      folderName: 'Sample Show',
+      title: 'Sample Show',
       files: [
         {
-          filePath: '/media/Northern Lights/Season 01/Northern.Lights.S01E01.mkv',
+          filePath: '/media/Sample Show/Season 01/Sample.Show.S01E01.mkv',
           seasonNumber: 1,
           episodeNumber: 1,
         },
@@ -200,7 +200,7 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     });
     mediaRepo.findOne
       .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(unmatchedRow(9, 'Northern Lights', MediaType.SERIES));
+      .mockResolvedValueOnce(unmatchedRow(9, 'Sample Show', MediaType.SERIES));
     nfo.readNfoFile.mockResolvedValue(null);
     nfo.readForVideoFile.mockResolvedValue({ title: 'Episode-derived title' });
     mediaService.createUnmatched.mockResolvedValue({ id: 9 });
@@ -213,7 +213,7 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     await service.relinkOrphans(seriesDto, null);
 
     expect(nfo.readForVideoFile).toHaveBeenCalledWith(
-      '/media/Northern Lights/Season 01/Northern.Lights.S01E01.mkv',
+      '/media/Sample Show/Season 01/Sample.Show.S01E01.mkv',
     );
     expect(mediaService.createUnmatched).toHaveBeenCalledWith(
       expect.objectContaining({ nfo: { title: 'Episode-derived title' } }),
@@ -225,7 +225,7 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     const { service, mediaRepo, mediaService } = makeService();
     mediaRepo.findOne.mockResolvedValueOnce(null);
     const outsideDto = dto({
-      files: [{ filePath: '/etc/Quiet.Harbour.2009.1080p.mkv' }],
+      files: [{ filePath: '/etc/Sample.Movie.2009.1080p.mkv' }],
     });
 
     await expect(service.relinkOrphans(outsideDto, null)).rejects.toThrow(
@@ -243,7 +243,7 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
       type: MediaType.SERIES,
       folderName: '../../etc',
       files: [
-        { filePath: '/media/Northern Lights/Season 01/Escape.S01E01.mkv' },
+        { filePath: '/media/Sample Show/Season 01/Escape.S01E01.mkv' },
       ],
     });
 
@@ -256,7 +256,7 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
   it('reuses the unmatched row already pinned to the same folder on a second scan', async () => {
     const { service, mediaRepo, mediaService, nfo } = makeService();
     mediaRepo.findOne.mockResolvedValueOnce(
-      unmatchedRow(42, 'Quiet Harbour (2009)'),
+      unmatchedRow(42, 'Sample Movie (2009)'),
     );
     mediaService.linkExistingFileInPlace.mockResolvedValue({
       fileId: 2,
@@ -284,12 +284,12 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     const { service, mediaRepo, mediaService, metadata } = makeService();
     const seriesDto = dto({
       type: MediaType.SERIES,
-      folderName: 'Northern Lights',
-      title: 'Northern Lights',
+      folderName: 'Sample Show',
+      title: 'Sample Show',
       year: 2011,
       files: [
         {
-          filePath: '/media/Northern Lights/Northern.Lights.S01E01.mkv',
+          filePath: '/media/Sample Show/Sample.Show.S01E01.mkv',
           seasonNumber: 1,
           episodeNumber: 1,
         },
@@ -297,7 +297,7 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     });
     mediaRepo.findOne
       .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(unmatchedRow(7, 'Northern Lights', MediaType.SERIES));
+      .mockResolvedValueOnce(unmatchedRow(7, 'Sample Show', MediaType.SERIES));
     mediaService.createUnmatched.mockResolvedValue({ id: 7 });
     // A slot is invented for the file, which would normally trigger the backfill.
     mediaService.linkExistingFileInPlace.mockResolvedValue({

--- a/backend/src/modules/imports/local-artwork.util.spec.ts
+++ b/backend/src/modules/imports/local-artwork.util.spec.ts
@@ -15,11 +15,11 @@ describe('findLocalArtwork', () => {
   });
 
   it('prefers the basename-prefixed poster over a generic one', async () => {
-    writeFileSync(join(dir, 'Quiet Harbour-poster.jpg'), '');
+    writeFileSync(join(dir, 'Sample Movie-poster.jpg'), '');
     writeFileSync(join(dir, 'poster.jpg'), '');
 
-    const out = await findLocalArtwork(dir, 'Quiet Harbour');
-    expect(out.poster).toBe(join(dir, 'Quiet Harbour-poster.jpg'));
+    const out = await findLocalArtwork(dir, 'Sample Movie');
+    expect(out.poster).toBe(join(dir, 'Sample Movie-poster.jpg'));
   });
 
   it('falls back through folder, cover, movie in order', async () => {

--- a/backend/src/modules/imports/nfo-metadata.service.spec.ts
+++ b/backend/src/modules/imports/nfo-metadata.service.spec.ts
@@ -6,8 +6,8 @@ describe('NfoMetadataService.parse', () => {
   it('reads every field from a full Kodi movie NFO', () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <movie>
-  <title>Quiet Harbour</title>
-  <originaltitle>Quiet Harbour Original</originaltitle>
+  <title>Sample Movie</title>
+  <originaltitle>Sample Movie Original</originaltitle>
   <year>2009</year>
   <plot>A long plot about a harbour.</plot>
   <outline>Short outline.</outline>
@@ -32,8 +32,8 @@ describe('NfoMetadataService.parse', () => {
     const out = service.parse(xml);
 
     expect(out).toMatchObject({
-      title: 'Quiet Harbour',
-      originalTitle: 'Quiet Harbour Original',
+      title: 'Sample Movie',
+      originalTitle: 'Sample Movie Original',
       year: 2009,
       plot: 'A long plot about a harbour.',
       genres: ['Drama', 'Mystery'],
@@ -52,7 +52,7 @@ describe('NfoMetadataService.parse', () => {
 
   it('reads a tvshow.nfo with showtitle and an <id> tvdb id', () => {
     const xml = `<tvshow>
-  <showtitle>Salt Meadow</showtitle>
+  <showtitle>Sample Show</showtitle>
   <year>2015</year>
   <genre>Comedy</genre>
   <id>556677</id>
@@ -60,7 +60,7 @@ describe('NfoMetadataService.parse', () => {
 
     const out = service.parse(xml);
     expect(out).toMatchObject({
-      title: 'Salt Meadow',
+      title: 'Sample Show',
       year: 2015,
       genres: ['Comedy'],
       tvdbId: 556677,

--- a/backend/src/modules/media/media-service/media-import.createunmatched.spec.ts
+++ b/backend/src/modules/media/media-service/media-import.createunmatched.spec.ts
@@ -14,7 +14,7 @@ describe('MediaImportService.createUnmatched', () => {
       update: jest.fn(async (id: number, m: any) => {
         updates.push({ id, ...m });
       }),
-      findOne: jest.fn().mockResolvedValue({ id: 1, title: 'Quiet Harbour' }),
+      findOne: jest.fn().mockResolvedValue({ id: 1, title: 'Sample Movie' }),
     };
     const emitDomain = jest.fn();
     const svc = new MediaImportService(
@@ -43,16 +43,16 @@ describe('MediaImportService.createUnmatched', () => {
   it('creates an unmonitored, released title with no provider id', async () => {
     const { svc, saved, emitDomain } = makeService();
     const media = await svc.createUnmatched({
-      title: 'Quiet Harbour',
+      title: 'Sample Movie',
       year: 2009,
       type: MediaType.MOVIE,
       libraryId: 3,
-      folderName: 'Quiet Harbour (2009)',
+      folderName: 'Sample Movie (2009)',
     });
 
     expect(saved[0]).toMatchObject({
-      title: 'Quiet Harbour',
-      originalTitle: 'Quiet Harbour',
+      title: 'Sample Movie',
+      originalTitle: 'Sample Movie',
       monitored: false,
       status: MediaStatus.RELEASED,
     });
@@ -72,13 +72,13 @@ describe('MediaImportService.createUnmatched', () => {
   it('fills empty fields from the nfo but never overrides a real title', async () => {
     const { svc, saved } = makeService();
     await svc.createUnmatched({
-      title: 'Salt Meadow',
+      title: 'Sample Movie 2',
       type: MediaType.MOVIE,
       libraryId: 3,
-      folderName: 'Salt Meadow (2011)',
+      folderName: 'Sample Movie 2 (2011)',
       nfo: {
-        title: 'Salt Meadow Extended',
-        originalTitle: 'Salt Meadow Original',
+        title: 'Sample Movie 2 Extended',
+        originalTitle: 'Sample Movie 2 Original',
         year: 2011,
         plot: 'A tale of a meadow.',
         genres: ['Drama'],
@@ -89,8 +89,8 @@ describe('MediaImportService.createUnmatched', () => {
     });
 
     expect(saved[0]).toMatchObject({
-      title: 'Salt Meadow',
-      originalTitle: 'Salt Meadow Original',
+      title: 'Sample Movie 2',
+      originalTitle: 'Sample Movie 2 Original',
       year: 2011,
       overview: 'A tale of a meadow.',
       genres: ['Drama'],
@@ -103,15 +103,15 @@ describe('MediaImportService.createUnmatched', () => {
   it('uses the nfo title when the guess is just the folder name', async () => {
     const { svc, saved } = makeService();
     await svc.createUnmatched({
-      title: 'Salt Meadow (2011)',
+      title: 'Sample Movie 2 (2011)',
       type: MediaType.MOVIE,
       libraryId: 3,
-      folderName: 'Salt Meadow (2011)',
-      nfo: { title: 'Salt Meadow' },
+      folderName: 'Sample Movie 2 (2011)',
+      nfo: { title: 'Sample Movie 2' },
     });
 
-    expect(saved[0].title).toBe('Salt Meadow');
-    expect(saved[0].originalTitle).toBe('Salt Meadow');
+    expect(saved[0].title).toBe('Sample Movie 2');
+    expect(saved[0].originalTitle).toBe('Sample Movie 2');
   });
 
   it('stores sibling artwork and writes the local image urls', async () => {
@@ -122,21 +122,21 @@ describe('MediaImportService.createUnmatched', () => {
       );
     const { svc, updates } = makeService({ storeFromDisk });
     await svc.createUnmatched({
-      title: 'Quiet Harbour',
+      title: 'Sample Movie',
       type: MediaType.MOVIE,
       libraryId: 3,
-      folderName: 'Quiet Harbour (2009)',
-      artwork: { poster: '/media/Quiet Harbour (2009)/poster.jpg', fanart: '/media/Quiet Harbour (2009)/fanart.jpg' },
+      folderName: 'Sample Movie (2009)',
+      artwork: { poster: '/media/Sample Movie (2009)/poster.jpg', fanart: '/media/Sample Movie (2009)/fanart.jpg' },
     });
 
     expect(storeFromDisk).toHaveBeenCalledWith(
-      '/media/Quiet Harbour (2009)/poster.jpg',
+      '/media/Sample Movie (2009)/poster.jpg',
       'media',
       1,
       'poster',
     );
     expect(storeFromDisk).toHaveBeenCalledWith(
-      '/media/Quiet Harbour (2009)/fanart.jpg',
+      '/media/Sample Movie (2009)/fanart.jpg',
       'media',
       1,
       'fanart',
@@ -154,11 +154,11 @@ describe('MediaImportService.createUnmatched', () => {
 
     await expect(
       svc.createUnmatched({
-        title: 'Quiet Harbour',
+        title: 'Sample Movie',
         type: MediaType.MOVIE,
         libraryId: 3,
-        folderName: 'Quiet Harbour (2009)',
-        artwork: { poster: '/media/Quiet Harbour (2009)/poster.jpg' },
+        folderName: 'Sample Movie (2009)',
+        artwork: { poster: '/media/Sample Movie (2009)/poster.jpg' },
       }),
     ).resolves.toBeDefined();
     expect(saved).toHaveLength(1);

--- a/backend/src/modules/media/media-service/media-metadata.resolve-provider.spec.ts
+++ b/backend/src/modules/media/media-service/media-metadata.resolve-provider.spec.ts
@@ -31,7 +31,7 @@ describe('MediaMetadataService.resolveProviderForMedia, imdb-only fallback', () 
     const { service, mediaRepo, tmdb } = harness();
     const media = {
       id: 5,
-      title: 'Quiet Harbour',
+      title: 'Sample Movie',
       tmdbId: null,
       tvdbId: null,
       imdbId: 'tt1234567',

--- a/backend/src/modules/scheduler/scheduler.service.spec.ts
+++ b/backend/src/modules/scheduler/scheduler.service.spec.ts
@@ -111,7 +111,7 @@ function makeMetadataService(
 function unidentifiedMedia(id: number) {
   return {
     id,
-    title: 'Unnamed Reel',
+    title: 'Sample Movie',
     type: MediaType.MOVIE,
     status: MediaStatus.RELEASED,
     tmdbId: null,
@@ -128,7 +128,7 @@ function unidentifiedMedia(id: number) {
 function identifiedMedia(id: number) {
   return {
     ...unidentifiedMedia(id),
-    title: 'Quiet Harbour',
+    title: 'Sample Movie 2',
     tmdbId: 42,
   };
 }

--- a/backend/src/modules/subtitles/providers/opensubtitles.provider.spec.ts
+++ b/backend/src/modules/subtitles/providers/opensubtitles.provider.spec.ts
@@ -24,15 +24,15 @@ describe('OpenSubtitlesProvider.search', () => {
   });
 
   it('sends the title as a free-text query when hash and ids are absent', async () => {
-    await provider().search({ title: 'Quiet Harbour', year: 2020, language: 'en' });
+    await provider().search({ title: 'Sample Movie', year: 2020, language: 'en' });
 
     const url = new URL(mockedFetch.mock.calls[0][1] as string);
-    expect(url.searchParams.get('query')).toBe('Quiet Harbour');
+    expect(url.searchParams.get('query')).toBe('Sample Movie');
     expect(url.searchParams.get('year')).toBe('2020');
   });
 
   it('does not send the title when a tmdbId is present', async () => {
-    await provider().search({ title: 'Quiet Harbour', tmdbId: 42, language: 'en' });
+    await provider().search({ title: 'Sample Movie', tmdbId: 42, language: 'en' });
 
     const url = new URL(mockedFetch.mock.calls[0][1] as string);
     expect(url.searchParams.has('query')).toBe(false);

--- a/backend/src/modules/subtitles/providers/subdl.provider.spec.ts
+++ b/backend/src/modules/subtitles/providers/subdl.provider.spec.ts
@@ -23,26 +23,26 @@ describe('SubdlProvider.search', () => {
   });
 
   it('sends the title as film_name when hash and ids are absent', async () => {
-    await provider().search({ title: 'Quiet Harbour', year: 2020, language: 'en' });
+    await provider().search({ title: 'Sample Movie', year: 2020, language: 'en' });
 
     const url = new URL(mockedFetch.mock.calls[0][1] as string);
-    expect(url.searchParams.get('film_name')).toBe('Quiet Harbour');
+    expect(url.searchParams.get('film_name')).toBe('Sample Movie');
     expect(url.searchParams.get('year')).toBe('2020');
   });
 
   it('sends film_name even when a moviehash is present, Subdl has no hash search', async () => {
     await provider().search({
-      title: 'Quiet Harbour',
+      title: 'Sample Movie',
       moviehash: 'deadbeefcafebabe',
       language: 'en',
     });
 
     const url = new URL(mockedFetch.mock.calls[0][1] as string);
-    expect(url.searchParams.get('film_name')).toBe('Quiet Harbour');
+    expect(url.searchParams.get('film_name')).toBe('Sample Movie');
   });
 
   it('does not send the title when a tmdbId is present', async () => {
-    await provider().search({ title: 'Quiet Harbour', tmdbId: 42, language: 'en' });
+    await provider().search({ title: 'Sample Movie', tmdbId: 42, language: 'en' });
 
     const url = new URL(mockedFetch.mock.calls[0][1] as string);
     expect(url.searchParams.has('film_name')).toBe(false);


### PR DESCRIPTION
## Why

Repo rule: no movie or show titles in source artefacts, invented film-sounding ones included. The specs added for the unidentified-titles work (#1263, #1264, #1265) and one older matching spec used such names.

## What

Renames the fixtures to neutral placeholders (`Sample Movie`, `Sample Show`, `sample.movie.2009.1080p.mkv`, ...) keeping every relation the assertions rely on (folder name equals title, distinct titles stay distinct, the matcher length-guard cases keep their character counts). No logic change.

## Verification

`jest src/modules/imports src/modules/media src/modules/scheduler src/modules/subtitles` green; grep for the old names over `backend/src` and `client/src` prints nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
