### PR TITLE
feat(subtitles): record a sync failure as its own status

### DIFF
--- a/backend/src/common/constants/subtitle-codecs.spec.ts
+++ b/backend/src/common/constants/subtitle-codecs.spec.ts
@@ -43,6 +43,13 @@ describe('hasCoveringSub', () => {
     expect(hasCoveringSub(subs, want())).toBe(false);
   });
 
+  it('counts a sync failure as covering: the file plays, only its timing is off', () => {
+    const subs = [
+      { language: 'fr', codec: 'subrip', status: SubtitleStatus.SYNC_FAILED },
+    ];
+    expect(hasCoveringSub(subs, want())).toBe(true);
+  });
+
   it('counts an in-progress OCR (text) row as covering the language', () => {
     const subs = [
       { language: 'fr', codec: 'subrip', status: SubtitleStatus.PROCESSING },

--- a/backend/src/common/enums/subtitle-status.enum.ts
+++ b/backend/src/common/enums/subtitle-status.enum.ts
@@ -4,6 +4,9 @@ export enum SubtitleStatus {
   UPGRADED = 'upgraded',
   SYNCED = 'synced',
   FAILED = 'failed',
+  /** The file is on disk and servable; only shifting its timing failed. Every
+   *  guard that drops a FAILED row keeps this one, on purpose. */
+  SYNC_FAILED = 'sync_failed',
   EMBEDDED = 'embedded',
   /** OCR extraction of an image-based subtitle is running in the background */
   PROCESSING = 'processing',

--- a/backend/src/migrations/1784900000000-add-sync-failed-subtitle-status.ts
+++ b/backend/src/migrations/1784900000000-add-sync-failed-subtitle-status.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * A subtitle whose timing sync failed is still a servable file, so it can't
+ * share `failed` with a row that has no file at all. Postgres `ADD VALUE` can't
+ * be undone, so `down` is a no-op.
+ */
+export class AddSyncFailedSubtitleStatus1784900000000
+  implements MigrationInterface
+{
+  name = 'AddSyncFailedSubtitleStatus1784900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."subtitle_files_status_enum" ADD VALUE IF NOT EXISTS 'sync_failed'`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // Postgres has no DROP VALUE; intentionally irreversible.
+  }
+}

--- a/backend/src/modules/subtitles/subtitle-sync.service.ts
+++ b/backend/src/modules/subtitles/subtitle-sync.service.ts
@@ -235,6 +235,9 @@ export class SubtitleSyncService {
       return args;
     };
 
+    // A fresh attempt owns the outcome: drop whatever the last one recorded.
+    subtitle.errorMessage = null;
+
     try {
       await execFileAsync(
         'ffsubsync',
@@ -296,9 +299,13 @@ export class SubtitleSyncService {
         subtitle.synced = true;
         subtitle.status = SubtitleStatus.SYNCED;
       } catch (alassErr: any) {
-        this.logger.error(
-          `Subtitle sync failed for #${id}:\n  ffsubsync stderr: ${err.stderr || '(none)'}\n  alass stderr: ${alassErr.stderr || '(none)'}\n  alass stdout: ${alassErr.stdout || '(none)'}\n  alass message: ${alassErr.message || alassErr}`,
-        );
+        const detail = `ffsubsync stderr: ${err.stderr || '(none)'}\nalass stderr: ${alassErr.stderr || '(none)'}\nalass stdout: ${alassErr.stdout || '(none)'}\nalass message: ${alassErr.message || alassErr}`;
+        this.logger.error(`Subtitle sync failed for #${id}:\n${detail}`);
+        // Persisted before the throw: the caller only propagates the failure to
+        // its own queue, which no page outlives.
+        subtitle.status = SubtitleStatus.SYNC_FAILED;
+        subtitle.errorMessage = detail.slice(0, 2000);
+        await this.repo.save(subtitle);
         throw new Error(`Sync failed: ${(alassErr as Error).message}`);
       }
     }

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1126,6 +1126,7 @@
     "add_to_list": "Zu Liste hinzufügen",
     "unlike": "Gefällt mir nicht mehr",
     "subtitle_failed": "Fehlgeschlagen",
+    "subtitle_sync_failed": "Sync fehlgeschlagen",
     "delete_no_folder": "Dieser Titel hat keinen eigenen Ordner: Nur der Bibliothekseintrag wird entfernt, die Datei bleibt auf der Festplatte."
   },
   "requests": {
@@ -1212,6 +1213,7 @@
     "status_upgraded": "Aktualisiert",
     "status_synced": "Synchronisiert",
     "status_failed": "Fehlgeschlagen",
+    "status_sync_failed": "Sync fehlgeschlagen",
     "error_detail_title": "Fehlerdetails",
     "subtitle_error_interrupted": "Die OCR wurde durch einen Serverneustart unterbrochen."
   },

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1134,6 +1134,7 @@
     "add_to_list": "Add to list",
     "unlike": "Unlike",
     "subtitle_failed": "Failed",
+    "subtitle_sync_failed": "Sync failed",
     "delete_no_folder": "This title has no folder of its own: only the library entry will be removed, the file stays on disk."
   },
   "requests": {
@@ -1220,6 +1221,7 @@
     "status_upgraded": "Upgraded",
     "status_synced": "Synced",
     "status_failed": "Failed",
+    "status_sync_failed": "Sync failed",
     "error_detail_title": "Failure detail",
     "subtitle_error_interrupted": "The OCR run was interrupted by a server restart."
   },

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1126,6 +1126,7 @@
     "add_to_list": "Añadir a una lista",
     "unlike": "Ya no me gusta",
     "subtitle_failed": "Error",
+    "subtitle_sync_failed": "Sincronización fallida",
     "delete_no_folder": "Este título no tiene una carpeta propia: solo se eliminará la entrada de la biblioteca, el archivo permanece en el disco."
   },
   "requests": {
@@ -1212,6 +1213,7 @@
     "status_upgraded": "Mejorado",
     "status_synced": "Sincronizado",
     "status_failed": "Fallido",
+    "status_sync_failed": "Sincronización fallida",
     "error_detail_title": "Detalle del fallo",
     "subtitle_error_interrupted": "El OCR se interrumpió por un reinicio del servidor."
   },

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1134,6 +1134,7 @@
     "add_to_list": "Ajouter à une liste",
     "unlike": "Je n’aime plus",
     "subtitle_failed": "Échec",
+    "subtitle_sync_failed": "Échec de la synchro",
     "delete_no_folder": "Ce titre n'a pas de dossier propre : seule l'entrée de la bibliothèque sera supprimée, le fichier reste sur le disque."
   },
   "requests": {
@@ -1220,6 +1221,7 @@
     "status_upgraded": "Mis à niveau",
     "status_synced": "Synchronisé",
     "status_failed": "Échec",
+    "status_sync_failed": "Échec de la synchro",
     "error_detail_title": "Détail de l'échec",
     "subtitle_error_interrupted": "L'OCR a été interrompu par un redémarrage du serveur."
   },

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1126,6 +1126,7 @@
     "add_to_list": "Aggiungi a un elenco",
     "unlike": "Non mi piace più",
     "subtitle_failed": "Non riuscito",
