### PR TITLE
feat(libraries): link movie files that sit directly under the library root

### DIFF
--- a/backend/src/common/library-ingest/library-ingest.service.spec.ts
+++ b/backend/src/common/library-ingest/library-ingest.service.spec.ts
@@ -233,4 +233,23 @@ describe('LibraryIngestService.ingest', () => {
     expect(result.imported[0].file.relativePath).toContain('S00E02');
     expect(h.episodeRepo.update).toHaveBeenCalledWith(9002, { hasFile: true });
   });
+
+  it('refuses to place a grabbed file at the library root when the media has no folder of its own', async () => {
+    const h = buildHarness();
+    const srcFile = path.join(srcDir, 'Quiet.Harbor.2020.mkv');
+    fs.writeFileSync(srcFile, 'x');
+
+    const media = buildMovie({ id: 9, folderName: '', path: '/library/movies' });
+    h.mediaRepo.findOne.mockResolvedValue(media);
+
+    await expect(
+      h.service.ingest({
+        mediaId: 9,
+        files: [{ path: srcFile }],
+        transfer: 'copy',
+        fallbackQuality: 'WEBDL-1080p',
+        sourceLabel: 'Quiet Harbor',
+      }),
+    ).rejects.toThrow('has no folder of its own');
+  });
 });

--- a/backend/src/common/library-ingest/library-ingest.service.spec.ts
+++ b/backend/src/common/library-ingest/library-ingest.service.spec.ts
@@ -236,7 +236,7 @@ describe('LibraryIngestService.ingest', () => {
 
   it('refuses to place a grabbed file at the library root when the media has no folder of its own', async () => {
     const h = buildHarness();
-    const srcFile = path.join(srcDir, 'Quiet.Harbor.2020.mkv');
+    const srcFile = path.join(srcDir, 'sample.movie.2001.1080p.mkv');
     fs.writeFileSync(srcFile, 'x');
 
     const media = buildMovie({ id: 9, folderName: '', path: '/library/movies' });
@@ -248,7 +248,7 @@ describe('LibraryIngestService.ingest', () => {
         files: [{ path: srcFile }],
         transfer: 'copy',
         fallbackQuality: 'WEBDL-1080p',
-        sourceLabel: 'Quiet Harbor',
+        sourceLabel: 'Sample Movie',
       }),
     ).rejects.toThrow('has no folder of its own');
   });

--- a/backend/src/common/library-ingest/library-ingest.service.ts
+++ b/backend/src/common/library-ingest/library-ingest.service.ts
@@ -90,6 +90,13 @@ export class LibraryIngestService {
         `Media #${req.mediaId} is not anchored to a library folder`,
       );
     }
+    // A grab must never land loose files at the library root: `media.path`
+    // falls back to it when `folderName` is empty.
+    if (!media.folderName) {
+      throw new Error(
+        `Media #${req.mediaId} has no folder of its own, refusing to place files at the library root`,
+      );
+    }
     if (!req.files.length) return { imported: [], alreadyPresent: [] };
 
     // A series release carrying several video files is a season pack: every file

