### PR TITLE
chore(deps): update tar to 7.5.22 in the client and desktop trees

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "3.2.1",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "3.2.1",
+      "version": "3.7.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@angular/cdk": "^21.2.4",
@@ -17336,9 +17336,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fliks-desktop",
-  "version": "1.12.3",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fliks-desktop",
-      "version": "1.12.3",
+      "version": "3.7.0",
       "dependencies": {
         "electron-updater": "^6.8.9"
       },
@@ -3806,9 +3806,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
Supersedes #1246.

## Context

trivy flags CVE-2026-59873 (gzip-bomb DoS in node-tar) on the lockfiles. Worth fixing, but the severity label deserves context: `tar` is **not** a dependency of either app.

- **client**: no root `dependencies` / `devDependencies` entry. The hoisted copy is pulled by `@capacitor/cli`, `@webosose/ares-cli`, `node-gyp` and `pacote` — build tooling, none of which reaches the browser bundle.
- **desktop**: the entry is marked `"dev": true`.
- **backend**: no `tar` in the tree at all.

So the exposure is a build machine extracting a hostile archive, not the shipped product.

## Why no `overrides`

Every parent that pulls the hoisted copy already asks for a caret range — `^7.5.3`, `^7.5.4`, `^7.4.3` — all of which accept the fixed version. `npm update tar` is enough, and the whole diff stays inside the two lockfiles: **0 lines of `package.json`, 10 lines of lock**.

#1246 added 23 lines of per-parent `overrides` for this. Three of its seven entries (`@angular/cli`, `@npmcli/run-script`, and `tar` itself) name packages that declare no `tar` dependency in the lock, and `"tar": { "tar": "…" }` is a no-op.

## What is deliberately left alone

`@webosose/ares-cli` pins `tar` to exactly `2.2.2` in a nested copy (`node_modules/@webosose/ares-cli/node_modules/tar`). It is the oldest copy in the tree and the only one an override could actually help — but escaping that pin forces a 2.x → 7.x jump on the webOS packaging CLI, whose API changed across that major. That needs a green `webos:build` behind it, not a rider on a patch bump. #1246 declared an override for it and did not move it either; the nested 2.2.2 is untouched there too.

## Incidental

`npm` realigns each lockfile's own `version` field from its `package.json`: client `3.2.1` → `3.7.0`, desktop `1.12.3` → `3.7.0`. release-please bumps the `package.json` files through `extra-files` but never the `version` embedded in the locks, so all three had drifted (backend's is still `3.0.0`, untouched here since it has no `tar`). Worth its own fix.

## Verification

- `npm view tar@7.5.22 dist.integrity` matches the hash written into both lockfiles, from the official registry URL.
- `npm ls tar --all` resolves clean in the client: every hoisted consumer deduped on 7.5.22, no `invalid`.