+    "subtitle_sync_failed": "Sincronizzazione non riuscita",
     "delete_no_folder": "Questo titolo non ha una cartella propria: verrà rimossa solo la voce della libreria, il file rimane sul disco."
   },
   "requests": {
@@ -1212,6 +1213,7 @@
     "status_upgraded": "Aggiornato",
     "status_synced": "Sincronizzato",
     "status_failed": "Fallito",
+    "status_sync_failed": "Sincronizzazione non riuscita",
     "error_detail_title": "Dettaglio dell'errore",
     "subtitle_error_interrupted": "L'OCR è stato interrotto da un riavvio del server."
   },

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1126,6 +1126,7 @@
     "add_to_list": "Adicionar a uma lista",
     "unlike": "Já não gosto",
     "subtitle_failed": "Falhou",
+    "subtitle_sync_failed": "Sincronização falhou",
     "delete_no_folder": "Este título não tem uma pasta própria: apenas a entrada da biblioteca será removida, o ficheiro permanece no disco."
   },
   "requests": {
@@ -1212,6 +1213,7 @@
     "status_upgraded": "Atualizado",
     "status_synced": "Sincronizado",
     "status_failed": "Falhou",
+    "status_sync_failed": "Sincronização falhou",
     "error_detail_title": "Detalhe da falha",
     "subtitle_error_interrupted": "O OCR foi interrompido por um reinício do servidor."
   },

