### PR TITLE
fix(player): prefer the remembered hearing-impaired flag when restoring subtitles

### DIFF
--- a/client/src/app/core/services/cast-playback-target.ts
+++ b/client/src/app/core/services/cast-playback-target.ts
@@ -75,7 +75,7 @@ export class CastPlaybackTarget implements PlaybackTarget {
       return;
     }
     this.cp.activeSubtitleId.set(s.id);
-    this.cp.saveSubtitleSelection(s.language, s.forced);
+    this.cp.saveSubtitleSelection(s.language, s.forced, s.hearingImpaired);
     if (s.burnIn) {
       this.cp.changeBurnIn(s.castTrackId ?? 0);
     } else if (s.castTrackId) {

--- a/client/src/app/core/services/cast-player.service.ts
+++ b/client/src/app/core/services/cast-player.service.ts
@@ -25,6 +25,7 @@ export interface CastSubtitleOption {
   language: string;
   burnIn: boolean;
   forced?: boolean;
+  hearingImpaired?: boolean;
   castTrackId?: number;
   subtitleDbId?: number;
 }
@@ -99,6 +100,7 @@ interface SubtitleInfo {
   subtitleDbId?: number;
   url: string;
   forced?: boolean;
+  hearingImpaired?: boolean;
 }
 
 /**
@@ -353,6 +355,7 @@ export class CastPlayerService {
       language: s.language,
       burnIn: s.burnIn,
       forced: s.forced,
+      hearingImpaired: s.hearingImpaired,
       subtitleDbId: s.subtitleDbId,
       castTrackId: s.burnIn ? s.subtitleDbId : trackId++,
     })));
@@ -669,17 +672,20 @@ export class CastPlayerService {
     if (!settings.rememberSubtitleSelections || !mediaId) return null;
     const saved = this.playerSettings.getRememberedSubtitleTrack(mediaId);
     if (!saved || saved === 'off') return null;
-    const [savedLang, savedType] = saved.split(':');
-    const wantForced = savedType === 'forced';
+    const parts = saved.split(':');
+    const savedLang = parts[0];
+    const wantForced = parts.includes('forced');
+    const wantHi = parts.includes('hi');
     const match =
-      subtitles.find((s) => !s.burnIn && s.language === savedLang && !!s.forced === wantForced)
+      subtitles.find((s) => !s.burnIn && s.language === savedLang && !!s.forced === wantForced && !!s.hearingImpaired === wantHi)
+      ?? subtitles.find((s) => !s.burnIn && s.language === savedLang && !!s.forced === wantForced)
       ?? subtitles.find((s) => !s.burnIn && s.language === savedLang && !s.forced);
     return match?.id ?? null;
   }
 
-  saveSubtitleSelection(language: string | null, forced = false) {
+  saveSubtitleSelection(language: string | null, forced = false, hearingImpaired = false) {
     const mId = this.mediaId();
-    if (mId) this.trackManager.saveSubtitleSelection(mId, language, forced);
+    if (mId) this.trackManager.saveSubtitleSelection(mId, language, forced, false, false, hearingImpaired);
   }
 
   private async loadSpriteMetadata(mediaFileId: number) {
@@ -776,6 +782,7 @@ export class CastPlayerService {
             ? ''
             : this.streamingApi.getEmbeddedSubtitleUrl(opts.mediaFileId, t.streamIndex!),
       forced: t.forced,
+      hearingImpaired: t.hearingImpaired,
     }));
 
     const audioTracks = buildCastAudioOptions(streamInfo?.audio, this.translate);

--- a/client/src/app/core/services/track-manager.service.ts
+++ b/client/src/app/core/services/track-manager.service.ts
@@ -24,6 +24,7 @@ export interface SubtitleOption {
   subtitleDbId?: number;
   /** True if this is a forced subtitle track */
   forced?: boolean;
+  hearingImpaired?: boolean;
   /** Origin: `translated`, `ocr`, `embedded`, or a download provider name. */
   providerType?: string | null;
   /** Player-menu two-line label: language head + details subline ("SRT • …"). */
@@ -121,10 +122,10 @@ export class TrackManagerService {
   }
 
   /** Save subtitle selection for this media. Pass null = user explicitly disabled.
-   *  Stores "language[:forced][:embedded][:image]", or "off" when disabled. */
-  saveSubtitleSelection(mediaId: number, language: string | null, forced = false, embedded = false, image = false): void {
+   *  Stores "language[:forced][:embedded][:image][:hi]", or "off" when disabled. */
+  saveSubtitleSelection(mediaId: number, language: string | null, forced = false, embedded = false, image = false, hearingImpaired = false): void {
     if (!this.playerSettings.get().rememberSubtitleSelections || !mediaId) return;
-    const flags = [forced ? 'forced' : '', embedded ? 'embedded' : '', image ? 'image' : ''].filter(Boolean).join(':');
+    const flags = [forced ? 'forced' : '', embedded ? 'embedded' : '', image ? 'image' : '', hearingImpaired ? 'hi' : ''].filter(Boolean).join(':');
     const value = language ? `${language}${flags ? ':' + flags : ''}` : 'off';
     this.playerSettings.saveRememberedSubtitleTrack(mediaId, value);
   }
@@ -175,6 +176,7 @@ export class TrackManagerService {
         burnIn: t.kind === 'embedded' && t.isImage && !rendersImageNatively,
         subtitleDbId: t.subtitleId,
         forced: t.forced,
+        hearingImpaired: t.hearingImpaired,
         providerType: t.providerType,
         };
       });
