### PR TITLE
fix(remote): release a target that goes offline and keep its exit reachable

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2458,6 +2458,7 @@
     "idle_hint": "Wählen Sie einen Titel, er startet hier.",
     "starting_message": "Wird geladen...",
     "offline_message": "Dieses Gerät ist nicht mehr erreichbar.",
+    "released_offline": "Das Gerät ist offline gegangen und wird nicht mehr gesteuert.",
     "play_here_instead": "Stattdessen hier abspielen",
     "autoplay_blocked": "Dieses Gerät kann die Wiedergabe nicht selbst starten. Drücken Sie am Gerät auf Wiedergabe.",
     "grant_offer": "Code anzeigen",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2485,6 +2485,7 @@
     "idle_hint": "Pick a title and it will start here.",
     "starting_message": "Loading...",
     "offline_message": "This device isn't reachable anymore.",
+    "released_offline": "That device went offline, so it is no longer being controlled.",
     "play_here_instead": "Play here instead",
     "autoplay_blocked": "This device cannot start playback on its own. Press play on the device itself.",
     "grant_offer": "Show a code",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2458,6 +2458,7 @@
     "idle_hint": "Elige un título y empezará aquí.",
     "starting_message": "Cargando...",
     "offline_message": "Este dispositivo ya no está disponible.",
+    "released_offline": "El dispositivo se ha desconectado, ya no se controla.",
     "play_here_instead": "Reproducir aquí en su lugar",
     "autoplay_blocked": "Este dispositivo no puede iniciar la reproducción por sí solo. Pulsa reproducir en el dispositivo.",
     "grant_offer": "Mostrar un código",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2485,6 +2485,7 @@
     "idle_hint": "Choisissez un titre, il démarrera ici.",
     "starting_message": "Chargement...",
     "offline_message": "Cet appareil n'est plus joignable.",
+    "released_offline": "L'appareil s'est déconnecté, il n'est plus contrôlé.",
     "play_here_instead": "Lire ici à la place",
     "autoplay_blocked": "Cet appareil ne peut pas démarrer la lecture seul. Appuyez sur lecture sur l'appareil.",
     "grant_offer": "Afficher un code",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2458,6 +2458,7 @@
     "idle_hint": "Scegli un titolo e partirà qui.",
     "starting_message": "Caricamento...",
     "offline_message": "Questo dispositivo non è più raggiungibile.",
+    "released_offline": "Il dispositivo si è disconnesso, non è più controllato.",
     "play_here_instead": "Riproduci qui invece",
     "autoplay_blocked": "Questo dispositivo non può avviare la riproduzione da solo. Premi play sul dispositivo.",
     "grant_offer": "Mostra un codice",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2458,6 +2458,7 @@
     "idle_hint": "Escolha um título e começará aqui.",
     "starting_message": "A carregar...",
     "offline_message": "Este dispositivo já não está acessível.",
+    "released_offline": "O dispositivo ficou offline, já não está a ser controlado.",
     "play_here_instead": "Reproduzir aqui",
     "autoplay_blocked": "Este dispositivo não consegue iniciar a reprodução sozinho. Prima reproduzir no próprio dispositivo.",
     "grant_offer": "Mostrar um código",

