### PR TITLE
fix(remote): open the player directly on a remote load

### DIFF
--- a/client/src/app/core/services/remote.service.spec.ts
+++ b/client/src/app/core/services/remote.service.spec.ts
@@ -251,6 +251,46 @@ describe('RemoteService stop handling', () => {
 });
 
 describe('RemoteService applyLoad', () => {
+  function loadCmd(): RemoteCommand {
+    return {
+      type: 'remote.command',
+      cmdId: 'cmd-load',
+      expiresAt: Date.now() + 10_000,
+      byTargetId: null,
+      action: 'load',
+      mediaFileId: 42,
+      positionSeconds: 0,
+    };
+  }
+
+  /** A load from a detail page went home first, so the target flashed the home
+   *  page before the film instead of opening it. */
+  it('goes straight to the player from anywhere but a player', async () => {
+    setup();
+    const router = TestBed.inject(Router);
+    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    const bounceSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+    vi.spyOn(router, 'url', 'get').mockReturnValue('/movies/7');
+
+    TestBed.inject(SseService).commands.next(loadCmd());
+
+    await vi.waitFor(() => expect(navigateSpy).toHaveBeenCalled());
+    expect(bounceSpy).not.toHaveBeenCalled();
+  });
+
+  it('remounts a player already on screen', async () => {
+    setup();
+    const router = TestBed.inject(Router);
+    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    const bounceSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+    vi.spyOn(router, 'url', 'get').mockReturnValue('/watch/3');
+
+    TestBed.inject(SseService).commands.next(loadCmd());
+
+    await vi.waitFor(() => expect(navigateSpy).toHaveBeenCalled());
+    expect(bounceSpy).toHaveBeenCalledWith('/', { skipLocationChange: true });
+  });
+
   it('puts t=0 on the load url when the position is exactly zero', async () => {
     const { service } = setup();
     const router = TestBed.inject(Router);

--- a/client/src/app/core/services/remote.service.ts
+++ b/client/src/app/core/services/remote.service.ts
@@ -369,9 +369,12 @@ export class RemoteService {
     if (cmd.mediaId) queryParams['mediaId'] = cmd.mediaId;
     if (cmd.episodeId) queryParams['episodeId'] = cmd.episodeId;
     if (cmd.positionSeconds !== undefined) queryParams['t'] = Math.floor(cmd.positionSeconds);
-    // Force a remount so the same file reloads too, which is what lets this
-    // work identically whether or not a player is already on screen.
-    await this.router.navigateByUrl('/', { skipLocationChange: true });
+    // Only a player already on screen needs the bounce, to remount on a load
+    // the router would otherwise consider the same route: from anywhere else it
+    // just flashed the home page on the way to the film.
+    if (this.router.url.startsWith('/watch')) {
+      await this.router.navigateByUrl('/', { skipLocationChange: true });
+    }
     await this.router.navigate(['/watch', cmd.mediaFileId], { queryParams });
   }
 


### PR DESCRIPTION
## Problem

Browsing to a title from the remote opens it on the target, but pressing play made the target go **back to the home page first**, then open the player.

`applyLoad` unconditionally did `navigateByUrl('/', { skipLocationChange: true })` before navigating to `/watch/:id` — so every load from a detail page flashed the home page and paid for its lazy chunk on the way to the film.

## Fix

That bounce exists only to force a remount when the router would otherwise consider the load the same route, which can only happen with a player already on screen. It is now gated on `router.url.startsWith('/watch')`.

## Tests

2 new specs: straight to the player from a detail page (no bounce), remount when a player is already on screen. `ng test` on the remote service: 31 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)