### PR TITLE
refactor(client): drop the redundant OnPush declarations

### DIFF
--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, effect, inject, untracked, OnInit, OnDestroy } from '@angular/core';
+import { Component, effect, inject, untracked, OnInit, OnDestroy } from '@angular/core';
 import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
 import { filter, take } from 'rxjs';
 import { Capacitor, registerPlugin } from '@capacitor/core';
@@ -29,7 +29,6 @@ import { TvKeyboardDeferralService } from './core/services/tv-keyboard-deferral.
 @Component({
   selector: 'app-root',
   imports: [RouterOutlet, ToastContainerComponent, ConfirmationModalComponent, FolderPickerModalComponent, SelectPickerComponent, CastOverlayComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './app.html',
 })
 export class App implements OnInit, OnDestroy {

--- a/client/src/app/features/account/account-shell.ts
+++ b/client/src/app/features/account/account-shell.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 import { SettingsDrawerComponent } from '../../shared/components/settings-drawer/settings-drawer';
@@ -11,7 +11,6 @@ import { LucideUser, LucideLock, LucideSparkles, LucideUsers, LucideEyeOff } fro
     SettingsDrawerComponent,
     LucideUser, LucideLock, LucideSparkles, LucideUsers, LucideEyeOff,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './account-shell.html',
 })
 export class AccountShellComponent {}

