### PR TITLE
refactor(media-detail): remove the unidentified-title callout

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1124,7 +1124,6 @@
     "add_to_list": "Zu Liste hinzufügen",
     "unlike": "Gefällt mir nicht mehr",
     "subtitle_failed": "Fehlgeschlagen",
-    "unidentified_callout": "Dieser Titel ist nicht identifiziert. Die angezeigten Informationen stammen aus der Datei.",
     "delete_no_folder": "Dieser Titel hat keinen eigenen Ordner: Nur der Bibliothekseintrag wird entfernt, die Datei bleibt auf der Festplatte."
   },
   "requests": {

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1132,7 +1132,6 @@
     "add_to_list": "Add to list",
     "unlike": "Unlike",
     "subtitle_failed": "Failed",
-    "unidentified_callout": "This title isn't identified. The information shown comes from the file.",
     "delete_no_folder": "This title has no folder of its own: only the library entry will be removed, the file stays on disk."
   },
   "requests": {

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1124,7 +1124,6 @@
     "add_to_list": "Añadir a una lista",
     "unlike": "Ya no me gusta",
     "subtitle_failed": "Error",
-    "unidentified_callout": "Este título no está identificado. La información mostrada proviene del archivo.",
     "delete_no_folder": "Este título no tiene una carpeta propia: solo se eliminará la entrada de la biblioteca, el archivo permanece en el disco."
   },
   "requests": {

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1132,7 +1132,6 @@
     "add_to_list": "Ajouter à une liste",
     "unlike": "Je n’aime plus",
     "subtitle_failed": "Échec",
-    "unidentified_callout": "Ce titre n'est pas identifié. Les informations affichées viennent du fichier.",
     "delete_no_folder": "Ce titre n'a pas de dossier propre : seule l'entrée de la bibliothèque sera supprimée, le fichier reste sur le disque."
   },
   "requests": {

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1124,7 +1124,6 @@
     "add_to_list": "Aggiungi a un elenco",
     "unlike": "Non mi piace più",
     "subtitle_failed": "Non riuscito",
-    "unidentified_callout": "Questo titolo non è identificato. Le informazioni mostrate provengono dal file.",
     "delete_no_folder": "Questo titolo non ha una cartella propria: verrà rimossa solo la voce della libreria, il file rimane sul disco."
   },
   "requests": {

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1124,7 +1124,6 @@
     "add_to_list": "Adicionar a uma lista",
     "unlike": "Já não gosto",
     "subtitle_failed": "Falhou",
-    "unidentified_callout": "Este título não está identificado. As informações exibidas vêm do arquivo.",
     "delete_no_folder": "Este título não tem uma pasta própria: apenas a entrada da biblioteca será removida, o ficheiro permanece no disco."
   },
   "requests": {

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -171,14 +171,6 @@
       <!-- ===== NORMAL MODE (movie / series) ===== -->
     } @else {
       <div class="flex flex-col">
-        @if (isAdmin() && unidentified()) {
-          <div role="alert" class="alert alert-info mb-4 flex items-center justify-between py-2">
-            <span class="text-sm">{{ 'media_detail.unidentified_callout' | translate }}</span>
-            <button class="btn btn-sm btn-ghost" (click)="openIdentifyModal()">
-              {{ 'media_detail.identify' | translate }}
-            </button>
-          </div>
-        }
         <app-media-info-header
           [title]="m.title"
           [mediaId]="m.id"

--- a/client/src/app/features/media-detail/media-detail.unidentified.spec.ts
+++ b/client/src/app/features/media-detail/media-detail.unidentified.spec.ts
@@ -1,7 +1,7 @@
 import { provideZonelessChangeDetection, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
-import { provideTranslateService, TranslateLoader, TranslatePipe } from '@ngx-translate/core';
+import { provideTranslateService, TranslateLoader } from '@ngx-translate/core';
 import { of } from 'rxjs';
 import { vi, afterEach, describe, it, expect } from 'vitest';
 import { MediaDetailComponent } from './media-detail';
@@ -55,16 +55,6 @@ const UNIDENTIFIED_MOVIE: Media = {
   tvdbId: null,
   imdbId: null,
 };
-
-/** Only the admin-callout markup, so the test doesn't drag in the whole page's child tree. */
-const CALLOUT_TEMPLATE = `
-  @if (isAdmin() && unidentified()) {
-    <div class="unidentified-callout">
-      {{ 'media_detail.unidentified_callout' | translate }}
-      <button (click)="openIdentifyModal()">{{ 'media_detail.identify' | translate }}</button>
-    </div>
-  }
-`;
 
 function createHarness(media: Media, isAdmin: boolean) {
   const getSimilar = vi.fn(async () => []);
@@ -127,9 +117,7 @@ function createHarness(media: Media, isAdmin: boolean) {
     ],
   });
 
-  TestBed.overrideComponent(MediaDetailComponent, {
-    set: { template: CALLOUT_TEMPLATE, imports: [TranslatePipe] },
-  });
+  TestBed.overrideComponent(MediaDetailComponent, { set: { template: '' } });
 
   const fixture = TestBed.createComponent(MediaDetailComponent);
   const mediaService = TestBed.inject(MediaService) as unknown as {
@@ -141,33 +129,6 @@ function createHarness(media: Media, isAdmin: boolean) {
 
 describe('MediaDetailComponent, unidentified title', () => {
   afterEach(() => TestBed.resetTestingModule());
-
-  it('shows the callout to an admin on an unidentified title', async () => {
-    const { fixture } = createHarness(UNIDENTIFIED_MOVIE, true);
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    const el = fixture.nativeElement as HTMLElement;
-    expect(el.querySelector('.unidentified-callout')).not.toBeNull();
-  });
-
-  it('hides the callout from a non-admin viewer even on an unidentified title', async () => {
-    const { fixture } = createHarness(UNIDENTIFIED_MOVIE, false);
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    const el = fixture.nativeElement as HTMLElement;
-    expect(el.querySelector('.unidentified-callout')).toBeNull();
-  });
-
-  it('hides the callout for an admin on an identified title', async () => {
-    const { fixture } = createHarness(BASE_MOVIE, true);
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    const el = fixture.nativeElement as HTMLElement;
-    expect(el.querySelector('.unidentified-callout')).toBeNull();
-  });
 
   it('never calls getSimilar for an unidentified title', async () => {
     const { fixture, getSimilar } = createHarness(UNIDENTIFIED_MOVIE, true);


### PR DESCRIPTION
The blue banner that flashes when opening some titles. Removed rather than fixed — see below.

## What it was

[`media-detail.html`](client/src/app/features/media-detail/media-detail.html) carried a DaisyUI `alert alert-info` under `@if (isAdmin() && unidentified())`, saying the title had no metadata provider and offering an *Identify* button.

## Why it flashed

`unidentified()` is true as soon as a media is loaded and `hasProviderId()` finds no `tmdbId`, `tvdbId` or `imdbId`. But `seedFromHandedEpisode` paints the page immediately from a stub:

```ts
this.media.set({ id: mediaId, type: 'series', title: seed.title ?? '', monitored: true } as unknown as Media);
```

No provider id in it, so the banner appeared until `getOne(id)` returned and replaced the stub.

It only affected some titles because the card has two handoff shapes: `{ media: series }` when it knows the series — full object, no flash — and `{ episode: {...} }` otherwise, which is the stub path. So it hit series opened from an episode card that does not carry its series: continue-watching and episode rails.

Worth noting the same trap is already documented two lines below the stub, on the neighbouring field:

```ts
// `monitored` is bound straight through to the header, and an undefined here
// reads as false — flashing an "unmonitored" badge on every seeded load.
```

## Why remove instead of guard

I first added a `mediaResolved` signal so the callout stayed quiet until a fetched title landed — three lines, and it worked. Removing the banner is better: the capability is already on the page without it. `app-media-info-header` takes `[identified]="!unidentified()"` from the same signal and exposes `(identify)="openIdentifyModal()"`, so an admin keeps both the signal and the action. The banner was a second, more fragile rendering of information the header already shows.

## Scope

- the `@if` block, 8 lines;
- `media_detail.unidentified_callout` from all six locales, one line each, now orphaned;
- three callout assertions and the cut-down template from `media-detail.unidentified.spec.ts`.

`unidentified()` and `openIdentifyModal()` both stay — the header binding and the guard that skips provider-derived fetches read them. The spec keeps its two `getSimilar` tests, which are the real coverage of that guard.

Net **+2 / −55**.

## Verification

- `tsc --noEmit` on `tsconfig.app.json` and `tsconfig.spec.json` — clean.
- `ng build --configuration=production` — green, zero warnings.
- Commit message validated against the parser `.github/scripts/check-commit-parse.mjs` uses, plus the 100-character body limit.