@@ -202,6 +204,7 @@ export class TrackManagerService {
             language: emb.language,
             burnIn: false,
             forced: emb.forced ?? false,
+            hearingImpaired: emb.hearingImpaired ?? false,
           });
         }
       }
@@ -241,7 +244,7 @@ export class TrackManagerService {
     const subs = subtitles.filter((s) => !s.isImage);
     if (!subs.length && !subtitles.length) return;
 
-    // Priority 1: remembered selection by "language[:forced][:embedded]" or "off"
+    // Priority 1: remembered selection by "language[:forced][:embedded][:image][:hi]" or "off"
     if (settings.rememberSubtitleSelections) {
       const saved = this.playerSettings.getRememberedSubtitleTrack(mediaId);
       if (saved === 'off') return; // User explicitly disabled subtitles
@@ -251,14 +254,17 @@ export class TrackManagerService {
         const wantForced = parts.includes('forced');
         const wantEmbedded = parts.includes('embedded');
         const wantImage = parts.includes('image');
+        const wantHi = parts.includes('hi');
         const isEmbedded = (s: SubtitleOption) => s.id.startsWith('emb-');
         const sameImage = (s: SubtitleOption) => !!s.isImage === wantImage;
+        const sameHi = (s: SubtitleOption) => !!s.hearingImpaired === wantHi;
         // Restore image picks too — selectSubtitle renders them natively
         // (direct play) or burns them in (web / transcode).
         const pool = wantImage ? subtitles : subs;
-        // Best match: language + image-ness + type (embedded/external) + forced.
+        // Best match: language + image-ness + forced + hearing-impaired + type (embedded/external).
         const match =
-          pool.find((s) => s.language === savedLang && sameImage(s) && !!s.forced === wantForced && isEmbedded(s) === wantEmbedded)
+          pool.find((s) => s.language === savedLang && sameImage(s) && !!s.forced === wantForced && sameHi(s) && isEmbedded(s) === wantEmbedded)
+          ?? pool.find((s) => s.language === savedLang && sameImage(s) && !!s.forced === wantForced && sameHi(s))
           ?? pool.find((s) => s.language === savedLang && sameImage(s) && !!s.forced === wantForced)
           ?? pool.find((s) => s.language === savedLang && sameImage(s))
           ?? subs.find((s) => s.language === savedLang && !s.forced);

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -4172,6 +4172,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         sub.forced,
         sub.id.startsWith('emb-'),
         true,
+        sub.hearingImpaired,
       );
       await this.reloadStream();
       return;
@@ -4205,7 +4206,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     }
 
     this.activeSubtitleId.set(sub.id);
-    this.trackManager.saveSubtitleSelection(this.mediaId, sub.language, sub.forced, sub.id.startsWith('emb-'), sub.isImage);
+    this.trackManager.saveSubtitleSelection(this.mediaId, sub.language, sub.forced, sub.id.startsWith('emb-'), sub.isImage, sub.hearingImpaired);
   }
 
   // Bound DOM handlers kept as stable references so ngOnDestroy can remove

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -92,6 +92,7 @@ export interface MediaInfoHeaderSubtitle {
   sub?: string;
   language: string;
   forced?: boolean;
+  hearingImpaired?: boolean;
   /** Bitmap (PGS/VOBSUB) track. */
   image?: boolean;
 }
@@ -459,9 +460,11 @@ export class MediaInfoHeaderComponent {
       const lang = parts[0];
       const wantForced = parts.includes('forced');
       const wantImage = parts.includes('image');
+      const wantHi = parts.includes('hi');
       const subs = this.subtitles();
       const match =
-        subs.find(s => s.language === lang && !!s.image === wantImage && !!s.forced === wantForced)
+        subs.find(s => s.language === lang && !!s.image === wantImage && !!s.forced === wantForced && !!s.hearingImpaired === wantHi)
+        ?? subs.find(s => s.language === lang && !!s.image === wantImage && !!s.forced === wantForced)
         ?? subs.find(s => s.language === lang && !!s.image === wantImage)
         ?? subs.find(s => s.language === lang && !s.forced);
       this.selectedSubtitleId.set(match?.id ?? null);
@@ -544,7 +547,7 @@ export class MediaInfoHeaderComponent {
       this.trackManager.saveSubtitleSelection(mediaId, null);
     } else {
       const sub = this.subtitles().find(s => s.id === id);
-      if (sub) this.trackManager.saveSubtitleSelection(mediaId, sub.language, sub.forced, sub.id.startsWith('emb-'), sub.image);
+      if (sub) this.trackManager.saveSubtitleSelection(mediaId, sub.language, sub.forced, sub.id.startsWith('emb-'), sub.image, sub.hearingImpaired);
     }
   }
 

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -498,6 +498,7 @@ export class SubtitlesModalComponent {
         sub: parts.sub,
         language: s.language,
         forced: s.forced,
+        hearingImpaired: s.hearingImpaired,
         image: isImageBasedSubtitleCodec(s.codec),
       };
     });


### PR DESCRIPTION
## Problem
Watching a series with an FR subtitle selected, then moving to an episode that has both FR and FR (hearing-impaired): the remembered key was `lang[:forced][:embedded][:image]`, so both tracks matched and the first one in track order won.

## Fix
- The remembered key gains an `hi` tag when the picked track is hearing-impaired.
- Every restore path (player auto-select, cast resume, detail-page header) tries an exact `hi` match first, then falls back to the existing language + forced tiers, so older stored keys still resolve.
- `hearingImpaired` is carried through the player, cast and header subtitle option shapes.

## Verification
- `tsc -p tsconfig.app.json --noEmit` green.
- `media-info-header.spec.ts` passes (35 tests).