--- a/client/src/app/features/account/account.ts
+++ b/client/src/app/features/account/account.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, signal, computed } from '@angular/core';
+import { Component, inject, signal, computed } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { UsersApiService } from '../../core/services/api/users-api.service';
@@ -8,7 +8,6 @@ import { ToastService } from '../../core/services/toast.service';
 @Component({
   selector: 'app-account',
   imports: [FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './account.html',
 })
 export class AccountComponent {

--- a/client/src/app/features/account/privacy.ts
+++ b/client/src/app/features/account/privacy.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   OnInit,
   inject,
@@ -29,7 +28,6 @@ interface SocialPrefs {
 @Component({
   selector: 'app-account-privacy',
   imports: [TranslatePipe, ToggleFieldComponent, LucideCheck, LucideX],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './privacy.html',
 })
 export class AccountPrivacyComponent implements OnInit {

--- a/client/src/app/features/account/recommendations.ts
+++ b/client/src/app/features/account/recommendations.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, signal, OnInit } from '@angular/core';
+import { Component, inject, signal, OnInit } from '@angular/core';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { LucideRotateCcw } from '@lucide/angular';
 import { StreamingApiService } from '../../core/services/api/streaming-api.service';
@@ -13,7 +13,6 @@ import { ToastService } from '../../core/services/toast.service';
 @Component({
   selector: 'app-account-recommendations',
   imports: [TranslatePipe, LucideRotateCcw],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './recommendations.html',
 })
 export class AccountRecommendationsComponent implements OnInit {

--- a/client/src/app/features/account/spoilers.ts
+++ b/client/src/app/features/account/spoilers.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { ToggleFieldComponent } from '../../shared/components/forms/toggle-field/toggle-field';
 import {
@@ -11,7 +11,6 @@ import { ToastService } from '../../core/services/toast.service';
 @Component({
   selector: 'app-account-spoilers',
   imports: [TranslatePipe, ToggleFieldComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './spoilers.html',
 })
 export class AccountSpoilersComponent {

--- a/client/src/app/features/admin/admin-shell.ts
+++ b/client/src/app/features/admin/admin-shell.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 import { LucideShield } from '@lucide/angular';
@@ -13,7 +13,6 @@ import { SettingsSectionsService } from './settings-sections.service';
     SettingsDrawerComponent, SettingsIconComponent,
     LucideShield,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './admin-shell.html',
 })
 export class AdminShellComponent {

--- a/client/src/app/features/admin/settings-icon.ts
+++ b/client/src/app/features/admin/settings-icon.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import {
   LucideBarChart3,
   LucideLayoutGrid,
@@ -31,7 +31,6 @@ import {
     LucideHistory,
     LucideSettings,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './settings-icon.html',
   styles: [`:host { display: inline-flex; } svg { width: 100%; height: 100%; }`],
 })

--- a/client/src/app/features/app-settings/app-settings-shell.ts
+++ b/client/src/app/features/app-settings/app-settings-shell.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 import { SettingsDrawerComponent } from '../../shared/components/settings-drawer/settings-drawer';
@@ -14,7 +14,6 @@ import { DeviceService } from '../../core/services/device.service';
     LucideSettings, LucidePlay, LucideCaptions, LucideCast, LucideHardDrive, LucideMonitor,
     LucideMonitorSmartphone, LucideHouse, LucideDownload,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './app-settings-shell.html',
 })
 export class AppSettingsShellComponent {

--- a/client/src/app/features/app-settings/display-settings/display-settings.ts
+++ b/client/src/app/features/app-settings/display-settings/display-settings.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, signal, OnInit } from '@angular/core';
+import { Component, inject, signal, OnInit } from '@angular/core';
 import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { FormsModule } from '@angular/forms';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -9,7 +9,6 @@ import { ToggleFieldComponent } from '../../../shared/components/forms/toggle-fi
 @Component({
   selector: 'app-display-settings',
   imports: [TvSelectDirective, FormsModule, TranslatePipe, ToggleFieldComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './display-settings.html',
 })
 export class DisplaySettingsPageComponent implements OnInit {

--- a/client/src/app/features/app-settings/home-settings/home-settings.ts
+++ b/client/src/app/features/app-settings/home-settings/home-settings.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   ElementRef,
   inject,
   signal,
@@ -59,7 +58,6 @@ import { ModalFooterComponent } from '../../../shared/components/modal-footer';
     SelectFieldComponent,
     ToggleFieldComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './home-settings.html',
 })
 export class HomeSettingsPageComponent implements OnInit {

--- a/client/src/app/features/app-settings/remote-settings/remote-settings.ts
+++ b/client/src/app/features/app-settings/remote-settings/remote-settings.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   OnDestroy,
   OnInit,
@@ -30,7 +29,6 @@ import { formatTime } from '../../../core/utils/player.utils';
 @Component({
   selector: 'app-remote-settings',
   imports: [DatePipe, FormsModule, TranslatePipe, ToggleFieldComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './remote-settings.html',
 })
 export class RemoteSettingsPageComponent implements OnInit, OnDestroy {

--- a/client/src/app/features/app-settings/update-settings/update-settings.ts
+++ b/client/src/app/features/app-settings/update-settings/update-settings.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit, computed, inject } from '@angular/core';
+import { Component, OnInit, computed, inject } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
 import {
   LucideCircleAlert,
@@ -28,7 +28,6 @@ import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
     LucideExternalLink,
     LucideRocket,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './update-settings.html',
   styles: [
     `

--- a/client/src/app/features/calendar/calendar.ts
+++ b/client/src/app/features/calendar/calendar.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   inject,
   OnInit,
@@ -27,7 +26,6 @@ interface CalendarDay {
 @Component({
   selector: 'app-calendar',
   imports: [RouterLink, TranslatePipe, NgClass, LocaleDatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './calendar.html',
 })
 export class CalendarComponent implements OnInit {

--- a/client/src/app/features/dashboard/dashboard.ts
+++ b/client/src/app/features/dashboard/dashboard.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   inject,
   OnInit,
@@ -30,7 +29,6 @@ interface StatsReport {
 @Component({
   selector: 'app-dashboard',
   imports: [RouterLink, TranslatePipe, LocaleDatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './dashboard.html',
 })
 export class DashboardComponent implements OnInit {

--- a/client/src/app/features/downloads/downloads.ts
+++ b/client/src/app/features/downloads/downloads.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   computed,
   effect,
@@ -50,7 +49,6 @@ export interface DisplayDownloadTask extends DownloadTask {
     LucideAlertCircle,
     LucideRotateCcw,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './downloads.html',
 })
 export class DownloadsComponent implements OnInit, OnDestroy {

--- a/client/src/app/features/forced-password-change/forced-password-change.ts
+++ b/client/src/app/features/forced-password-change/forced-password-change.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, computed, inject, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -15,7 +15,6 @@ import { UsersApiService } from '../../core/services/api/users-api.service';
 @Component({
   selector: 'app-forced-password-change',
   imports: [ReactiveFormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './forced-password-change.html',
 })
 export class ForcedPasswordChangeComponent {

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, signal, computed, effect, OnInit, OnDestroy, Injector, viewChild } from '@angular/core';
+import { Component, inject, signal, computed, effect, OnInit, OnDestroy, Injector, viewChild } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { filter } from 'rxjs';
 import { keepRouteFresh } from '../../core/services/keep-route-fresh';
@@ -93,7 +93,6 @@ import { itemArtwork } from '../../shared/utils/media-artwork.util';
     RequestDeclineModalComponent,
     DownloadDetailModalComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './home.html',
 })
 export class HomeComponent implements OnInit, OnDestroy {

--- a/client/src/app/features/import-disk/import-disk.ts
+++ b/client/src/app/features/import-disk/import-disk.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   inject,
   computed,
@@ -58,7 +57,6 @@ export type ImportMethod = 'copy' | 'move';
 @Component({
   selector: 'app-import-disk',
   imports: [TvSelectDirective, DecimalPipe, FormsModule, TranslatePipe, SearchableSelectComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './import-disk.html',
 })
 export class ImportDiskComponent implements OnInit {

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   computed,
   inject,
@@ -99,7 +98,6 @@ const NATURAL_ORDER_BY_SORT: Record<string, SortOrder> = {
     CardSkeletonComponent,
     ImportProgressBannerComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './library.html',
 })
 export class LibraryComponent implements OnInit, OnDestroy {

--- a/client/src/app/features/login/login.ts
+++ b/client/src/app/features/login/login.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, signal, inject } from '@angular/core';
+import { Component, signal, inject } from '@angular/core';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -9,7 +9,6 @@ import { ServerConfigService } from '../../core/services/server-config.service';
 @Component({
   selector: 'app-login',
   imports: [ReactiveFormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './login.html',
 })
 export class LoginComponent {

--- a/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   inject,
@@ -43,7 +42,6 @@ export interface IdentifyModalConfig {
     FormsModule,
     ResolveUrlPipe,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-identify-modal.component.html',
 })
 export class MediaDetailIdentifyModalComponent {

--- a/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-library-modal/media-detail-library-modal.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   input,
@@ -23,7 +22,6 @@ import { ModalFooterComponent } from '../../../../shared/components/modal-footer
     TvSelectDirective,
     ModalHeaderComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-library-modal.component.html',
 })
 export class MediaDetailLibraryModalComponent {

--- a/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-profiles-modal/media-detail-profiles-modal.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   input,
@@ -21,7 +20,6 @@ import { ModalFooterComponent } from '../../../../shared/components/modal-footer
     TvSelectDirective,
     ModalHeaderComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-profiles-modal.component.html',
 })
 export class MediaDetailProfilesModalComponent {

--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   effect,
@@ -79,7 +78,6 @@ function readEpisodeViewFromStorage(): EpisodeView {
 @Component({
   selector: 'app-media-detail-seasons',
   imports: [TranslatePipe, UpperCasePipe, SeasonLabelPipe, NgTemplateOutlet, RouterLink, LocaleDatePipe, HorizontalScrollerComponent, CollapsibleSectionComponent, MediaCardComponent, DropdownMenuComponent, DropdownOptionComponent, TvRowDirective, SynopsisComponent, LucideCheck, LucideClipboardList, LucideDownload, LucideEllipsisVertical, LucideEye, LucideEyeOff, LucideHeart, LucideLayoutGrid, LucideList, LucideListChecks, LucideListPlus, LucidePackage, LucideUserPlus, LucideX],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-seasons.component.html',
 })
 export class MediaDetailSeasonsComponent {

--- a/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-subtitle-search-modal/media-detail-subtitle-search-modal.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   input,
@@ -24,7 +23,6 @@ import { ModalFooterComponent } from '../../../../shared/components/modal-footer
     LocalizeLanguagePipe,
     TvSelectDirective,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail-subtitle-search-modal.component.html',
 })
 export class MediaDetailSubtitleSearchModalComponent {

--- a/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.ts
+++ b/client/src/app/features/media-detail/components/releases-modal/releases-modal.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   computed,
@@ -44,7 +43,6 @@ type IndexerSearchStateOrAll = IndexerRosterEntry['state'] | 'all';
     LucideTriangleAlert,
     LucideCirclePause,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './releases-modal.component.html',
 })
 export class ReleasesModalComponent {

--- a/client/src/app/features/media-detail/components/releases-table/releases-table.component.ts
+++ b/client/src/app/features/media-detail/components/releases-table/releases-table.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   inject,
   input,
@@ -22,7 +21,6 @@ import { ConfirmationService } from '../../../../core/services/confirmation.serv
 @Component({
   selector: 'app-releases-table',
   imports: [TranslatePipe, LucideTriangleAlert, LucideCheck, LucideCircleAlert, LucideDownload, LucidePackage],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './releases-table.component.html',
 })
 export class ReleasesTableComponent {

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   OnDestroy,
@@ -155,7 +154,6 @@ const GRAB_HANDOFF_MS = 8000;
     ImgFadeInDirective,
     TvSectionDirective,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-detail.html',
 })
 export class MediaDetailComponent implements OnInit, OnDestroy {

--- a/client/src/app/features/pending-requests/pending-requests.ts
+++ b/client/src/app/features/pending-requests/pending-requests.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   OnInit,
   effect,
@@ -23,7 +22,6 @@ import { LucideMonitor, LucideTablet, LucideSmartphone, LucideTv, LucideMonitorS
     LucideTv,
     LucideMonitorSmartphone,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './pending-requests.html',
 })
 export class PendingRequestsComponent implements OnInit {

--- a/client/src/app/features/person-detail/person-detail.ts
+++ b/client/src/app/features/person-detail/person-detail.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   inject,
   OnInit,
@@ -21,7 +20,6 @@ import { CachedSrcDirective } from '../../shared/directives/cached-src.directive
   selector: 'app-person-detail',
   imports: [
     CachedSrcDirective,TranslatePipe, RouterLink, RouterLinkActive, RouterOutlet, ResolveUrlPipe, ClampToggleDirective, LucideChevronLeft],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './person-detail.html',
 })
 export class PersonDetailComponent implements OnInit {

--- a/client/src/app/features/person-detail/person-filmography.ts
+++ b/client/src/app/features/person-detail/person-filmography.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, signal, inject, OnInit } from '@angular/core';
+import { Component, signal, inject, OnInit } from '@angular/core';
 import { SlicePipe } from '@angular/common';
 import { TranslatePipe } from '@ngx-translate/core';
 import { LucideFilm } from '@lucide/angular';
@@ -14,7 +14,6 @@ import { CachedSrcDirective } from '../../shared/directives/cached-src.directive
   selector: 'app-person-filmography',
   imports: [
     CachedSrcDirective,TranslatePipe, SlicePipe, ResolveUrlPipe, LucideFilm],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './person-filmography.html',
 })
 export class PersonFilmographyComponent implements OnInit {

--- a/client/src/app/features/person-detail/person-library.ts
+++ b/client/src/app/features/person-detail/person-library.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
 import { MediaCardComponent } from '../../shared/components/media-card/media-card';
 import { PersonDetailComponent } from './person-detail';
@@ -6,7 +6,6 @@ import { PersonDetailComponent } from './person-detail';
 @Component({
   selector: 'app-person-library',
   imports: [TranslatePipe, MediaCardComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './person-library.html',
 })
 export class PersonLibraryComponent {

--- a/client/src/app/features/persons/persons.ts
+++ b/client/src/app/features/persons/persons.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   inject,
   Injector,
@@ -27,7 +26,6 @@ const ALPHABET = '#ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
   selector: 'app-persons',
   imports: [TvSelectDirective, 
     CachedSrcDirective,FormsModule, TranslatePipe, RouterLink, ResolveUrlPipe, LucideSearch, LucideUsers],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './persons.html',
 })
 export class PersonsComponent implements OnInit, OnDestroy {

--- a/client/src/app/features/playback-settings/cast-settings/cast-settings.ts
+++ b/client/src/app/features/playback-settings/cast-settings/cast-settings.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   inject,
   signal,
   OnInit,
@@ -17,7 +16,6 @@ import { QUALITY_OPTIONS, AUDIO_CHANNEL_OPTIONS } from '../playback-options';
 @Component({
   selector: 'app-cast-settings',
   imports: [TvSelectDirective, FormsModule, TranslatePipe, SubtitleAppearanceComponent, ToggleFieldComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './cast-settings.html',
 })
 export class CastSettingsPageComponent implements OnInit {

--- a/client/src/app/features/playback-settings/player-settings/player-settings.ts
+++ b/client/src/app/features/playback-settings/player-settings/player-settings.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, signal, OnInit } from '@angular/core';
+import { Component, inject, signal, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { LucideTrash2 } from '@lucide/angular';
@@ -18,7 +18,6 @@ import { LANGUAGE_OPTIONS } from '../playback-options';
     ToggleFieldComponent,
     SelectFieldComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './player-settings.html',
 })
 export class PlayerSettingsPageComponent implements OnInit {

--- a/client/src/app/features/playback-settings/storage-settings/storage-settings.ts
+++ b/client/src/app/features/playback-settings/storage-settings/storage-settings.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { FormsModule } from '@angular/forms';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -16,7 +16,6 @@ import { DeviceService } from '../../../core/services/device.service';
 @Component({
   selector: 'app-storage-settings',
   imports: [TvSelectDirective, FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './storage-settings.html',
 })
 export class StorageSettingsPageComponent {

--- a/client/src/app/features/playback-settings/subtitle-settings/subtitle-settings.ts
+++ b/client/src/app/features/playback-settings/subtitle-settings/subtitle-settings.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, signal, OnInit } from '@angular/core';
+import { Component, inject, signal, OnInit } from '@angular/core';
 import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { FormsModule } from '@angular/forms';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -15,7 +15,6 @@ import {
 @Component({
   selector: 'app-subtitle-settings',
   imports: [TvSelectDirective, FormsModule, TranslatePipe, LucideTrash2, SubtitleAppearanceComponent, ToggleFieldComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './subtitle-settings.html',
 })
 export class SubtitleSettingsPageComponent implements OnInit {

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   HostListener,
@@ -117,7 +116,6 @@ interface AppearanceRow {
     SeekbarComponent,
     ResolveUrlPipe,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './player-controls.html',
   // Bar insets live on the host so the floating cues inherit them and line up
   // with the controls' right edge.

--- a/client/src/app/features/player/overlay/player-stats-overlay.ts
+++ b/client/src/app/features/player/overlay/player-stats-overlay.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { UpperCasePipe } from '@angular/common';
 import { TranslatePipe } from '@ngx-translate/core';
 
@@ -42,7 +42,6 @@ export interface PlayerStats {
 @Component({
   selector: 'app-player-stats-overlay',
   imports: [UpperCasePipe, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './player-stats-overlay.html',
 })
 export class PlayerStatsOverlayComponent {

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1,6 +1,5 @@
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   OnDestroy,
@@ -147,7 +146,6 @@ class PausableTimeout {
 
 @Component({
   imports: [TranslatePipe, LucideCircleAlert, LucideInfo, LucideX, PlayerControlsComponent, PlayerStatsOverlayComponent, DefaultFocusDirective],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './player.html',
   encapsulation: ViewEncapsulation.None,
   styles: [`

--- a/client/src/app/features/playlists/playlist-detail/playlist-detail.ts
+++ b/client/src/app/features/playlists/playlist-detail/playlist-detail.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   DestroyRef,
   ElementRef,
   computed,
@@ -108,7 +107,6 @@ type PlaylistGroupedEntry =
     ModalHeaderComponent,
     ResolveUrlPipe,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './playlist-detail.html',
 })
 export class PlaylistDetailComponent {

--- a/client/src/app/features/playlists/playlists.ts
+++ b/client/src/app/features/playlists/playlists.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   ElementRef,
   OnInit,
   inject,
@@ -28,7 +27,6 @@ import { ModalFooterComponent } from '../../shared/components/modal-footer';
     LucidePlus,
     ModalHeaderComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './playlists.html',
 })
 export class PlaylistsComponent implements OnInit {

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnDestroy, computed, effect, inject, signal } from '@angular/core';
+import { Component, OnDestroy, computed, effect, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
@@ -116,7 +116,6 @@ const PLUGIN_PROVIDER_LABELS: ProviderListLabels = {
 @Component({
   selector: 'app-plugin-view',
   imports: [TranslatePipe, LucideTriangleAlert, SchemaFormComponent, ProviderListComponent, DataTableComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugin-view.html',
 })
 export class PluginViewComponent implements OnDestroy {

--- a/client/src/app/features/profile/avatar-editor/avatar-editor.ts
+++ b/client/src/app/features/profile/avatar-editor/avatar-editor.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   computed,
@@ -27,7 +26,6 @@ const OUTPUT = 512;
 @Component({
   selector: 'app-avatar-editor',
   imports: [ModalFooterComponent, ModalHeaderComponent, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './avatar-editor.html',
 })
 export class AvatarEditorComponent {

--- a/client/src/app/features/profile/profile-connections.ts
+++ b/client/src/app/features/profile/profile-connections.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   effect,
@@ -22,7 +21,6 @@ type ConnectionsMode = 'followers' | 'following';
 @Component({
   selector: 'app-profile-connections',
   imports: [UserAvatarComponent, RouterLink, TranslatePipe, LucideUserPlus, LucideUserCheck, LucideClock],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './profile-connections.html',
 })
 export class ProfileConnectionsComponent {

--- a/client/src/app/features/profile/profile-overview.ts
+++ b/client/src/app/features/profile/profile-overview.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   inject,
@@ -28,7 +27,6 @@ import { itemArtwork } from '../../shared/utils/media-artwork.util';
     MediaCardComponent,
     HorizontalScrollerComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './profile-overview.html',
 })
 export class ProfileOverviewComponent {

--- a/client/src/app/features/profile/profile-recommendations.ts
+++ b/client/src/app/features/profile/profile-recommendations.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   effect,
   inject,
@@ -26,7 +25,6 @@ import { itemArtwork } from '../../shared/utils/media-artwork.util';
   selector: 'app-profile-recommendations',
   imports: [
     CachedSrcDirective,TranslatePipe, RouterLink, ResolveUrlPipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './profile-recommendations.html',
 })
 export class ProfileRecommendationsComponent {

--- a/client/src/app/features/profile/profile-statistics.ts
+++ b/client/src/app/features/profile/profile-statistics.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   effect,
@@ -31,7 +30,6 @@ import { ProfileContextService } from './profile-context.service';
     LucideListVideo,
     LucideClipboardList,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './profile-statistics.html',
 })
 export class ProfileStatisticsComponent {

--- a/client/src/app/features/profile/profile.ts
+++ b/client/src/app/features/profile/profile.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   computed,
@@ -55,7 +54,6 @@ import { UserAvatarComponent } from '../../shared/components/user-avatar/user-av
     LucideCamera,
     AvatarEditorComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './profile.html',
 })
 export class ProfileComponent {

--- a/client/src/app/features/quick-connect/quick-connect-wait.ts
+++ b/client/src/app/features/quick-connect/quick-connect-wait.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   OnDestroy,
@@ -21,7 +20,6 @@ type View = 'starting' | 'waiting' | 'denied' | 'expired' | 'error';
 @Component({
   selector: 'app-quick-connect-wait',
   imports: [TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './quick-connect-wait.html',
 })
 export class QuickConnectWaitComponent implements OnInit, OnDestroy {

--- a/client/src/app/features/requests/request-card/request-card.ts
+++ b/client/src/app/features/requests/request-card/request-card.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   inject,
@@ -31,7 +30,6 @@ import { clearPosterStamps } from '../../../shared/utils/view-transition';
     RequestStatusBadgeComponent,
     LucideTrash2,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   // The host is the scroller flex item: fixed width, and a column flex so the
   // inner card fills the row's stretched height (all cards same height).
   // Compact on mobile, growing to full size on desktop/TV.

--- a/client/src/app/features/requests/request-decline-modal/request-decline-modal.component.ts
+++ b/client/src/app/features/requests/request-decline-modal/request-decline-modal.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   input,
@@ -14,7 +13,6 @@ import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 @Component({
   selector: 'app-request-decline-modal',
   imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './request-decline-modal.component.html',
 })
 export class RequestDeclineModalComponent {

--- a/client/src/app/features/requests/request-edit-modal/request-edit-modal.component.ts
+++ b/client/src/app/features/requests/request-edit-modal/request-edit-modal.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   input,
@@ -17,7 +16,6 @@ import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 @Component({
   selector: 'app-request-edit-modal',
   imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './request-edit-modal.component.html',
 })
 export class RequestEditModalComponent {

--- a/client/src/app/features/requests/request-poster.ts
+++ b/client/src/app/features/requests/request-poster.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   inject,
   input,
   signal,
@@ -23,7 +22,6 @@ const detailsCache = new Map<
 @Component({
   selector: 'app-request-poster',
   imports: [ResolveUrlPipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'block w-full h-full min-h-0' },
   template: `
     @if (imageUrl()) {

--- a/client/src/app/features/requests/request-status-badge/request-status-badge.component.ts
+++ b/client/src/app/features/requests/request-status-badge/request-status-badge.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   inject,
@@ -36,7 +35,6 @@ import {
   selector: 'app-request-status-badge',
   standalone: true,
   imports: [TranslatePipe, ProgressBadgeComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   // Transparent to layout so the inner badge stays the flex item it replaced.
   host: { class: 'contents' },
   templateUrl: './request-status-badge.component.html',

--- a/client/src/app/features/requests/request-view-decline-modal/request-view-decline-modal.component.ts
+++ b/client/src/app/features/requests/request-view-decline-modal/request-view-decline-modal.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   input,
@@ -18,7 +17,6 @@ export interface RequestViewDeclinePayload {
 @Component({
   selector: 'app-request-view-decline-modal',
   imports: [ModalFooterComponent, ModalHeaderComponent, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './request-view-decline-modal.component.html',
 })
 export class RequestViewDeclineModalComponent {

--- a/client/src/app/features/requests/requests.ts
+++ b/client/src/app/features/requests/requests.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   inject,
   computed,
@@ -63,7 +62,6 @@ import { LocaleDatePipe } from '../../core/pipes/locale-date.pipe';
     LucidePencil,
     LucideTrash2,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './requests.html',
 })
 export class RequestsComponent implements OnInit, OnDestroy {

--- a/client/src/app/features/search/search.ts
+++ b/client/src/app/features/search/search.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   effect,
   untracked,
@@ -45,7 +44,6 @@ import { UserAvatarComponent } from '../../shared/components/user-avatar/user-av
 @Component({
   selector: 'app-search',
   imports: [TvSelectDirective, UserAvatarComponent, FormsModule, TranslatePipe, NgTemplateOutlet, MediaCardComponent, HorizontalScrollerComponent, DropdownMenuComponent, LucideSearch, LucideX, LucideSettings, ModalHeaderComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './search.html',
 })
 export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {

--- a/client/src/app/features/select-user/select-user.ts
+++ b/client/src/app/features/select-user/select-user.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   ElementRef,
@@ -29,7 +28,6 @@ import { LucideMonitorSmartphone, LucideKeyRound, LucideUserRoundPen } from '@lu
     UserAvatarComponent,
     DefaultFocusDirective,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './select-user.html',
 })
 export class SelectUserComponent {

--- a/client/src/app/features/settings/auto-approval/auto-approval.ts
+++ b/client/src/app/features/settings/auto-approval/auto-approval.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   ElementRef,
   computed,
   signal,
@@ -39,7 +38,6 @@ type RuleMediaType = '' | 'movie' | 'series';
     FormsModule,
     TranslatePipe,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './auto-approval.html',
 })
 export class AutoApprovalSettingsComponent implements OnInit {

--- a/client/src/app/features/settings/custom-formats/custom-formats.ts
+++ b/client/src/app/features/settings/custom-formats/custom-formats.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   ElementRef,
   computed,
   signal,
@@ -49,7 +48,6 @@ const VALUE_OPTIONS: Partial<Record<CustomFormatSpecType, readonly string[]>> = 
 @Component({
   selector: 'app-custom-formats-settings',
   imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './custom-formats.html',
 })
 export class CustomFormatsSettingsComponent implements OnInit {

--- a/client/src/app/features/settings/data-imports/data-imports.ts
+++ b/client/src/app/features/settings/data-imports/data-imports.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   OnInit,
   computed,
@@ -85,7 +84,6 @@ type LibrarySelection = number | null;
     LucideDownload,
     ImportDiskComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './data-imports.html',
 })
 export class DataImportsSettingsComponent implements OnInit {

--- a/client/src/app/features/settings/general/general.ts
+++ b/client/src/app/features/settings/general/general.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   inject,
   OnInit,
@@ -20,7 +19,6 @@ import {
 @Component({
   selector: 'app-general-settings',
   imports: [TvSelectDirective, FormsModule, TranslatePipe, SetupChecklistComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './general.html',
 })
 export class GeneralSettingsComponent implements OnInit {

--- a/client/src/app/features/settings/language-profiles/language-profiles.ts
+++ b/client/src/app/features/settings/language-profiles/language-profiles.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   ElementRef,
   signal,
   inject,
@@ -43,7 +42,6 @@ const subKey = (isoCode: string, forced: boolean) =>
 @Component({
   selector: 'app-language-profiles',
   imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './language-profiles.html',
 })
 export class LanguageProfilesComponent implements OnInit {

--- a/client/src/app/features/settings/libraries/libraries.ts
+++ b/client/src/app/features/settings/libraries/libraries.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal } from '@angular/core';
 import { UpperCasePipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -10,7 +10,6 @@ import {
 @Component({
   selector: 'app-libraries-settings',
   imports: [RouterLink, TranslatePipe, UpperCasePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './libraries.html',
 })
 export class LibrariesSettingsComponent implements OnInit {

--- a/client/src/app/features/settings/libraries/library-detail/library-detail.ts
+++ b/client/src/app/features/settings/libraries/library-detail/library-detail.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import {
   ActivatedRoute,
   Router,
@@ -30,7 +30,6 @@ import { ImportProgressBannerComponent } from '../../../../shared/components/imp
     ImportProgressBannerComponent,
   ],
   providers: [LibraryDetailState],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './library-detail.html',
 })
 export class LibraryDetailComponent implements OnInit {

--- a/client/src/app/features/settings/libraries/library-detail/library-form-fields/library-form-fields.ts
+++ b/client/src/app/features/settings/libraries/library-detail/library-form-fields/library-form-fields.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { TvSelectDirective } from '../../../../../shared/directives/tv-select.directive';
 import { FormsModule } from '@angular/forms';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -19,7 +19,6 @@ import { LibraryDetailState } from '../library-detail.state';
 @Component({
   selector: 'app-library-form-fields',
   imports: [TvSelectDirective, FormsModule, TranslatePipe, LucideIconComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './library-form-fields.html',
   host: { class: 'flex flex-col gap-5' },
 })

--- a/client/src/app/features/settings/libraries/library-detail/library-general.ts
+++ b/client/src/app/features/settings/libraries/library-detail/library-general.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
 import { LibraryDetailState } from './library-detail.state';
 import { LibraryFormFieldsComponent } from './library-form-fields/library-form-fields';
@@ -6,7 +6,6 @@ import { LibraryFormFieldsComponent } from './library-form-fields/library-form-f
 @Component({
   selector: 'app-library-general',
   imports: [TranslatePipe, LibraryFormFieldsComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './library-general.html',
 })
 export class LibraryGeneralComponent {

--- a/client/src/app/features/settings/libraries/library-detail/library-media.ts
+++ b/client/src/app/features/settings/libraries/library-detail/library-media.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   computed,
   effect,
   inject,
@@ -34,7 +33,6 @@ const PAGE_SIZE = 30;
     PaginationComponent,
     OrphanScanModalComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './library-media.html',
 })
 export class LibraryMediaComponent implements OnInit {

--- a/client/src/app/features/settings/libraries/library-detail/library-user-picker/library-user-picker.ts
+++ b/client/src/app/features/settings/libraries/library-detail/library-user-picker/library-user-picker.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
 import { LibraryDetailState } from '../library-detail.state';
 
 @Component({
   selector: 'app-library-user-picker',
   imports: [TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './library-user-picker.html',
   host: { class: 'flex flex-col gap-5' },
 })

--- a/client/src/app/features/settings/libraries/library-detail/library-users.ts
+++ b/client/src/app/features/settings/libraries/library-detail/library-users.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
 import { LibraryDetailState } from './library-detail.state';
 import { LibraryUserPickerComponent } from './library-user-picker/library-user-picker';
@@ -6,7 +6,6 @@ import { LibraryUserPickerComponent } from './library-user-picker/library-user-p
 @Component({
   selector: 'app-library-users',
   imports: [TranslatePipe, LibraryUserPickerComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './library-users.html',
 })
 export class LibraryUsersComponent {

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-modal/orphan-scan-modal.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-modal/orphan-scan-modal.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, output, viewChild } from '@angular/core';
+import { Component, ElementRef, output, viewChild } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
 import { ModalHeaderComponent } from '../../../../../shared/components/modal-header';
 import { OrphanScanPanelComponent } from '../orphan-scan-panel/orphan-scan-panel';
@@ -7,7 +7,6 @@ import { ModalFooterComponent } from '../../../../../shared/components/modal-foo
 @Component({
   selector: 'app-orphan-scan-modal',
   imports: [ModalFooterComponent, TranslatePipe, ModalHeaderComponent, OrphanScanPanelComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './orphan-scan-modal.html',
 })
 export class OrphanScanModalComponent {

--- a/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
+++ b/client/src/app/features/settings/libraries/library-detail/orphan-scan-panel/orphan-scan-panel.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   inject,
@@ -58,7 +57,6 @@ interface GroupVM {
     LucideChevronsUpDown,
     PaginationComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './orphan-scan-panel.html',
   host: { class: 'flex flex-col min-h-0 flex-1' },
 })

--- a/client/src/app/features/settings/libraries/library-wizard/library-wizard-media.ts
+++ b/client/src/app/features/settings/libraries/library-wizard/library-wizard-media.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   inject,
@@ -16,7 +15,6 @@ import { OrphanScanPanelComponent } from '../library-detail/orphan-scan-panel/or
 @Component({
   selector: 'app-library-wizard-media',
   imports: [FormsModule, TranslatePipe, OrphanScanPanelComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './library-wizard-media.html',
 })
 export class LibraryWizardMediaComponent {

--- a/client/src/app/features/settings/libraries/library-wizard/library-wizard.ts
+++ b/client/src/app/features/settings/libraries/library-wizard/library-wizard.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   OnInit,
   inject,
   signal,
@@ -31,7 +30,6 @@ import { LibraryWizardMediaComponent } from './library-wizard-media';
     LibraryUserPickerComponent,
     LibraryWizardMediaComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './library-wizard.html',
   providers: [LibraryDetailState],
 })

--- a/client/src/app/features/settings/media-servers/media-servers.ts
+++ b/client/src/app/features/settings/media-servers/media-servers.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   ElementRef,
   signal,
   computed,
@@ -24,7 +23,6 @@ import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 @Component({
   selector: 'app-media-servers-settings',
   imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-servers.html',
 })
 export class MediaServersSettingsComponent implements OnInit {

--- a/client/src/app/features/settings/naming/naming.ts
+++ b/client/src/app/features/settings/naming/naming.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   inject,
   computed,
@@ -63,7 +62,6 @@ function applySeasonFolderFormat(format: string): string {
 @Component({
   selector: 'app-naming-settings',
   imports: [FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './naming.html',
 })
 export class NamingSettingsComponent implements OnInit {

--- a/client/src/app/features/settings/notifications/notifications.ts
+++ b/client/src/app/features/settings/notifications/notifications.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   ElementRef,
   computed,
   signal,
@@ -46,7 +45,6 @@ interface CreateNotificationBody {
 @Component({
   selector: 'app-notifications-settings',
   imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './notifications.html',
 })
 export class NotificationsSettingsComponent implements OnInit {

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue-page.ts
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue-page.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit, computed, inject, signal, viewChild } from '@angular/core';
+import { Component, OnInit, computed, inject, signal, viewChild } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { LucideChevronLeft } from '@lucide/angular';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -18,7 +18,6 @@ import { PluginCatalogueComponent } from './plugin-catalogue';
 @Component({
   selector: 'app-plugin-catalogue-page',
   imports: [RouterLink, LucideChevronLeft, TranslatePipe, PluginInstallConsentComponent, PluginCatalogueComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugin-catalogue-page.html',
 })
 export class PluginCataloguePageComponent implements OnInit {

--- a/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.ts
+++ b/client/src/app/features/settings/plugins/plugin-catalogue/plugin-catalogue.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit, inject, input, output, signal } from '@angular/core';
+import { Component, OnInit, inject, input, output, signal } from '@angular/core';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { LucideChevronDown } from '@lucide/angular';
 import {
@@ -23,7 +23,6 @@ interface CatalogueRow {
 @Component({
   selector: 'app-plugin-catalogue',
   imports: [TranslatePipe, DropdownToggleDirective, LucideChevronDown, SelectedOptionDirective],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugin-catalogue.html',
 })
 export class PluginCatalogueComponent implements OnInit {

--- a/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.ts
+++ b/client/src/app/features/settings/plugins/plugin-install-consent/plugin-install-consent.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   ElementRef,
   computed,
   inject,
@@ -27,7 +26,6 @@ import { ModalFooterComponent } from '../../../../shared/components/modal-footer
 @Component({
   selector: 'app-plugin-install-consent',
   imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugin-install-consent.html',
 })
 export class PluginInstallConsentComponent {

--- a/client/src/app/features/settings/plugins/plugin-metrics-panel/plugin-metrics-panel.ts
+++ b/client/src/app/features/settings/plugins/plugin-metrics-panel/plugin-metrics-panel.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
 import type { PluginMetricsEntry } from '../../../../core/services/api/plugins-api.service';
 
@@ -7,7 +7,6 @@ import type { PluginMetricsEntry } from '../../../../core/services/api/plugins-a
 @Component({
   selector: 'app-plugin-metrics-panel',
   imports: [TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugin-metrics-panel.html',
 })
 export class PluginMetricsPanelComponent {

--- a/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.ts
+++ b/client/src/app/features/settings/plugins/plugin-settings/plugin-settings.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   WritableSignal,
@@ -28,7 +27,6 @@ const ALLOW_UNSIGNED_KEY = 'plugins.allow_unsigned';
 @Component({
   selector: 'app-plugin-settings',
   imports: [ModalFooterComponent, ModalHeaderComponent, TranslatePipe, ToggleFieldComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugin-settings.html',
 })
 export class PluginSettingsComponent {

--- a/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.ts
+++ b/client/src/app/features/settings/plugins/plugin-sources/plugin-sources.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   OnInit,
@@ -38,7 +37,6 @@ function createErrorKey(code: string | undefined): string {
 @Component({
   selector: 'app-plugin-sources',
   imports: [ModalHeaderComponent, FormsModule, DatePipe, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugin-sources.html',
 })
 export class PluginSourcesComponent implements OnInit {

--- a/client/src/app/features/settings/plugins/plugins.ts
+++ b/client/src/app/features/settings/plugins/plugins.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   OnInit,
@@ -41,7 +40,6 @@ import { trustBadgeFor } from './plugin-trust';
     PluginSourcesComponent,
     PluginMetricsPanelComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './plugins.html',
 })
 export class PluginsSettingsComponent implements OnInit {

--- a/client/src/app/features/settings/quality-definitions/quality-definitions.ts
+++ b/client/src/app/features/settings/quality-definitions/quality-definitions.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   inject,
   OnInit,
@@ -19,7 +18,6 @@ const MAX_SLIDER = 60000; // MB/h max for slider
 @Component({
   selector: 'app-quality-definitions',
   imports: [FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './quality-definitions.html',
 })
 export class QualityDefinitionsComponent implements OnInit {

--- a/client/src/app/features/settings/quality-profiles/quality-profiles.ts
+++ b/client/src/app/features/settings/quality-profiles/quality-profiles.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   ElementRef,
   signal,
   inject,
@@ -30,7 +29,6 @@ import { ModalFooterComponent } from '../../../shared/components/modal-footer';
     RouterLink,
     TranslatePipe,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './quality-profiles.html',
 })
 export class QualityProfilesComponent implements OnInit {

--- a/client/src/app/features/settings/roles/roles.ts
+++ b/client/src/app/features/settings/roles/roles.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   ElementRef,
   signal,
   viewChild,
@@ -20,7 +19,6 @@ import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 @Component({
   selector: 'app-roles-settings',
   imports: [ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './roles.html',
 })
 export class RolesSettingsComponent implements OnInit {

--- a/client/src/app/features/settings/schedulers/schedulers.ts
+++ b/client/src/app/features/settings/schedulers/schedulers.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   OnInit,
@@ -30,7 +29,6 @@ interface SchedulerInfo {
 @Component({
   selector: 'app-schedulers',
   imports: [LucideCirclePlay, TranslatePipe, LocaleDatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './schedulers.html',
 })
 export class SchedulersComponent implements OnInit {

--- a/client/src/app/features/settings/settings-shell.ts
+++ b/client/src/app/features/settings/settings-shell.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 
 /**
@@ -7,7 +7,6 @@ import { RouterOutlet } from '@angular/router';
 @Component({
   selector: 'app-settings-shell',
   imports: [RouterOutlet],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<div class="w-full"><router-outlet /></div>`,
 })
 export class SettingsShellComponent {}

--- a/client/src/app/features/settings/streaming/streaming.ts
+++ b/client/src/app/features/settings/streaming/streaming.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, signal, OnInit } from '@angular/core';
+import { Component, inject, signal, OnInit } from '@angular/core';
 import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
 import { FormsModule } from '@angular/forms';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -12,7 +12,6 @@ import { ToastService } from '../../../core/services/toast.service';
 @Component({
   selector: 'app-streaming-settings',
   imports: [TvSelectDirective, FormsModule, TranslatePipe, ToggleFieldComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './streaming.html',
 })
 export class StreamingSettingsComponent implements OnInit {

--- a/client/src/app/features/settings/subtitle-providers/subtitle-providers.ts
+++ b/client/src/app/features/settings/subtitle-providers/subtitle-providers.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   ElementRef,
   signal,
   inject,
@@ -114,7 +113,6 @@ const LABELS: ProviderListLabels = {
     TranslatePipe,
     ProviderListComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './subtitle-providers.html',
 })
 export class SubtitleProvidersSettingsComponent implements OnInit {

--- a/client/src/app/features/settings/subtitles-activity/subtitles-activity.ts
+++ b/client/src/app/features/settings/subtitles-activity/subtitles-activity.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   inject,
   OnInit,
@@ -23,7 +22,6 @@ import { episodeLabel } from '../../../shared/utils/episode-label';
 @Component({
   selector: 'app-subtitles-activity',
   imports: [TvSelectDirective, TranslatePipe, LocaleDatePipe, LocalizeLanguagePipe, NgClass, RouterLink, FormsModule, PaginationComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './subtitles-activity.html',
 })
 export class SubtitlesActivityComponent implements OnInit {

--- a/client/src/app/features/settings/subtitles/subtitles-settings.ts
+++ b/client/src/app/features/settings/subtitles/subtitles-settings.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   inject,
   OnInit,
@@ -14,7 +13,6 @@ import { ToggleFieldComponent } from '../../../shared/components/forms/toggle-fi
 @Component({
   selector: 'app-subtitles-settings',
   imports: [FormsModule, TranslatePipe, ToggleFieldComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './subtitles-settings.html',
 })
 export class SubtitlesSettingsComponent implements OnInit {

--- a/client/src/app/features/settings/subtitles/subtitles-shell.ts
+++ b/client/src/app/features/settings/subtitles/subtitles-shell.ts
@@ -1,11 +1,10 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-subtitles-shell',
   imports: [RouterLink, RouterLinkActive, RouterOutlet, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="flex flex-col gap-6">
       <div>

--- a/client/src/app/features/settings/subtitles/subtitles-stats.ts
+++ b/client/src/app/features/settings/subtitles/subtitles-stats.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   OnInit,
   computed,
@@ -21,7 +20,6 @@ import { PaginationComponent } from '../../../shared/components/pagination/pagin
 @Component({
   selector: 'app-subtitles-stats',
   imports: [LucideSearch, RouterLink, TranslatePipe, PaginationComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './subtitles-stats.html',
 })
 export class SubtitlesStatsComponent implements OnInit {

--- a/client/src/app/features/settings/users/user-detail/user-detail.ts
+++ b/client/src/app/features/settings/users/user-detail/user-detail.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   inject,
   OnInit,
 } from '@angular/core';
@@ -17,7 +16,6 @@ import { UserDetailState } from './user-detail.state';
   selector: 'app-user-detail',
   imports: [LucideChevronLeft, LucideUser, TranslatePipe, RouterLink, RouterLinkActive, RouterOutlet],
   providers: [UserDetailState],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './user-detail.html',
 })
 export class UserDetailComponent implements OnInit {

--- a/client/src/app/features/settings/users/user-detail/user-general.ts
+++ b/client/src/app/features/settings/users/user-detail/user-general.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   inject,
   OnInit,
@@ -23,7 +22,6 @@ import { LucideIconComponent } from '../../../../shared/components/lucide-icon';
 @Component({
   selector: 'app-user-general',
   imports: [TvSelectDirective, FormsModule, TranslatePipe, LucideIconComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './user-general.html',
 })
 export class UserGeneralComponent implements OnInit {

--- a/client/src/app/features/settings/users/user-detail/user-requests.ts
+++ b/client/src/app/features/settings/users/user-detail/user-requests.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   computed,
   inject,
@@ -17,7 +16,6 @@ import { UserDetailState } from './user-detail.state';
 @Component({
   selector: 'app-user-requests',
   imports: [LocaleDatePipe, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './user-requests.html',
 })
 export class UserRequestsComponent implements OnInit {

--- a/client/src/app/features/settings/users/user-detail/user-stats.ts
+++ b/client/src/app/features/settings/users/user-detail/user-stats.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, inject, OnInit, signal } from '@angular/core';
+import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import {
   LucideClock,
@@ -29,7 +29,6 @@ import { formatRelativeTime } from '../../../../core/utils/relative-time';
     LucideUserPlus,
     LucideZap,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './user-stats.html',
 })
 export class UserStatsComponent implements OnInit {

--- a/client/src/app/features/settings/users/users.ts
+++ b/client/src/app/features/settings/users/users.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   ElementRef,
   signal,
   viewChild,
@@ -28,7 +27,6 @@ import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 @Component({
   selector: 'app-users-settings',
   imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, RouterLink, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './users.html',
 })
 export class UsersSettingsComponent implements OnInit {

--- a/client/src/app/features/setup/setup.ts
+++ b/client/src/app/features/setup/setup.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   ElementRef,
   signal,
   inject,
@@ -27,7 +26,6 @@ export function withHttpsFallback(base: string): string[] {
 @Component({
   selector: 'app-setup',
   imports: [FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './setup.html',
 })
 export class SetupComponent {

--- a/client/src/app/features/system/backups/backups.ts
+++ b/client/src/app/features/system/backups/backups.ts
@@ -1,5 +1,5 @@
 import {
-  Component, ChangeDetectionStrategy, signal, inject, OnInit,
+  Component, signal, inject, OnInit,
 } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -10,7 +10,6 @@ import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
 @Component({
   selector: 'app-system-backups',
   imports: [TranslatePipe, LocaleDatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './backups.html',
 })
 export class SystemBackupsComponent implements OnInit {

--- a/client/src/app/features/system/logs/logs.ts
+++ b/client/src/app/features/system/logs/logs.ts
@@ -1,5 +1,5 @@
 import {
-  Component, ChangeDetectionStrategy, signal, inject, OnInit, OnDestroy,
+  Component, signal, inject, OnInit, OnDestroy,
 } from '@angular/core';
 import { DatePipe, NgClass } from '@angular/common';
 import { TvSelectDirective } from '../../../shared/directives/tv-select.directive';
@@ -11,7 +11,6 @@ import { firstValueFrom } from 'rxjs';
 @Component({
   selector: 'app-system-logs',
   imports: [TvSelectDirective, TranslatePipe, DatePipe, NgClass, FormsModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './logs.html',
 })
 export class SystemLogsComponent implements OnInit, OnDestroy {

--- a/client/src/app/features/system/status/status.ts
+++ b/client/src/app/features/system/status/status.ts
@@ -1,5 +1,5 @@
 import {
-  Component, ChangeDetectionStrategy, signal, inject, OnInit, OnDestroy, effect, computed,
+  Component, signal, inject, OnInit, OnDestroy, effect, computed,
 } from '@angular/core';
 import { DecimalPipe, NgClass } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
@@ -38,7 +38,6 @@ const MAX_VISIBLE_CHILDREN = 5;
 @Component({
   selector: 'app-system-status',
   imports: [TranslatePipe, LocaleDatePipe, DecimalPipe, NgClass, RouterLink, LucideTrash2, PaginationComponent, DropdownMenuComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './status.html',
 })
 export class SystemStatusComponent implements OnInit, OnDestroy {

--- a/client/src/app/features/system/streams/streams.ts
+++ b/client/src/app/features/system/streams/streams.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   OnDestroy,
   OnInit,
@@ -34,7 +33,6 @@ import { ModalHeaderComponent } from '../../../shared/components/modal-header';
     LucidePlay,
     LucideSquare,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './streams.html',
 })
 export class SystemStreamsComponent implements OnInit, OnDestroy {

--- a/client/src/app/features/system/system.ts
+++ b/client/src/app/features/system/system.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-system',
   imports: [TranslatePipe, RouterLink, RouterLinkActive, RouterOutlet],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './system.html',
 })
 export class SystemComponent {}

--- a/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.ts
+++ b/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   computed,
@@ -25,7 +24,6 @@ import { ModalFooterComponent } from '../../../../shared/components/modal-footer
 @Component({
   selector: 'app-import-modal',
   imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './import-modal.component.html',
 })
 export class ImportModalComponent {

--- a/client/src/app/features/tmdb-preview/components/preview-seasons/preview-seasons.component.ts
+++ b/client/src/app/features/tmdb-preview/components/preview-seasons/preview-seasons.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   effect,
@@ -28,7 +27,6 @@ import { TvRowDirective } from '../../../../shared/directives/tv-row.directive';
     ClampToggleDirective,
     TvRowDirective,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './preview-seasons.component.html',
   host: { class: 'block' },
 })

--- a/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.ts
+++ b/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   computed,
@@ -23,7 +22,6 @@ import { ModalFooterComponent } from '../../../../shared/components/modal-footer
 @Component({
   selector: 'app-request-modal',
   imports: [TvSelectDirective, ModalFooterComponent, ModalHeaderComponent, FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './request-modal.component.html',
 })
 export class RequestModalComponent {

--- a/client/src/app/features/tmdb-preview/tmdb-preview.ts
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   inject,
   computed,
@@ -50,7 +49,6 @@ import { PreviewSeasonsComponent } from './components/preview-seasons/preview-se
 @Component({
   selector: 'app-tmdb-preview',
   imports: [FormsModule, CurrencyPipe, DecimalPipe, NgTemplateOutlet, TranslatePipe, ResolveUrlPipe, LocaleDatePipe, RequestModalComponent, ImportModalComponent, MobileFanartHeroComponent, HorizontalScrollerComponent, ClampToggleDirective, CollapsibleSectionComponent, PreviewSeasonsComponent, RequestDeclineModalComponent, RequestEditModalComponent, LucideFilm, LucideUser, LucidePlay, LucidePlus],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './tmdb-preview.html',
 })
 export class TmdbPreviewComponent implements OnInit, OnDestroy {

--- a/client/src/app/features/watch-history/watch-history.ts
+++ b/client/src/app/features/watch-history/watch-history.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, signal, computed, Injector, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, signal, computed, Injector, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { LucideHistory, LucideTrash2, LucidePlay, LucideFilm, LucideTv, LucideCheck, LucideEllipsisVertical } from '@lucide/angular';
@@ -15,7 +15,6 @@ import { CachedSrcDirective } from '../../shared/directives/cached-src.directive
   selector: 'app-watch-history',
   imports: [
     CachedSrcDirective,TranslatePipe, ResolveUrlPipe, PaginationComponent, DropdownMenuComponent, LucideHistory, LucideTrash2, LucidePlay, LucideFilm, LucideTv, LucideCheck, LucideEllipsisVertical],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './watch-history.html',
 })
 export class WatchHistoryComponent implements OnInit, OnDestroy {

--- a/client/src/app/shared/cast-overlay/cast-overlay.ts
+++ b/client/src/app/shared/cast-overlay/cast-overlay.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   HostListener,
   computed,
@@ -59,7 +58,6 @@ interface PickerRow {
     DropdownOptionComponent,
     TranslatePipe,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './cast-overlay.html',
 })
 export class CastOverlayComponent {

--- a/client/src/app/shared/components/add-to-playlist-modal/add-to-playlist-modal.component.ts
+++ b/client/src/app/shared/components/add-to-playlist-modal/add-to-playlist-modal.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   inject,
@@ -36,7 +35,6 @@ import { ModalFooterComponent } from '../modal-footer';
     LucidePlus,
     ModalHeaderComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './add-to-playlist-modal.component.html',
 })
 export class AddToPlaylistModalComponent {

--- a/client/src/app/shared/components/app-update-modal/app-update-modal.ts
+++ b/client/src/app/shared/components/app-update-modal/app-update-modal.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   computed,
@@ -29,7 +28,6 @@ import { ModalFooterComponent } from '../modal-footer';
     LucideRocket,
     ModalHeaderComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './app-update-modal.html',
   styles: [
     `

--- a/client/src/app/shared/components/background/background.ts
+++ b/client/src/app/shared/components/background/background.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   effect,
   inject,
@@ -23,7 +22,6 @@ import { CachedSrcDirective } from '../../directives/cached-src.directive';
   selector: 'app-background',
   imports: [
     CachedSrcDirective,ResolveUrlPipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './background.html',
 })
 export class BackgroundComponent {

--- a/client/src/app/shared/components/bottom-sheet.ts
+++ b/client/src/app/shared/components/bottom-sheet.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   input,
   output,
   signal,
@@ -23,7 +22,6 @@ import {
 @Component({
   selector: 'app-bottom-sheet',
   standalone: true,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   // Same reason as `app-popover-menu`: the backdrop and sheet are
   // `position: fixed`, so the host needs no box — and left with one it becomes
   // a stray grid item in a parent like daisyUI's `.modal` (display: grid),

--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   effect,
@@ -111,7 +110,6 @@ import { CachedSrcDirective } from '../../directives/cached-src.directive';
     NgTemplateOutlet,
     RouterLink,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './card-actions-panel.html',
 })
 export class CardActionsPanelComponent {

--- a/client/src/app/shared/components/card-skeleton.ts
+++ b/client/src/app/shared/components/card-skeleton.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 
 /**
  * One card-shaped placeholder: art box plus a title and subtitle bar. Sized by
@@ -9,7 +9,6 @@ import { ChangeDetectionStrategy, Component, input } from '@angular/core';
  */
 @Component({
   selector: 'app-card-skeleton',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './card-skeleton.html',
   host: { class: 'block' },
 })

--- a/client/src/app/shared/components/collapsible-section/collapsible-section.ts
+++ b/client/src/app/shared/components/collapsible-section/collapsible-section.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   OnDestroy,
   OnInit,
@@ -40,7 +39,6 @@ export function writeSectionOpen(key: string, open: boolean): void {
 @Component({
   selector: 'app-collapsible-section',
   imports: [LucideChevronDown],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './collapsible-section.html',
   host: { class: 'block' },
 })

--- a/client/src/app/shared/components/confirmation-modal.ts
+++ b/client/src/app/shared/components/confirmation-modal.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   inject,
   computed,
   effect,
@@ -15,7 +14,6 @@ import { ModalFooterComponent } from './modal-footer';
 @Component({
   selector: 'app-confirmation-modal',
   imports: [ModalFooterComponent, ModalHeaderComponent, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './confirmation-modal.html',
 })
 export class ConfirmationModalComponent {

--- a/client/src/app/shared/components/data-table/data-table.ts
+++ b/client/src/app/shared/components/data-table/data-table.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   OnInit,
@@ -83,7 +82,6 @@ const BADGE_CLASSES: Readonly<Record<BadgeTone, string>> = {
     ProgressBadgeComponent,
   ],
   providers: [LocaleDatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './data-table.html',
 })
 export class DataTableComponent implements OnInit {

--- a/client/src/app/shared/components/discover-card/discover-card.component.ts
+++ b/client/src/app/shared/components/discover-card/discover-card.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { MetadataSearchResult } from '../../../core/services/api/metadata.service';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
@@ -11,7 +11,6 @@ export type CardStatus = 'library' | 'pending' | 'declined' | null;
   selector: 'app-discover-card',
   imports: [
     CachedSrcDirective,DecimalPipe, ResolveUrlPipe, LucideFilm, LucideCheck, LucideClock, LucideX],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './discover-card.component.html',
 })
 export class DiscoverCardComponent {

--- a/client/src/app/shared/components/download-detail-modal/download-detail-modal.ts
+++ b/client/src/app/shared/components/download-detail-modal/download-detail-modal.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   computed,
@@ -57,7 +56,6 @@ interface SeasonRow {
   selector: 'app-download-detail-modal',
   standalone: true,
   imports: [ModalFooterComponent, TranslatePipe, ProgressBarComponent, ModalHeaderComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './download-detail-modal.html',
 })
 export class DownloadDetailModalComponent {

--- a/client/src/app/shared/components/download-quality-modal/download-quality-modal.ts
+++ b/client/src/app/shared/components/download-quality-modal/download-quality-modal.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   input,
   output,
@@ -22,7 +21,6 @@ import { formatBytes } from '../../utils/download-format';
 @Component({
   selector: 'app-download-quality-modal',
   imports: [TranslatePipe, LucideDownload, LucideX],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <dialog #dialog class="modal">
       <div class="modal-box max-w-sm">

--- a/client/src/app/shared/components/dropdown-menu.ts
+++ b/client/src/app/shared/components/dropdown-menu.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   ElementRef,
@@ -49,7 +48,6 @@ type Placement = 'bottom-end' | 'bottom-start' | 'top-end' | 'top-start';
   selector: 'app-dropdown-menu',
   standalone: true,
   imports: [NgTemplateOutlet, BottomSheetComponent, DropdownToggleDirective],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ng-template #triggerTpl><ng-content select="[trigger]"></ng-content></ng-template>
     <ng-template #itemsTpl><ng-content></ng-content></ng-template>

--- a/client/src/app/shared/components/dropdown-option/dropdown-option.ts
+++ b/client/src/app/shared/components/dropdown-option/dropdown-option.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import { CachedSrcDirective } from '../../directives/cached-src.directive';
 
@@ -19,7 +19,6 @@ import { CachedSrcDirective } from '../../directives/cached-src.directive';
   selector: 'app-dropdown-option',
   imports: [
     CachedSrcDirective,ResolveUrlPipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './dropdown-option.html',
   host: { class: 'contents' },
 })

--- a/client/src/app/shared/components/folder-picker-modal/folder-picker-modal.ts
+++ b/client/src/app/shared/components/folder-picker-modal/folder-picker-modal.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   ElementRef,
   effect,
   inject,
@@ -28,7 +27,6 @@ interface FsListing {
 @Component({
   selector: 'app-folder-picker-modal',
   imports: [ModalFooterComponent, ModalHeaderComponent, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './folder-picker-modal.html',
 })
 export class FolderPickerModalComponent {

--- a/client/src/app/shared/components/follow-requests-card/follow-requests-card.ts
+++ b/client/src/app/shared/components/follow-requests-card/follow-requests-card.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   OnInit,
   effect,
@@ -23,7 +22,6 @@ import { UserAvatarComponent } from '../user-avatar/user-avatar';
 @Component({
   selector: 'app-follow-requests-card',
   imports: [UserAvatarComponent, RouterLink, TranslatePipe, LucideCheck, LucideX],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './follow-requests-card.html',
 })
 export class FollowRequestsCardComponent implements OnInit {

--- a/client/src/app/shared/components/forms/input-field/input-field.ts
+++ b/client/src/app/shared/components/forms/input-field/input-field.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   input,
   model,
@@ -25,7 +24,6 @@ export type InputFieldType =
 @Component({
   selector: 'app-input-field',
   imports: [FormsModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './input-field.html',
 })
 export class InputFieldComponent {

--- a/client/src/app/shared/components/forms/multi-select/multi-select.ts
+++ b/client/src/app/shared/components/forms/multi-select/multi-select.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   computed,
@@ -38,7 +37,6 @@ const FILTER_FROM_OPTIONS = 8;
   selector: 'app-multi-select',
   standalone: true,
   imports: [FormsModule, TranslatePipe, PopoverMenuComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './multi-select.html',
   host: { class: 'block' },
 })

--- a/client/src/app/shared/components/forms/searchable-select/searchable-select.ts
+++ b/client/src/app/shared/components/forms/searchable-select/searchable-select.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   HostListener,
@@ -29,7 +28,6 @@ export interface SearchableSelectOption {
   selector: 'app-searchable-select',
   standalone: true,
   imports: [FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './searchable-select.html',
   host: { class: 'relative inline-block' },
 })

--- a/client/src/app/shared/components/forms/select-field/select-field.ts
+++ b/client/src/app/shared/components/forms/select-field/select-field.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   input,
   model,
@@ -20,7 +19,6 @@ import { TvSelectDirective } from '../../../directives/tv-select.directive';
 @Component({
   selector: 'app-select-field',
   imports: [TvSelectDirective, FormsModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './select-field.html',
 })
 export class SelectFieldComponent<T = unknown> {

--- a/client/src/app/shared/components/forms/toggle-field/toggle-field.ts
+++ b/client/src/app/shared/components/forms/toggle-field/toggle-field.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   input,
   model,
@@ -17,7 +16,6 @@ import { FormsModule } from '@angular/forms';
 @Component({
   selector: 'app-toggle-field',
   imports: [FormsModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './toggle-field.html',
 })
 export class ToggleFieldComponent {

--- a/client/src/app/shared/components/horizontal-scroller.ts
+++ b/client/src/app/shared/components/horizontal-scroller.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   DestroyRef,
   HostListener,
   inject,
@@ -22,7 +21,6 @@ import { rowTopOffset, snapRowOnFocus } from '../../core/utils/focus-snap.util';
 @Component({
   selector: 'app-horizontal-scroller',
   imports: [LucideChevronLeft, LucideChevronRight, TvRowDirective],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './horizontal-scroller.html',
   styleUrl: './horizontal-scroller.css',
 })

--- a/client/src/app/shared/components/identify-modal-host/identify-modal-host.ts
+++ b/client/src/app/shared/components/identify-modal-host/identify-modal-host.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, inject, viewChild } from '@angular/core';
+import { Component, effect, inject, viewChild } from '@angular/core';
 import { IdentifyModalService } from '../../../core/services/identify-modal.service';
 import { MediaDetailIdentifyModalComponent } from '../../../features/media-detail/components/media-detail-identify-modal/media-detail-identify-modal.component';
 
@@ -7,7 +7,6 @@ import { MediaDetailIdentifyModalComponent } from '../../../features/media-detai
   selector: 'app-identify-modal-host',
   standalone: true,
   imports: [MediaDetailIdentifyModalComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<app-media-detail-identify-modal (identified)="service.markIdentified()" />`,
 })
 export class IdentifyModalHostComponent {

--- a/client/src/app/shared/components/import-progress-banner/import-progress-banner.ts
+++ b/client/src/app/shared/components/import-progress-banner/import-progress-banner.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
 import { SseService, TaskProgress, formatProgressSubject } from '../../../core/services/sse.service';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
@@ -27,7 +27,6 @@ const PHASES: { command: string; phase: ImportPhase }[] = [
 @Component({
   selector: 'app-import-progress-banner',
   imports: [TranslatePipe, ProgressBarComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './import-progress-banner.html',
   host: { role: 'status', 'aria-live': 'polite' },
 })

--- a/client/src/app/shared/components/lucide-icon.ts
+++ b/client/src/app/shared/components/lucide-icon.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import {
   LucideFilm,
   LucideTv,
@@ -33,7 +33,6 @@ import {
     LucideStar, LucideGlobe, LucideMonitor, LucidePopcorn,
     LucideClapperboard, LucideUsers, LucideFolder, LucideSwords,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @switch (name()) {
       @case ('film') { <svg lucideFilm></svg> }

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, ElementRef, input, output, computed, inject, linkedSignal, viewChild } from '@angular/core';
+import { Component, ElementRef, input, output, computed, inject, linkedSignal, viewChild } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { NgClass, DecimalPipe } from '@angular/common';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -49,7 +49,6 @@ export type CardStatus = 'watched' | 'missing' | null;
     CachedSrcDirective,RouterLink, NgClass, DecimalPipe, ResolveUrlPipe, TranslatePipe,
     LucideFilm, LucidePlay, LucideStar, LucideCheck, LucideClock, LucideEllipsisVertical, LucideCircleX, LucideHeart,
     CardActionsDirective, SpoilerDirective],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-card.html',
 })
 export class MediaCardComponent {

--- a/client/src/app/shared/components/media-file-info.ts
+++ b/client/src/app/shared/components/media-file-info.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   inject,
@@ -27,7 +26,6 @@ type FileInput = {
 @Component({
   selector: 'app-media-file-info',
   imports: [TranslatePipe, CollapsibleSectionComponent, LucideVideo, LucideVolume2, LucideTrash2],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-file-info.html',
 })
 export class MediaFileInfoComponent {

--- a/client/src/app/shared/components/media-info-extra/media-info-extra.ts
+++ b/client/src/app/shared/components/media-info-extra/media-info-extra.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   computed,
@@ -27,7 +26,6 @@ import { CollapsibleSectionComponent } from '../collapsible-section/collapsible-
 @Component({
   selector: 'app-media-info-extra',
   imports: [LocaleDatePipe, CurrencyPipe, TranslatePipe, CollapsibleSectionComponent, LucidePlay],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-info-extra.html',
 })
 export class MediaInfoExtraComponent {

--- a/client/src/app/shared/components/media-info-header/media-info-header.ts
+++ b/client/src/app/shared/components/media-info-header/media-info-header.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   effect,
@@ -140,7 +139,6 @@ interface AudioTrack {
     LucideCheck, LucideDownload, LucideEllipsisVertical,
     LucideFilm, LucideHeart, LucideListPlus, LucidePlay, LucideRotateCcw,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './media-info-header.html',
 })
 export class MediaInfoHeaderComponent {

--- a/client/src/app/shared/components/mobile-fanart-hero.ts
+++ b/client/src/app/shared/components/mobile-fanart-hero.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 import { ImgFadeInDirective } from '../directives/img-fade-in.directive';
 
@@ -28,7 +28,6 @@ import { ImgFadeInDirective } from '../directives/img-fade-in.directive';
       }
     </div>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MobileFanartHeroComponent {
   readonly fanartUrl = input<string | null | undefined>(null);

--- a/client/src/app/shared/components/modal-footer.ts
+++ b/client/src/app/shared/components/modal-footer.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   booleanAttribute,
   input,
@@ -12,7 +11,6 @@ import {
  */
 @Component({
   selector: 'app-modal-footer',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content />',
   host: {
     class: 'modal-action border-t border-base-200 bg-base-100',

--- a/client/src/app/shared/components/modal-header.ts
+++ b/client/src/app/shared/components/modal-header.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, booleanAttribute, input, output } from '@angular/core';
+import { Component, booleanAttribute, input, output } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
 
 /**
@@ -15,7 +15,6 @@ import { TranslatePipe } from '@ngx-translate/core';
 @Component({
   selector: 'app-modal-header',
   imports: [TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './modal-header.html',
   host: {
     class:

--- a/client/src/app/shared/components/mosaic-card/mosaic-card.ts
+++ b/client/src/app/shared/components/mosaic-card/mosaic-card.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   input,
   output,
@@ -11,7 +10,6 @@ import { ImgFadeInDirective } from '../../directives/img-fade-in.directive';
 @Component({
   selector: 'app-mosaic-card',
   imports: [LucideFolder, ResolveUrlPipe, ImgFadeInDirective],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <button
       type="button"

--- a/client/src/app/shared/components/pagination/pagination.ts
+++ b/client/src/app/shared/components/pagination/pagination.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   input,
@@ -14,7 +13,6 @@ type Slot = number | 'ellipsis';
   selector: 'app-pagination',
   standalone: true,
   imports: [TranslatePipe, LucideChevronLeft, LucideChevronRight],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './pagination.html',
   host: { class: 'block' },
 })

--- a/client/src/app/shared/components/popover-menu.ts
+++ b/client/src/app/shared/components/popover-menu.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   computed,
@@ -42,7 +41,6 @@ import {
   selector: 'app-popover-menu',
   standalone: true,
   imports: [BottomSheetComponent, NgTemplateOutlet],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   // `display: contents` keeps the host out of its parent's layout — the
   // backdrop + content divs are `position: fixed` so they don't need a
   // box of their own, and the host would otherwise act as a stray grid

--- a/client/src/app/shared/components/progress-badge/progress-badge.component.ts
+++ b/client/src/app/shared/components/progress-badge/progress-badge.component.ts
@@ -1,11 +1,10 @@
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 
 /** A daisyUI badge that doubles as a progress indicator: when `percent` is set
  *  the badge fills left-to-right and appends the value. Used by the request
  *  views to show a download advancing inside the status badge. */
 @Component({
   selector: 'app-progress-badge',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './progress-badge.component.html',
 })
 export class ProgressBadgeComponent {

--- a/client/src/app/shared/components/progress-bar/progress-bar.component.ts
+++ b/client/src/app/shared/components/progress-bar/progress-bar.component.ts
@@ -1,11 +1,10 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { ProgressVariant } from '../../utils/download-format';
 
 /** Thin reusable progress bar. `percent` is 0–100; `variant` drives the colour.
  *  Shared by the Activity queue, request rows, and media-detail. */
 @Component({
   selector: 'app-progress-bar',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './progress-bar.component.html',
 })
 export class ProgressBarComponent {

--- a/client/src/app/shared/components/provider-list/provider-list.ts
+++ b/client/src/app/shared/components/provider-list/provider-list.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   OnInit,
@@ -77,7 +76,6 @@ export function resolveRowActionRoute(route: string, id: number | string): strin
     LucideRotateCcw,
     LucideSearch,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './provider-list.html',
 })
 export class ProviderListComponent implements OnInit {

--- a/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.ts
+++ b/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   OnInit,
   computed,
@@ -50,7 +49,6 @@ import { itemArtwork } from '../../utils/media-artwork.util';
     LucideHeart,
     LucideListPlus,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './received-recommendations-card.html',
   host: { class: 'contents' },
 })

--- a/client/src/app/shared/components/recommend-modal/recommend-modal.component.ts
+++ b/client/src/app/shared/components/recommend-modal/recommend-modal.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   inject,
@@ -27,7 +26,6 @@ import { ToastService } from '../../../core/services/toast.service';
 @Component({
   selector: 'app-recommend-modal',
   imports: [FormsModule, TranslatePipe, LucideSend, ModalHeaderComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './recommend-modal.component.html',
 })
 export class RecommendModalComponent {

--- a/client/src/app/shared/components/schema-form/schema-form.ts
+++ b/client/src/app/shared/components/schema-form/schema-form.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, inject, input, model } from '@angular/core';
+import { Component, computed, inject, input, model } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { FieldDef, FormCaption, FormGroup, FormItem, FormStatus } from '@fliks/plugin-contract/ui';
@@ -49,7 +49,6 @@ interface FieldError {
     NgTemplateOutlet,
     TranslatePipe,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './schema-form.html',
 })
 export class SchemaFormComponent {

--- a/client/src/app/shared/components/seekbar/seekbar.ts
+++ b/client/src/app/shared/components/seekbar/seekbar.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   computed,
@@ -14,7 +13,6 @@ import { TvService } from '../../../core/services/tv.service';
 
 @Component({
   selector: 'app-seekbar',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './seekbar.html',
 })
 export class SeekbarComponent {

--- a/client/src/app/shared/components/select-picker.ts
+++ b/client/src/app/shared/components/select-picker.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { SelectPickerService } from '../../core/services/select-picker.service';
 import { PopoverMenuComponent } from './popover-menu';
 
@@ -12,7 +12,6 @@ import { PopoverMenuComponent } from './popover-menu';
   selector: 'app-select-picker',
   standalone: true,
   imports: [PopoverMenuComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <app-popover-menu
       [open]="picker.open()"

--- a/client/src/app/shared/components/settings-drawer/settings-drawer.ts
+++ b/client/src/app/shared/components/settings-drawer/settings-drawer.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   signal,
   effect,
   input,
@@ -25,7 +24,6 @@ import { TvService } from '../../../core/services/tv.service';
 @Component({
   selector: 'app-settings-drawer',
   imports: [RouterOutlet, RouterLink, LucideChevronLeft, LucideMenu],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './settings-drawer.html',
 })
 export class SettingsDrawerComponent implements OnInit, OnDestroy {

--- a/client/src/app/shared/components/setup-checklist/setup-checklist.ts
+++ b/client/src/app/shared/components/setup-checklist/setup-checklist.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   inject,
@@ -33,7 +32,6 @@ import {
     LucideTriangleAlert,
     LucideX,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './setup-checklist.html',
 })
 export class SetupChecklistComponent implements OnInit {

--- a/client/src/app/shared/components/subtitle-appearance/subtitle-appearance.ts
+++ b/client/src/app/shared/components/subtitle-appearance/subtitle-appearance.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   input,
   output,
@@ -27,7 +26,6 @@ import {
   selector: 'app-subtitle-appearance',
   standalone: true,
   imports: [TvSelectDirective, FormsModule, TranslatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="flex flex-col gap-5">
       <div class="flex flex-col gap-1">

--- a/client/src/app/shared/components/subtitle-viewer-modal/subtitle-viewer-modal.ts
+++ b/client/src/app/shared/components/subtitle-viewer-modal/subtitle-viewer-modal.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   inject,
@@ -19,7 +18,6 @@ import { ModalFooterComponent } from '../modal-footer';
 @Component({
   selector: 'app-subtitle-viewer-modal',
   imports: [ModalFooterComponent, TranslatePipe, ModalHeaderComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './subtitle-viewer-modal.html',
 })
 export class SubtitleViewerModalComponent {

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   computed,
@@ -82,7 +81,6 @@ interface SubtitleRow {
     LucideChevronDown,
     LucideUpload,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './subtitles-modal.html',
 })
 export class SubtitlesModalComponent {

--- a/client/src/app/shared/components/synopsis/synopsis.ts
+++ b/client/src/app/shared/components/synopsis/synopsis.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
 import { ClampToggleDirective } from '../../directives/clamp-toggle.directive';
 import { SpoilerDirective } from '../../directives/spoiler.directive';
@@ -7,7 +7,6 @@ import { SpoilerDirective } from '../../directives/spoiler.directive';
 @Component({
   selector: 'app-synopsis',
   imports: [TranslatePipe, ClampToggleDirective, SpoilerDirective],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './synopsis.html',
   host: { class: 'block' },
 })

--- a/client/src/app/shared/components/toast-container.ts
+++ b/client/src/app/shared/components/toast-container.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   ElementRef,
   effect,
   inject,
@@ -19,7 +18,6 @@ import {
 @Component({
   selector: 'app-toast-container',
   imports: [TranslatePipe, LucideCircleCheck, LucideCircleX, LucideTriangleAlert, LucideInfo, LucideX],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './toast-container.html',
   styles: [
     `

--- a/client/src/app/shared/components/tracking-modal-host/tracking-modal-host.ts
+++ b/client/src/app/shared/components/tracking-modal-host/tracking-modal-host.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, inject, viewChild } from '@angular/core';
+import { Component, effect, inject, viewChild } from '@angular/core';
 import { TrackingModalService } from '../../../core/services/tracking-modal.service';
 import { TrackingStatusModalComponent } from '../tracking-status-modal/tracking-status-modal';
 
@@ -11,7 +11,6 @@ import { TrackingStatusModalComponent } from '../tracking-status-modal/tracking-
   selector: 'app-tracking-modal-host',
   standalone: true,
   imports: [TrackingStatusModalComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<app-tracking-status-modal />`,
 })
 export class TrackingModalHostComponent {

--- a/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.ts
+++ b/client/src/app/shared/components/tracking-status-modal/tracking-status-modal.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   computed,
@@ -37,7 +36,6 @@ export type TrackingScope =
     LucideCircleAlert,
     LucideEyeOff,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './tracking-status-modal.html',
 })
 export class TrackingStatusModalComponent {

--- a/client/src/app/shared/components/user-avatar/user-avatar.ts
+++ b/client/src/app/shared/components/user-avatar/user-avatar.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   inject,
@@ -20,7 +19,6 @@ import { initialsAvatar } from '../../../core/utils/initials-avatar';
 @Component({
   selector: 'app-user-avatar',
   imports: [TranslatePipe, LucideCheck],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './user-avatar.html',
 })
 export class UserAvatarComponent {

--- a/client/src/app/shared/components/user-menu.ts
+++ b/client/src/app/shared/components/user-menu.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 import { AuthService } from '../../core/services/auth.service';
@@ -24,7 +24,6 @@ import {
     LucideUser, LucideSettings, LucideShield, LucideRepeat, LucideLogOut,
     LucideServer, LucideMonitorSmartphone,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './user-menu.html',
 })
 export class UserMenuComponent {

--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   inject,
   signal,
   computed,
@@ -88,7 +87,6 @@ const SIDEBAR_COUNTS_DEBOUNCE_MS = 400;
     BackgroundComponent,
     ResolveUrlPipe,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './layout.html',
 })
 export class LayoutComponent implements OnInit, OnDestroy {

--- a/client/src/app/shared/layout/nav-icon.ts
+++ b/client/src/app/shared/layout/nav-icon.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import {
   LucideHome,
   LucideSearch,
@@ -22,7 +22,6 @@ import {
     LucideHome, LucideSearch, LucideUserRound, LucideListVideo,
     LucideDownload, LucideHistory, LucideClipboardList, LucideCalendar, LucideCircle,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './nav-icon.html',
   styles: [`:host { display: inline-flex; } svg { width: 100%; height: 100%; }`],
 })

--- a/client/src/app/shared/remote-picker/remote-picker.ts
+++ b/client/src/app/shared/remote-picker/remote-picker.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Signal, computed, inject, signal } from '@angular/core';
+import { Component, Signal, computed, inject, signal } from '@angular/core';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { RouterLink } from '@angular/router';
 import {
@@ -43,7 +43,6 @@ interface PickerRow {
     LucideTv, LucideTablet, LucideSmartphone, LucideMonitor, LucideCast, LucidePlus,
     RouterLink,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './remote-picker.html',
 })
 export class RemotePickerComponent {


### PR DESCRIPTION
Follows #1282. Pure deletion: **171 files, +57 / −342**.

## Why they are redundant

Angular 22's own enum states it — [`@angular/core/types/_debug_node-chunk.d.ts`](https://github.com/angular/angular):

```ts
declare enum ChangeDetectionStrategy {
  /** NOTE: OnPush is enabled by default. */
  OnPush = 0,
  Eager = 1,
  /** @deprecated Use `Eager` instead. */
  Default = 1
}
```

All 171 components spelled `changeDetection: ChangeDetectionStrategy.OnPush` out, so every one of those lines restated the framework default, and the `ChangeDetectionStrategy` import beside it became dead weight. Both are gone; zero references to the symbol remain in `client/src`.

Nothing in the app asks for `Eager` (0 usages of `Eager` or the deprecated `Default`), so no component needed the property kept. The compiler reads the same enum value either way, and the app has been zoneless since `provideZonelessChangeDetection()`.

## Verification

- `tsc --noEmit -p tsconfig.app.json` and `-p tsconfig.spec.json` — clean.
- `ng build --configuration=production` — green, zero warnings.
- `BROWSERSLIST='chrome 85' ng build --configuration tizen` and `--configuration webos` — both green.
- No empty `import { } from` left behind.

## Note on the commit message

Validated before committing against the same parser `.github/scripts/check-commit-parse.mjs` uses, plus the 100-character body limit — #1282's squash message failed both on `main` (see the discussion there).