### PR TITLE
feat(media-card): add a like heart beside the actions button

### DIFF
--- a/client/src/app/features/home/home.html
+++ b/client/src/app/features/home/home.html
@@ -95,6 +95,8 @@
                 [titleLink]="item.episodeId ? ['/' + (item.mediaType === 'series' ? 'series' : 'movies'), '' + item.mediaId] : null"
                 [dismissable]="true"
                 [interactiveWatched]="true"
+                [liked]="isLiked(item.mediaId, item.episodeId)"
+                (likeToggled)="toggleLike({ mediaId: item.mediaId, episodeId: item.episodeId ?? undefined }, $event)"
                 [clickIntent]="'play'"
                 (clicked)="playContinueWatching(item)"
                 (dismissed)="removeContinueWatching(item)"
@@ -118,6 +120,8 @@
                 [subtitle]="'' + rec.media.year"
                 [link]="['/' + (rec.media.type === 'series' ? 'series' : 'movies'), '' + rec.media.id]"
                 [playlistMediaId]="rec.media.id"
+                [liked]="isLiked(rec.media.id)"
+                (likeToggled)="toggleLike({ mediaId: rec.media.id }, $event)"
                 [status]="rec.media.available ? null : 'missing'"
                 [playable]="rec.media.available"
                 [dismissable]="true"
@@ -144,6 +148,8 @@
                 [link]="likeLink(item)"
                 [playlistMediaId]="item.mediaId"
                 [playlistEpisodeId]="item.episodeId"
+                [liked]="true"
+                (likeToggled)="toggleLike({ mediaId: item.mediaId, seasonId: item.seasonId ?? undefined, episodeId: item.episodeId ?? undefined }, $event)"
               />
             }
           </app-horizontal-scroller>
@@ -163,6 +169,8 @@
                 [hideStatusBar]="true"
                 [interactiveWatched]="canMarkMediaWatched(m)"
                 (watchedToggled)="toggleRecentMediaWatched(m, $event)"
+                [liked]="isLiked(m.id)"
+                (likeToggled)="toggleLike({ mediaId: m.id }, $event)"
               />
             }
           </app-horizontal-scroller>
@@ -201,6 +209,8 @@
                 [subtitle]="entry.date | localeDate"
                 [link]="['/' + (entry.type === 'series' ? 'series' : 'movies'), '' + entry.mediaId]"
                 [playlistMediaId]="entry.mediaId"
+                [liked]="isLiked(entry.mediaId)"
+                (likeToggled)="toggleLike({ mediaId: entry.mediaId }, $event)"
               />
             }
           </app-horizontal-scroller>
@@ -241,6 +251,8 @@
                 [hideStatusBar]="true"
                 [interactiveWatched]="canMarkMediaWatched(m)"
                 (watchedToggled)="toggleLibraryRecentWatched(section.libraryId!, m, $event)"
+                [liked]="isLiked(m.id)"
+                (likeToggled)="toggleLike({ mediaId: m.id }, $event)"
               />
             }
           </app-horizontal-scroller>

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -9,7 +9,7 @@ import { StreamingApiService, ContinueWatchingItem, RecommendationItem } from '.
 import { OfflinePlaybackSyncService } from '../../core/services/offline-playback-sync.service';
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
 import { PlaylistsApiService, Playlist } from '../../core/services/api/playlists-api.service';
