### PR TITLE
fix(player): floor the subtitle size, key it to the surface short side

### DIFF
--- a/client/ios/App/App/SubtitleOverlayView.swift
+++ b/client/ios/App/App/SubtitleOverlayView.swift
@@ -141,12 +141,21 @@ final class SubtitleOverlayView: UIView {
         positionLabel()
     }
 
+    /// Text height as a fraction of the surface, shared with the DOM and
+    /// ExoPlayer renderers (subtitle-presets.ts, SubtitleOverlay.java).
+    private static let textSizeFraction: CGFloat = 0.035
+
+    /// Floor under the fraction: a phone's short side is ~390pt, too short for
+    /// the fraction alone to stay readable. Matches MIN_TEXT_SIZE_SP on Android.
+    private static let minPointSize: CGFloat = 18
+
     private func buildAttributed(_ lines: [[SubtitleRun]]) -> NSAttributedString {
         // Size to the screen's short side so captions stay the same size in
         // portrait and landscape (the short side is orientation-invariant),
         // rather than the full height (oversized in portrait) or the
         // letterboxed video band (undersized in portrait).
-        let pointSize = max(8, min(bounds.width, bounds.height) * 0.035 * style.fontScale)
+        let fitted = min(bounds.width, bounds.height) * Self.textSizeFraction * style.fontScale
+        let pointSize = max(Self.minPointSize * style.fontScale, fitted)
         let base = UIFont.systemFont(ofSize: pointSize, weight: .semibold)
         let out = NSMutableAttributedString()
         for (lineIdx, runs) in lines.enumerated() {

--- a/client/src/app/core/services/player-settings.service.ts
+++ b/client/src/app/core/services/player-settings.service.ts
@@ -3,6 +3,7 @@ import { DeviceService } from './device.service';
 import {
   DOM_SUBTITLE_HEIGHT_FRACTION,
   NATIVE_SUBTITLE_SIZE_SCALE,
+  SUBTITLE_MIN_TEXT_PX,
 } from '../utils/subtitle-presets';
 
 
@@ -80,12 +81,13 @@ export function normalizeLang(code: string | undefined): string {
 
 // ── Subtitle appearance maps ──
 
-/** The DOM cue sizes are the native ladder in `vh`, so a preset keeps the same
- *  proportions on every surface. */
+/** The DOM cue sizes are the native ladder in `vmin` — the viewport's short
+ *  side, so a rotation doesn't resize the cues (`vh` collapsed them to ~12px
+ *  in landscape on a phone) — under the same floor the native renderers use. */
 export const SUBTITLE_SIZE_MAP: Record<string, string> = Object.fromEntries(
   Object.entries(NATIVE_SUBTITLE_SIZE_SCALE).map(([size, scale]) => [
     size,
-    `${+(scale * DOM_SUBTITLE_HEIGHT_FRACTION * 100).toFixed(2)}vh`,
+    `max(${+(scale * SUBTITLE_MIN_TEXT_PX).toFixed(2)}px, ${+(scale * DOM_SUBTITLE_HEIGHT_FRACTION * 100).toFixed(2)}vmin)`,
   ]),
 );
 

--- a/client/src/app/core/utils/subtitle-presets.ts
+++ b/client/src/app/core/utils/subtitle-presets.ts
@@ -16,16 +16,25 @@
  *  look bigger on Cast than on the same device's local playback, the
  *  Cast scale is the lever to retune — not the Native one. */
 
-/** Text height at scale 1.0, as a fraction of the surface height, for the
- *  engines that own their renderer. The ExoPlayer and AVPlayer overlays
- *  hardcode the same value (SubtitleOverlay.java, SubtitleOverlayView.swift) —
- *  retune the three together. */
+/** Text height at scale 1.0, as a fraction of the surface's *short* side, for
+ *  the engines that own their renderer. The short side is orientation-
+ *  invariant, so a cue keeps its size across a rotation; the full height would
+ *  oversize portrait, where the picture is mostly letterbox. The ExoPlayer and
+ *  AVPlayer overlays hardcode the same value (SubtitleOverlay.java,
+ *  SubtitleOverlayView.swift) — retune the three together. */
 export const SUBTITLE_HEIGHT_FRACTION = 0.035;
 
 /** Same ladder for DOM cues, one notch lower: the browser path is mostly read
  *  on a desktop monitor, further away than a held device. TVs sit on this path
  *  too but default to the `large` preset. */
 export const DOM_SUBTITLE_HEIGHT_FRACTION = 0.03;
+
+/** Floor under the fraction, in CSS px / dp / pt. A phone's short side is
+ *  ~390 of those, so the fraction alone lands around 12px — unreadable at
+ *  arm's length. Scaled by the preset like the fraction is, so the ladder
+ *  keeps its steps. Repeated by the two native renderers
+ *  (MIN_TEXT_SIZE_SP, minPointSize). */
+export const SUBTITLE_MIN_TEXT_PX = 18;
 
 export const NATIVE_SUBTITLE_SIZE_SCALE: Record<string, number> = {
   xsmall: 0.7,


### PR DESCRIPTION
## Why

On an iPhone every subtitle preset reads too small, in the app and in Safari. A phone's short side is ~390px, so the size fraction alone lands around 12px.

Android already solved this — `SubtitleOverlay.java` floors its ladder at `18sp * fontScale`. The AVPlayer overlay and the DOM cues never got the equivalent, so the three renderers had three different formulas.

## What

One shape for all three: `max(18 * scale, shortSide * fraction * scale)`.

- **iOS** (`SubtitleOverlayView.swift`): adds the `18pt * fontScale` floor. The `max(8, …)` it replaces was unreachable.
- **DOM** (`SUBTITLE_SIZE_MAP`): same floor in px, and the fraction moves from `vh` to `vmin`. `vh` is the viewport *height*, so cues collapsed to ~12px in landscape and changed size on every rotation; `vmin` is the short side, the invariant the native overlays already used.
- `SUBTITLE_MIN_TEXT_PX` in `subtitle-presets.ts` documents the floor the two native renderers repeat.

Measured on an iPhone XS (390 short side), `normal` preset:

| | before | after |
|---|---|---|
| app | 13.1pt | 18pt |
| Safari portrait | 25.3px | 18px |
| Safari landscape | 11.7px | 18px |

The whole ladder moves with it, so the steps between presets keep their proportions.

## Deliberately not normalised

- The fractions stay 0.035 native / 0.03 DOM — the browser path is mostly read on a monitor, further away than a held device. On a phone both land on the floor anyway.
- The bottom margin stays in `vh` on both sides: it is a position relative to the surface height, not a size.

## Not affected

Desktop and TV: in landscape `vmin` == `vh`, and at a 1080px short side the fraction (32px at `normal`) stays above the floor. iPad likewise — 834pt short side gives 29pt.

## Test

- `ng build` clean, `playback-options.spec.ts` green.
- 18pt confirmed by eye on a physical iPhone XS.