--- a/backend/src/modules/imports/disk-import.orphan-scan.spec.ts
+++ b/backend/src/modules/imports/disk-import.orphan-scan.spec.ts
@@ -85,7 +85,7 @@ describe('orphan scan', () => {
     expect(series?.nfo?.tmdbId).toBe(4242);
 
     const movie = res.groups.find(
-      (g) => g.mediaType === MediaType.MOVIE && g.folderName === 'Quiet Harbour (2009)',
+      (g) => g.mediaType === MediaType.MOVIE && g.folderName === 'Sample Movie (2009)',
     );
     expect(movie?.files).toHaveLength(1);
     expect(movie?.guessYear).toBe(2009);

--- a/backend/src/modules/imports/disk-import.orphan-scan.spec.ts
+++ b/backend/src/modules/imports/disk-import.orphan-scan.spec.ts
@@ -117,7 +117,7 @@ describe('orphan scan', () => {
     const seriesRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'orphan-scan-series-root-'));
     try {
       await fs.writeFile(
-        path.join(seriesRoot, 'Northern.Lights.S01E01.1080p.mkv'),
+        path.join(seriesRoot, 'Sample.Show.S01E01.1080p.mkv'),
         'x',
       );
       const res = await service.previewOrphans({ path: seriesRoot });

--- a/backend/src/modules/imports/disk-import.orphan-scan.spec.ts
+++ b/backend/src/modules/imports/disk-import.orphan-scan.spec.ts
@@ -69,12 +69,12 @@ describe('orphan scan', () => {
     await fs.rm(root, { recursive: true, force: true });
   });
 
-  it('groups episodes under one show, keeps movies per file, drops root files', async () => {
+  it('groups episodes under one show, keeps movies per file, groups a root-level movie file', async () => {
     const res = await service.previewOrphans({ path: root });
 
     expect(res.scannedFiles).toBe(6);
     expect(res.orphanCount).toBe(6);
-    expect(res.looseFiles.map((f) => f.filename)).toEqual(['stray.mkv']);
+    expect(res.groups).toHaveLength(3);
 
     const series = res.groups.find((g) => g.mediaType === MediaType.SERIES);
     expect(series?.folderName).toBe('Sample Show');
@@ -84,9 +84,17 @@ describe('orphan scan', () => {
     expect(series?.guessTitle).toBe('Sample Show');
     expect(series?.nfo?.tmdbId).toBe(4242);
 
-    const movie = res.groups.find((g) => g.mediaType === MediaType.MOVIE);
+    const movie = res.groups.find(
+      (g) => g.mediaType === MediaType.MOVIE && g.folderName === 'Quiet Harbour (2009)',
+    );
     expect(movie?.files).toHaveLength(1);
     expect(movie?.guessYear).toBe(2009);
+
+    // A movie file directly at the library root is its own group, folderName ''.
+    const rootMovie = res.groups.find(
+      (g) => g.mediaType === MediaType.MOVIE && g.folderName === '',
+    );
+    expect(rootMovie?.files.map((f) => f.filename)).toEqual(['stray.mkv']);
 
     // One probe per group, not per file — the probe is up to four reads.
     expect(readSpy).toHaveBeenCalledTimes(res.groups.length);
@@ -98,9 +106,26 @@ describe('orphan scan', () => {
       mediaTypes: [MediaType.MOVIE],
     });
 
-    expect(res.groups).toHaveLength(1);
-    expect(res.groups[0].mediaType).toBe(MediaType.MOVIE);
-    // The root-level file counts as an orphan too, it just isn't groupable.
+    // Both movie files (folder-based and root-level) are groupable; only the
+    // series files are filtered out for not matching the requested type.
+    expect(res.groups).toHaveLength(2);
+    expect(res.groups.every((g) => g.mediaType === MediaType.MOVIE)).toBe(true);
     expect(res.orphanCount).toBe(2);
+  });
+
+  it('a series file directly at the library root is not groupable and not counted as an orphan', async () => {
+    const seriesRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'orphan-scan-series-root-'));
+    try {
+      await fs.writeFile(
+        path.join(seriesRoot, 'Northern.Lights.S01E01.1080p.mkv'),
+        'x',
+      );
+      const res = await service.previewOrphans({ path: seriesRoot });
+      expect(res.scannedFiles).toBe(1);
+      expect(res.groups).toHaveLength(0);
+      expect(res.orphanCount).toBe(0);
+    } finally {
+      await fs.rm(seriesRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -280,15 +280,12 @@ export class DiskImportService {
     // Pass 2 — group in walk order, so a group's first file is its sample.
     const groups = new Map<string, OrphanGroup>();
     const sampleFile = new Map<string, string>();
-    const looseFiles: OrphanFileEntry[] = [];
     let orphanCount = 0;
     for (const f of scanned) {
       if (!f) continue;
+      // A series file at the library root can't be grouped: a series needs a folder.
+      if (!f.folderName && f.mediaType === MediaType.SERIES) continue;
       orphanCount++;
-      if (!f.folderName) {
-        looseFiles.push(f.entry);
-        continue;
-      }
       const key =
         f.mediaType === MediaType.SERIES
           ? `series:${f.folderName}`
@@ -328,12 +325,11 @@ export class DiskImportService {
     emit(unlinked.length + 1);
 
     this.logger.log(
-      `Orphan scan finished — ${label} scanned=${allFiles.length} orphans=${orphanCount} groups=${groups.size} loose=${looseFiles.length}`,
+      `Orphan scan finished - ${label} scanned=${allFiles.length} orphans=${orphanCount} groups=${groups.size}`,
     );
     return {
       libraryPath: root,
       groups: [...groups.values()],
-      looseFiles,
       scannedFiles: allFiles.length,
       orphanCount,
     };
@@ -436,6 +432,9 @@ export class DiskImportService {
     }
     if (!dto.externalId && dto.reorganize) {
       throw new BadRequestException('Reorganize needs an identified title');
+    }
+    if (dto.folderName === '' && dto.reorganize) {
+      throw new BadRequestException('Reorganize needs a title with its own folder');
     }
 
     const { media, created } = dto.externalId
@@ -625,18 +624,33 @@ export class DiskImportService {
     library: Library,
     addedByUserId: number | null,
   ): Promise<{ media: Media; created: boolean }> {
-    const existing = await this.mediaRepo.findOne({
-      where: {
-        library: { id: library.id },
-        type: dto.type,
-        folderName: dto.folderName,
-        tmdbId: IsNull(),
-        tvdbId: IsNull(),
-        imdbId: IsNull(),
-      },
-      relations: ['library', 'files'],
-    });
-    if (existing) return { media: existing, created: false };
+    const where = {
+      library: { id: library.id },
+      type: dto.type,
+      folderName: dto.folderName,
+      tmdbId: IsNull(),
+      tvdbId: IsNull(),
+      imdbId: IsNull(),
+    };
+    if (dto.folderName === '') {
+      // Every root-level movie shares folderName '': disambiguate reuse by its
+      // own file, or unrelated titles would collapse into the first one found.
+      const wanted = new Set(dto.files.map((f) => path.basename(f.filePath)));
+      const candidates = await this.mediaRepo.find({
+        where,
+        relations: ['library', 'files'],
+      });
+      const existing = candidates.find((m) =>
+        (m.files ?? []).some((f) => wanted.has(f.relativePath)),
+      );
+      if (existing) return { media: existing, created: false };
+    } else {
+      const existing = await this.mediaRepo.findOne({
+        where,
+        relations: ['library', 'files'],
+      });
+      if (existing) return { media: existing, created: false };
+    }
 
     const sample = path.resolve(dto.files[0].filePath);
     const artworkDir =

--- a/backend/src/modules/imports/disk-import.service.ts
+++ b/backend/src/modules/imports/disk-import.service.ts
@@ -557,6 +557,13 @@ export class DiskImportService {
       }
     }
 
+    // A newly created unmatched row that failed to link any file is dead
+    // weight: for a root movie especially, an ambiguous folderName '' twin
+    // would otherwise linger and confuse the next reuse lookup.
+    if (!dto.externalId && created && linked === 0) {
+      await this.mediaRepo.delete(media.id);
+    }
+
     this.logger.log(
       `Orphan relink — media #${media.id} created=${created} linked=${linked} errors=${errors.length}`,
     );
@@ -669,20 +676,30 @@ export class DiskImportService {
       throw new BadRequestException('File outside the library root');
     }
 
-    const nfo =
-      dto.type === MediaType.SERIES
-        ? (await this.nfo.readNfoFile(path.join(artworkDir, 'tvshow.nfo'))) ??
-          (await this.nfo.readForVideoFile(sample))
-        : await this.nfo.readForVideoFile(sample);
+    // A root movie's artworkDir IS the shared library root: generic sidecar
+    // names (poster.jpg, movie.nfo, ...) there belong to no title in particular.
+    const isRootMovie = dto.folderName === '';
     const artworkBasename =
       dto.type === MediaType.SERIES
         ? undefined
         : path.basename(sample, path.extname(sample));
-    const artwork = await findLocalArtwork(artworkDir, artworkBasename);
+    const nfo =
+      dto.type === MediaType.SERIES
+        ? (await this.nfo.readNfoFile(path.join(artworkDir, 'tvshow.nfo'))) ??
+          (await this.nfo.readForVideoFile(sample))
+        : isRootMovie
+          ? await this.nfo.readNfoFile(path.join(artworkDir, `${artworkBasename}.nfo`))
+          : await this.nfo.readForVideoFile(sample);
+    const artwork = await findLocalArtwork(artworkDir, artworkBasename, {
+      basenameOnly: isRootMovie,
+    });
 
     const created = await this.mediaService.createUnmatched(
       {
-        title: dto.title?.trim() || dto.folderName,
+        title:
+          dto.title?.trim() ||
+          extractMediaTitle(path.basename(sample)).title ||
+          dto.folderName,
         year: dto.year,
         type: dto.type,
         libraryId: dto.libraryId,

--- a/backend/src/modules/imports/disk-import.unmatched.spec.ts
+++ b/backend/src/modules/imports/disk-import.unmatched.spec.ts
@@ -26,7 +26,7 @@ const dto = (overrides: Partial<RelinkOrphansDto> = {}): RelinkOrphansDto =>
   }) as RelinkOrphansDto;
 
 function makeService() {
-  const mediaRepo = { findOne: jest.fn(), update: jest.fn() };
+  const mediaRepo = { findOne: jest.fn(), find: jest.fn(), update: jest.fn() };
   const mediaService = {
     importMedia: jest.fn(),
     createUnmatched: jest.fn(),
@@ -340,5 +340,98 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     expect(mediaService.createUnmatched).not.toHaveBeenCalled();
     expect(res.created).toBe(true);
     expect(res.mediaId).toBe(55);
+  });
+
+  it('refuses reorganize for an identified movie with no folder of its own', async () => {
+    const { service } = makeService();
+    const rootDto = dto({
+      externalId: '999',
+      provider: 'tmdb',
+      reorganize: true,
+      folderName: '',
+      files: [{ filePath: '/media/Quiet.Harbour.2009.1080p.mkv' }],
+    });
+    await expect(service.relinkOrphans(rootDto, null)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+});
+
+describe('DiskImportService.relinkOrphans: movie files directly at the library root', () => {
+  const rootDto = (overrides: Partial<RelinkOrphansDto> = {}): RelinkOrphansDto =>
+    dto({
+      folderName: '',
+      title: 'Quiet Harbour',
+      files: [{ filePath: '/media/Quiet.Harbour.2009.1080p.mkv' }],
+      ...overrides,
+    });
+
+  it('creates the media with an empty folderName and links the file in place', async () => {
+    const { service, mediaRepo, mediaService } = makeService();
+    mediaRepo.find.mockResolvedValueOnce([]); // no unmatched root row yet
+    mediaRepo.findOne.mockResolvedValueOnce(unmatchedRow(1, ''));
+    mediaService.createUnmatched.mockResolvedValue({ id: 1 });
+    mediaService.linkExistingFileInPlace.mockResolvedValue({
+      fileId: 1,
+      episodeId: null,
+      created: false,
+    });
+
+    const res = await service.relinkOrphans(rootDto(), null);
+
+    expect(mediaService.createUnmatched).toHaveBeenCalledWith(
+      expect.objectContaining({ folderName: '' }),
+      null,
+    );
+    expect(res.created).toBe(true);
+    expect(res.mediaId).toBe(1);
+  });
+
+  it('does not merge two different root-level movies sharing folderName \'\'', async () => {
+    const { service, mediaRepo, mediaService } = makeService();
+    const movieA = {
+      ...unmatchedRow(1, ''),
+      files: [{ relativePath: 'Movie.A.2019.mkv' }],
+    };
+    // The only existing unmatched root row is a different file: reuse must
+    // not pick it just because folderName also happens to be ''.
+    mediaRepo.find.mockResolvedValueOnce([movieA]);
+    mediaRepo.findOne.mockResolvedValueOnce(unmatchedRow(2, ''));
+    mediaService.createUnmatched.mockResolvedValue({ id: 2 });
+    mediaService.linkExistingFileInPlace.mockResolvedValue({
+      fileId: 2,
+      episodeId: null,
+      created: false,
+    });
+
+    const res = await service.relinkOrphans(
+      rootDto({ files: [{ filePath: '/media/Movie.B.2020.mkv' }] }),
+      null,
+    );
+
+    expect(mediaService.createUnmatched).toHaveBeenCalled();
+    expect(res.mediaId).toBe(2);
+  });
+
+  it('reuses the same root row when its own file is scanned again', async () => {
+    const { service, mediaRepo, mediaService } = makeService();
+    const movieA = {
+      ...unmatchedRow(1, ''),
+      files: [{ relativePath: 'Movie.A.2019.mkv' }],
+    };
+    mediaRepo.find.mockResolvedValueOnce([movieA]);
+    mediaService.linkExistingFileInPlace.mockResolvedValue({
+      fileId: 1,
+      episodeId: null,
+      created: false,
+    });
+
+    const res = await service.relinkOrphans(
+      rootDto({ files: [{ filePath: '/media/Movie.A.2019.mkv' }] }),
+      null,
+    );
+
+    expect(mediaService.createUnmatched).not.toHaveBeenCalled();
+    expect(res.mediaId).toBe(1);
   });
 });

--- a/backend/src/modules/imports/disk-import.unmatched.spec.ts
+++ b/backend/src/modules/imports/disk-import.unmatched.spec.ts
@@ -349,7 +349,7 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
       provider: 'tmdb',
       reorganize: true,
       folderName: '',
-      files: [{ filePath: '/media/Quiet.Harbour.2009.1080p.mkv' }],
+      files: [{ filePath: '/media/sample.movie.2001.1080p.mkv' }],
     });
     await expect(service.relinkOrphans(rootDto, null)).rejects.toThrow(
       BadRequestException,
@@ -361,8 +361,8 @@ describe('DiskImportService.relinkOrphans: movie files directly at the library r
   const rootDto = (overrides: Partial<RelinkOrphansDto> = {}): RelinkOrphansDto =>
     dto({
       folderName: '',
-      title: 'Quiet Harbour',
-      files: [{ filePath: '/media/Quiet.Harbour.2009.1080p.mkv' }],
+      title: 'Sample Movie',
+      files: [{ filePath: '/media/sample.movie.2001.1080p.mkv' }],
       ...overrides,
     });
 
@@ -391,7 +391,7 @@ describe('DiskImportService.relinkOrphans: movie files directly at the library r
     const { service, mediaRepo, mediaService } = makeService();
     const movieA = {
       ...unmatchedRow(1, ''),
-      files: [{ relativePath: 'Movie.A.2019.mkv' }],
+      files: [{ relativePath: 'sample.movie.2001.mkv' }],
     };
     // The only existing unmatched root row is a different file: reuse must
     // not pick it just because folderName also happens to be ''.
@@ -405,7 +405,7 @@ describe('DiskImportService.relinkOrphans: movie files directly at the library r
     });
 
     const res = await service.relinkOrphans(
-      rootDto({ files: [{ filePath: '/media/Movie.B.2020.mkv' }] }),
+      rootDto({ files: [{ filePath: '/media/sample.movie.2.2002.mkv' }] }),
       null,
     );
 
@@ -417,7 +417,7 @@ describe('DiskImportService.relinkOrphans: movie files directly at the library r
     const { service, mediaRepo, mediaService } = makeService();
     const movieA = {
       ...unmatchedRow(1, ''),
-      files: [{ relativePath: 'Movie.A.2019.mkv' }],
+      files: [{ relativePath: 'sample.movie.2001.mkv' }],
     };
     mediaRepo.find.mockResolvedValueOnce([movieA]);
     mediaService.linkExistingFileInPlace.mockResolvedValue({
@@ -427,7 +427,7 @@ describe('DiskImportService.relinkOrphans: movie files directly at the library r
     });
 
     const res = await service.relinkOrphans(
-      rootDto({ files: [{ filePath: '/media/Movie.A.2019.mkv' }] }),
+      rootDto({ files: [{ filePath: '/media/sample.movie.2001.mkv' }] }),
       null,
     );
 

--- a/backend/src/modules/imports/disk-import.unmatched.spec.ts
+++ b/backend/src/modules/imports/disk-import.unmatched.spec.ts
@@ -26,7 +26,7 @@ const dto = (overrides: Partial<RelinkOrphansDto> = {}): RelinkOrphansDto =>
   }) as RelinkOrphansDto;
 
 function makeService() {
-  const mediaRepo = { findOne: jest.fn(), find: jest.fn(), update: jest.fn() };
+  const mediaRepo = { findOne: jest.fn(), find: jest.fn(), update: jest.fn(), delete: jest.fn() };
   const mediaService = {
     importMedia: jest.fn(),
     createUnmatched: jest.fn(),
@@ -99,6 +99,7 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     expect(mockedFindLocalArtwork).toHaveBeenCalledWith(
       '/media/Sample Movie (2009)',
       'Sample.Movie.2009.1080p',
+      { basenameOnly: false },
     );
     expect(mediaService.createUnmatched).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -146,6 +147,7 @@ describe('DiskImportService.relinkOrphans: creating an unmatched title', () => {
     expect(mockedFindLocalArtwork).toHaveBeenCalledWith(
       '/media/Sample Show',
       undefined,
+      { basenameOnly: false },
     );
   });
 
@@ -433,5 +435,67 @@ describe('DiskImportService.relinkOrphans: movie files directly at the library r
 
     expect(mediaService.createUnmatched).not.toHaveBeenCalled();
     expect(res.mediaId).toBe(1);
+  });
+
+  it('only matches basename-prefixed artwork and reads the per-file nfo, not the shared root', async () => {
+    const { service, mediaRepo, mediaService, nfo } = makeService();
+    mediaRepo.find.mockResolvedValueOnce([]);
+    mediaRepo.findOne.mockResolvedValueOnce(unmatchedRow(3, ''));
+    mediaService.createUnmatched.mockResolvedValue({ id: 3 });
+    mediaService.linkExistingFileInPlace.mockResolvedValue({
+      fileId: 1,
+      episodeId: null,
+      created: false,
+    });
+
+    await service.relinkOrphans(rootDto(), null);
+
+    expect(nfo.readNfoFile).toHaveBeenCalledWith('/media/sample.movie.2001.1080p.nfo');
+    expect(nfo.readForVideoFile).not.toHaveBeenCalled();
+    expect(mockedFindLocalArtwork).toHaveBeenCalledWith(
+      '/media',
+      'sample.movie.2001.1080p',
+      { basenameOnly: true },
+    );
+  });
+
+  it('derives the title from the filename when the client sent none', async () => {
+    const { service, mediaRepo, mediaService } = makeService();
+    mediaRepo.find.mockResolvedValueOnce([]);
+    mediaRepo.findOne.mockResolvedValueOnce(unmatchedRow(4, ''));
+    mediaService.createUnmatched.mockResolvedValue({ id: 4 });
+    mediaService.linkExistingFileInPlace.mockResolvedValue({
+      fileId: 1,
+      episodeId: null,
+      created: false,
+    });
+
+    await service.relinkOrphans(
+      rootDto({
+        title: '',
+        files: [{ filePath: '/media/Sample.Movie.Two.2002.1080p.mkv' }],
+      }),
+      null,
+    );
+
+    expect(mediaService.createUnmatched).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Sample Movie Two' }),
+      null,
+    );
+  });
+
+  it('deletes the freshly created row when its only file fails to link', async () => {
+    const { service, mediaRepo, mediaService } = makeService();
+    mediaRepo.find.mockResolvedValueOnce([]);
+    mediaRepo.findOne.mockResolvedValueOnce(unmatchedRow(5, ''));
+    mediaService.createUnmatched.mockResolvedValue({ id: 5 });
+    mediaService.linkExistingFileInPlace.mockResolvedValue({
+      error: 'file outside the media folder',
+    });
+
+    const res = await service.relinkOrphans(rootDto(), null);
+
+    expect(res.linked).toBe(0);
+    expect(mediaRepo.delete).toHaveBeenCalledWith(5);
   });
 });

--- a/backend/src/modules/imports/dto/orphan-scan.dto.ts
+++ b/backend/src/modules/imports/dto/orphan-scan.dto.ts
@@ -16,7 +16,8 @@ export interface OrphanFileEntry {
 /**
  * A re-linkable unit: a single movie file, or all episode files sharing one
  * show folder. `folderName` is the on-disk folder (first path segment under
- * the library root) that the re-created media will be pinned to.
+ * the library root) that the re-created media will be pinned to; empty for a
+ * movie file sitting directly at the library root (a series always needs one).
  */
 export interface OrphanGroup {
   groupKey: string;
@@ -32,8 +33,6 @@ export interface OrphanGroup {
 export interface OrphanScanResult {
   libraryPath: string;
   groups: OrphanGroup[];
-  /** Video files directly at the library root — not re-linkable in V1. */
-  looseFiles: OrphanFileEntry[];
   scannedFiles: number;
   orphanCount: number;
 }

--- a/backend/src/modules/imports/local-artwork.util.spec.ts
+++ b/backend/src/modules/imports/local-artwork.util.spec.ts
@@ -70,4 +70,29 @@ describe('findLocalArtwork', () => {
     writeFileSync(join(dir, 'sub', 'poster.jpg'), '');
     expect(await findLocalArtwork(dir)).toEqual({});
   });
+
+  it('basenameOnly: matches the basename-prefixed poster/fanart, ignoring generic names', async () => {
+    writeFileSync(join(dir, 'Sample Movie-poster.jpg'), '');
+    writeFileSync(join(dir, 'Sample Movie-fanart.jpg'), '');
+    // A sibling root-level movie's own generic-named artwork sitting in the
+    // same shared directory must not be picked up.
+    writeFileSync(join(dir, 'poster.jpg'), '');
+    writeFileSync(join(dir, 'folder.jpg'), '');
+    writeFileSync(join(dir, 'clearlogo.png'), '');
+
+    const out = await findLocalArtwork(dir, 'Sample Movie', { basenameOnly: true });
+
+    expect(out.poster).toBe(join(dir, 'Sample Movie-poster.jpg'));
+    expect(out.fanart).toBe(join(dir, 'Sample Movie-fanart.jpg'));
+    expect(out.logo).toBeUndefined();
+  });
+
+  it('basenameOnly: matches nothing when no basename-prefixed file exists', async () => {
+    writeFileSync(join(dir, 'poster.jpg'), '');
+    writeFileSync(join(dir, 'fanart.jpg'), '');
+
+    const out = await findLocalArtwork(dir, 'Sample Movie', { basenameOnly: true });
+
+    expect(out).toEqual({});
+  });
 });

--- a/backend/src/modules/imports/local-artwork.util.ts
+++ b/backend/src/modules/imports/local-artwork.util.ts
@@ -3,21 +3,25 @@ import * as path from 'path';
 
 const EXTS = ['jpg', 'jpeg', 'png', 'webp'];
 
-/** Candidate basenames (without extension), in precedence order. */
-function candidateNames(kind: 'poster' | 'fanart' | 'logo', basename?: string): string[] {
+/** Candidate basenames (without extension), in precedence order. `basenameOnly`
+ *  drops every generic name: a shared directory (a root movie's library root)
+ *  must not match another title's `poster.jpg`/`folder.jpg`/etc. */
+function candidateNames(
+  kind: 'poster' | 'fanart' | 'logo',
+  basename?: string,
+  basenameOnly?: boolean,
+): string[] {
   switch (kind) {
     case 'poster':
-      return [
-        ...(basename ? [`${basename}-poster`] : []),
-        'poster',
-        'folder',
-        'cover',
-        'movie',
-      ];
+      return basenameOnly
+        ? basename ? [`${basename}-poster`] : []
+        : [...(basename ? [`${basename}-poster`] : []), 'poster', 'folder', 'cover', 'movie'];
     case 'fanart':
-      return [...(basename ? [`${basename}-fanart`] : []), 'fanart', 'backdrop'];
+      return basenameOnly
+        ? basename ? [`${basename}-fanart`] : []
+        : [...(basename ? [`${basename}-fanart`] : []), 'fanart', 'backdrop'];
     case 'logo':
-      return ['clearlogo', 'logo'];
+      return basenameOnly ? [] : ['clearlogo', 'logo'];
   }
 }
 
@@ -28,10 +32,13 @@ export interface LocalArtwork {
 }
 
 /** Finds the usual sidecar artwork next to a video file (movie, `basename` given) or
- *  in a series folder (omitted). One `readdir`, case-insensitive matching. */
+ *  in a series folder (omitted). One `readdir`, case-insensitive matching.
+ *  `basenameOnly` restricts matches to the `<basename>-poster`/`<basename>-fanart`
+ *  form, for a directory shared with other titles (a root-level movie's library root). */
 export async function findLocalArtwork(
   dir: string,
   basename?: string,
+  opts: { basenameOnly?: boolean } = {},
 ): Promise<LocalArtwork> {
   let entries: string[];
   try {
@@ -42,7 +49,7 @@ export async function findLocalArtwork(
   const byLower = new Map(entries.map((e) => [e.toLowerCase(), e]));
 
   const firstMatch = (kind: 'poster' | 'fanart' | 'logo'): string | undefined => {
-    for (const name of candidateNames(kind, basename)) {
+    for (const name of candidateNames(kind, basename, opts.basenameOnly)) {
       for (const ext of EXTS) {
         const hit = byLower.get(`${name}.${ext}`.toLowerCase());
         if (hit) return path.join(dir, hit);

--- a/backend/src/modules/media/entities/media.entity.spec.ts
+++ b/backend/src/modules/media/entities/media.entity.spec.ts
@@ -25,8 +25,13 @@ describe('Media.path serialization', () => {
     expect(plain.path).toBe('/medias/tvshows/Some Show');
   });
 
-  it('serializes path as null when there is no folder', () => {
+  it('falls back to the library root when the media has no folder of its own', () => {
     const plain = instanceToPlain(mediaWith('/medias/tvshows', undefined));
+    expect(plain.path).toBe('/medias/tvshows');
+  });
+
+  it('serializes path as null when there is no library at all', () => {
+    const plain = instanceToPlain(mediaWith(undefined, undefined));
     expect(plain.path).toBeNull();
   });
 });

--- a/backend/src/modules/media/entities/media.entity.ts
+++ b/backend/src/modules/media/entities/media.entity.ts
@@ -103,12 +103,14 @@ export class Media extends BaseEntity {
   @Column({ nullable: true })
   folderName: string;
 
-  /** Virtual computed path: library.path + '/' + folderName */
+  /** Virtual computed path: library.path + '/' + folderName, or the bare
+   *  library root for a movie with no folder of its own. */
   @Expose()
   get path(): string | null {
-    return this.library?.path && this.folderName
+    if (!this.library?.path) return null;
+    return this.folderName
       ? nodePath.join(this.library.path, this.folderName)
-      : null;
+      : this.library.path;
   }
 
   @Column({ nullable: true })

--- a/backend/src/modules/media/media-service/media-mutation.service.spec.ts
+++ b/backend/src/modules/media/media-service/media-mutation.service.spec.ts
@@ -161,10 +161,11 @@ describe('MediaMutationService remove disk cleanup', () => {
       id: 1,
       title: 'placeholder',
       library: root ? { path: root } : undefined,
+      folderName,
       get path() {
         return this.library?.path && folderName
           ? path.join(this.library.path, folderName)
-          : null;
+          : (this.library?.path ?? null);
       },
     };
   }
@@ -231,6 +232,17 @@ describe('MediaMutationService remove disk cleanup', () => {
 
     expect(result.diskPath).toBeNull();
     expect(mediaRepo.remove).toHaveBeenCalled();
+  });
+
+  it('returns no folder for a movie with no folder of its own (root-level file)', async () => {
+    query.findOne.mockResolvedValue(mediaIn('/library/movies', ''));
+
+    const result = await service.remove(1);
+
+    // `media.path` resolves to the library root itself: never delete it.
+    expect(result.diskPath).toBeNull();
+    expect(mediaRepo.remove).toHaveBeenCalled();
+    expect(rmSpy).not.toHaveBeenCalled();
   });
 
   it('deleteMediaFolder removes the folder recursively', async () => {

--- a/backend/src/modules/media/media-service/media-mutation.service.ts
+++ b/backend/src/modules/media/media-service/media-mutation.service.ts
@@ -247,6 +247,9 @@ export class MediaMutationService {
    * escape it (e.g. via '..'). Returns null when there is no folder to delete.
    */
   private resolveSafeMediaDir(media: Media): string | null {
+    // A media with no folder of its own has nothing on disk to delete: its
+    // `path` getter falls back to the library root.
+    if (!media.folderName) return null;
     const root = media.library?.path;
     const dir = media.path;
     if (!root || !dir) return null;

--- a/backend/src/modules/media/media-service/media-rescan.service.spec.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.spec.ts
@@ -156,7 +156,7 @@ describe('MediaRescanService.rescanFiles — quality from probe results', () => 
       id: 8,
       title: 'Ember Horizon',
       type: MediaType.MOVIE,
-      folderName: 'Ember Horizon (2022)',
+      folderName: 'Sample Movie (2001)',
       files: [],
       get path() {
         return mediaDir;
@@ -213,7 +213,7 @@ describe('MediaRescanService.rescanFiles - a movie with no folder of its own', (
   function rootMovieMedia(over: Record<string, unknown>) {
     return {
       id: 11,
-      title: 'Quiet Harbour',
+      title: 'Sample Movie',
       type: MediaType.MOVIE,
       folderName: '',
       files: [],
@@ -226,10 +226,10 @@ describe('MediaRescanService.rescanFiles - a movie with no folder of its own', (
 
   it('never walks the shared library root: a sibling root-level movie file is not discovered', async () => {
     const h = buildHarness();
-    const ownFilename = 'Quiet.Harbour.2009.1080p.mkv';
+    const ownFilename = 'sample.movie.2001.1080p.mkv';
     fs.writeFileSync(path.join(mediaDir, ownFilename), 'video-bytes');
     // Another root-level movie's own file, sitting right next to this one.
-    fs.writeFileSync(path.join(mediaDir, 'Some.Other.Movie.2020.mkv'), 'video-bytes');
+    fs.writeFileSync(path.join(mediaDir, 'sample.movie.2.2002.1080p.mkv'), 'video-bytes');
     const dbFile = {
       id: 21,
       relativePath: ownFilename,
@@ -248,7 +248,7 @@ describe('MediaRescanService.rescanFiles - a movie with no folder of its own', (
 
     expect(res.added).toBe(0);
     expect(h.mediaFileRepo.save).not.toHaveBeenCalledWith(
-      expect.objectContaining({ relativePath: 'Some.Other.Movie.2020.mkv' }),
+      expect.objectContaining({ relativePath: 'sample.movie.2.2002.1080p.mkv' }),
     );
     // Its own file is still refreshed.
     expect(res.updated).toBe(1);

--- a/backend/src/modules/media/media-service/media-rescan.service.spec.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.spec.ts
@@ -267,3 +267,25 @@ describe('MediaRescanService.rescanFiles - a movie with no folder of its own', (
     expect(fs.existsSync(cacheDir)).toBe(true);
   });
 });
+
+describe('MediaRescanService.linkExistingFileInPlace - a movie with no folder of its own', () => {
+  it('refuses a file nested in a subfolder of the shared library root', async () => {
+    const h = buildHarness();
+    const media = {
+      id: 11,
+      type: MediaType.MOVIE,
+      folderName: '',
+      path: '/library/movies',
+    } as never;
+
+    const res = await h.service.linkExistingFileInPlace({
+      media,
+      absPath: '/library/movies/Some Folder/sample.movie.2001.mkv',
+    });
+
+    expect(res).toEqual({
+      error: 'a title with no folder can only own files at the library root',
+    });
+    expect(h.mediaFileRepo.findOne).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/media/media-service/media-rescan.service.spec.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.spec.ts
@@ -156,6 +156,7 @@ describe('MediaRescanService.rescanFiles — quality from probe results', () => 
       id: 8,
       title: 'Ember Horizon',
       type: MediaType.MOVIE,
+      folderName: 'Ember Horizon (2022)',
       files: [],
       get path() {
         return mediaDir;
@@ -195,5 +196,74 @@ describe('MediaRescanService.rescanFiles — quality from probe results', () => 
     expect(h.mediaFileRepo.save).toHaveBeenCalledWith(
       expect.objectContaining({ relativePath: filename, quality: 'WEBDL-480p' }),
     );
+  });
+});
+
+describe('MediaRescanService.rescanFiles - a movie with no folder of its own', () => {
+  let mediaDir: string;
+
+  beforeEach(() => {
+    mediaDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rescan-root-movie-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(mediaDir, { recursive: true, force: true });
+  });
+
+  function rootMovieMedia(over: Record<string, unknown>) {
+    return {
+      id: 11,
+      title: 'Quiet Harbour',
+      type: MediaType.MOVIE,
+      folderName: '',
+      files: [],
+      get path() {
+        return mediaDir;
+      },
+      ...over,
+    };
+  }
+
+  it('never walks the shared library root: a sibling root-level movie file is not discovered', async () => {
+    const h = buildHarness();
+    const ownFilename = 'Quiet.Harbour.2009.1080p.mkv';
+    fs.writeFileSync(path.join(mediaDir, ownFilename), 'video-bytes');
+    // Another root-level movie's own file, sitting right next to this one.
+    fs.writeFileSync(path.join(mediaDir, 'Some.Other.Movie.2020.mkv'), 'video-bytes');
+    const dbFile = {
+      id: 21,
+      relativePath: ownFilename,
+      size: 1,
+      quality: 'WEBDL-1080p',
+      streamInfo: null,
+    };
+    h.mediaRepo.findOne.mockResolvedValue(rootMovieMedia({ files: [dbFile] }));
+    h.ffprobe.detectMediaFileInfo.mockResolvedValue({
+      video: [{ width: 1920, height: 1080 }],
+      audio: [],
+      subtitles: [],
+    });
+
+    const res = await h.service.rescanFiles(11, { skipWarmup: true });
+
+    expect(res.added).toBe(0);
+    expect(h.mediaFileRepo.save).not.toHaveBeenCalledWith(
+      expect.objectContaining({ relativePath: 'Some.Other.Movie.2020.mkv' }),
+    );
+    // Its own file is still refreshed.
+    expect(res.updated).toBe(1);
+  });
+
+  it('does not wipe the shared .cache directory at the library root', async () => {
+    const h = buildHarness();
+    const cacheDir = path.join(mediaDir, '.cache');
+    fs.mkdirSync(cacheDir);
+    fs.writeFileSync(path.join(cacheDir, 'marker.txt'), 'x');
+    h.mediaRepo.findOne.mockResolvedValue(rootMovieMedia({ files: [] }));
+    h.ffprobe.detectMediaFileInfo.mockResolvedValue({ video: [], audio: [], subtitles: [] });
+
+    await h.service.rescanFiles(11, { skipWarmup: true });
+
+    expect(fs.existsSync(cacheDir)).toBe(true);
   });
 });

--- a/backend/src/modules/media/media-service/media-rescan.service.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.ts
@@ -440,13 +440,17 @@ export class MediaRescanService {
 
     // Wipe the whole per-media `.cache/` tree (subtitles + any other cached
     // artefact) — streamInfo is about to be re-read so anything derived
-    // from the old layout is stale.
-    try {
-      await clearMediaCache(media.path);
-    } catch (err) {
-      this.log.warn(
-        `Rescan[media #${mediaId}]: clearMediaCache failed for "${media.path}": ${err instanceof Error ? err.message : err}`,
-      );
+    // from the old layout is stale. Skipped for a media with no folder of its
+    // own: its `.cache/` would be the library root's, shared by every sibling
+    // root-level movie.
+    if (media.folderName) {
+      try {
+        await clearMediaCache(media.path);
+      } catch (err) {
+        this.log.warn(
+          `Rescan[media #${mediaId}]: clearMediaCache failed for "${media.path}": ${err instanceof Error ? err.message : err}`,
+        );
+      }
     }
     // The subtitle cache lives outside `.cache/`, in the images volume, so it
     // needs its own invalidation to preserve "full rescan wipes every cached VTT".
@@ -473,24 +477,38 @@ export class MediaRescanService {
       `Rescan: started — media #${mediaId} "${media.title}" root="${mediaDir}"`,
     );
 
-    // 1. Collect all video files on disk
-    const rawDiskFiles = await this.collectVideoFilesRecursive(
-      mediaDir,
-      0,
-      mediaId,
-    );
+    // 1. Collect video files on disk. A media with no folder of its own sits
+    // at the library root, shared by every sibling root-level movie: walking
+    // it would pick up their files too, so only its own known files are stat'd.
     const diskFiles: string[] = [];
     const diskRelPaths = new Set<string>();
-    for (const f of rawDiskFiles) {
-      const rel = relativePathUnderMediaRoot(mediaDir, f);
-      if (!rel) {
-        this.log.error(
-          `Rescan[media #${mediaId}]: file is outside resolved media folder — mediaDir="${mediaDir}" file="${f}"`,
-        );
-        continue;
+    if (media.folderName) {
+      const rawDiskFiles = await this.collectVideoFilesRecursive(
+        mediaDir,
+        0,
+        mediaId,
+      );
+      for (const f of rawDiskFiles) {
+        const rel = relativePathUnderMediaRoot(mediaDir, f);
+        if (!rel) {
+          this.log.error(
+            `Rescan[media #${mediaId}]: file is outside resolved media folder - mediaDir="${mediaDir}" file="${f}"`,
+          );
+          continue;
+        }
+        diskRelPaths.add(rel);
+        diskFiles.push(f);
       }
-      diskRelPaths.add(rel);
-      diskFiles.push(f);
+    } else {
+      for (const dbFile of media.files ?? []) {
+        const rel = dbFile.relativePath?.replace(/\\/g, '/');
+        if (!rel) continue;
+        const abs = path.join(mediaDir, rel);
+        if (await pathExists(abs)) {
+          diskRelPaths.add(rel);
+          diskFiles.push(abs);
+        }
+      }
     }
     this.log.log(
       `Rescan: found ${diskFiles.length} file(s) on disk, ${(media.files ?? []).length} in DB`,

--- a/backend/src/modules/media/media-service/media-rescan.service.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.ts
@@ -173,6 +173,9 @@ export class MediaRescanService {
     if (!relativePath) {
       return { error: 'file outside the media folder' };
     }
+    if (!media.folderName && relativePath.includes('/')) {
+      return { error: 'a title with no folder can only own files at the library root' };
+    }
 
     const existing = await this.mediaFileRepo.findOne({
       where: { media: { id: media.id }, relativePath },

--- a/backend/src/modules/scheduler/scheduler.service.ts
+++ b/backend/src/modules/scheduler/scheduler.service.ts
@@ -826,6 +826,9 @@ export class SchedulerService implements OnModuleInit {
 
     const candidates = allMedia.filter((m) => {
       if (!m.path) return false;
+      // A root-level movie with no files can never gain one here: rescanFiles
+      // never walks the shared library root to discover them.
+      if (!m.folderName && !m.files?.length) return false;
       // No files at all
       if (!m.files || m.files.length === 0) return true;
       // Series with unlinked files (missing episodeId)

--- a/backend/src/modules/subtitles/subtitles.discover-root-movie.spec.ts
+++ b/backend/src/modules/subtitles/subtitles.discover-root-movie.spec.ts
@@ -1,0 +1,29 @@
+import { SubtitlesService } from './subtitles.service';
+
+/**
+ * `discoverExternalSubtitles` is only exercised here for the root-level-movie
+ * guard: a bare prototype instance with just `mediaRepo` wired is enough
+ * since the guard returns before any other collaborator is touched.
+ */
+function buildHarness() {
+  const service = Object.create(SubtitlesService.prototype) as SubtitlesService;
+  const mediaRepo = { findOne: jest.fn() };
+  (service as unknown as Record<string, unknown>).mediaRepo = mediaRepo;
+  return { service, mediaRepo };
+}
+
+describe('SubtitlesService.discoverExternalSubtitles — a movie with no folder of its own', () => {
+  it('never scans the shared library root: a sibling root-level movie could share it', async () => {
+    const { service, mediaRepo } = buildHarness();
+    mediaRepo.findOne.mockResolvedValue({
+      id: 1,
+      folderName: '',
+      path: '/library/movies',
+      files: [{ id: 1, relativePath: 'Quiet.Harbor.2020.mkv' }],
+    });
+
+    const discovered = await service.discoverExternalSubtitles(1);
+
+    expect(discovered).toBe(0);
+  });
+});

--- a/backend/src/modules/subtitles/subtitles.discover-root-movie.spec.ts
+++ b/backend/src/modules/subtitles/subtitles.discover-root-movie.spec.ts
@@ -12,14 +12,14 @@ function buildHarness() {
   return { service, mediaRepo };
 }
 
-describe('SubtitlesService.discoverExternalSubtitles — a movie with no folder of its own', () => {
+describe('SubtitlesService.discoverExternalSubtitles - a movie with no folder of its own', () => {
   it('never scans the shared library root: a sibling root-level movie could share it', async () => {
     const { service, mediaRepo } = buildHarness();
     mediaRepo.findOne.mockResolvedValue({
       id: 1,
       folderName: '',
       path: '/library/movies',
-      files: [{ id: 1, relativePath: 'Quiet.Harbor.2020.mkv' }],
+      files: [{ id: 1, relativePath: 'sample.movie.2001.1080p.mkv' }],
     });
 
     const discovered = await service.discoverExternalSubtitles(1);

--- a/backend/src/modules/subtitles/subtitles.discover-root-movie.spec.ts
+++ b/backend/src/modules/subtitles/subtitles.discover-root-movie.spec.ts
@@ -1,29 +1,54 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { SubtitlesService } from './subtitles.service';
 
 /**
  * `discoverExternalSubtitles` is only exercised here for the root-level-movie
- * guard: a bare prototype instance with just `mediaRepo` wired is enough
- * since the guard returns before any other collaborator is touched.
+ * guard: a bare prototype instance with `mediaRepo` and `repo` wired is
+ * enough since no other collaborator is touched on this path.
  */
 function buildHarness() {
   const service = Object.create(SubtitlesService.prototype) as SubtitlesService;
   const mediaRepo = { findOne: jest.fn() };
-  (service as unknown as Record<string, unknown>).mediaRepo = mediaRepo;
-  return { service, mediaRepo };
+  const repo = { find: jest.fn().mockResolvedValue([]), save: jest.fn() };
+  const wired = service as unknown as Record<string, unknown>;
+  wired.mediaRepo = mediaRepo;
+  wired.repo = repo;
+  wired.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+  return { service, mediaRepo, repo };
 }
 
 describe('SubtitlesService.discoverExternalSubtitles - a movie with no folder of its own', () => {
-  it('never scans the shared library root: a sibling root-level movie could share it', async () => {
-    const { service, mediaRepo } = buildHarness();
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'fliks-subtitle-discover-root-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('attaches a subtitle whose name matches its own file, ignoring a sibling root movie sidecar', async () => {
+    const { service, mediaRepo, repo } = buildHarness();
+    writeFileSync(join(dir, 'sample.movie.2001.mkv'), '');
+    writeFileSync(join(dir, 'sample.movie.2001.en.srt'), '');
+    // A sidecar for a different root-level movie, sitting right next to it.
+    writeFileSync(join(dir, 'stray-orphan.srt'), '');
     mediaRepo.findOne.mockResolvedValue({
       id: 1,
       folderName: '',
-      path: '/library/movies',
-      files: [{ id: 1, relativePath: 'sample.movie.2001.1080p.mkv' }],
+      path: dir,
+      files: [{ id: 1, relativePath: 'sample.movie.2001.mkv', episodeId: null }],
     });
 
     const discovered = await service.discoverExternalSubtitles(1);
 
-    expect(discovered).toBe(0);
+    expect(discovered).toBe(1);
+    expect(repo.save).toHaveBeenCalledTimes(1);
+    expect(repo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ relativePath: 'sample.movie.2001.en.srt' }),
+    );
   });
 });

--- a/backend/src/modules/subtitles/subtitles.service.ts
+++ b/backend/src/modules/subtitles/subtitles.service.ts
@@ -739,6 +739,9 @@ export class SubtitlesService {
       relations: ['files'],
     });
     if (!media?.path || !media.files?.length) return 0;
+    // A media with no folder of its own shares its "root" with every sibling
+    // root-level movie: scanning it would cross-match their sidecar subtitles.
+    if (!media.folderName) return 0;
 
     // Build a map: video basename (without ext, lowercase) → MediaFile
     const fileByBasename = new Map<string, MediaFile>();

--- a/backend/src/modules/subtitles/subtitles.service.ts
+++ b/backend/src/modules/subtitles/subtitles.service.ts
@@ -739,9 +739,6 @@ export class SubtitlesService {
       relations: ['files'],
     });
     if (!media?.path || !media.files?.length) return 0;
-    // A media with no folder of its own shares its "root" with every sibling
-    // root-level movie: scanning it would cross-match their sidecar subtitles.
-    if (!media.folderName) return 0;
 
     // Build a map: video basename (without ext, lowercase) → MediaFile
     const fileByBasename = new Map<string, MediaFile>();
@@ -808,7 +805,9 @@ export class SubtitlesService {
         // long as it sits in a folder with exactly one video — attach it there
         // (or the media's only file). Folders with several videos (a season
         // folder) are left to the precise name match so episodes aren't crossed.
-        if (!matchedFile) {
+        // A media with no folder of its own shares its root with every sibling
+        // root-level movie, so a lone-video-in-dir guess is not safe there.
+        if (!matchedFile && media.folderName) {
           const videosInDir = media.files.filter(
             (f) => path.dirname(path.join(media.path!, f.relativePath)) === dir,
           );

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1124,7 +1124,8 @@
     "add_to_list": "Zu Liste hinzufügen",
     "unlike": "Gefällt mir nicht mehr",
     "subtitle_failed": "Fehlgeschlagen",
-    "unidentified_callout": "Dieser Titel ist nicht identifiziert. Die angezeigten Informationen stammen aus der Datei."
+    "unidentified_callout": "Dieser Titel ist nicht identifiziert. Die angezeigten Informationen stammen aus der Datei.",
+    "delete_no_folder": "Dieser Titel hat keinen eigenen Ordner: Nur der Bibliothekseintrag wird entfernt, die Datei bleibt auf der Festplatte."
   },
   "requests": {
     "title": "Anfragen",
@@ -1965,7 +1966,6 @@
       "scan_linked": "{{count}} Datei(en) verknüpft",
       "scan_nothing_linked": "Keine Datei verknüpft (Duplikat bereits im Medium vorhanden).",
       "scan_error": "Scan fehlgeschlagen.",
-      "scan_loose_skipped": "{{count}} Datei(en) im Stammverzeichnis übersprungen — verschieben Sie sie in einen Unterordner, um sie zu verknüpfen.",
       "scan_files": "{{count}} Datei(en)",
       "scan_add_unmatched": "Ohne Metadaten hinzufügen",
       "scan_unmatched_badge": "Keine Metadaten",
@@ -1973,7 +1973,8 @@
       "scan_reorganize_needs_match": "Verschieben/Umbenennen gilt nur für identifizierte Titel",
       "scan_queued_unmatched": "{{count}} Titel ohne Metadaten hinzugefügt, identifizieren Sie sie im Tab Medien",
       "scan_search_failed_count": "{{count}} Ordner nicht analysiert (Suche fehlgeschlagen), starten Sie den Scan im Tab Medien erneut",
-      "media_filter_unidentified": "Nicht identifiziert"
+      "media_filter_unidentified": "Nicht identifiziert",
+      "scan_reorganize_needs_folder": "Verschieben/Umbenennen gilt nur für Titel mit eigenem Ordner"
     },
     "users": {
       "title": "Benutzer",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1132,7 +1132,8 @@
     "add_to_list": "Add to list",
     "unlike": "Unlike",
     "subtitle_failed": "Failed",
-    "unidentified_callout": "This title isn't identified. The information shown comes from the file."
+    "unidentified_callout": "This title isn't identified. The information shown comes from the file.",
+    "delete_no_folder": "This title has no folder of its own: only the library entry will be removed, the file stays on disk."
   },
   "requests": {
     "title": "Requests",
@@ -1982,7 +1983,6 @@
       "scan_linked": "{{count}} file(s) linked",
       "scan_nothing_linked": "No file linked (duplicate already present in the media).",
       "scan_error": "Scan failed.",
-      "scan_loose_skipped": "{{count}} file(s) at the root skipped — move them into a subfolder to link them.",
       "scan_files": "{{count}} file(s)",
       "scan_add_unmatched": "Add without metadata",
       "scan_unmatched_badge": "No metadata",
@@ -1990,7 +1990,8 @@
       "scan_reorganize_needs_match": "Move/rename only applies to identified titles",
       "scan_queued_unmatched": "{{count}} title(s) added without metadata, identify them from the Media tab",
       "scan_search_failed_count": "{{count}} folder(s) not scanned (search failed), relaunch the scan from the Media tab",
-      "media_filter_unidentified": "Unidentified"
+      "media_filter_unidentified": "Unidentified",
+      "scan_reorganize_needs_folder": "Move/rename only applies to titles with their own folder"
     },
     "users": {
       "title": "Users",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1124,7 +1124,8 @@
     "add_to_list": "Añadir a una lista",
     "unlike": "Ya no me gusta",
     "subtitle_failed": "Error",
-    "unidentified_callout": "Este título no está identificado. La información mostrada proviene del archivo."
+    "unidentified_callout": "Este título no está identificado. La información mostrada proviene del archivo.",
+    "delete_no_folder": "Este título no tiene una carpeta propia: solo se eliminará la entrada de la biblioteca, el archivo permanece en el disco."
   },
   "requests": {
     "title": "Solicitudes",
@@ -1965,7 +1966,6 @@
       "scan_linked": "{{count}} archivo(s) vinculado(s)",
       "scan_nothing_linked": "No se ha vinculado ningún archivo (duplicado ya presente en el medio).",
       "scan_error": "Error del análisis.",
-      "scan_loose_skipped": "{{count}} archivo(s) en la raíz ignorado(s) — muévalos a una subcarpeta para vincularlos.",
       "scan_files": "{{count}} archivo(s)",
       "scan_add_unmatched": "Añadir sin metadatos",
       "scan_unmatched_badge": "Sin metadatos",
@@ -1973,7 +1973,8 @@
       "scan_reorganize_needs_match": "Mover/renombrar solo se aplica a títulos identificados",
       "scan_queued_unmatched": "{{count}} título(s) añadido(s) sin metadatos, identifíquelos desde la pestaña Medios",
       "scan_search_failed_count": "{{count}} carpeta(s) no analizada(s) (búsqueda fallida), vuelva a lanzar el análisis desde la pestaña Medios",
-      "media_filter_unidentified": "No identificados"
+      "media_filter_unidentified": "No identificados",
+      "scan_reorganize_needs_folder": "Mover/renombrar solo se aplica a títulos con su propia carpeta"
     },
     "users": {
       "title": "Usuarios",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1132,7 +1132,8 @@
     "add_to_list": "Ajouter à une liste",
     "unlike": "Je n’aime plus",
     "subtitle_failed": "Échec",
-    "unidentified_callout": "Ce titre n'est pas identifié. Les informations affichées viennent du fichier."
+    "unidentified_callout": "Ce titre n'est pas identifié. Les informations affichées viennent du fichier.",
+    "delete_no_folder": "Ce titre n'a pas de dossier propre : seule l'entrée de la bibliothèque sera supprimée, le fichier reste sur le disque."
   },
   "requests": {
     "title": "Demandes",
@@ -1982,7 +1983,6 @@
       "scan_linked": "{{count}} fichier(s) lié(s)",
       "scan_nothing_linked": "Aucun fichier lié (doublon déjà présent dans le média).",
       "scan_error": "Échec de l'analyse.",
-      "scan_loose_skipped": "{{count}} fichier(s) à la racine ignoré(s) — déplacez-les dans un sous-dossier pour les lier.",
       "scan_files": "{{count}} fichier(s)",
       "scan_add_unmatched": "Ajouter sans métadonnées",
       "scan_unmatched_badge": "Sans métadonnées",
@@ -1990,7 +1990,8 @@
       "scan_reorganize_needs_match": "Le déplacement/renommage ne s'applique qu'aux titres identifiés",
       "scan_queued_unmatched": "{{count}} titre(s) ajouté(s) sans métadonnées, identifiez-les depuis l'onglet Médias",
       "scan_search_failed_count": "{{count}} dossier(s) non analysé(s) (recherche en erreur), relancez l'analyse depuis l'onglet Médias",
-      "media_filter_unidentified": "Non identifiés"
+      "media_filter_unidentified": "Non identifiés",
+      "scan_reorganize_needs_folder": "Le déplacement/renommage ne s'applique qu'aux titres dans leur propre dossier"
     },
     "users": {
       "title": "Utilisateurs",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1124,7 +1124,8 @@
     "add_to_list": "Aggiungi a un elenco",
     "unlike": "Non mi piace più",
     "subtitle_failed": "Non riuscito",
-    "unidentified_callout": "Questo titolo non è identificato. Le informazioni mostrate provengono dal file."
+    "unidentified_callout": "Questo titolo non è identificato. Le informazioni mostrate provengono dal file.",
+    "delete_no_folder": "Questo titolo non ha una cartella propria: verrà rimossa solo la voce della libreria, il file rimane sul disco."
   },
   "requests": {
     "title": "Richieste",
@@ -1965,7 +1966,6 @@
       "scan_linked": "{{count}} file collegato/i",
       "scan_nothing_linked": "Nessun file collegato (duplicato già presente nel file multimediale).",
       "scan_error": "Analisi fallita.",
-      "scan_loose_skipped": "{{count}} file nella radice ignorato/i — spostali in una sottocartella per collegarli.",
       "scan_files": "{{count}} file",
       "scan_add_unmatched": "Aggiungi senza metadati",
       "scan_unmatched_badge": "Senza metadati",
@@ -1973,7 +1973,8 @@
       "scan_reorganize_needs_match": "Sposta/rinomina si applica solo ai titoli identificati",
       "scan_queued_unmatched": "{{count}} titolo/i aggiunto/i senza metadati, identificali dalla scheda Media",
       "scan_search_failed_count": "{{count}} cartella/e non analizzata/e (ricerca fallita), rilancia la scansione dalla scheda Media",
-      "media_filter_unidentified": "Non identificati"
+      "media_filter_unidentified": "Non identificati",
+      "scan_reorganize_needs_folder": "Sposta/rinomina si applica solo ai titoli con una propria cartella"
     },
     "users": {
       "title": "Utenti",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1124,7 +1124,8 @@
     "add_to_list": "Adicionar a uma lista",
     "unlike": "Já não gosto",
     "subtitle_failed": "Falhou",
-    "unidentified_callout": "Este título não está identificado. As informações exibidas vêm do arquivo."
+    "unidentified_callout": "Este título não está identificado. As informações exibidas vêm do arquivo.",
+    "delete_no_folder": "Este título não tem uma pasta própria: apenas a entrada da biblioteca será removida, o ficheiro permanece no disco."
   },
   "requests": {
     "title": "Pedidos",
@@ -1965,7 +1966,6 @@
       "scan_linked": "{{count}} ficheiro(s) associado(s)",
       "scan_nothing_linked": "Nenhum ficheiro associado (duplicado já presente no media).",
       "scan_error": "Falha na análise.",
-      "scan_loose_skipped": "{{count}} ficheiro(s) na raiz ignorado(s) — mova-os para uma subpasta para os associar.",
       "scan_files": "{{count}} ficheiro(s)",
       "scan_add_unmatched": "Adicionar sem metadados",
       "scan_unmatched_badge": "Sem metadados",
@@ -1973,7 +1973,8 @@
       "scan_reorganize_needs_match": "Mover/renomear aplica-se apenas a títulos identificados",
       "scan_queued_unmatched": "{{count}} título(s) adicionado(s) sem metadados, identifique-os no separador Media",
       "scan_search_failed_count": "{{count}} pasta(s) não analisada(s) (pesquisa falhou), reinicie a análise no separador Media",
-      "media_filter_unidentified": "Não identificados"
+      "media_filter_unidentified": "Não identificados",
+      "scan_reorganize_needs_folder": "Mover/renomear aplica-se apenas a títulos com pasta própria"
     },
     "users": {
       "title": "Utilizadores",

--- a/client/src/app/core/services/api/imports-api.service.ts
+++ b/client/src/app/core/services/api/imports-api.service.ts
@@ -36,7 +36,6 @@ export interface OrphanGroup {
 export interface OrphanScanResult {
   libraryPath: string;
   groups: OrphanGroup[];
-  looseFiles: OrphanFileEntry[];
   scannedFiles: number;
   orphanCount: number;
 }

--- a/client/src/app/core/services/api/media.service.ts
+++ b/client/src/app/core/services/api/media.service.ts
@@ -67,6 +67,8 @@ export interface Media {
   status: string;
   monitored: boolean;
   path?: string | null;
+  /** On-disk folder name under the library root; empty for a movie file that sits directly at the root. */
+  folderName?: string;
   libraryId?: number | null;
   library?: { id: number; name: string } | null;
   posterUrl: string | null;

--- a/client/src/app/features/media-detail/media-detail.delete-confirm.spec.ts
+++ b/client/src/app/features/media-detail/media-detail.delete-confirm.spec.ts
@@ -1,0 +1,125 @@
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { provideTranslateService, TranslateLoader } from '@ngx-translate/core';
+import { EMPTY, of } from 'rxjs';
+import { vi, afterEach, describe, it, expect } from 'vitest';
+import { MediaDetailComponent } from './media-detail';
+import { MediaService, Media } from '../../core/services/api/media.service';
+import { MediaDetailReleasePickerService } from './media-detail-release-picker.service';
+import { AuthService } from '../../core/services/auth.service';
+import { ProfilesService } from '../../core/services/api/profiles.service';
+import { LibrariesApiService } from '../../core/services/api/libraries-api.service';
+import { NavbarService } from '../../core/services/navbar.service';
+import { BackgroundService } from '../../core/services/background.service';
+import { StreamingApiService } from '../../core/services/api/streaming-api.service';
+import { MarkersApiService } from '../../core/services/api/markers-api.service';
+import { RequestsService } from '../../core/services/api/requests.service';
+import { ConfirmationService } from '../../core/services/confirmation.service';
+import { ToastService } from '../../core/services/toast.service';
+import { SseService } from '../../core/services/sse.service';
+import { DownloadManagerService } from '../../core/services/download-manager.service';
+import { DownloadProgressService } from '../../core/services/download-progress.service';
+import { TvService } from '../../core/services/tv.service';
+import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
+import { AddToPlaylistService } from '../../core/services/add-to-playlist.service';
+import { RecommendService } from '../../core/services/recommend.service';
+import { LikesApiService } from '../../core/services/api/likes-api.service';
+
+const MEDIA_ID = 42;
+
+const baseMovie: Media = {
+  id: MEDIA_ID,
+  title: 'Test Movie',
+  originalTitle: 'Test Movie',
+  year: 2024,
+  type: 'movie',
+  tmdbId: 1,
+  overview: '',
+  status: 'released',
+  monitored: true,
+  posterUrl: null,
+  fanartUrl: null,
+  logoUrl: null,
+  additionalFanartUrls: [],
+  rating: 0,
+  runtime: 100,
+  files: [],
+};
+
+/** Deletion is destructive, so the confirm dialog must name the right consequence
+ *  (folder removed vs. DB row only) before the user commits to it. */
+function createHarness() {
+  const confirm = vi.fn().mockResolvedValue(false);
+
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideTranslateService({
+        lang: 'en',
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+      }),
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          paramMap: EMPTY,
+          snapshot: { data: { kind: 'movie' }, paramMap: { get: () => null } },
+        },
+      },
+      { provide: Router, useValue: { navigate: vi.fn(), getCurrentNavigation: () => null } },
+      { provide: MediaService, useValue: { getOne: vi.fn(async () => baseMovie), delete: vi.fn() } },
+      { provide: MediaDetailReleasePickerService, useValue: {} },
+      { provide: AuthService, useValue: { hasPermission: () => false } },
+      { provide: ProfilesService, useValue: {} },
+      { provide: LibrariesApiService, useValue: {} },
+      { provide: NavbarService, useValue: { enterHeroPage: vi.fn(), leaveHeroPage: vi.fn() } },
+      { provide: BackgroundService, useValue: { clear: vi.fn(), setBackgrounds: vi.fn(), setBackground: vi.fn(), url: signal(null) } },
+      { provide: ConfirmationService, useValue: { confirm } },
+      { provide: ToastService, useValue: { success: vi.fn(), error: vi.fn() } },
+      { provide: SseService, useValue: { lastEvent: signal(null) } },
+      { provide: StreamingApiService, useValue: {} },
+      { provide: MarkersApiService, useValue: {} },
+      { provide: RequestsService, useValue: {} },
+      { provide: DownloadManagerService, useValue: {} },
+      { provide: DownloadProgressService, useValue: { progress: signal(new Map()) } },
+      { provide: TvService, useValue: { isTv: () => false } },
+      { provide: ScrollMemoryService, useValue: { activate: vi.fn(), deactivate: vi.fn(), restoreSticky: vi.fn() } },
+      { provide: AddToPlaylistService, useValue: {} },
+      { provide: RecommendService, useValue: {} },
+      { provide: LikesApiService, useValue: { state: vi.fn(async () => ({ media: false, seasonIds: [], episodeIds: [] })) } },
+    ],
+  });
+
+  TestBed.overrideComponent(MediaDetailComponent, { set: { template: '', imports: [] } });
+
+  const fixture = TestBed.createComponent(MediaDetailComponent);
+  fixture.detectChanges();
+
+  return { fixture, confirm };
+}
+
+describe('MediaDetailComponent.deleteMedia — confirm message', () => {
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('warns about the on-disk folder for a title that owns one', async () => {
+    const { fixture, confirm } = createHarness();
+    fixture.componentInstance.media.set({ ...baseMovie, folderName: 'Test Movie (2024)' });
+
+    await fixture.componentInstance.deleteMedia();
+
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'media_detail.confirm_delete' }),
+    );
+  });
+
+  it('says only the library entry goes for a movie with no folder of its own', async () => {
+    const { fixture, confirm } = createHarness();
+    fixture.componentInstance.media.set({ ...baseMovie, folderName: '' });
+
+    await fixture.componentInstance.deleteMedia();
+
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'media_detail.delete_no_folder' }),
+    );
+  });
+});

--- a/client/src/app/features/media-detail/media-detail.delete-confirm.spec.ts
+++ b/client/src/app/features/media-detail/media-detail.delete-confirm.spec.ts
@@ -98,7 +98,7 @@ function createHarness() {
   return { fixture, confirm };
 }
 
-describe('MediaDetailComponent.deleteMedia — confirm message', () => {
+describe('MediaDetailComponent.deleteMedia - confirm message', () => {
   afterEach(() => TestBed.resetTestingModule());
 
   it('warns about the on-disk folder for a title that owns one', async () => {

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -1403,10 +1403,13 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   async deleteMedia() {
     const m = this.media();
     if (!m) return;
+    const messageKey = m.folderName
+      ? 'media_detail.confirm_delete'
+      : 'media_detail.delete_no_folder';
     if (
       !(await this.confirmation.confirm({
         title: this.translate.instant('common.confirm'),
-        message: this.translate.instant('media_detail.confirm_delete', { title: m.title }),
+        message: this.translate.instant(messageKey, { title: m.title }),
         variant: 'danger',
       }))
     )

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.html
@@ -58,7 +58,7 @@
                     ? 'settings.libraries.scan_group_series'
                     : 'settings.libraries.scan_group_movie') | translate }}
                 </span>
-                <span class="font-mono text-sm text-base-content/70 truncate">{{ vm.group.folderName }}</span>
+                <span class="font-mono text-sm text-base-content/70 truncate">{{ vm.group.folderName || vm.group.files[0].filename }}</span>
                 <span class="text-xs text-base-content/50 shrink-0">
                   {{ 'settings.libraries.scan_files' | translate: { count: vm.group.files.length } }}
                 </span>
@@ -163,7 +163,7 @@
                   @if (!deferLink()) {
                     <div class="flex justify-end">
                       <button type="button" class="btn btn-sm btn-primary"
-                        [title]="(reorganize() && !vm.pick) ? ('settings.libraries.scan_reorganize_needs_match' | translate) : ''"
+                        [title]="reorganizeTooltip(vm)"
                         (click)="link(i)" [disabled]="vm.linking || vm.searching">
                         @if (vm.linking) { <span class="loading loading-spinner loading-xs"></span> }
                         {{ (vm.pick?.existingMediaId
@@ -190,11 +190,6 @@
       />
     }
 
-    @if (looseCount() > 0) {
-        <p class="text-xs text-base-content/50 mt-4">
-          {{ 'settings.libraries.scan_loose_skipped' | translate: { count: looseCount() } }}
-        </p>
-      }
     }
   </div>
 

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.spec.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.spec.ts
@@ -58,7 +58,6 @@ const scanResult = (folders: string[]): OrphanScanResult => ({
       },
     ],
   })),
-  looseFiles: [],
   scannedFiles: folders.length,
   orphanCount: folders.length,
 });
@@ -244,6 +243,102 @@ describe('OrphanScanPanelComponent — a failing search', () => {
 
     expect(panel.groups()[0].error).toBe(
       'Metadata search failed on tmdb: HTTP 401 — Invalid API key (HTTP 503)',
+    );
+  });
+});
+
+describe('OrphanScanPanelComponent - a movie file directly at the library root', () => {
+  function setupRoot(filename: string, metadataOverrides: Record<string, unknown> = {}) {
+    const relinked: RelinkOrphansBody[] = [];
+    const rootResult: OrphanScanResult = {
+      libraryPath: '/medias',
+      groups: [
+        {
+          groupKey: `movie:/medias/${filename}`,
+          mediaType: 'movie',
+          folderName: '',
+          guessTitle: 'Quiet Harbor',
+          guessYear: 2020,
+          nfo: null,
+          suggestedProvider: 'tmdb',
+          files: [
+            {
+              filePath: `/medias/${filename}`,
+              filename,
+              size: 1,
+              qualityName: 'HDTV-720p',
+              qualityId: 1,
+              seasonNumber: null,
+              episodeNumber: null,
+              episodeEnd: null,
+            },
+          ],
+        },
+      ],
+      scannedFiles: 1,
+      orphanCount: 1,
+    };
+    const importsApi = {
+      previewOrphans: () => Promise.resolve(rootResult),
+      relinkOrphansBatch: (items: RelinkOrphansBody[]) => {
+        relinked.push(...items);
+        return Promise.resolve({ queued: items.length });
+      },
+      relinkOrphans: (body: RelinkOrphansBody) => {
+        relinked.push(body);
+        return Promise.resolve({ mediaId: 1, created: true, linked: body.files.length, errors: [] });
+      },
+    };
+    const metadata = {
+      searchMovie: () => Promise.resolve([result(11, 'Quiet Harbor')]),
+      searchTv: () => Promise.resolve([]),
+      ...metadataOverrides,
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        provideTranslateService({
+          lang: 'en',
+          loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+        }),
+        { provide: ImportsApiService, useValue: importsApi as unknown as ImportsApiService },
+        { provide: MetadataService, useValue: metadata as unknown as MetadataService },
+        { provide: ToastService, useValue: { success: () => undefined } },
+      ],
+    });
+    const fixture = TestBed.createComponent(OrphanScanPanelComponent);
+    return { panel: fixture.componentInstance, fixture, relinked };
+  }
+
+  it('shows the file name in the collapsed header instead of the empty folder name', async () => {
+    const { panel, fixture } = setupRoot('Quiet.Harbor.2020.mkv');
+    await panel.scanPath('/medias', ['movie'], 'tmdb');
+    fixture.detectChanges();
+
+    const header = fixture.nativeElement.querySelector('.collapse-title .font-mono');
+    expect(header?.textContent?.trim()).toBe('Quiet.Harbor.2020.mkv');
+  });
+
+  it('forwards folderName \'\' untouched and forces reorganize off even with a match', async () => {
+    const { panel, relinked } = setupRoot('Quiet.Harbor.2020.mkv');
+    await panel.scanPath('/medias', ['movie'], 'tmdb');
+    expect(panel.groups()[0].pick?.title).toBe('Quiet Harbor');
+
+    await panel.importAll(7);
+
+    expect(relinked).toHaveLength(1);
+    expect(relinked[0].folderName).toBe('');
+    expect(relinked[0].externalId).toBe('11');
+    expect(relinked[0].reorganize).toBe(false);
+  });
+
+  it('explains why reorganize is skipped for a root-level movie', async () => {
+    const { panel } = setupRoot('Quiet.Harbor.2020.mkv');
+    await panel.scanPath('/medias', ['movie'], 'tmdb');
+
+    expect(panel.reorganizeTooltip(panel.groups()[0])).toBe(
+      'settings.libraries.scan_reorganize_needs_folder',
     );
   });
 });

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.spec.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.spec.ts
@@ -257,7 +257,7 @@ describe('OrphanScanPanelComponent - a movie file directly at the library root',
           groupKey: `movie:/medias/${filename}`,
           mediaType: 'movie',
           folderName: '',
-          guessTitle: 'Quiet Harbor',
+          guessTitle: 'Sample Movie',
           guessYear: 2020,
           nfo: null,
           suggestedProvider: 'tmdb',
@@ -290,7 +290,7 @@ describe('OrphanScanPanelComponent - a movie file directly at the library root',
       },
     };
     const metadata = {
-      searchMovie: () => Promise.resolve([result(11, 'Quiet Harbor')]),
+      searchMovie: () => Promise.resolve([result(11, 'Sample Movie')]),
       searchTv: () => Promise.resolve([]),
       ...metadataOverrides,
     };
@@ -312,18 +312,18 @@ describe('OrphanScanPanelComponent - a movie file directly at the library root',
   }
 
   it('shows the file name in the collapsed header instead of the empty folder name', async () => {
-    const { panel, fixture } = setupRoot('Quiet.Harbor.2020.mkv');
+    const { panel, fixture } = setupRoot('sample.movie.2001.mkv');
     await panel.scanPath('/medias', ['movie'], 'tmdb');
     fixture.detectChanges();
 
     const header = fixture.nativeElement.querySelector('.collapse-title .font-mono');
-    expect(header?.textContent?.trim()).toBe('Quiet.Harbor.2020.mkv');
+    expect(header?.textContent?.trim()).toBe('sample.movie.2001.mkv');
   });
 
   it('forwards folderName \'\' untouched and forces reorganize off even with a match', async () => {
-    const { panel, relinked } = setupRoot('Quiet.Harbor.2020.mkv');
+    const { panel, relinked } = setupRoot('sample.movie.2001.mkv');
     await panel.scanPath('/medias', ['movie'], 'tmdb');
-    expect(panel.groups()[0].pick?.title).toBe('Quiet Harbor');
+    expect(panel.groups()[0].pick?.title).toBe('Sample Movie');
 
     await panel.importAll(7);
 
@@ -334,7 +334,7 @@ describe('OrphanScanPanelComponent - a movie file directly at the library root',
   });
 
   it('explains why reorganize is skipped for a root-level movie', async () => {
-    const { panel } = setupRoot('Quiet.Harbor.2020.mkv');
+    const { panel } = setupRoot('sample.movie.2001.mkv');
     await panel.scanPath('/medias', ['movie'], 'tmdb');
 
     expect(panel.reorganizeTooltip(panel.groups()[0])).toBe(

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
@@ -81,7 +81,6 @@ export class OrphanScanPanelComponent {
   readonly scanError = signal('');
   readonly scannedFiles = signal(0);
   readonly orphanCount = signal(0);
-  readonly looseCount = signal(0);
   readonly groups = signal<GroupVM[]>([]);
 
   /** Live file counter pushed by the server walk, so a multi-minute scan of a
@@ -148,7 +147,6 @@ export class OrphanScanPanelComponent {
     this.groups.set([]);
     this.scannedFiles.set(0);
     this.orphanCount.set(0);
-    this.looseCount.set(0);
 
     this.page.set(1);
 
@@ -157,7 +155,6 @@ export class OrphanScanPanelComponent {
       const res = await scan();
       this.scannedFiles.set(res.scannedFiles);
       this.orphanCount.set(res.orphanCount);
-      this.looseCount.set(res.looseFiles.length);
       this.groups.set(
         res.groups.map((group) => ({
           group,
@@ -259,7 +256,8 @@ export class OrphanScanPanelComponent {
             year: vm.year ?? undefined,
           }),
       folderName: group.folderName,
-      reorganize: pick ? this.reorganize() : false,
+      // A root-level movie has no folder to move into; the server refuses it anyway.
+      reorganize: pick && group.folderName !== '' ? this.reorganize() : false,
       files: group.files.map((f) => ({
         filePath: f.filePath,
         seasonNumber: f.seasonNumber ?? undefined,
@@ -343,6 +341,16 @@ export class OrphanScanPanelComponent {
   /** The "add as is" pseudo-option: always sets an unmatched pick, no toggle. */
   pickUnmatched(index: number) {
     this.patch(index, { pick: null, fromNfo: false });
+  }
+
+  /** Why the reorganize toggle is ignored for this group's link button, or '' when it applies. */
+  reorganizeTooltip(vm: GroupVM): string {
+    if (!this.reorganize()) return '';
+    if (!vm.pick) return this.translate.instant('settings.libraries.scan_reorganize_needs_match');
+    if (vm.group.folderName === '') {
+      return this.translate.instant('settings.libraries.scan_reorganize_needs_folder');
+    }
+    return '';
   }
 
   async link(index: number) {


### PR DESCRIPTION
## Why

A movie file sitting directly under a library root was counted by the orphan scan and then dropped ("N root files skipped, move them into a folder"). With titles no longer gated on a provider match (#1264), the last reason a file on disk stays invisible is its location. Phase 5 of `plan/local-media-without-metadata.md`.

## What

- `Media.path` falls back to `library.path` when `folderName` is empty; such a title owns exactly one file at the root. Because `media.path` feeds destructive code, every consumer was audited and the ones that matter are guarded and tested:
  - `resolveSafeMediaDir` returns `null` for a title with no folder (the row is deleted, the file stays, the library root is never touched); the delete confirmation says so (`media_detail.delete_no_folder`).
  - `LibraryIngestService.ingest` refuses to place files for a title with no folder (grabs, manual imports and reorganize all go through it).
  - `reorganize` is refused for a root title on relink; `linkExistingFileInPlace` refuses a nested path for it.
  - `rescanFiles` only stats the title's own files and never walks or cache-wipes the shared root; `doRescanMissingFiles` skips a root title with no files.
  - `discoverExternalSubtitles` keeps the exact basename match and disables only the lone-video-in-folder fallback for a root title.
  - Sibling `.nfo` / artwork (#1265) for a root title are limited to `<basename>.nfo` and `<basename>-poster` / `<basename>-fanart`, never the folder-level `poster.jpg` of the whole library.
- Orphan scan: a root movie is an ordinary group (`folderName: ''`, one file); root series files stay excluded (a series is a folder). `looseFiles` is gone from the API and the panel, which now labels such a group by its file name and forces `reorganize` off with a tooltip.
- `findOrCreateUnmatched`: reuse for root titles is matched on the file itself (every root movie shares `folderName: ''`); a title created but not linked is removed again; the title falls back to the release-name parse when none is given.

## Verification

- Backend `tsc` clean; `jest src/modules/imports src/modules/media src/common src/modules/scheduler src/modules/subtitles`: 574 tests green, incl. one spec per guard above.
- Client `ng build` clean; orphan-scan-panel and media-detail specs: 55 tests green.
- Dev stack smoke test on a root-level movie file: see the PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