-import { LikesApiService, LikedItem } from '../../core/services/api/likes-api.service';
+import { LikesApiService, LikedItem, LikeTarget } from '../../core/services/api/likes-api.service';
 import { RequestsService, FliksRequestRow } from '../../core/services/api/requests.service';
 import { SseService } from '../../core/services/sse.service';
 import {
@@ -326,6 +326,21 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   openPlaylist(id: number): void {
     void this.router.navigate(['/playlists', id]);
+  }
+
+  isLiked(mediaId: number, episodeId?: number | null, seasonId?: number | null): boolean {
+    return this.likes().some(
+      (l) => l.mediaId === mediaId && l.episodeId === (episodeId ?? null) && l.seasonId === (seasonId ?? null),
+    );
+  }
+
+  /** Refetches the row: a new like needs the title/artwork only the server has. */
+  async toggleLike(target: LikeTarget, liked: boolean) {
+    try {
+      await (liked ? this.likesApi.like(target) : this.likesApi.unlike(target));
+      const likes = await this.likesApi.mine(undefined, { force: true });
+      this.likes.set(likes);
+    } catch { /* interceptor surfaces errors */ }
   }
 
   /** Route to a liked item: the episode page when it targets an episode,

--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -363,6 +363,8 @@
                   [progressPercent]="item.progressPercent ?? 0"
                   [interactiveWatched]="canMarkMediaWatched(item)"
                   (watchedToggled)="toggleMediaWatched(item, $event)"
+                  [liked]="isLiked(item.id)"
+                  (likeToggled)="toggleLike(item, $event)"
                 />
               </div>
             } @else {
@@ -373,6 +375,8 @@
                   [progressPercent]="item.progressPercent ?? 0"
                   [interactiveWatched]="canMarkMediaWatched(item)"
                   (watchedToggled)="toggleMediaWatched(item, $event)"
+                  [liked]="isLiked(item.id)"
+                  (likeToggled)="toggleLike(item, $event)"
                 />
               </div>
             }

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -390,6 +390,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
       this.scrollMemory.activate(scrollKey);
       this.syncQueryParams();
       await this.load(lib.id);
+      void this.loadLikes();
       if (this.viewMode() === 'suggestions') {
         // Either a deep-link with `?view=suggestions` or a return from
         // back-nav with the persisted mode. Fetch the suggestions data
@@ -427,10 +428,10 @@ export class LibraryComponent implements OnInit, OnDestroy {
       const lib = this.library();
       if (lib) {
         void this.load(lib.id, true);
+        void this.loadLikes();
         if (this.viewMode() === 'genres') void this.loadGenres();
         else if (this.viewMode() === 'collections') void this.loadCollections();
         else if (this.viewMode() === 'suggestions') void this.loadSuggestions();
-        else if (this.viewMode() === 'likes') void this.loadLikes();
       }
     });
   }
@@ -441,9 +442,9 @@ export class LibraryComponent implements OnInit, OnDestroy {
     const lib = this.library();
     if (!lib) return;
     void this.load(lib.id, true);
+    void this.loadLikes();
     if (this.viewMode() === 'suggestions') void this.loadSuggestions();
     else if (this.viewMode() === 'genres') void this.loadGenres();
-    else if (this.viewMode() === 'likes') void this.loadLikes();
   }
 
   ngOnDestroy() {
@@ -821,6 +822,17 @@ export class LibraryComponent implements OnInit, OnDestroy {
    *  reference and the action would silently no-op. */
   canMarkMediaWatched(m: Media): boolean {
     return m.type === 'series' || !!m.files?.length;
+  }
+
+  isLiked(mediaId: number): boolean {
+    return this.likesList().some((l) => l.mediaId === mediaId && !l.seasonId && !l.episodeId);
+  }
+
+  async toggleLike(m: Media, liked: boolean) {
+    try {
+      await (liked ? this.likesApi.like({ mediaId: m.id }) : this.likesApi.unlike({ mediaId: m.id }));
+      await this.loadLikes();
+    } catch { /* interceptor surfaces errors */ }
   }
 
   async toggleMediaWatched(m: Media, watched: boolean) {

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.html
@@ -30,7 +30,23 @@
         </button>
       </div>
     }
-    <app-dropdown-menu placement="bottom-end" [class]="canSwitchEpisodeView() ? 'order-last' : 'order-last ms-auto'">
+    @if (selSeason) {
+      <button
+        type="button"
+        class="order-last btn btn-ghost btn-circle shrink-0"
+        [class.ms-auto]="!canSwitchEpisodeView()"
+        (click)="toggleSeasonLike.emit(selSeason.id)"
+        [attr.aria-label]="(isSeasonLiked(selSeason.id) ? 'likes.unlike_season' : 'likes.like_season') | translate"
+      >
+        <svg
+          lucideHeart
+          class="h-5 w-5"
+          [class.text-error]="isSeasonLiked(selSeason.id)"
+          [attr.fill]="isSeasonLiked(selSeason.id) ? 'currentColor' : 'none'"
+        ></svg>
+      </button>
+    }
+    <app-dropdown-menu placement="bottom-end" class="order-last" [class.ms-auto]="!canSwitchEpisodeView() && !selSeason">
       <button trigger type="button" class="btn btn-ghost btn-circle shrink-0">
         <svg lucideEllipsisVertical class="h-5 w-5"></svg>
       </button>
@@ -254,6 +270,8 @@
                 [link]="episodeRoute(ep)"
                 [playlistMediaId]="m.id"
                 [playlistEpisodeId]="ep.id"
+                [liked]="likedEpisodeIds().includes(ep.id)"
+                (likeToggled)="toggleEpisodeLike.emit(ep.id)"
                 [replaceUrl]="hideControls()"
                 [playable]="ep.hasFile"
                 [interactiveWatched]="ep.hasFile"
@@ -316,6 +334,8 @@
             [link]="episodeRoute(ep)"
             [playlistMediaId]="m.id"
             [playlistEpisodeId]="ep.id"
+            [liked]="likedEpisodeIds().includes(ep.id)"
+            (likeToggled)="toggleEpisodeLike.emit(ep.id)"
             [replaceUrl]="hideControls()"
             [playable]="ep.hasFile"
             [interactiveWatched]="ep.hasFile"

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -127,6 +127,7 @@ export class MediaDetailSeasonsComponent {
   readonly activeEpisodeId = input<number | null>(null);
   /** Season ids the viewer has liked — drives the season heart entry. */
   readonly likedSeasonIds = input<number[]>([]);
+  readonly likedEpisodeIds = input<number[]>([]);
 
   /**
    * Card the rail should land on: the episode the page is showing, or the one
@@ -156,6 +157,7 @@ export class MediaDetailSeasonsComponent {
   readonly viewSeasonTracking = output<number>();
   /** Toggle the viewer's like on this season (emits the season id). */
   readonly toggleSeasonLike = output<number>();
+  readonly toggleEpisodeLike = output<number>();
   /** Recommend this season to another member (emits the season id). */
   readonly recommendSeason = output<number>();
   readonly seasonWatchedBusyId = input<number | null>(null);

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -105,6 +105,8 @@
               [episodeProgress]="episodeProgress()"
               [hideControls]="true"
               [sectionTitle]="'media_detail.more_from_season' | translate: { season: s.seasonNumber }"
+              [likedEpisodeIds]="likeState().episodeIds"
+              (toggleEpisodeLike)="toggleEpisodeLike($event)"
               (toggleEpisodeWatched)="onToggleEpisodeWatched(m.id, $event.episode, $event.watched)"
             />
           }
@@ -130,6 +132,8 @@
                   [interactiveWatched]="true"
                   [status]="seasonFullyWatched(other) ? 'watched' : null"
                   [highlighted]="other.id === focusedSeason()?.id"
+                  [liked]="seasonLiked(other.id)"
+                  (likeToggled)="toggleSeasonLike(other.id)"
                   (watchedToggled)="onToggleSeasonWatched(m.id, other, $event)"
                 />
               }