--- a/client/src/app/features/settings/subtitles-activity/subtitles-activity.html
+++ b/client/src/app/features/settings/subtitles-activity/subtitles-activity.html
@@ -8,6 +8,7 @@
     <option value="upgraded">{{ 'activity.status_upgraded' | translate }}</option>
     <option value="synced">{{ 'activity.status_synced' | translate }}</option>
     <option value="failed">{{ 'activity.status_failed' | translate }}</option>
+    <option value="sync_failed">{{ 'activity.status_sync_failed' | translate }}</option>
   </select>
   <select
     appTvSelect class="select select-bordered select-sm" [ngModel]="subFilterLang()" (ngModelChange)="subFilterLang.set($event); applySubFilters()">

--- a/client/src/app/features/settings/subtitles-activity/subtitles-activity.ts
+++ b/client/src/app/features/settings/subtitles-activity/subtitles-activity.ts
@@ -102,6 +102,8 @@ export class SubtitlesActivityComponent implements OnInit {
     switch (status) {
       case 'downloaded': case 'synced': return 'badge-success';
       case 'upgraded': return 'badge-warning';
+      // The file plays; only its timing is off. Not the same red as a row with no file.
+      case 'sync_failed': return 'badge-warning';
       case 'failed': return 'badge-error';
       default: return 'badge-ghost';
     }

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -165,6 +165,11 @@
                           'media_detail.subtitle_failed' | translate
                         }}</span>
                       }
+                      @if (sub.status === 'sync_failed') {
+                        <span class="badge badge-sm badge-warning mr-1">{{
+                          'media_detail.subtitle_sync_failed' | translate
+                        }}</span>
+                      }
                       @if (sub.forced) {
                         <span class="badge badge-sm badge-outline mr-1">F</span>
                       }


### PR DESCRIPTION
## Why a status and not a flag

A sync failure had nowhere durable to live: it only reached `SyncQueueItem.status` / `.error` (in memory, gone on restart) and a log line. #1294 removed the one attempt to record it, because assigning `FAILED` was wrong — `failed` means *no servable file*, and it is what tells `hasCoveringSub`, `/subtitles/missing` and the upgrade sweep to go fetch the language again. A subtitle whose timing sync failed is a perfectly playable file.

So it needs its own state. `sync_failed` is that state, and it turns out to be the low-risk option rather than the risky one:

- Every guard in the subtitle paths tests `!== FAILED` (`subtitles.service.ts`, `subtitle-codecs.ts`, `subtitle-scheduler.service.ts` x4) or `<> 'failed'` in the missing SQL. A *new* value therefore inherits the servable-and-covering semantics by default — no call site has to learn about it, and none can silently drop the row.
- Nothing whitelists subtitle statuses: the backend only assigns them or compares against `FAILED`/`PROCESSING`. No other client reads them (Tizen, webOS, desktop, Apple TV and Android never look at the field) and no plugin DTO exposes them.
- Auto-sync only runs immediately after a download or an upgrade, never as a sweep over unsynced rows, so a persisted failure cannot feed a retry loop.

A boolean flag alongside `status` would have left the row reading `downloaded` while carrying a failure message, which is exactly the confusing badge this work set out to remove.

## What it does

- `SubtitleStatus.SYNC_FAILED`, plus a migration adding the Postgres enum value (irreversible, like the two enum migrations before it).
- The alass fallback now composes its detail once, logs it, and persists it on the row as `sync_failed` + `errorMessage` **before** rethrowing, so the queue still reports the failure to its caller.
- A fresh attempt clears the previously recorded cause; a success still moves the row to `synced`.
- Front end: the activity page gets a `sync_failed` filter option and paints the badge amber rather than red (the file plays), and the media-detail subtitle modal shows the state where the re-sync action already lives.

## Checks

- `tsc --noEmit` green on both projects, `ng build` green.
- `jest src/common/constants/subtitle-codecs.spec.ts src/modules/subtitles src/modules/scheduler --runInBand`: 32 suites, 302 tests pass, including a new case pinning the property this design rests on — a `SYNC_FAILED` row still covers its language.
- Seeded a `sync_failed` row in the dev database: `/subtitles/history?status=sync_failed` returns it with its `errorMessage`, and the badge opens the ffsubsync/alass output.
