### PR TITLE
fix(tv): restore the Tizen app and fix dialog focus on a D-pad

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -54,6 +54,7 @@
             },
             "tizen": {
               "baseHref": "./",
+              "polyfills": ["src/tv-polyfills.ts"],
               "outputHashing": "all",
               "optimization": {
                 "scripts": true,
@@ -66,6 +67,7 @@
             },
             "webos": {
               "baseHref": "./",
+              "polyfills": ["src/tv-polyfills.ts"],
               "outputHashing": "all",
               "optimization": {
                 "scripts": true,

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1,6 +1,8 @@
 {
   "app": {
-    "name": "Fliks"
+    "name": "Fliks",
+    "exit_title": "Fliks beenden?",
+    "exit_message": "Möchten Sie die Anwendung schließen?"
   },
   "file_info": {
     "title": "Dateiinformationen",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1,6 +1,8 @@
 {
   "app": {
-    "name": "Fliks"
+    "name": "Fliks",
+    "exit_title": "Exit Fliks?",
+    "exit_message": "Do you want to close the application?"
   },
   "file_info": {
     "title": "File information",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1,6 +1,8 @@
 {
   "app": {
-    "name": "Fliks"
+    "name": "Fliks",
+    "exit_title": "¿Salir de Fliks?",
+    "exit_message": "¿Quieres cerrar la aplicación?"
   },
   "file_info": {
     "title": "Información del archivo",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1,6 +1,8 @@
 {
   "app": {
-    "name": "Fliks"
+    "name": "Fliks",
+    "exit_title": "Quitter Fliks ?",
+    "exit_message": "Voulez-vous fermer l'application ?"
   },
   "file_info": {
     "title": "Informations du fichier",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1,6 +1,8 @@
 {
   "app": {
-    "name": "Fliks"
+    "name": "Fliks",
+    "exit_title": "Uscire da Fliks?",
+    "exit_message": "Vuoi chiudere l'applicazione?"
   },
   "file_info": {
     "title": "Informazioni del file",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1,6 +1,8 @@
 {
   "app": {
-    "name": "Fliks"
+    "name": "Fliks",
+    "exit_title": "Sair do Fliks?",
+    "exit_message": "Deseja fechar a aplicação?"
   },
   "file_info": {
     "title": "Informações do ficheiro",

--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -14,6 +14,7 @@ import { TvService } from './core/services/tv.service';
 import { TvSpatialNavService } from './core/services/tv-spatial-nav.service';
 import { ToastContainerComponent } from './shared/components/toast-container';
 import { ConfirmationModalComponent } from './shared/components/confirmation-modal';
+import { ConfirmationService } from './core/services/confirmation.service';
 import { FolderPickerModalComponent } from './shared/components/folder-picker-modal/folder-picker-modal';
 import { SelectPickerComponent } from './shared/components/select-picker';
 import { DismissableStackService } from './core/services/dismissable-stack.service';
@@ -25,6 +26,7 @@ import { RemoteService } from './core/services/remote.service';
 import { remoteOverlayOpen } from './core/services/remote-playback-target';
 import { CastOverlayComponent } from './shared/cast-overlay/cast-overlay';
 import { TvKeyboardDeferralService } from './core/services/tv-keyboard-deferral.service';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-root',
@@ -56,6 +58,8 @@ export class App implements OnInit, OnDestroy {
   /** Injected so a command aimed at this device is honoured wherever the user
    *  is in the app: including the player route, which sits outside the layout. */
   private readonly remote = inject(RemoteService);
+  private readonly confirmation = inject(ConfirmationService);
+  private readonly translate = inject(TranslateService);
   private backButtonListener?: { remove: () => Promise<void> };
   private visibilityListener?: () => void;
 
@@ -290,12 +294,25 @@ export class App implements OnInit, OnDestroy {
     // webOS's platformBack (returns to the launcher / previous app).
     const platform = this.tv.tvPlatform();
     if (platform === 'tizen') {
-      const tizen = (window as unknown as { tizen?: { application?: { getCurrentApplication: () => { exit: () => void } } } }).tizen;
-      try {
-        tizen?.application?.getCurrentApplication().exit();
-      } catch {
-        /* exit() can throw on dev profiles — ignore */
-      }
+      // Samsung certification: Return on the top-level page must ask before
+      // quitting, and the popup has to be ours — no system dialog exists.
+      if (this.confirmation.state()) return;
+      void this.confirmation
+        .confirm({
+          title: this.translate.instant('app.exit_title'),
+          message: this.translate.instant('app.exit_message'),
+          confirmLabel: this.translate.instant('common.yes'),
+          cancelLabel: this.translate.instant('common.no'),
+        })
+        .then((confirmed) => {
+          if (!confirmed) return;
+          const tizen = (window as unknown as { tizen?: { application?: { getCurrentApplication: () => { exit: () => void } } } }).tizen;
+          try {
+            tizen?.application?.getCurrentApplication().exit();
+          } catch {
+            /* exit() can throw on dev profiles — ignore */
+          }
+        });
     } else if (platform === 'webos') {
       const sys = (window as unknown as { webOSSystem?: { platformBack?: () => void } }).webOSSystem;
       try {

--- a/client/src/app/core/services/focusable.constants.ts
+++ b/client/src/app/core/services/focusable.constants.ts
@@ -107,7 +107,9 @@ export function isFocusOptedOut(el: HTMLElement): boolean {
   // `a[href]` matches regardless of tabindex, so a media-card's inner links
   // (tabindex=-1 on TV) would otherwise show up as separate targets.
   if (el.getAttribute('tabindex') === '-1') return true;
-  // A collapsed section keeps its content laid out, just inert: it measures
-  // as visible but refuses focus, which dead-ends the move.
-  return !!el.closest('[inert]');
+  // `[inert]`: a collapsed section keeps its content laid out, just inert, so it
+  // measures as visible but refuses focus and dead-ends the move.
+  // `.modal-backdrop`: its click-outside button spans the viewport, so it wins
+  // every direction from inside a dialog and paints a full-screen focus ring.
+  return !!el.closest('[inert], .modal-backdrop');
 }

--- a/client/src/app/core/services/focusable.spec.ts
+++ b/client/src/app/core/services/focusable.spec.ts
@@ -26,6 +26,11 @@ describe('focus opt-outs', () => {
     expect(isFocusOptedOut(section)).toBe(true);
   });
 
+  it('rejects the full-screen click-outside button of a modal backdrop', () => {
+    const form = html('<form class="modal-backdrop"><button>close</button></form>');
+    expect(isFocusOptedOut(form.querySelector('button') as HTMLElement)).toBe(true);
+  });
+
   it('takes the same element once its section is no longer inert', () => {
     const section = html('<div inert><a href="/x">x</a></div>');
     const link = section.querySelector('a') as HTMLElement;

--- a/client/src/app/shared/components/confirmation-modal.html
+++ b/client/src/app/shared/components/confirmation-modal.html
@@ -27,7 +27,7 @@
           {{ cancelLabel() }}
         </button>
       }
-      <button class="btn" [class]="confirmBtnClass()" (click)="confirmService.accept()">
+      <button autofocus class="btn" [class]="confirmBtnClass()" (click)="confirmService.accept()">
         {{ alertOnly() ? ('common.ok' | translate) : confirmLabel() }}
       </button>
     </app-modal-footer>

--- a/client/src/tv-polyfills.ts
+++ b/client/src/tv-polyfills.ts
@@ -1,0 +1,39 @@
+/** TV browsers lag the bundle's Baseline: Tizen 6.5 and webOS 6 ship
+ *  Chromium 76-85, and `BROWSERSLIST` only lowers syntax, never builtins.
+ *  Angular core calls `Object.hasOwn` on every input/output binding, so
+ *  without this the app dies before the first paint. */
+
+if (!Object.hasOwn) {
+  Object.defineProperty(Object, 'hasOwn', {
+    value: (o: object, k: PropertyKey) => Object.prototype.hasOwnProperty.call(o, k),
+    configurable: true,
+    writable: true,
+  });
+}
+
+for (const proto of [Array.prototype, String.prototype] as { at?: unknown }[]) {
+  if (!proto.at) {
+    Object.defineProperty(proto, 'at', {
+      value: function (this: ArrayLike<unknown>, i: number) {
+        const n = Math.trunc(i) || 0;
+        return this[n < 0 ? this.length + n : n];
+      },
+      configurable: true,
+      writable: true,
+    });
+  }
+}
+
+if (typeof crypto !== 'undefined' && !crypto.randomUUID) {
+  Object.defineProperty(crypto, 'randomUUID', {
+    value: () =>
+      '10000000-1000-4000-8000-100000000000'.replace(/[018]/g, (c) =>
+        (
+          Number(c) ^
+          (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (Number(c) / 4)))
+        ).toString(16),
+      ),
+    configurable: true,
+    writable: true,
+  });
+}


### PR DESCRIPTION
## Why

The Tizen app was showing a blank screen since the Angular 22 upgrade (#1282). `BROWSERSLIST='chrome 85'`
lowers *syntax* only, never builtins, so the TV bundles shipped `Object.hasOwn` (Chrome 93+) into a
Chromium 76-85 WebView. Angular core calls it on every input and output binding, so the app threw
`TypeError: Object.hasOwn is not a function` before the first paint. The build only warned about CSS, so
nothing caught it.

While fixing the Tizen exit path on the same panel, two more D-pad defects surfaced in the confirmation
dialog.

## What

**`fix(tv)`** — `client/src/tv-polyfills.ts`, wired as `polyfills` on the `tizen` and `webos` build
configurations only. The app is zoneless, so there was no polyfills entry to inherit. Covers the three
post-Chrome-85 builtins actually present in the bundle: `Object.hasOwn` (93), `Array/String.prototype.at`
(92, one admin page) and an unguarded `crypto.randomUUID` (92) of ours. The cast SDK self-polyfills its
own. webOS 6 ships Chromium 79 and had the same hole, fixed by the same entry but not tested on an LG
panel.

**`fix(tizen)`** — Return on a top-level page now raises an exit confirmation and quits only on accept.
[Samsung's termination policy](https://developer.samsung.com/smarttv/develop/guides/fundamentals/terminating-applications.html)
requires it, and requires the popup to be the app's own since no system dialog is offered. Return already
suppressed the platform default, so the app quit outright. Reuses `ConfirmationService`; no new component.
A second Return press while the popup is up resolves it as a decline, through the existing `dialog[open]`
branch of the back handler.

**`fix(spatial-nav)`** — two dialog focus defects, both visible on any TV, not just Tizen:
- `showModal()` focuses the first focusable descendant, which is the header close button, so every dialog
  opened with the D-pad on the cross. `autofocus` on the primary action, the marker `initialOverlayFocus`
  already honours for the other overlays.
- the modal backdrop's click-outside button spans the viewport, so it won every direction from inside a
  dialog and painted a full-screen focus ring. Excluded in `isFocusOptedOut`, folded into the existing
  `[inert]` lookup so a whole-document scan of several hundred cards keeps one ancestor walk per
  candidate. 43 templates carry that backdrop and all benefit. Mouse click-outside and Escape are
  unaffected.

## Verification

- `tsc -p client/tsconfig.app.json --noEmit` clean.
- Deployed to the Samsung QE85Q80BATXXC test panel: the app renders again, the exit confirmation behaves,
  focus lands on the primary action, and the full-screen ring is gone.
- webOS not tested on a device.

## Follow-up worth doing after any Angular major

Grep the TV bundle for post-Baseline builtins, not just the build warnings:

```
grep -ohE 'Object\.hasOwn|structuredClone|Object\.groupBy|\.findLast|\.at\(-|randomUUID|toSorted' \
  client/dist/tizen-stage/*.js
```