@@ -334,6 +338,8 @@
             [canRequest]="canRequest()"
             [userRequestedSeasonNumbers]="requestedSeasons()"
             [likedSeasonIds]="likeState().seasonIds"
+            [likedEpisodeIds]="likeState().episodeIds"
+            (toggleEpisodeLike)="toggleEpisodeLike($event)"
             (selectSeason)="selectSeason($event)"
             (episodesHasFileOnlyChange)="setEpisodesHasFileOnly($event)"
             (loadSeasonReleases)="loadSeasonReleases(m.id, $event)"

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -2176,19 +2176,26 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     this.recommend.open({ mediaId: m.id, seasonId });
   }
 
-  async toggleSeasonLike(seasonId: number): Promise<void> {
+  toggleSeasonLike(seasonId: number): Promise<void> {
+    return this.toggleIdLike('seasonIds', seasonId);
+  }
+
+  toggleEpisodeLike(episodeId: number): Promise<void> {
+    return this.toggleIdLike('episodeIds', episodeId);
+  }
+
+  private async toggleIdLike(key: 'seasonIds' | 'episodeIds', id: number): Promise<void> {
     const m = this.media();
     if (!m) return;
-    const wasLiked = this.seasonLiked(seasonId);
+    const wasLiked = this.likeState()[key].includes(id);
     this.likeState.update((st) => ({
       ...st,
-      seasonIds: wasLiked
-        ? st.seasonIds.filter((i) => i !== seasonId)
-        : [...st.seasonIds, seasonId],
+      [key]: wasLiked ? st[key].filter((i) => i !== id) : [...st[key], id],
     }));
+    const target = key === 'seasonIds' ? { mediaId: m.id, seasonId: id } : { mediaId: m.id, episodeId: id };
     try {
-      if (wasLiked) await this.likesApi.unlike({ mediaId: m.id, seasonId });
-      else await this.likesApi.like({ mediaId: m.id, seasonId });
+      if (wasLiked) await this.likesApi.unlike(target);
+      else await this.likesApi.like(target);
     } catch {
       void this.loadLikeState(m.id);
     }

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -110,20 +110,17 @@
     } @else if (interactiveWatched()) {
       <button
         type="button"
-        class="absolute top-1.5 right-1.5 z-10 w-5 h-5 rounded-full flex items-center justify-center shadow transition-colors cursor-pointer pointer-events-auto"
+        class="absolute top-2 right-2 z-10 btn btn-circle btn-xs border-0 transition-colors pointer-events-auto"
         [class.bg-success]="status() === 'watched'"
-        [class.hover:bg-success/90]="status() === 'watched'"
+        [class.hover:bg-success/80]="status() === 'watched'"
+        [class.text-success-content]="status() === 'watched'"
         [class.bg-black/50]="status() !== 'watched'"
-        [class.hover:bg-black/70]="status() !== 'watched'"
+        [class.hover:bg-neutral-500/50]="status() !== 'watched'"
+        [class.text-white]="status() !== 'watched'"
         (click)="onWatchedClick($event)"
         [attr.aria-label]="(status() === 'watched' ? 'media_card.mark_unwatched' : 'media_card.mark_watched') | translate"
       >
-        <svg
-          lucideCheck
-          class="h-3 w-3"
-          [class.text-success-content]="status() === 'watched'"
-          [class.text-white/80]="status() !== 'watched'"
-        ></svg>
+        <svg lucideCheck class="h-3.5 w-3.5" [strokeWidth]="2"></svg>
       </button>
     } @else if (_resolvedStatus() === 'watched') {
       <div class="absolute top-1.5 right-1.5 z-10">
@@ -154,16 +151,30 @@
       </div>
     }
 
-    <!-- Actions button (desktop) — opens the same panel as TV menu / mobile long-press -->
-    @if (showHoverOverlay() && cardActions().length) {
-      <button
-        type="button"
-        class="absolute bottom-2 right-2 z-10 btn btn-circle btn-sm border-0 bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-neutral-500/50 pointer-events-auto"
-        (click)="openActions($event)"
-        [attr.aria-label]="'media_card.actions' | translate"
-      >
-        <svg lucideEllipsisVertical class="h-4 w-4" [strokeWidth]="2"></svg>
-      </button>
+    <!-- Bottom-right (desktop): like heart + actions button opening the same panel as TV menu / mobile long-press -->
+    @if (showHoverOverlay() && (liked() !== null || cardActions().length)) {
+      <div class="absolute bottom-2 right-2 z-10 flex items-center gap-1 pointer-events-auto">
+        @if (liked() !== null) {
+          <button
+            type="button"
+            class="btn btn-circle btn-xs border-0 bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-neutral-500/50"
+            (click)="onLikeClick($event)"
+            [attr.aria-label]="(liked() ? 'likes.unlike' : 'likes.like') | translate"
+          >
+            <svg lucideHeart class="h-3.5 w-3.5" [strokeWidth]="2" [class.text-error]="liked()" [attr.fill]="liked() ? 'currentColor' : 'none'"></svg>
+          </button>
+        }
+        @if (cardActions().length) {
+          <button
+            type="button"
+            class="btn btn-circle btn-xs border-0 bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-neutral-500/50"
+            (click)="openActions($event)"
+            [attr.aria-label]="'media_card.actions' | translate"
+          >
+            <svg lucideEllipsisVertical class="h-3.5 w-3.5" [strokeWidth]="2"></svg>
+          </button>
+        }
+      </div>
     }
     </div>
   </figure>

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -2,7 +2,7 @@ import { Component, ChangeDetectionStrategy, ElementRef, input, output, computed
 import { Router, RouterLink } from '@angular/router';
 import { NgClass, DecimalPipe } from '@angular/common';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { LucideFilm, LucidePlay, LucideStar, LucideCheck, LucideClock, LucideEllipsisVertical, LucideCircleX } from '@lucide/angular';
+import { LucideFilm, LucidePlay, LucideStar, LucideCheck, LucideClock, LucideEllipsisVertical, LucideCircleX, LucideHeart } from '@lucide/angular';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import { Media } from '../../../core/services/api/media.service';
 import { computeMediaBarStatus } from '../../utils/media-status.util';
@@ -47,7 +47,7 @@ export type CardStatus = 'watched' | 'missing' | null;
   selector: 'app-media-card',
   imports: [
     CachedSrcDirective,RouterLink, NgClass, DecimalPipe, ResolveUrlPipe, TranslateModule,
-    LucideFilm, LucidePlay, LucideStar, LucideCheck, LucideClock, LucideEllipsisVertical, LucideCircleX,
+    LucideFilm, LucidePlay, LucideStar, LucideCheck, LucideClock, LucideEllipsisVertical, LucideCircleX, LucideHeart,
     CardActionsDirective, SpoilerDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-card.html',
@@ -155,6 +155,8 @@ export class MediaCardComponent {
    * change, otherwise the click does nothing.
    */
   readonly interactiveWatched = input(false);
+  /** Viewer's like on this card; `null` hides the heart. Parents persist via {@link likeToggled}. */
+  readonly liked = input<boolean | null>(null);
   /**
    * Escape hatch for a caller-owned action the `card.actions` registry can't
    * express (e.g. home's recommendation-row "mark watched", which drops the
@@ -178,6 +180,8 @@ export class MediaCardComponent {
   readonly dismissed = output<void>();
   /** Emits the desired target state (true = mark watched, false = unmark). */
   readonly watchedToggled = output<boolean>();
+  /** Emits the desired target state (true = like, false = unlike). */
+  readonly likeToggled = output<boolean>();
 
   // Resolved template values (explicit input wins over media-derived default)
   protected readonly _img = computed(() => this.imageUrl() ?? this.media()?.posterUrl ?? null);
@@ -410,6 +414,11 @@ export class MediaCardComponent {
   protected onWatchedClick(event: Event) {
     event.stopPropagation();
     this.watchedToggled.emit(this.status() !== 'watched');
+  }
+
+  protected onLikeClick(event: Event) {
+    event.stopPropagation();
+    this.likeToggled.emit(!this.liked());
   }
 
   protected onPlayClick(event: Event) {


### PR DESCRIPTION
## Summary
- media-card: heart button left of the actions button, same `btn-xs` circle, `bg-black/50` and hover; hover-only like the ellipsis, filled red when liked. New `liked` input (null hides it) and `likeToggled` output.
- The interactive watched toggle is restyled to match the same button family.
- Home: hearts on continue-watching, recommendations, likes row, recent, per-library recent and coming-soon rows; the likes row is refetched after a toggle.
- Library: hearts on the grid. Likes are now loaded alongside the grid, not only on the Likes tab.
- Detail page: hearts on episode cards (both seasons instances, list and rail), other-seasons cards, and a heart button next to the season "more" menu. Season and episode toggles share one optimistic helper that resyncs on error.

Not covered: search results, which have no like data on the page.

## Test plan
- [x] `ng build` development
- [x] media-card spec (36) and media-detail specs (76) green
- [ ] Manual: like/unlike from a home row, the library grid, and the "more from season" rail on an episode page

🤖 Generated with [Claude Code](https://claude.com/claude-code)