### PR TITLE
ci(release-please): bump the version inside the three package-lock files

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -14,13 +14,43 @@
         },
         {
           "type": "json",
+          "path": "backend/package-lock.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "backend/package-lock.json",
+          "jsonpath": "$.packages[''].version"
+        },
+        {
+          "type": "json",
           "path": "client/package.json",
           "jsonpath": "$.version"
         },
         {
           "type": "json",
+          "path": "client/package-lock.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "client/package-lock.json",
+          "jsonpath": "$.packages[''].version"
+        },
+        {
+          "type": "json",
           "path": "desktop/package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "desktop/package-lock.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "desktop/package-lock.json",
+          "jsonpath": "$.packages[''].version"
         },
         {
           "type": "json",


### PR DESCRIPTION
Follow-up to #1277, which surfaced the drift.

## Problem

`extra-files` in [`.github/release-please-config.json`](.github/release-please-config.json) bumps `backend/`, `client/` and `desktop/` `package.json`, but never the `version` field npm mirrors inside each `package-lock.json`. All three had drifted badly from the released tag:

| lockfile | `version` before | `package.json` |
|---|---|---|
| `client/package-lock.json` | `3.2.1` | `3.7.0` |
| `backend/package-lock.json` | `3.0.0` | `3.7.0` |
| `desktop/package-lock.json` | `1.12.3` | `3.7.0` |

The drift is invisible until some npm command rewrites a lock, at which point the realignment shows up as a diff unrelated to whatever dependency was actually being changed. That's exactly how #1246 ended up carrying a version bump alongside a `tar` upgrade, and why #1277 has to explain the same two lines.

## Fix

Two `extra-files` entries per lockfile — a lockfile stores the version twice, at the top level and again under the root package entry `packages[""]`:

```json
{ "type": "json", "path": "client/package-lock.json", "jsonpath": "$.version" },
{ "type": "json", "path": "client/package-lock.json", "jsonpath": "$.packages[''].version" }
```

## Verification

The empty-string key is the part worth checking, since it has to survive the jsonpath dialect release-please's `json` updater parses. Resolved against the `jsonpath` package on all three real lockfiles — 6/6 paths match exactly one node each:

```
backend/package-lock.json $.version                  -> ["3.0.0"]
backend/package-lock.json $.packages[''].version     -> ["3.0.0"]
client/package-lock.json  $.version                  -> ["3.2.1"]
client/package-lock.json  $.packages[''].version     -> ["3.2.1"]
desktop/package-lock.json $.version                  -> ["1.12.3"]
desktop/package-lock.json $.packages[''].version     -> ["1.12.3"]
```

`examples/plugin-scaffold` and `tools` also have lockfiles, but their `package.json` versions aren't release-managed, so they're left out.

Since release PR #1153 is regenerated on every push to `main`, the 4.0.0 release will pick this up and realign all three.