### PR TITLE
fix(media-detail): resume the episode rail from where the viewer left it

### DIFF
--- a/client/src/app/shared/utils/center-rail.ts
+++ b/client/src/app/shared/utils/center-rail.ts
@@ -1,6 +1,7 @@
-/** Last offset each keyed rail was centred at, so a rail rebuilt by a
- *  navigation resumes from there instead of from the far left. */
+/** Where each keyed rail was last scrolled to, by the viewer or by us, so a
+ *  rail rebuilt by a navigation resumes from there instead of from the far left. */
 const lastOffset = new Map<string, number>();
+const tracked = new WeakSet<Element>();
 
 /**
  * Centre a horizontal rail on one of its cards, addressed by element id. No-op
@@ -14,9 +15,11 @@ export function centerRailOnCard(cardId: string, memoryKey?: string): void {
   const card = document.getElementById(cardId);
   const rail = card?.parentElement;
   if (!card || !rail || rail.scrollWidth <= rail.clientWidth) return;
-  if (memoryKey !== undefined && rail.scrollLeft === 0) {
+  if (memoryKey !== undefined && !tracked.has(rail)) {
+    tracked.add(rail);
     const previous = lastOffset.get(memoryKey);
     if (previous) rail.scrollTo({ left: previous, behavior: 'instant' });
+    rail.addEventListener('scroll', () => lastOffset.set(memoryKey, rail.scrollLeft), { passive: true });
   }
   const offset =
     card.getBoundingClientRect().left -
@@ -24,7 +27,5 @@ export function centerRailOnCard(cardId: string, memoryKey?: string): void {
     rail.scrollLeft -
     rail.clientWidth / 2 +
     card.offsetWidth / 2;
-  const target = Math.max(0, offset);
-  if (memoryKey !== undefined) lastOffset.set(memoryKey, target);
-  rail.scrollTo({ left: target, behavior: 'smooth' });
+  rail.scrollTo({ left: Math.max(0, offset), behavior: 'smooth' });
 }


### PR DESCRIPTION
## Problem
On an episode page, the "More from season X" rail is rebuilt on every episode navigation. Its memory stored the offset it was last **centred** at, not where the viewer scrolled. From episode 19, scrolling left and opening episode 3 restored the episode-19 offset, then animated all the way back to 3.

## Fix
- The memory follows the rail's real `scrollLeft` through a passive scroll listener, attached once per rail element (`WeakSet`).
- The restore is gated on "rail not seen yet" instead of `scrollLeft === 0`, which also stops a rail the viewer deliberately scrolled to the start from being yanked back.
- The centring scroll is now only the short hop from where the viewer actually was.

## Verification
- `tsc -p tsconfig.app.json --noEmit` green.
- Manual scenario to check: ep 19 → scroll left → open ep 3 (no long animation); ep 1 → scroll right → open ep 19 (unchanged).