### PR TITLE
fix(subtitles): size android cues off the surface short side

### DIFF
--- a/client/android/app/src/main/java/media/fliks/app/SubtitleOverlay.java
+++ b/client/android/app/src/main/java/media/fliks/app/SubtitleOverlay.java
@@ -54,13 +54,6 @@ class SubtitleOverlay {
             applyTextSize();
             applyBottomMargin();
         });
-        // The picture only gets its height once the video's aspect is known, and
-        // it changes again on rotation — the cue size follows it.
-        if (surfaceView != null) {
-            surfaceView.addOnLayoutChangeListener(
-                    (v, l, t, r, b, ol, ot, or_, ob) -> applyTextSize());
-        }
-
         // Added to `wrapper` (a FrameLayout we own) so the gravity-bearing
         // FrameLayout.LayoutParams cast stays valid regardless of the host
         // WebView parent's layout type.
@@ -89,12 +82,12 @@ class SubtitleOverlay {
         renderImageCue(null);
     }
 
-    /** Text height as a fraction of the video, not of the view: the view spans the
-     *  whole screen, which in portrait is mostly letterbox. */
+    /** Text height as a fraction of the surface's short side, which is invariant
+     *  across rotation and fill mode — unlike the letterboxed picture. */
     private static final float TEXT_SIZE_FRACTION = 0.035f;
 
-    /** Floor under the fraction: a phone's picture is ~200dp tall in portrait and
-     *  ~360dp in landscape, too short for the fraction alone to stay readable. */
+    /** Floor under the fraction, for a surface too short to reach a readable
+     *  size from it alone. */
     private static final float MIN_TEXT_SIZE_SP = 18f;
 
     private float fontScale = 1f;
@@ -115,9 +108,9 @@ class SubtitleOverlay {
         float minPx = TypedValue.applyDimension(
                 TypedValue.COMPLEX_UNIT_SP, MIN_TEXT_SIZE_SP * fontScale,
                 subtitleView.getResources().getDisplayMetrics());
-        int videoH = surfaceView != null ? surfaceView.getHeight() : 0;
+        int shortSide = Math.min(subtitleView.getWidth(), subtitleView.getHeight());
         subtitleView.setFixedTextSize(TypedValue.COMPLEX_UNIT_PX,
-                Math.max(videoH * TEXT_SIZE_FRACTION * fontScale, minPx));
+                Math.max(shortSide * TEXT_SIZE_FRACTION * fontScale, minPx));
     }
 
     private void applyBottomMargin() {


### PR DESCRIPTION
Subtitles read too small in the Android app on a tablet, at every preset.

## Cause

`SubtitleOverlay.applyTextSize` multiplied the fraction by `surfaceView.getHeight()` — the
**letterboxed picture**, not the surface. So the cue size followed the video's aspect ratio and the
orientation. On a tablet whose short side is 800dp:

| | before | after |
| --- | --- | --- |
| landscape 16:9 | 25sp | 28sp |
| portrait | 18sp (the floor) | 28sp |
| phone | 18sp | 18sp — unchanged |

A phone never showed the defect because its short side keeps it under the 18sp floor, which does
the calibrating there.

#1286 moved the AVPlayer overlay and the DOM cues onto the surface's short side and stated the
three renderers shared one shape, `max(18 x scale, shortSide x fraction x scale)` — but it never
applied it to Android. This applies it.

## Change

One file. `Math.min(subtitleView.getWidth(), subtitleView.getHeight())` replaces the picture
height; the `surfaceView` layout listener that existed only to track the picture goes with it, as
`subtitleView`'s own listener already covers rotation. The calibration constants are untouched —
only the base the fraction multiplies changes.

The short side is invariant across rotation and fill mode, so the cue size also stops changing when
the viewer toggles fill-screen.

## Validation

Sized on device on an Android tablet, landscape and portrait, across several passes narrowing the
value; the phone path is unchanged by construction since the floor still wins there.