### PR TITLE
fix(player): read a pause intent instead of the initial paused flag

### DIFF
--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -3289,7 +3289,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         await this.streamingApi.stopSession(prevSid).catch(() => {});
       }
       if (opts.unmute) this.engine.muted = false;
-      const wasPaused = opts.preservePause ? this.paused() : false;
+      const wasPaused = opts.preservePause ? this.pauseIntent() : false;
       const deviceProfile = this.deviceProfileService.getProfile();
       // Pass the active rung as startQuality so the backend prewarms ffmpeg at
       // the resume position — main session at -ss pos plus the bounded early
@@ -3357,6 +3357,14 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
    * left unplayed. The single enforcement point keeps every reload path
    * consistent.
    */
+  /** The viewer's pause intent. Before the first frame `paused` still holds its
+   *  initial `true` — a launch that hasn't started, never a pause to preserve.
+   *  A native launch autoplays without calling `play()`, so nothing else would
+   *  distinguish the two. */
+  private pauseIntent(): boolean {
+    return this.state.videoStarted() && this.paused();
+  }
+
   private restorePlayState(wasPaused: boolean): void {
     if (!this.engine) return;
     if (wasPaused) this.engine.pause().catch(() => {});
@@ -4083,7 +4091,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       // Capture the play/pause intent first: a native engine reloads the stream
       // to switch track, which comes back playing — switching language must not
       // resume a player the user paused. `reloadStream` does the same below.
-      const wasPaused = this.paused();
+      const wasPaused = this.pauseIntent();
       // Show spinner during audio switch (native player reloads the stream)
       if (this.isNativeEngine()) {
         this.state.buffering.set(true);
@@ -4538,7 +4546,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
         : this.engine.currentTime;
       // Capture the user's play/pause intent before tearing the stream down — a
       // quality / audio / subtitle switch must not resume a paused player.
-      const wasPaused = this.paused();
+      const wasPaused = this.pauseIntent();
 
       // Remember active subtitle so we can restore it after reload
       const activeSub = this.activeSubtitleId()


### PR DESCRIPTION
On Android, "Resume at ..." opened on a black screen with the controls up and the transport
showing paused. Pressing play started it, at the correct position — so the stream was fine, only
the play state was wrong.

## Cause

`state.paused` is initialised to `true`, and a native launch never calls `play()`: ExoPlayer and
AVPlayer start on their own from `playWhenReady`. Until the engine emits its first `playing`, that
`true` therefore means "not started yet", not "the viewer paused" — but the three reload paths that
preserve the play state could not tell the difference:

- `onSelectAudioTrack`
- `doReloadStream` (quality / subtitle / audio switch)
- `refreshSidAndReload` (lost-session recovery)

`loadAudioTracks` applies the remembered audio language on a 2 s timer. A resume seeks ffmpeg cold,
so the first frame lands after that timer; the switch captured `paused === true` and
`restorePlayState` then issued a real `pause()`. Playing from the start reached the first frame
before the timer, which is why only the resume path showed it.

Nothing recovered afterwards either: `checkStall` bails while `paused()` is true, so the wedged
launch was completely silent.

## Change

One helper, used at the three capture sites:

```ts
private pauseIntent(): boolean {
  return this.state.videoStarted() && this.paused();
}
```

`videoStarted` already marks the first rendered frame of the session, flipped per engine off the
`firstFrame` event. No new state.

The opposite case still holds: `state.reset()` runs only on launch and on an episode change, never
in `doReloadStream`, so `videoStarted` stays `true` across a mid-playback switch and a viewer who
really did pause is still restored paused.

## Validation

Confirmed on an Android tablet: resume with a non-default audio language now autoplays, and a
quality switch on a paused player still comes back paused.

## Not in scope

`checkStall` gating on `paused()` means a native launch stuck paused has no watchdog and logs
nothing. That is what made this bug silent; worth hardening separately.