### PR TITLE
feat(subtitles): open the failure cause from the activity badge

### DIFF
--- a/backend/src/migrations/1784800000000-add-subtitle-error-message.ts
+++ b/backend/src/migrations/1784800000000-add-subtitle-error-message.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/** A failed subtitle row said nothing about why; the activity page now opens it. */
+export class AddSubtitleErrorMessage1784800000000 implements MigrationInterface {
+  name = 'AddSubtitleErrorMessage1784800000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "subtitle_files" ADD COLUMN IF NOT EXISTS "errorMessage" text`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "subtitle_files" DROP COLUMN IF EXISTS "errorMessage"`,
+    );
+  }
+}

--- a/backend/src/modules/subtitles/entities/subtitle-file.entity.ts
+++ b/backend/src/modules/subtitles/entities/subtitle-file.entity.ts
@@ -107,6 +107,11 @@ export class SubtitleFile extends BaseEntity {
   @Column({ type: 'int', nullable: true })
   syncOffset: number;
 
+  /** Why a FAILED row failed: a raw engine error, or a translation key when the
+   *  cause is ours to name. Read by the activity page's failure dialog. */
+  @Column({ type: 'text', nullable: true })
+  errorMessage: string | null;
+
   @Column({ default: false })
   locked: boolean;
 

--- a/backend/src/modules/subtitles/subtitle-activity.controller.ts
+++ b/backend/src/modules/subtitles/subtitle-activity.controller.ts
@@ -108,6 +108,7 @@ export class SubtitleActivityController {
         forced: sf.forced,
         hearingImpaired: sf.hearingImpaired,
         synced: sf.synced,
+        errorMessage: sf.errorMessage,
         createdAt: sf.createdAt,
       })),
       total,

--- a/backend/src/modules/subtitles/subtitle-ocr.service.ts
+++ b/backend/src/modules/subtitles/subtitle-ocr.service.ts
@@ -91,7 +91,10 @@ export class SubtitleOcrService implements OnModuleInit {
   async onModuleInit(): Promise<void> {
     const { affected } = await this.repo.update(
       { providerType: SubtitleProviderType.OCR, status: SubtitleStatus.PROCESSING },
-      { status: SubtitleStatus.FAILED },
+      {
+        status: SubtitleStatus.FAILED,
+        errorMessage: 'activity.subtitle_error_interrupted',
+      },
     );
     if (affected) this.log.warn(`Marked ${affected} interrupted OCR run(s) as failed`);
   }
@@ -288,7 +291,11 @@ export class SubtitleOcrService implements OnModuleInit {
       // already tried, so the language falls through to the providers instead
       // of re-running a 30-minute OCR on every scheduled sweep. Deleting it
       // re-arms the automatic retry.
-      await this.repo.update(placeholderId, { status: SubtitleStatus.FAILED });
+      await this.repo.update(placeholderId, {
+        status: SubtitleStatus.FAILED,
+        // Bounded: an ffmpeg/tesseract failure can carry a whole stderr dump.
+        errorMessage: String(err).slice(0, 2000),
+      });
     }
   }
 

--- a/backend/src/modules/subtitles/subtitle-sync.service.ts
+++ b/backend/src/modules/subtitles/subtitle-sync.service.ts
@@ -299,7 +299,6 @@ export class SubtitleSyncService {
         this.logger.error(
           `Subtitle sync failed for #${id}:\n  ffsubsync stderr: ${err.stderr || '(none)'}\n  alass stderr: ${alassErr.stderr || '(none)'}\n  alass stdout: ${alassErr.stdout || '(none)'}\n  alass message: ${alassErr.message || alassErr}`,
         );
-        subtitle.status = SubtitleStatus.FAILED;
         throw new Error(`Sync failed: ${(alassErr as Error).message}`);
       }
     }