--- a/client/src/app/core/services/remote-playback-target.ts
+++ b/client/src/app/core/services/remote-playback-target.ts
@@ -86,8 +86,11 @@ export class RemotePlaybackTarget implements PlaybackTarget {
 
   constructor() {
     effect(() => {
-      this.remote.selectedTargetId();
+      const targetId = this.remote.selectedTargetId();
       untracked(() => {
+        // Every release path funnels through here, so the card cannot be left
+        // open over a device that is no longer ours to control.
+        if (!targetId) remoteOverlayOpen.set(false);
         this.tracksLoadedForKey = null;
         this.audioOptions.set([]);
         this.subtitleOptions.set([]);

--- a/client/src/app/core/services/remote.service.spec.ts
+++ b/client/src/app/core/services/remote.service.spec.ts
@@ -9,6 +9,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { RemoteService, type RemoteTarget } from './remote.service';
 import { SseService, type RemoteCommand, type RemoteState } from './sse.service';
 import { ToastService } from './toast.service';
+import { SKIP_ERROR_TOAST } from '../interceptors/error.interceptor';
 
 function frame(over: Partial<RemoteState> = {}): RemoteState {
   return {
@@ -515,5 +516,78 @@ describe('RemoteService restored selection', () => {
     expect(service.selectedTargetId()).toBeNull();
     expect(service.targetOffline()).toBe(false);
     expect(localStorage.getItem('fliks.remote.target')).toBeNull();
+  });
+});
+
+/**
+ * Powering the target off stranded the controller: the chip that opens its
+ * control card reads the live listing, so the only way to release the device
+ * went away with the device, while every mirrored navigation kept POSTing a
+ * browse that toasted "not reachable".
+ */
+describe('RemoteService offline target', () => {
+  const target: RemoteTarget = {
+    targetId: 'tv#1',
+    userAgent: null,
+    deviceName: null,
+    systemName: null,
+    formFactor: null,
+    tvPlatform: null,
+    nowPlaying: null,
+  };
+
+  async function goOffline(service: RemoteService) {
+    const httpMock = TestBed.inject(HttpTestingController);
+    let done = service.refreshTargets();
+    httpMock.expectOne((req) => req.url === '/api/remote/targets').flush([target]);
+    await done;
+    done = service.refreshTargets();
+    httpMock.expectOne((req) => req.url === '/api/remote/targets').flush([]);
+    await done;
+  }
+
+  it('keeps the chip on an offline target, then releases it', async () => {
+    vi.useFakeTimers();
+    try {
+      const { service } = setup();
+      await goOffline(service);
+
+      expect(service.targetOffline()).toBe(true);
+      expect(service.selectedTarget()?.targetId).toBe('tv#1');
+
+      vi.advanceTimersByTime(46_000);
+      expect(service.selectedTargetId()).toBeNull();
+      expect(service.selectedTarget()).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('holds the selection while the target answers again in time', async () => {
+    vi.useFakeTimers();
+    try {
+      const { service, remoteState } = setup();
+      await goOffline(service);
+
+      vi.advanceTimersByTime(30_000);
+      remoteState.set(frame());
+      service.ingestState();
+      vi.advanceTimersByTime(30_000);
+
+      expect(service.targetOffline()).toBe(false);
+      expect(service.selectedTargetId()).toBe('tv#1');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports a failed browse itself instead of letting the interceptor toast it', async () => {
+    const { service } = setup();
+    const httpMock = TestBed.inject(HttpTestingController);
+    const done = service.browse({ mediaId: 7, mediaType: 'movie' }, false);
+    const req = httpMock.expectOne((r) => r.url === '/api/remote/tv%231/command');
+    expect(req.request.context.get(SKIP_ERROR_TOAST)).toBe(true);
+    req.flush({ message: 'remote.error_device_offline' }, { status: 404, statusText: 'Not Found' });
+    await done;
   });
 });

--- a/client/src/app/core/services/remote.service.ts
+++ b/client/src/app/core/services/remote.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, computed, effect, inject, signal, untracked } from '@angular/core';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpContext, HttpErrorResponse } from '@angular/common/http';
 import { NavigationEnd, Router } from '@angular/router';
 import { Subject, filter, firstValueFrom } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 import { RemoteCommand, RemoteQualityRung, SseService } from './sse.service';
+import { SKIP_ERROR_TOAST } from '../interceptors/error.interceptor';
 import { ToastService } from './toast.service';
 import { CastSettingsService } from './cast-settings.service';
 import { CastService } from './cast.service';
@@ -79,6 +80,10 @@ const SELECTED_TARGET_KEY = 'fliks.remote.target';
 /** How long a freshly selected target is assumed to maybe be playing, before
  *  its silence is taken as "idle". */
 const FIRST_REPORT_GRACE_MS = 12_000;
+/** How long a selected target may stay off the listing before the selection is
+ *  released. Longer than the SSE reconnect backoff (30s at its longest), since
+ *  a target riding that out is still there. */
+const OFFLINE_RELEASE_MS = 45_000;
 
 const browseKey = (c: { mediaId?: number; episodeId?: number }) => `${c.mediaId}:${c.episodeId ?? ''}`;
 
@@ -124,10 +129,16 @@ export class RemoteService {
    *  rather than needing its own bookkeeping. */
   readonly restarting = computed(() => this.pendingAction() === 'quality');
   readonly targetOffline = signal(false);
+  private offlineTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Last listing of the selected target. The offline card that releases the
+   *  device is reached from the chip this feeds, so a target that drops off the
+   *  listing must not take its own way out with it. */
+  private readonly selectedRow = signal<RemoteTarget | null>(null);
 
   readonly selectedTarget = computed(() => {
     const id = this.selectedTargetId();
-    return id ? (this.targets().find((t) => t.targetId === id) ?? null) : null;
+    if (!id) return null;
+    return this.targets().find((t) => t.targetId === id) ?? this.selectedRow();
   });
   /** A selection, not its live listing: a target that drops off `targets()`
    *  is still the one we're remoting to, just offline, so the overlay stays
@@ -395,6 +406,7 @@ export class RemoteService {
         this.http.post<{ cmdId: string }>(
           `/api/remote/${encodeURIComponent(targetId)}/command`,
           { ...input, action: 'browse', byTargetId: this.sse.targetId() },
+          { context: new HttpContext().set(SKIP_ERROR_TOAST, true) },
         ),
       );
     } catch (err) {
@@ -437,17 +449,16 @@ export class RemoteService {
           ? rows
           : rows.filter((r) => !r.ownerUsername || r.targetId === selected),
       );
-      if (selected && !rows.some((r) => r.targetId === selected)) {
-        // Never fall back to local playback on its own: offer it, don't do it.
-        this.targetOffline.set(true);
-        console.warn('[remote] selected target went offline', selected);
+      const listed = selected ? rows.find((r) => r.targetId === selected) : undefined;
+      if (selected && !listed) {
+        this.markOffline(selected);
       } else if (selected) {
-        this.targetOffline.set(false);
+        this.selectedRow.set(listed ?? null);
+        this.clearOffline();
         // The target sends a farewell heartbeat as it leaves the player, which
         // lands after any local clear and would then sit there forever. Let the
         // server settle it: a live playback reports every 10s, so a silent
         // target the listing shows as empty really has stopped.
-        const listed = rows.find((r) => r.targetId === selected);
         const silentFor = Date.now() - this.stateAt;
         if (listed && !listed.nowPlaying && this.reportedState() && silentFor > 15_000) {
           console.debug('[remote] target reports nothing playing, clearing its state');
@@ -468,13 +479,40 @@ export class RemoteService {
     if (targetId && this.cast.isConnected()) this.cast.disconnect();
     this.selectedTargetId.set(targetId);
     this.reportedState.set(null);
-    this.targetOffline.set(false);
+    this.selectedRow.set(null);
+    this.clearOffline();
     this.expectedMediaFileId = null;
     try {
       if (targetId) localStorage.setItem(SELECTED_TARGET_KEY, targetId);
       else localStorage.removeItem(SELECTED_TARGET_KEY);
     } catch { /* blocked storage: selection is per-session only */ }
 
+  }
+
+  /** Both ways a target turns out to be gone — absent from a listing, or a
+   *  command it never took — land here, so one countdown covers them. A powered
+   *  off device never comes back under the same target id (the nonce is per
+   *  tab), so holding its selection only strands the UI: offer the local
+   *  fallback while it might still answer, then release it.  */
+  private markOffline(targetId: string): void {
+    this.targetOffline.set(true);
+    console.warn('[remote] selected target is offline', targetId);
+    if (this.offlineTimer) return;
+    this.offlineTimer = setTimeout(() => {
+      this.offlineTimer = null;
+      if (this.selectedTargetId() !== targetId || !this.targetOffline()) return;
+      console.warn('[remote] releasing a target that stayed offline', targetId);
+      this.selectTarget(null);
+      this.toast.error(this.translate.instant('remote.released_offline'));
+    }, OFFLINE_RELEASE_MS);
+  }
+
+  private clearOffline(): void {
+    this.targetOffline.set(false);
+    if (this.offlineTimer) {
+      clearTimeout(this.offlineTimer);
+      this.offlineTimer = null;
+    }
   }
 
   /** Coalesce a dragged control so one gesture costs a handful of POSTs. */
@@ -526,7 +564,7 @@ export class RemoteService {
         }
       }
       this.pendingAction.set(null);
-      this.targetOffline.set(true);
+      this.markOffline(targetId);
       console.warn('[remote] command failed', input.action, targetId, err);
       // The interceptor already toasts an HTTP failure, with the server's own
       // reason rather than one generic line, so toasting here too showed the
@@ -599,7 +637,7 @@ export class RemoteService {
       audioTrackIndex: s.audioTrackIndex,
       subtitleTrackIndex: s.subtitleTrackIndex,
     });
-    this.targetOffline.set(false);
+    this.clearOffline();
     const pinned = this.pinnedVolume();
     if (pinned !== null) {
       const converged = s.volume !== null && Math.abs(s.volume - pinned) < 0.02;

--- a/client/src/app/shared/cast-overlay/cast-overlay.html
+++ b/client/src/app/shared/cast-overlay/cast-overlay.html
@@ -46,13 +46,6 @@
               <p class="text-sm opacity-50">{{ 'remote.idle_hint' | translate }}</p>
             </div>
           </div>
-
-          <div class="shrink-0 flex justify-center px-4 pt-3"
-               style="padding-bottom: max(1rem, env(safe-area-inset-bottom))">
-            <button class="btn btn-ghost btn-sm text-base-content/50" (click)="disconnect()">
-              {{ 'remote.stop_controlling' | translate }}
-            </button>
-          </div>
         } @else {
         <!-- Poster beside the controls on a short, wide phone, above them when
              the viewport is tall, and in the header of the desktop card, which
@@ -230,6 +223,17 @@
           </div>
         </div>
         </div>
+        }
+
+        <!-- One way out of both waiting states: there is nothing on screen to
+             act on yet, and a load that never lands must not trap the card. -->
+        @if ((t.isStarting() || t.isIdle()) && t.canStopControlling) {
+          <div class="shrink-0 flex justify-center px-4 pt-3"
+               style="padding-bottom: max(1rem, env(safe-area-inset-bottom))">
+            <button class="btn btn-ghost btn-sm text-base-content/50" (click)="disconnect()">
+              {{ 'remote.stop_controlling' | translate }}
+            </button>
+          </div>
         }
 
       </div>


### PR DESCRIPTION
## Problem

Powering off a device being remote-controlled stranded the controller:

- every navigation to a detail page popped **\"That device is not reachable\"**, because the route mirroring keeps POSTing a `browse` the target can no longer answer;
- the **release button became unreachable**: the topbar chip that opens the control card reads the live target listing, and the offline device drops off it, taking its own way out with it. `isRemoting()` stayed true forever.

## Fix

Root cause is one hole with three faces — a selection that outlives the device, with no exit.

- `browse()` already documented that it reports its own failures; the request just never carried `SKIP_ERROR_TOAST`, so the global interceptor toasted the 404 anyway.
- `selectedTarget()` falls back to the last listing of the selected device, so the chip → card → release button stay reachable during the outage.
- `markOffline()` / `clearOffline()` gather both ways a target turns out to be gone (absent from a listing, or a command it never took) and release the selection after **45s** of continuous silence, with a toast. 45s is past the client's SSE reconnect backoff (30s at its longest), so a real network blip still self-heals; a powered-off device never comes back under the same target id anyway, since the nonce is per tab.
- Invariant in `RemotePlaybackTarget`: no selection ⇒ card closed, whatever the release path.
- The card's two waiting states shared their footer only in the `isIdle()` branch, so a `load` that never landed left no way out for the whole 20s ack timeout. One shared footer now covers both, gated on `canStopControlling` (false for Cast).

`remote.released_offline` added in the 6 languages.

## Tests

3 new specs in `remote.service.spec.ts`: the chip survives then the selection is released; a target that answers again in time keeps it; a failed browse carries the no-toast context. `ng test` on the remote service (29), layout and error-interceptor specs pass; `ng build` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)