### PR TITLE
fix(view-transitions): repair the chrome and the poster morph on android

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -51,7 +51,6 @@ import {
   leavingPosterPage,
   leafRoutePath,
   markViewTransition,
-  stampChromeInsets,
   WATCH_PATH,
 } from './shared/utils/view-transition';
 
@@ -148,7 +147,6 @@ export const appConfig: ApplicationConfig = {
                   (enteringPosterPage(from, to) && POSTER_IN_CLASS);
                 if (posterTrip) {
                   const root = document.documentElement;
-                  stampChromeInsets();
                   root.classList.add(posterTrip);
                   const done = () => root.classList.remove(posterTrip);
                   void transition.finished.then(done, done);

--- a/client/src/app/core/services/background.service.ts
+++ b/client/src/app/core/services/background.service.ts
@@ -45,6 +45,19 @@ export class BackgroundService {
     this.url.set(next[Math.floor(Math.random() * next.length)]);
   }
 
+  /**
+   * Apply a fanart pool, or clear when the user has page backgrounds off. The
+   * pick stays stable for an unchanged pool, so a page holds the same image for
+   * as long as the user is on it.
+   */
+  applyPool(pool: readonly string[], enabled: boolean): void {
+    if (!enabled) {
+      this.clear();
+      return;
+    }
+    if (pool.length) this.setBackgrounds([...pool]);
+  }
+
   clear(): void {
     this.pool = [];
     this.url.set(null);

--- a/client/src/app/core/services/navbar.service.ts
+++ b/client/src/app/core/services/navbar.service.ts
@@ -248,13 +248,6 @@ export class NavbarService {
     this.pageTitle.set('');
     this.heroTitle.set(title);
     this.heroLogoUrl.set(logoUrl);
-    // Re-evaluate scrollAtTop from the actual position. Without this, the
-    // navbar stays opaque after returning from /watch — the scroll value
-    // is whatever the previous page left it at and no scroll event fires
-    // on a programmatic nav.
-    if (typeof window !== 'undefined') {
-      this.scrollAtTop.set(window.scrollY < 20);
-    }
   }
 
   leaveHeroPage() {

--- a/client/src/app/core/services/scroll-memory.service.ts
+++ b/client/src/app/core/services/scroll-memory.service.ts
@@ -1,19 +1,38 @@
 import { Injectable, Injector, afterNextRender, inject } from '@angular/core';
-import { Router, NavigationStart } from '@angular/router';
+import { NavigationStart, Router, Scroll } from '@angular/router';
 
 @Injectable({ providedIn: 'root' })
 export class ScrollMemoryService {
   private positions = new Map<string, number>();
   private currentKey: string | null = null;
   private readonly router = inject(Router);
+  /** False between NavigationStart and the router's own scroll. */
+  private routerScrolled = true;
+  private queued: (() => void)[] = [];
 
   constructor() {
-    // Save scroll position BEFORE navigation starts (scroll is still intact)
     this.router.events.subscribe((event) => {
-      if (event instanceof NavigationStart && this.currentKey) {
-        this.positions.set(this.currentKey, window.scrollY);
+      // Save scroll position BEFORE navigation starts (scroll is still intact)
+      if (event instanceof NavigationStart) {
+        if (this.currentKey) this.positions.set(this.currentKey, window.scrollY);
+        this.routerScrolled = false;
+      }
+      if (event instanceof Scroll) {
+        this.routerScrolled = true;
+        const due = this.queued;
+        this.queued = [];
+        // A microtask, so this lands after the router's own subscriber has
+        // scrolled whatever subscriber order puts first — same task either
+        // way, so nothing in between is ever painted.
+        if (due.length) queueMicrotask(() => due.forEach((fn) => fn()));
       }
     });
+  }
+
+  /** The offset held for `key`, for a page that has to lay itself out for the
+   *  offset it is about to be restored to rather than the one it has. */
+  remembered(key: string): number | undefined {
+    return this.positions.get(key);
   }
 
   /** Call on component init to register which key to track. */
@@ -48,12 +67,11 @@ export class ScrollMemoryService {
   }
 
   /**
-   * Restore scroll past every concurrent scroll-fighter (Router's
-   * `withInMemoryScrolling` scroll-to-top, view transitions, browser native
-   * restore). Re-applies for ~600 ms with rAF gating: stops on the first
-   * frame where scrollY already equals the target — so a user scroll within
-   * the window stops the loop cleanly too. Use this on route reattach where
-   * the cached DOM is already laid out.
+   * Restore scroll on route reattach, where the cached DOM is already laid out.
+   * Applies once the router has taken its turn, then re-applies for ~600 ms
+   * with rAF gating for a document that is still growing — stopping on the
+   * first frame where scrollY already equals the target, so a user scroll
+   * within the window ends the loop cleanly too.
    *
    * `behavior: 'instant'` is mandatory: TV builds set `scroll-behavior: smooth`
    * on `html.tv-host` for D-pad navigation, which would otherwise turn each
@@ -62,12 +80,21 @@ export class ScrollMemoryService {
   restoreSticky(key: string): void {
     const target = this.positions.get(key);
     if (!target) return;
+    // A cached route is reattached before the router scrolls, so restoring now
+    // would scroll the page being left, be overwritten by the scroll-to-top,
+    // and then correct itself — three jumps, the first of them on the outgoing
+    // page. Wait for the router to have had its turn.
+    if (this.routerScrolled) this.stick(target);
+    else this.queued.push(() => this.stick(target));
+  }
+
+  private stick(target: number): void {
     const deadline = performance.now() + 600;
     const tick = () => {
       if (Math.abs(window.scrollY - target) < 1) return;
       window.scrollTo({ top: target, left: 0, behavior: 'instant' });
       if (performance.now() < deadline) requestAnimationFrame(tick);
     };
-    requestAnimationFrame(tick);
+    tick();
   }
 }

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -41,7 +41,7 @@ import { RequestCardComponent } from '../requests/request-card/request-card';
 import { RequestDeclineModalComponent } from '../requests/request-decline-modal/request-decline-modal.component';
 import { libraryColorVar } from '../../core/constants/library-appearance';
 import { StorageScopeService } from '../../core/services/storage-scope.service';
-import { itemArtwork } from '../../shared/utils/media-artwork.util';
+import { fanartPool, itemArtwork } from '../../shared/utils/media-artwork.util';
 
 /**
  * # Home page
@@ -134,6 +134,11 @@ export class HomeComponent implements OnInit, OnDestroy {
     // repaint nothing.
     refreshOnResume: () => void this.loadAllSections({ force: true }),
     scrollKey: HomeComponent.SCROLL_KEY,
+    onAttach: () =>
+      this.applyBackground(
+        this.recommendations(),
+        this.displaySettings.settings().homeBackground,
+      ),
   });
   private readonly declineModal = viewChild(RequestDeclineModalComponent);
   private readonly detailModal = viewChild(DownloadDetailModalComponent);
@@ -248,19 +253,17 @@ export class HomeComponent implements OnInit, OnDestroy {
    *  the BackgroundService keeps it stable while the user stays on
    *  the home — same contract as media-detail. */
   private readonly recommendationsBackgroundEffect = effect(() => {
-    const recs = this.recommendations();
-    if (recs.length === 0) return;
-    if (!this.displaySettings.settings().homeBackground) {
-      this.backgroundService.clear();
-      return;
-    }
-    const pool: string[] = [];
-    for (const r of recs) {
-      if (r.media.fanartUrl) pool.push(r.media.fanartUrl);
-      pool.push(...(r.media.additionalFanartUrls ?? []));
-    }
-    if (pool.length) this.backgroundService.setBackgrounds(pool);
+    this.applyBackground(this.recommendations(), this.displaySettings.settings().homeBackground);
   });
+
+  /** The background is global chrome, so a cached page has to reclaim it on the
+   *  way back in — the effect above won't re-run for data that never changed,
+   *  and the page left behind cleared it. Reclaiming it late is what made the
+   *  topbar flip from solid to frosted a frame after a back navigation. */
+  private applyBackground(recs: readonly RecommendationItem[], enabled: boolean): void {
+    if (recs.length === 0) return;
+    this.backgroundService.applyPool(fanartPool(recs.map((r) => r.media)), enabled);
+  }
 
   /** A playback that ended leaves this row stale, whether it ran here or on a
    *  device this one is driving. The server announces every session stop to all

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -32,6 +32,8 @@ import type {
   RecommendationItem,
 } from '../../core/services/api/streaming-api.service';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
+import { BackgroundService } from '../../core/services/background.service';
+import { DisplaySettingsService } from '../../core/services/display-settings.service';
 import { DefaultFocusDirective } from '../../shared/directives/default-focus.directive';
 import { TvRowDirective } from '../../shared/directives/tv-row.directive';
 import { NavbarService } from '../../core/services/navbar.service';
@@ -43,7 +45,8 @@ import { MosaicCardComponent } from '../../shared/components/mosaic-card/mosaic-
 import { CardSkeletonComponent } from '../../shared/components/card-skeleton';
 import { ImportProgressBannerComponent } from '../../shared/components/import-progress-banner/import-progress-banner';
 import { NgTemplateOutlet } from '@angular/common';
-import { itemArtwork } from '../../shared/utils/media-artwork.util';
+import { fanartPool, itemArtwork } from '../../shared/utils/media-artwork.util';
+import { renderRowsForOffset } from '../../shared/utils/restore-virtual-rows';
 import { PlayableMediaService } from '../../core/services/playable-media.service';
 import {
   CdkVirtualScrollViewport,
@@ -112,6 +115,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly scrollMemory = inject(ScrollMemoryService);
+  private readonly background = inject(BackgroundService);
+  private readonly displaySettings = inject(DisplaySettingsService);
   readonly navbar = inject(NavbarService);
   private readonly tv = inject(TvService);
   private readonly injector = inject(Injector);
@@ -129,8 +134,36 @@ export class LibraryComponent implements OnInit, OnDestroy {
     onAttach: () => {
       const lib = this.library();
       if (lib) this.navbar.setPageTitle(lib.name);
+      if (lib) this.prerenderRestoredRows(`library-${lib.id}`);
+      this.applyBackground();
     },
   });
+
+  /** Renders the rows for the offset the scroll is about to be restored to —
+   *  see {@link renderRowsForOffset}. The flush is CDK's own: `ApplicationRef
+   *  .tick()` in its place leaves the rows in the DOM but unplaced, captured
+   *  thousands of pixels off screen, so the internal call is the only one that
+   *  does the whole job. */
+  private prerenderRestoredRows(key: string): void {
+    const y = this.scrollMemory.remembered(key);
+    const vp = this.viewport;
+    if (y == null || !vp) return;
+    const render = (vp as unknown as { _doChangeDetection?: () => void })._doChangeDetection;
+    renderRowsForOffset(vp, y, () => render?.call(vp));
+  }
+
+  /** Same fanart backdrop as the home page, from this library's own titles, so
+   *  the topbar keeps its frosted look here too — but only to fill a gap.
+   *  Opening a library from the home page keeps the image already showing; it is
+   *  coming back from a detail page, which clears the background on its way out,
+   *  that leaves nothing behind to look at. */
+  private applyBackground(): void {
+    if (this.background.url()) return;
+    this.background.applyPool(
+      fanartPool(this.list.all()),
+      this.displaySettings.settings().homeBackground,
+    );
+  }
   private queryParamSub?: Subscription;
   /** Set while a state-driven `syncQueryParams` is being applied to the
    *  URL, so the `queryParamMap` subscription that fires right after
@@ -446,6 +479,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.background.clear();
     this.scrollMemory.deactivate();
     this.list.destroy();
     if (this.onResize) window.removeEventListener('resize', this.onResize);
@@ -794,6 +828,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
         this.streamingApi.getWatchedMediaIds().catch(() => [] as number[]),
       ]);
       this.list.setItems(res.data, (m) => m.title);
+      this.applyBackground();
       this.watchedIds.set(new Set(watchedIds));
     } finally {
       if (!silent) this.loading.set(false);
@@ -809,7 +844,10 @@ export class LibraryComponent implements OnInit, OnDestroy {
         this.streamingApi.getWatchedMediaIds({ force: true }).catch(() => null),
       ]).then(([res, watchedIds]) => {
         if (gen !== this.loadGen) return;
-        if (res) this.list.setItems(res.data, (m) => m.title);
+        if (res) {
+          this.list.setItems(res.data, (m) => m.title);
+          this.applyBackground();
+        }
         if (watchedIds) this.watchedIds.set(new Set(watchedIds));
       });
     });

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -187,7 +187,7 @@
           [libraryName]="m.library?.name ?? null"
           [qualityProfileName]="m.qualityProfile?.name ?? null"
           [languageProfileName]="m.languageProfile?.name ?? null"
-          [fanartUrl]="m.fanartUrl ?? null"
+          [fanartUrl]="m.fanartUrl ?? m.posterUrl ?? null"
           [posterUrl]="m.posterUrl ?? null"
           [backRoute]="['/', backSegment()]"
           [subtitles]="subtitleSection()?.headerSubtitles() ?? []"

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -13,6 +13,8 @@ import { TrackingModalService } from '../../../core/services/tracking-modal.serv
 import { CardActionsDirective } from '../../directives/card-actions.directive';
 import { SpoilerDirective } from '../../directives/spoiler.directive';
 import { clearPosterStamps, stampPoster } from '../../utils/view-transition';
+import { ServerConfigService } from '../../../core/services/server-config.service';
+import { imageUrlWithSize } from '../../../core/pipes/resolve-url.pipe';
 import { CardAction, CardActionsService } from '../../../core/services/card-actions.service';
 import { AddToPlaylistService } from '../../../core/services/add-to-playlist.service';
 import { RecommendService } from '../../../core/services/recommend.service';
@@ -339,6 +341,23 @@ export class MediaCardComponent {
     if (this.replaceUrl()) this.navbar.markAsBackNavigation();
   }
 
+  private readonly serverConfig = inject(ServerConfigService);
+
+  /**
+   * Warm the picture the destination will show, while the click is still being
+   * handled. A view transition captures the destination before its own images
+   * have decoded — measured `complete: false` at that exact point — so without
+   * this the morph has nothing of the target to carry and flies the card's
+   * poster instead. Decoding it here gives it the ~100 ms until the capture.
+   */
+  private prefetchHeroArtwork() {
+    const url = this.media()?.fanartUrl;
+    if (!url) return;
+    const img = new Image();
+    img.decoding = 'async';
+    img.src = this.serverConfig.resolveUrl(imageUrlWithSize(url, 'medium'));
+  }
+
   protected flagPosterForTransition() {
     // Pointless where the engine has no View Transitions (Chromium <111, Tizen 5.5
     // WebKit, webOS 5), and it costs a querySelectorAll per click.
@@ -352,6 +371,7 @@ export class MediaCardComponent {
     const id = this.resolveMediaId();
     const img = this.imgRef()?.nativeElement;
     if (id == null || !img) return;
+    this.prefetchHeroArtwork();
     stampPoster(img, id, this.episodeIdFromLink(), this.overlayRef()?.nativeElement);
   }
   protected readonly _playable = computed(() => {

--- a/client/src/app/shared/components/media-file-info.html
+++ b/client/src/app/shared/components/media-file-info.html
@@ -78,7 +78,11 @@
           @for (a of audioStreams(); track a.streamIndex) {
             <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-x-6 gap-y-1 text-sm">
               @if (a.title || a.codec) {
-                <div><span class="text-base-content/50">{{ 'file_info.track_title' | translate }} :&nbsp;</span><span class="font-medium">{{ a.title ?? formatAudioTitle(a) }}</span></div>
+                <!-- `break-all`, like the path above: a track title is often the
+                     whole release name, one dotted token with nowhere to wrap, and
+                     this page cannot clip its overflow — `main` stays visible-x on
+                     a hero page so the fanart can bleed. -->
+                <div class="min-w-0"><span class="text-base-content/50">{{ 'file_info.track_title' | translate }} :&nbsp;</span><span class="font-medium break-all">{{ a.title ?? formatAudioTitle(a) }}</span></div>
               }
               <div><span class="text-base-content/50">{{ 'file_info.language' | translate }} :&nbsp;</span><span class="font-medium">{{ a.language }}</span></div>
               <div><span class="text-base-content/50">{{ 'file_info.codec' | translate }} :&nbsp;</span><span class="font-medium">{{ a.codec }}</span></div>

--- a/client/src/app/shared/components/media-info-header/media-info-header.html
+++ b/client/src/app/shared/components/media-info-header/media-info-header.html
@@ -5,9 +5,10 @@
     [appSpoiler]="spoilerImage()"
     [revealLabel]="'spoilers.reveal' | translate"
     [fanartUrl]="fanartUrl()"
+    [viewTransitionName]="episodeId() ? 'media-poster-ep-' + episodeId() : 'media-poster-' + mediaId()"
   />
 
-  <div class="-mt-16 relative z-20">
+  <div data-hero-lead class="-mt-16 relative z-20">
     <!-- Title -->
     <h1 class="text-3xl font-semibold tracking-tight leading-tight">
       @if (episodeLabel()) {
@@ -423,8 +424,12 @@
     <!-- min-h reserves the tallest child (a `select-sm`): the subtitle dropdown
          arrives after the video/audio labels, which are plain text. -->
     <div appTvRow class="flex flex-wrap items-center gap-x-4 gap-y-1.5 mt-5 min-h-8">
-      <div class="flex items-center gap-2">
-        <span class="text-base-content/50">{{ 'media_info.video' | translate }}</span>
+      <!-- Every cell shrinks and every value wraps: a single long track label
+           (a commentary track names its whole channel layout) is otherwise wider
+           than the phone, and this page is the one that cannot clip its overflow
+           — `main` stays visible-x on a hero page so the fanart can bleed. -->
+      <div class="flex items-center gap-2 min-w-0">
+        <span class="shrink-0 text-base-content/50">{{ 'media_info.video' | translate }}</span>
         @if (multipleFiles()) {
           <select class="select select-bordered select-sm w-fit" appTvSelect [ngModel]="selectedFileId()" (ngModelChange)="selectedFileIdChange.emit($event)">
             @for (f of files(); track f.id) {
@@ -432,17 +437,17 @@
             }
           </select>
         } @else if (videoLabel()) {
-          <span>{{ videoLabel() }}</span>
+          <span class="min-w-0 break-words">{{ videoLabel() }}</span>
         }
       </div>
       @if (audioTracks().length) {
-        <div class="flex items-center gap-2">
-          <span class="text-base-content/50">{{ 'media_info.audio' | translate }}</span>
+        <div class="flex items-center gap-2 min-w-0">
+          <span class="shrink-0 text-base-content/50">{{ 'media_info.audio' | translate }}</span>
           @if (audioTracks().length === 1) {
-            <span>{{ audioTracks()[0].label }}</span>
+            <span class="min-w-0 break-words">{{ audioTracks()[0].label }}</span>
           } @else {
             <app-dropdown-menu placement="bottom-end">
-              <button trigger type="button" class="select select-bordered select-sm w-fit text-left cursor-pointer transition-colors hover:bg-base-content/10">
+              <button trigger type="button" class="select select-bordered select-sm w-fit max-w-full truncate text-left cursor-pointer transition-colors hover:bg-base-content/10">
                 {{ selectedAudio()?.head || selectedAudio()?.label }}
               </button>
               @for (t of audioTracks(); track t.index) {
@@ -458,10 +463,10 @@
         </div>
       }
       @if (subtitles().length) {
-        <div class="flex items-center gap-2">
-          <span class="text-base-content/50">{{ 'media_info.subtitles' | translate }}</span>
+        <div class="flex items-center gap-2 min-w-0">
+          <span class="shrink-0 text-base-content/50">{{ 'media_info.subtitles' | translate }}</span>
           <app-dropdown-menu placement="bottom-end">
-            <button trigger type="button" class="select select-bordered select-sm w-fit text-left cursor-pointer transition-colors hover:bg-base-content/10">
+            <button trigger type="button" class="select select-bordered select-sm w-fit max-w-full truncate text-left cursor-pointer transition-colors hover:bg-base-content/10">
               {{ selectedSubtitle()?.head || selectedSubtitle()?.label || ('player.off' | translate) }}
             </button>
             <app-dropdown-option

--- a/client/src/app/shared/components/mobile-fanart-hero.ts
+++ b/client/src/app/shared/components/mobile-fanart-hero.ts
@@ -12,15 +12,19 @@ import { ImgFadeInDirective } from '../directives/img-fade-in.directive';
   template: `
     <div class="relative -mx-4 -mt-4 hero-fanart-bleed">
       @if (fanartUrl()) {
+        <!-- The name rides the image, not the wrapper: desktop pairs img with
+             img and its morph shows the destination's picture, a div snapshot
+             does not. -->
         <img
           appImgFadeIn
+          [style.view-transition-name]="viewTransitionName()"
           [src]="fanartUrl()! | resolveUrl:'medium'"
           [alt]="imageAlt()"
           loading="eager"
           fetchpriority="high"
-          class="w-full min-h-[230px] h-[38svh] max-h-[53svh] landscape:min-h-0 landscape:h-auto landscape:max-h-[47vh] landscape:aspect-video object-cover object-[50%_25%]"
+          class="hero-fanart-fade relative w-full min-h-[230px] h-[38svh] max-h-[53svh] landscape:min-h-0 landscape:h-auto landscape:max-h-[47vh] landscape:aspect-video object-cover object-[50%_25%]"
         />
-        <div class="pointer-events-none absolute inset-0 bg-linear-to-t from-base-100 via-transparent to-black/20"></div>
+
       } @else {
         <div
           class="w-full min-h-[230px] h-[38svh] max-h-[53svh] landscape:min-h-0 landscape:h-auto landscape:aspect-video landscape:max-h-[47vh] bg-base-300"
@@ -32,4 +36,9 @@ import { ImgFadeInDirective } from '../directives/img-fade-in.directive';
 export class MobileFanartHeroComponent {
   readonly fanartUrl = input<string | null | undefined>(null);
   readonly imageAlt = input('');
+  /** Pairs this hero with the card that opened the page, so the poster morph
+   *  has a destination on mobile too — the box carries the whole aspect change,
+   *  portrait card into landscape hero. On the wrapper rather than the image so
+   *  the scrim the title sits on travels with it. Null where nothing pairs. */
+  readonly viewTransitionName = input<string | null>(null);
 }

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -10,6 +10,7 @@
     <nav
       appTvRow
       class="navbar fixed left-0 right-0 z-30 transition-all duration-300 tv:px-[var(--page-p)] tv:static"
+      [style.transition]="restorePending() ? 'none' : null"
       [style.padding-top]="tv.isTv() ? 'calc(env(safe-area-inset-top, 0px) + var(--page-p) / 2)' : 'calc(env(safe-area-inset-top, 0px) + 4px)'"
       [class.top-0]="!tv.isTv() || tv.isTizen()"
       [class.top-4]="tv.isAndroidTv()"
@@ -217,6 +218,7 @@
            circle). Active (current route): inverted via routerLinkActive.
            Arbitrary variants suppress the DaisyUI .dock-active underline. -->
       <a routerLink="/search"
+         data-chrome-fab
          [routerLinkActive]="['dock-active', '!bg-primary', '!text-primary-content']"
          [routerLinkActiveOptions]="{ exact: false }"
          (click)="onSearchNavClick()"

--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Title } from '@angular/platform-browser';
-import { RouterLink, RouterLinkActive, RouterOutlet, Router, NavigationEnd } from '@angular/router';
+import { RouterLink, RouterLinkActive, RouterOutlet, Router, NavigationEnd, Scroll } from '@angular/router';
 import { Capacitor, registerPlugin } from '@capacitor/core';
 import { Keyboard } from '@capacitor/keyboard';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -191,6 +191,10 @@ export class LayoutComponent implements OnInit, OnDestroy {
     this.title.setTitle(`${main} · ${this.translate.instant('app.name')}`);
   });
   private lastScrollY = 0;
+  /** NavigationEnd until the new page's navbar has painted: gates scroll
+   *  reads and, bound to the element, its CSS transition. */
+  readonly restorePending = signal(false);
+  private restoreFallback: ReturnType<typeof setTimeout> | undefined;
   private scrollRaf: number | null = null;
   private topSentinelObserver?: IntersectionObserver;
   /** TV never hides the navbar, so the scroll handler would exist only to
@@ -206,6 +210,7 @@ export class LayoutComponent implements OnInit, OnDestroy {
     });
   };
   private readScroll(): void {
+    if (this.restorePending()) return;
     const y = window.scrollY;
     this.navbar.scrollAtTop.set(y < 20);
     if (Math.abs(y - this.lastScrollY) < 10) return;
@@ -316,7 +321,9 @@ export class LayoutComponent implements OnInit, OnDestroy {
     this.router.events
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(e => {
+        if (e instanceof Scroll) this.endScrollRestore();
         if (e instanceof NavigationEnd) {
+          this.beginScrollRestore();
           this.replayPageEnter();
           this.bottomMenuOpen.set(false);
           this.isHomeRoute.set(e.urlAfterRedirects === '/' || e.urlAfterRedirects.startsWith('/?'));
@@ -324,6 +331,36 @@ export class LayoutComponent implements OnInit, OnDestroy {
         }
       });
     this.syncNavbarTitleFromRoute();
+  }
+
+  /** A navigation swaps pages before the router restores the scroll, so reads
+   *  in between report the offset of the page being left. Seed the state the
+   *  restore is about to produce and hold reads until it lands. */
+  private beginScrollRestore(): void {
+    this.restorePending.set(true);
+    this.navbarHidden.set(false);
+    this.navbar.scrollAtTop.set(true);
+    clearTimeout(this.restoreFallback);
+    // The router owes us a Scroll event; don't stay deaf to scrolling if it
+    // never comes (in-memory scrolling turned off, a skipped navigation).
+    this.restoreFallback = setTimeout(() => this.endScrollRestore(), 1000);
+  }
+
+  /** Two frames, not now: this runs from the event stream that drives the
+   *  scroll, and the navbar must paint the new page once before re-arming. */
+  private endScrollRestore(): void {
+    if (!this.restorePending()) return;
+    clearTimeout(this.restoreFallback);
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => {
+        this.restorePending.set(false);
+        // Adopt the restored offset instead of reading it: a restore is not a
+        // gesture, and against a zero baseline it reads as one long scroll
+        // down — which hid the navbar on every return to a scrolled page.
+        this.lastScrollY = window.scrollY;
+        this.navbar.scrollAtTop.set(window.scrollY < 20);
+      }),
+    );
   }
 
   /** Restart the page-enter animation. Re-adding the class a frame later is
@@ -363,6 +400,7 @@ export class LayoutComponent implements OnInit, OnDestroy {
       Keyboard.removeAllListeners();
     }
     if (this.sidebarCountsDebounceTimer) clearTimeout(this.sidebarCountsDebounceTimer);
+    clearTimeout(this.restoreFallback);
   }
 
   async refreshCounts() {

--- a/client/src/app/shared/utils/media-artwork.util.ts
+++ b/client/src/app/shared/utils/media-artwork.util.ts
@@ -10,3 +10,19 @@ export function itemArtwork(item: {
 }): string | null {
   return item.stillUrl ?? item.fanartUrl ?? item.posterUrl ?? null;
 }
+
+/**
+ * Fanart URLs for a page-background pool: the primary plus every extra. The
+ * BackgroundService keeps one stable pick per pool, so the page holds the same
+ * image for as long as the user stays on it.
+ */
+export function fanartPool(
+  items: readonly { fanartUrl?: string | null; additionalFanartUrls?: string[] | null }[],
+): string[] {
+  const pool: string[] = [];
+  for (const item of items) {
+    if (item.fanartUrl) pool.push(item.fanartUrl);
+    pool.push(...(item.additionalFanartUrls ?? []));
+  }
+  return pool;
+}

--- a/client/src/app/shared/utils/restore-virtual-rows.spec.ts
+++ b/client/src/app/shared/utils/restore-virtual-rows.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { renderRowsForOffset } from './restore-virtual-rows';
+
+describe('renderRowsForOffset', () => {
+  it('lays the viewport out at the target offset and hands the scroll back', () => {
+    const order: string[] = [];
+    const applied: number[] = [];
+    let scrollY = 4200;
+    const scroller = {
+      get scrollY() { return scrollY; },
+      scrollTo: (o: ScrollToOptions) => {
+        scrollY = o.top ?? 0;
+        applied.push(scrollY);
+      },
+    };
+    const viewport = { checkViewportSize: () => order.push(`measure@${scrollY}`) };
+
+    renderRowsForOffset(viewport, 27274, () => order.push(`flush@${scrollY}`), scroller);
+
+    // Both happen while the offset is the one the rows are needed for: CDK reads
+    // it to choose the range, and the flush is what renders that range.
+    expect(order).toEqual(['measure@27274', 'flush@27274']);
+    // And the page is left exactly where it was, or the page being navigated
+    // away from visibly jumps before the transition has snapshotted it.
+    expect(applied).toEqual([27274, 4200]);
+    expect(scrollY).toBe(4200);
+  });
+});

--- a/client/src/app/shared/utils/restore-virtual-rows.ts
+++ b/client/src/app/shared/utils/restore-virtual-rows.ts
@@ -1,0 +1,33 @@
+/**
+ * Lay a virtual viewport out for an offset the scroll is about to be restored
+ * to, so a view transition that snapshots the page in between finds the rows
+ * already there — otherwise the poster morph has no card to fly home to.
+ *
+ * The offset has to be real: CDK derives the rows AND their placement from it,
+ * and a range set by hand against a scroll of 0 lands every row thousands of
+ * pixels off screen. It also has to be given straight back — this runs before
+ * the transition has captured the page it is leaving, so a scroll left behind
+ * shows as that page jumping to its end. The rows survive the round trip
+ * because CDK only revisits the range on its next frame, by which time the
+ * restore proper has landed.
+ *
+ * `flush` renders the range CDK has just chosen; the placement only lands in a
+ * change-detection pass, and CDK asks for one rather than running it.
+ */
+export function renderRowsForOffset(
+  viewport: { checkViewportSize(): void },
+  offset: number,
+  flush: () => void,
+  scroller: Scroller = window,
+): void {
+  const held = scroller.scrollY;
+  scroller.scrollTo({ top: offset, left: 0, behavior: 'instant' });
+  viewport.checkViewportSize();
+  flush();
+  scroller.scrollTo({ top: held, left: 0, behavior: 'instant' });
+}
+
+interface Scroller {
+  readonly scrollY: number;
+  scrollTo(options: ScrollToOptions): void;
+}

--- a/client/src/app/shared/utils/view-transition.ts
+++ b/client/src/app/shared/utils/view-transition.ts
@@ -108,16 +108,3 @@ export function markViewTransition(transition: { finished: Promise<unknown> }): 
 export function viewTransitionRunning(): boolean {
   return document.documentElement.classList.contains(VIEW_TRANSITION_CLASS);
 }
-
-/**
- * The chrome the morph must not paint over, as insets the clip in `styles.css`
- * reads. Measured per trip: the sidebar is only docked at some widths, and the
- * dock only exists on a native phone.
- */
-export function stampChromeInsets(): void {
-  const side = document.querySelector('.app-chrome-side')?.getBoundingClientRect();
-  const dock = document.querySelector('.dock')?.getBoundingClientRect();
-  const style = document.documentElement.style;
-  style.setProperty('--vt-chrome-left', `${Math.max(0, side?.right ?? 0)}px`);
-  style.setProperty('--vt-chrome-bottom', `${dock ? Math.max(0, window.innerHeight - dock.top) : 0}px`);
-}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -105,15 +105,6 @@
   position: relative;
 }
 
-/* Router scroll-to-top on navigation goes through window.scrollTo, so smooth
-   here animates the jump instead of teleporting. Scroll restores that must land
-   instantly pass behavior:'instant'. */
-@media (prefers-reduced-motion: no-preference) {
-  html {
-    scroll-behavior: smooth;
-  }
-}
-
 /* Sidebar veil when a fanart background is showing — frosted
    look without depending on Tailwind's color-mix-based
    `bg-base-100/40`. Phones/tablets/desktop: 40 % alpha. TV: a
@@ -790,6 +781,10 @@ body.tv .mosaic-art > * > img:nth-child(4) {
    card at once and its snapshot came out with grey boxes for artwork. */
 html.nav-back .card-img-reveal {
   animation-duration: 0s;
+  /* `appSpoiler` puts a `transition` on the same img for its blur, and dropping
+     `opacity-0` on load rides it — so the artwork faded in on the way back even
+     with the reveal neutralised. Keep the blur eased, take opacity out. */
+  transition-property: filter, transform;
 }
 
 /* The opacity animation promotes the img to its own layer, and this WebView then
@@ -1223,18 +1218,84 @@ html.vt-poster-out::view-transition-new(.poster) {
   object-fit: cover;
 }
 
-/* A card scrolled out of its row still owns its real rect, so the box flies to
-   it over the sidebar or the native dock. Dropping the root snapshot leaves the
-   page itself painting under the pseudo-tree, so the box can be clipped to the
-   content area without the chrome going with it: the sidebar's translucent veil
-   then reads the live page behind it, not the poster passing under. */
-html.vt-poster-in,
-html.vt-poster-out {
-  view-transition-name: none;
+/* The root snapshot is what holds the chrome. Dropping it left the live page
+   painting under the pseudo-tree, and a `position: fixed` element that is not
+   itself captured is then dropped for the length of the transition once the
+   document is long enough — 45 000 px of library grid lost the dock, the topbar
+   and the alphabet column on Android while the in-flow cards painted fine. One
+   snapshot of the whole page cannot come apart that way. */
+
+/* The topbar and the hero's lead block are what the morph must pass under
+   rather than over, so both are captured and ordered above it. The bar's
+   frosted veil comes along: the snapshot bakes the blur of what it was over.
+   The lead block is named on the way in only — going back it has no half to
+   pair with, so it would be a lone layer fading out over the card list. */
+html.vt-poster-in nav.navbar,
+html.vt-poster-out nav.navbar {
+  view-transition-name: vt-topbar;
 }
-html.vt-poster-in::view-transition,
-html.vt-poster-out::view-transition {
-  clip-path: inset(0 0 var(--vt-chrome-bottom, 0px) var(--vt-chrome-left, 0px));
+html.vt-poster-in app-media-info-header [data-hero-lead] {
+  view-transition-name: vt-hero-lead;
+}
+/* The scrim the title reads against, as a mask on the picture rather than a
+   layer over it. An overlay is a second element: a view transition carries one,
+   so the gradient either stayed behind while the picture flew or, captured
+   beside it, brought a second copy of the image along. Masked, the fade is part
+   of what the image paints and travels with it for free. */
+.hero-fanart-fade {
+  mask-image: linear-gradient(to top, transparent 0, #000 38%);
+}
+/* The dock and the search button sit inside the root snapshot, so lifting the
+   lead block above root also lifted the overview — "voir plus" and all — in
+   front of them. They have to come along, ordered as they are on the settled
+   page: lead, then dock, then the button in its cradle. */
+html.vt-poster-in .dock,
+html.vt-poster-out .dock {
+  view-transition-name: vt-dock;
+}
+html.vt-poster-in [data-chrome-fab],
+html.vt-poster-out [data-chrome-fab] {
+  view-transition-name: vt-fab;
+}
+html.vt-poster-in::view-transition-group(vt-topbar),
+html.vt-poster-out::view-transition-group(vt-topbar),
+html.vt-poster-in::view-transition-group(vt-hero-lead) {
+  z-index: 2;
+}
+/* The bar is the same box on both sides, so it swaps rather than cross-fading —
+   opacity as well as the animation, or the outgoing bar stays stacked under the
+   incoming one and you get two logos at once. */
+html.vt-poster-in::view-transition-group(vt-topbar),
+html.vt-poster-out::view-transition-group(vt-topbar),
+html.vt-poster-in::view-transition-new(vt-topbar),
+html.vt-poster-out::view-transition-new(vt-topbar) {
+  animation: none;
+}
+html.vt-poster-in::view-transition-old(vt-topbar),
+html.vt-poster-out::view-transition-old(vt-topbar) {
+  animation: none;
+  opacity: 0;
+}
+html.vt-poster-in::view-transition-group(vt-dock),
+html.vt-poster-out::view-transition-group(vt-dock),
+html.vt-poster-in::view-transition-new(vt-dock),
+html.vt-poster-out::view-transition-new(vt-dock) {
+  z-index: 3;
+  animation: none;
+}
+html.vt-poster-in::view-transition-group(vt-fab),
+html.vt-poster-out::view-transition-group(vt-fab),
+html.vt-poster-in::view-transition-new(vt-fab),
+html.vt-poster-out::view-transition-new(vt-fab) {
+  z-index: 4;
+  animation: none;
+}
+html.vt-poster-in::view-transition-old(vt-dock),
+html.vt-poster-out::view-transition-old(vt-dock),
+html.vt-poster-in::view-transition-old(vt-fab),
+html.vt-poster-out::view-transition-old(vt-fab) {
+  animation: none;
+  opacity: 0;
 }
 
 /* Force the hero (poster) morph above root. The default pseudo-tree order
@@ -1247,6 +1308,10 @@ html.vt-poster-out::view-transition {
 }
 ::view-transition-group(root) {
   z-index: 0;
+  /* The pair does not cross-fade, so the group must not travel either: the two
+     roots are a short detail page and a 45 000 px library, and animating
+     between those geometries slid the whole page for the length of the trip. */
+  animation: none;
 }
 
 /* The card's own badges and progress bar ride above the poster that morphs


### PR DESCRIPTION
Diagnosed on the device over adb + CDP; every claim below is a measurement, not an inference.

## The chrome vanishing on a big library

Dropping the root snapshot on a poster trip leaves the live page painting under the
pseudo-tree, and an uncaptured `position: fixed` element is then dropped for the length of
the transition once the document is long enough. A Films library is a **45 866 px**
document: the dock, topbar and alphabet column disappeared while the in-flow cards painted
fine, which is why it looked item-dependent — it tracks the scroll offset. The search FAB
survived alone because `-translate-x-1/2` already put it on its own compositor layer;
`will-change: transform` on the others does **not** fix it (tested).

Capturing them fixes it, but the existing `::view-transition` clip then removed the dock
from the very tree that had become responsible for drawing it — an inset measured from the
dock's own rect. So: the root snapshot is kept, the clip is gone, and the chrome is ordered
explicitly (hero lead 2, dock 3, search button 4). At equal `z-index` the order falls back
to capture order, which had put the detail page's overview in front of the dock.

## The poster with nothing to fly home to

On a virtualised list the clicked card is destroyed while the detail page is open, and CDK
renders the rows for a restored offset one frame after the transition has snapshotted the
page — measured: at the capture point the card was absent, appearing 30 ms later. Neither
re-stamping the replacement card (it does not exist yet) nor `ApplicationRef.tick()` (the
rows land unplaced, `rect: -26685`) works. `renderRowsForOffset` borrows the scroll, lets
CDK measure and render, and hands it straight back, so the rows are there at capture
without the outgoing page being seen to jump to its end.

## Mobile: portrait card into a landscape hero

The target's picture was missing from the capture twice over. The hero image had not
decoded (`complete: false` at the capture point), so the card now warms it on
`pointerdown` — verified on a cleared cache with a never-opened title. And the name sat on
a wrapper `div`, which does not pair the way desktop's `img` does; back on the image, the
destination's artwork is what travels. Its bottom fade is a mask on the image rather than
an overlay: a transition carries one element, so a separate gradient either stayed behind
or, captured beside it, brought a second copy of the picture along.

## Also here

- The library takes the home page's fanart backdrop so its topbar stays frosted. It fills
  a gap rather than replacing an image already showing, so opening a library from home
  keeps what is on screen; coming back from a detail page, which clears it, restores one.
  `BackgroundService.applyPool` is now the single place that decides pool-or-clear.
- A scroll restore no longer reads as a gesture and slides the topbar away, and the navbar
  no longer animates the outgoing page's scroll state on arrival.
- A track title long enough to be a release name no longer scrolls the whole detail page.
  That page cannot clip its overflow — `main` stays `overflow-x: visible` on a hero page so
  the fanart can bleed — so the fix is at the source: `break-all`, since the value is one
  dotted token with nowhere to wrap.

## Verification

`tsc -p tsconfig.app.json` clean, `ng build` clean, and `restore-virtual-rows.spec.ts`
covers the timing assumption that nothing else would catch: that CDK is measured *and*
flushed while the target offset is applied, and that the scroll is handed back.

Behaviour was checked on device for both directions of the trip, from the library, from
home and from search, plus the desktop layout in a browser at `md`+.