--- a/backend/src/modules/subtitles/subtitle-translation.failure.spec.ts
+++ b/backend/src/modules/subtitles/subtitle-translation.failure.spec.ts
@@ -1,0 +1,35 @@
+import { SubtitleTranslationService } from './subtitle-translation.service';
+import { SubtitleStatus } from '../../common/enums';
+
+/** The placeholder row is the only record a failed run leaves in the database,
+ *  and the activity page opens the cause it carries. */
+describe('SubtitleTranslationService — what a failed run leaves behind', () => {
+  const run = async () => {
+    const update = jest.fn().mockResolvedValue({ affected: 1 });
+    const del = jest.fn();
+    const service = new SubtitleTranslationService(
+      { update, delete: del } as never,
+      { findOne: jest.fn().mockResolvedValue(null) } as never,
+      { get: jest.fn() } as never,
+      { emit: jest.fn() } as never,
+      { get: jest.fn() } as never,
+      {} as never,
+      {} as never,
+    );
+    await (service as never as {
+      runTranslation: (...args: unknown[]) => Promise<void>;
+    }).runTranslation(42, { id: 7, mediaId: 1, language: 'en' }, 'fr', { engine: 'gemini' }, 1);
+    return { update, del };
+  };
+
+  it('marks the placeholder FAILED with the cause instead of deleting it', async () => {
+    const { update, del } = await run();
+
+    expect(del).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledTimes(1);
+    const [id, patch] = update.mock.calls[0];
+    expect(id).toBe(42);
+    expect(patch.status).toBe(SubtitleStatus.FAILED);
+    expect(patch.errorMessage).toContain('media root folder not set');
+  });
+});

--- a/backend/src/modules/subtitles/subtitle-translation.service.ts
+++ b/backend/src/modules/subtitles/subtitle-translation.service.ts
@@ -40,9 +40,9 @@ const execFileAsync = promisify(execFile);
  * storing the result as a normal text sidecar tagged with the `TRANSLATED`
  * provider type and carrying the source subtitle's score. The work is slow (many
  * API calls), so callers get a `PROCESSING` placeholder row immediately and the
- * run finishes in the background — flipping the row to `DOWNLOADED` (or deleting
- * it on failure) and emitting SSE events the subtitle modal already reloads on,
- * plus a per-batch progress event.
+ * run finishes in the background — flipping the row to `DOWNLOADED` (or `FAILED`,
+ * carrying the cause) and emitting SSE events the subtitle modal already reloads
+ * on, plus a per-batch progress event.
  */
 @Injectable()
 export class SubtitleTranslationService {
@@ -303,7 +303,12 @@ export class SubtitleTranslationService {
         error: String(err),
         ...(err instanceof TranslationRateLimitError ? { reason: 'rate_limit' } : {}),
       });
-      await this.repo.delete(placeholderId);
+      // Kept, not deleted: the row is the only trace of the run, and translation
+      // is manual-only, so a FAILED one can't feed an automatic retry loop.
+      await this.repo.update(placeholderId, {
+        status: SubtitleStatus.FAILED,
+        errorMessage: String(err).slice(0, 2000),
+      });
     } finally {
       await this.cleanupTemp(base);
     }

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1211,7 +1211,9 @@
     "status_downloaded": "Heruntergeladen",
     "status_upgraded": "Aktualisiert",
     "status_synced": "Synchronisiert",
