### PR TITLE
chore(i18n): say codec level in the transcode reason label

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -114,7 +114,7 @@
       "VideoCodecNotSupported": "Video-Codec nicht unterstützt",
       "VideoHdrNotSupported": "HDR → SDR",
       "VideoProfileNotSupported": "Video-Profil nicht unterstützt",
-      "VideoLevelNotSupported": "Video-Level zu hoch",
+      "VideoLevelNotSupported": "Video-Codec-Level zu hoch",
       "VideoBitDepthNotSupported": "10-bit nicht unterstützt",
       "VideoResolutionNotSupported": "Auflösung zu hoch",
       "VideoCrop": "Entfernung der schwarzen Balken",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -119,7 +119,7 @@
       "VideoCodecNotSupported": "Video codec not supported",
       "VideoHdrNotSupported": "HDR → SDR",
       "VideoProfileNotSupported": "Video profile not supported",
-      "VideoLevelNotSupported": "Video level too high",
+      "VideoLevelNotSupported": "Video codec level too high",
       "VideoBitDepthNotSupported": "10-bit not supported",
       "VideoResolutionNotSupported": "Resolution too high",
       "VideoCrop": "Removing black bars",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -114,7 +114,7 @@
       "VideoCodecNotSupported": "Códec de vídeo no compatible",
       "VideoHdrNotSupported": "HDR → SDR",
       "VideoProfileNotSupported": "Perfil de vídeo no compatible",
-      "VideoLevelNotSupported": "Nivel de vídeo demasiado alto",
+      "VideoLevelNotSupported": "Nivel de códec de vídeo demasiado alto",
       "VideoBitDepthNotSupported": "10-bit no compatible",
       "VideoResolutionNotSupported": "Resolución demasiado alta",
       "VideoCrop": "Eliminación de las barras negras",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -119,7 +119,7 @@
       "VideoCodecNotSupported": "Codec vidéo non supporté",
       "VideoHdrNotSupported": "HDR → SDR",
       "VideoProfileNotSupported": "Profil vidéo non supporté",
-      "VideoLevelNotSupported": "Niveau vidéo trop élevé",
+      "VideoLevelNotSupported": "Niveau de codec vidéo trop élevé",
       "VideoBitDepthNotSupported": "10-bit non supporté",
       "VideoResolutionNotSupported": "{{codec}} non décodable à cette résolution",
       "VideoCrop": "Suppression des bandes noires",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -114,7 +114,7 @@
       "VideoCodecNotSupported": "Codec video non supportato",
       "VideoHdrNotSupported": "HDR → SDR",
       "VideoProfileNotSupported": "Profilo video non supportato",
-      "VideoLevelNotSupported": "Livello video troppo alto",
+      "VideoLevelNotSupported": "Livello del codec video troppo alto",
       "VideoBitDepthNotSupported": "10-bit non supportato",
       "VideoResolutionNotSupported": "Risoluzione troppo alta",
       "VideoCrop": "Rimozione delle bande nere",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -114,7 +114,7 @@
       "VideoCodecNotSupported": "Codec de vídeo não suportado",
       "VideoHdrNotSupported": "HDR → SDR",
       "VideoProfileNotSupported": "Perfil de vídeo não suportado",
-      "VideoLevelNotSupported": "Nível de vídeo demasiado elevado",
+      "VideoLevelNotSupported": "Nível do codec de vídeo demasiado elevado",
       "VideoBitDepthNotSupported": "10-bit não suportado",
       "VideoResolutionNotSupported": "Resolução demasiado elevada",
       "VideoCrop": "Remoção das barras pretas",


### PR DESCRIPTION
## What

Rename the `VideoLevelNotSupported` transcode-reason label across the six locales so it names the **codec** level:

| Locale | Before | After |
|---|---|---|
| en | Video level too high | Video codec level too high |
| fr | Niveau vidéo trop élevé | Niveau de codec vidéo trop élevé |
| de | Video-Level zu hoch | Video-Codec-Level zu hoch |
| es | Nivel de vídeo demasiado alto | Nivel de códec de vídeo demasiado alto |
| it | Livello video troppo alto | Livello del codec video troppo alto |
| pt | Nível de vídeo demasiado elevado | Nível do codec de vídeo demasiado elevado |

## Why

In the nerd-stats panel the old wording was ambiguous: "video level" reads like resolution or bitrate. The flag actually compares the H.264/HEVC level reported by ffprobe (`videoLevel`, `stream-builder.service.ts`) against the device profile's `maxLevel`, and blocks Direct Play when it exceeds it. Naming the codec removes the ambiguity.

No code change — string values only.