-    "status_failed": "Fehlgeschlagen"
+    "status_failed": "Fehlgeschlagen",
+    "error_detail_title": "Fehlerdetails",
+    "subtitle_error_interrupted": "Die OCR wurde durch einen Serverneustart unterbrochen."
   },
   "tracking": {
     "menu_item": "Tracking-Status ansehen",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1219,7 +1219,9 @@
     "status_downloaded": "Downloaded",
     "status_upgraded": "Upgraded",
     "status_synced": "Synced",
-    "status_failed": "Failed"
+    "status_failed": "Failed",
+    "error_detail_title": "Failure detail",
+    "subtitle_error_interrupted": "The OCR run was interrupted by a server restart."
   },
   "tracking": {
     "menu_item": "View tracking status",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1211,7 +1211,9 @@
     "status_downloaded": "Descargado",
     "status_upgraded": "Mejorado",
     "status_synced": "Sincronizado",
-    "status_failed": "Fallido"
+    "status_failed": "Fallido",
+    "error_detail_title": "Detalle del fallo",
+    "subtitle_error_interrupted": "El OCR se interrumpió por un reinicio del servidor."
   },
   "tracking": {
     "menu_item": "Ver el estado del seguimiento",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1219,7 +1219,9 @@
     "status_downloaded": "Téléchargé",
     "status_upgraded": "Mis à niveau",
     "status_synced": "Synchronisé",
-    "status_failed": "Échec"
+    "status_failed": "Échec",
+    "error_detail_title": "Détail de l'échec",
+    "subtitle_error_interrupted": "L'OCR a été interrompu par un redémarrage du serveur."
   },
   "tracking": {
     "menu_item": "Voir l'état du suivi",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1211,7 +1211,9 @@
     "status_downloaded": "Scaricato",
     "status_upgraded": "Aggiornato",
     "status_synced": "Sincronizzato",
-    "status_failed": "Fallito"
+    "status_failed": "Fallito",
+    "error_detail_title": "Dettaglio dell'errore",
+    "subtitle_error_interrupted": "L'OCR è stato interrotto da un riavvio del server."
   },
   "tracking": {
     "menu_item": "Vedi lo stato del monitoraggio",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1211,7 +1211,9 @@
     "status_downloaded": "Baixado",
     "status_upgraded": "Atualizado",
     "status_synced": "Sincronizado",
-    "status_failed": "Falhou"
+    "status_failed": "Falhou",
+    "error_detail_title": "Detalhe da falha",
+    "subtitle_error_interrupted": "O OCR foi interrompido por um reinício do servidor."
   },
   "tracking": {
     "menu_item": "Ver o estado do seguimento",

--- a/client/src/app/core/services/api/subtitles-api.service.ts
+++ b/client/src/app/core/services/api/subtitles-api.service.ts
@@ -235,6 +235,8 @@ export interface SubtitleHistoryEntry {
   forced: boolean;
   hearingImpaired: boolean;
   synced: boolean;
+  /** Why a failed entry failed: a raw engine error, or a translation key. */
+  errorMessage: string | null;
   createdAt: string;
 }
 

--- a/client/src/app/features/settings/subtitles-activity/subtitles-activity.html
+++ b/client/src/app/features/settings/subtitles-activity/subtitles-activity.html
@@ -66,7 +66,18 @@
             <td class="text-sm">{{ entry.providerType }}</td>
             <td class="text-center tabular-nums">{{ entry.score }}</td>
             <td class="text-center">
-              <span class="badge badge-sm" [ngClass]="subStatusClass(entry.status)">{{ entry.status }}</span>
+              @if (errorText(entry)) {
+                <button
+                  type="button"
+                  class="link link-hover"
+                  (click)="openError(entry)"
+                  [attr.aria-label]="'activity.error_detail_title' | translate"
+                >
+                  <span class="badge badge-sm" [ngClass]="subStatusClass(entry.status)">{{ entry.status }}</span>
+                </button>
+              } @else {
+                <span class="badge badge-sm" [ngClass]="subStatusClass(entry.status)">{{ entry.status }}</span>
+              }
             </td>
             <td class="text-center text-sm">
               @if (entry.forced) { <span class="badge badge-sm badge-outline mr-1">F</span> }
@@ -88,3 +99,18 @@
     />
   }
 }
+
+<dialog #errorDialog class="modal">
+  <div class="modal-box max-w-2xl">
+    <app-modal-header [title]="'activity.error_detail_title' | translate" (closed)="closeError()" />
+    <pre class="text-sm whitespace-pre-wrap break-words bg-base-200 rounded p-3 max-h-[60vh] overflow-auto">{{ errorDetail() }}</pre>
+    <app-modal-footer>
+      <button type="button" class="btn btn-ghost" (click)="closeError()">
+        {{ 'common.close' | translate }}
+      </button>
+    </app-modal-footer>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="button" (click)="closeError()" [attr.aria-label]="'common.close' | translate">close</button>
+  </form>
+</dialog>

--- a/client/src/app/features/settings/subtitles-activity/subtitles-activity.spec.ts
+++ b/client/src/app/features/settings/subtitles-activity/subtitles-activity.spec.ts
@@ -1,0 +1,50 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { SubtitlesActivityComponent } from './subtitles-activity';
+import {
+  SubtitlesApiService,
+  SubtitleHistoryEntry,
+} from '../../../core/services/api/subtitles-api.service';
+
+const entry = (errorMessage: string | null): SubtitleHistoryEntry =>
+  ({ id: 1, status: 'failed', errorMessage }) as SubtitleHistoryEntry;
+
+function setup() {
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideTranslateService({
+        lang: 'en',
+        loader: {
+          provide: TranslateLoader,
+          useValue: {
+            getTranslation: () => of({ activity: { subtitle_error_interrupted: 'Interrupted' } }),
+          },
+        },
+      }),
+      {
+        provide: SubtitlesApiService,
+        useValue: {
+          getHistory: () => Promise.resolve({ data: [], total: 0, page: 1, limit: 25 }),
+        } as unknown as SubtitlesApiService,
+      },
+    ],
+  });
+  return TestBed.createComponent(SubtitlesActivityComponent).componentInstance;
+}
+
+describe('SubtitlesActivityComponent.errorText', () => {
+  it('resolves a translation key and passes a raw engine error through', () => {
+    const page = setup();
+    expect(page.errorText(entry('activity.subtitle_error_interrupted'))).toBe('Interrupted');
+    expect(page.errorText(entry('tesseract: exit 1'))).toBe('tesseract: exit 1');
+  });
+
+  it('reports no detail for an entry without a message', () => {
+    const page = setup();
+    expect(page.errorText(entry(null))).toBe('');
+    expect(page.errorText(entry('  '))).toBe('');
+  });
+});

--- a/client/src/app/features/settings/subtitles-activity/subtitles-activity.ts
+++ b/client/src/app/features/settings/subtitles-activity/subtitles-activity.ts
@@ -2,6 +2,8 @@ import {
   Component,
   signal,
   inject,
+  viewChild,
+  ElementRef,
   OnInit,
 } from '@angular/core';
 import { NgClass } from '@angular/common';
@@ -14,6 +16,8 @@ import {
   SubtitleHistoryEntry,
 } from '../../../core/services/api/subtitles-api.service';
 import { PaginationComponent } from '../../../shared/components/pagination/pagination';
+import { ModalHeaderComponent } from '../../../shared/components/modal-header';
+import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
 import { LocalizeLanguagePipe } from '../../../core/pipes/localize-language.pipe';
 import { SUBTITLE_LANGUAGE_CODES } from '../../../core/constants/subtitle-languages';
@@ -21,7 +25,7 @@ import { episodeLabel } from '../../../shared/utils/episode-label';
 
 @Component({
   selector: 'app-subtitles-activity',
-  imports: [TvSelectDirective, TranslatePipe, LocaleDatePipe, LocalizeLanguagePipe, NgClass, RouterLink, FormsModule, PaginationComponent],
+  imports: [TvSelectDirective, TranslatePipe, LocaleDatePipe, LocalizeLanguagePipe, NgClass, RouterLink, FormsModule, PaginationComponent, ModalHeaderComponent, ModalFooterComponent],
   templateUrl: './subtitles-activity.html',
 })
 export class SubtitlesActivityComponent implements OnInit {
@@ -40,6 +44,9 @@ export class SubtitlesActivityComponent implements OnInit {
   readonly subHistoryError = signal('');
   readonly subFilterStatus = signal('');
   readonly subFilterLang = signal('');
+
+  readonly errorDetail = signal('');
+  private readonly errorDialog = viewChild<ElementRef<HTMLDialogElement>>('errorDialog');
 
   ngOnInit() {
     this.loadSubHistory(1);
@@ -69,6 +76,26 @@ export class SubtitlesActivityComponent implements OnInit {
 
   get subHistoryTotalPages(): number {
     return Math.max(1, Math.ceil(this.subHistoryTotal() / 25));
+  }
+
+  /** The entry's failure text, or '' when there is none to open. A translation
+   *  key resolves; a raw engine error comes through as-is. */
+  errorText(entry: SubtitleHistoryEntry): string {
+    const raw = (entry.errorMessage ?? '').trim();
+    if (!raw) return '';
+    const translated = this.translate.instant(raw);
+    return translated === raw ? raw : translated;
+  }
+
+  openError(entry: SubtitleHistoryEntry) {
+    const text = this.errorText(entry);
+    if (!text) return;
+    this.errorDetail.set(text);
+    this.errorDialog()?.nativeElement.showModal();
+  }
+
+  closeError() {
+    this.errorDialog()?.nativeElement.close();
   }
 
   subStatusClass(status: string): string {


### PR DESCRIPTION
## What

A failed subtitle row in **Settings > Activity > Subtitles** now says why it failed: the badge becomes a button and opens the cause in a dialog, the same affordance a failed download row already offers.

`SubtitleFile` gains an `errorMessage` column (text, nullable) carrying either a raw engine error, capped at 2000 characters because an ffmpeg or tesseract failure can drag a whole stderr dump along, or a translation key when the cause is ours to name. `/subtitles/history` returns it, and the page resolves a key through ngx-translate while passing a raw error straight through.

The front end reuses the pattern from `data-table`'s `detailField` (badge as a button, `<dialog>` with `app-modal-header` / `app-modal-footer`, `<pre>` scrolled inside the box) rather than converting this hand-written table to `app-data-table`.

## Two paths that were losing their failure

Both surfaced while wiring the dialog, and neither could ever reach it:

- **Sync.** The alass fallback assigned `FAILED` to the row and then threw before `repo.save`, so the status never reached the database. The assignment was wrong on its own terms anyway: a subtitle whose *sync* failed is still a perfectly servable file, and marking it `FAILED` would drop it out of the covering set and re-arm a download of a language that is not missing. The sync outcome already travels through the sync queue (`SyncQueueItem.status` / `.error`), so the dead assignment is simply gone.
- **Translation.** A failed run deleted its own placeholder, so nothing at all was left in the history. It now stays as `FAILED` carrying the cause. Safe because translation is manual-only (one controller endpoint, no scheduler path), so a failed row cannot feed an automatic retry loop the way a persisted OCR failure deliberately does.

## Known gap left alone

`SubtitleTranslationService` has no equivalent of `SubtitleOcrService.onModuleInit`'s corpse sweep, so a translation killed by a restart still sits at `PROCESSING` forever. It does not cover its language (both `PROCESSING` and `FAILED` are excluded from `hasCoveringSub`), so it is a stuck spinner rather than a hole in coverage. Out of scope here.

## Checks

- `tsc --noEmit` green on both projects, `ng build` green.
- `jest src/modules/subtitles src/modules/scheduler --runInBand`: 31 suites, 291 tests pass, including a new spec asserting a failed translation updates its placeholder to `FAILED` with the cause instead of deleting it.
- New client spec covers key-resolution vs. raw-error pass-through in `errorText`.
- Exercised against the dev database with two seeded failed rows (a multi-line ffmpeg/tesseract error and the interrupted-run key): dialog renders both, `/subtitles/history` returns `errorMessage`.
