### PR TITLE
feat(subtitles): keep a failed sync on the row as its own flag

### DIFF
--- a/backend/src/migrations/1784900000000-add-subtitle-sync-failed.ts
+++ b/backend/src/migrations/1784900000000-add-subtitle-sync-failed.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/** A sync failure is an axis of its own, beside `synced`: the file stays servable
+ *  and the row keeps its acquisition status. */
+export class AddSubtitleSyncFailed1784900000000 implements MigrationInterface {
+  name = 'AddSubtitleSyncFailed1784900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "subtitle_files" ADD COLUMN IF NOT EXISTS "syncFailed" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "subtitle_files" DROP COLUMN IF EXISTS "syncFailed"`,
+    );
+  }
+}

--- a/backend/src/modules/subtitles/entities/subtitle-file.entity.ts
+++ b/backend/src/modules/subtitles/entities/subtitle-file.entity.ts
@@ -104,6 +104,11 @@ export class SubtitleFile extends BaseEntity {
   @Column({ default: false })
   synced: boolean;
 
+  /** The last sync attempt failed. Its own axis, not a status: the file is still
+   *  servable, and the row keeps the acquisition state it was in. */
+  @Column({ default: false })
+  syncFailed: boolean;
+
   @Column({ type: 'int', nullable: true })
   syncOffset: number;
 

--- a/backend/src/modules/subtitles/subtitle-activity.controller.ts
+++ b/backend/src/modules/subtitles/subtitle-activity.controller.ts
@@ -108,6 +108,7 @@ export class SubtitleActivityController {
         forced: sf.forced,
         hearingImpaired: sf.hearingImpaired,
         synced: sf.synced,
+        syncFailed: sf.syncFailed,
         errorMessage: sf.errorMessage,
         createdAt: sf.createdAt,
       })),

--- a/backend/src/modules/subtitles/subtitle-sync.failure.spec.ts
+++ b/backend/src/modules/subtitles/subtitle-sync.failure.spec.ts
@@ -1,0 +1,71 @@
+const execFileMock = jest.fn();
+jest.mock('child_process', () => ({ execFile: execFileMock }));
+
+import { SubtitleSyncService } from './subtitle-sync.service';
+import { SubtitleFile } from './entities/subtitle-file.entity';
+import { SubtitleProviderType, SubtitleStatus } from '../../common/enums';
+
+/** The sync outcome is an axis of its own: a failure has to survive the throw
+ *  without touching the status that decides whether the language is covered. */
+describe('SubtitleSyncService — a failed sync', () => {
+  const build = (row: Partial<SubtitleFile>) => {
+    const subtitle: Partial<SubtitleFile> = {
+      id: 1,
+      mediaId: 1,
+      mediaFileId: 1,
+      language: 'fr',
+      relativePath: 'movie.fr.srt',
+      providerType: SubtitleProviderType.OPENSUBTITLES,
+      ...row,
+    };
+    const save = jest.fn(async (s: unknown) => s);
+    const service = new SubtitleSyncService(
+      { findOne: jest.fn().mockResolvedValue(subtitle), save } as never,
+      { findOne: jest.fn().mockResolvedValue({ id: 1, path: '/medias/movie' }) } as never,
+      { findOne: jest.fn().mockResolvedValue({ id: 1, relativePath: 'movie.mkv' }) } as never,
+      { dispatch: jest.fn() } as never,
+      { detectStreams: jest.fn().mockResolvedValue([]) } as never,
+      { emit: jest.fn() } as never,
+      { dispatch: jest.fn() } as never,
+    );
+    return { service, subtitle, save };
+  };
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+    // promisify hands the callback last; every tool call fails.
+    execFileMock.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: Error) => void;
+      cb(Object.assign(new Error('exit 1'), { stderr: 'could not parse subtitle file' }));
+    });
+  });
+
+  it('records the flag and the cause on the row, leaving the status alone', async () => {
+    const { service, subtitle, save } = build({ status: SubtitleStatus.DOWNLOADED });
+
+    await expect(service.syncSubtitle(1)).rejects.toThrow('Sync failed');
+
+    expect(save).toHaveBeenCalled();
+    expect(subtitle.syncFailed).toBe(true);
+    expect(subtitle.status).toBe(SubtitleStatus.DOWNLOADED);
+    expect(subtitle.errorMessage).toContain('could not parse subtitle file');
+  });
+
+  it('clears a previous failure when a later attempt succeeds', async () => {
+    const { service, subtitle } = build({
+      status: SubtitleStatus.DOWNLOADED,
+      syncFailed: true,
+      errorMessage: 'the previous run',
+    });
+    execFileMock.mockImplementation((...args: unknown[]) => {
+      (args[args.length - 1] as (e: null, out: string, err: string) => void)(null, '', '');
+    });
+
+    await service.syncSubtitle(1);
+
+    expect(subtitle.syncFailed).toBe(false);
+    expect(subtitle.errorMessage).toBeNull();
+    expect(subtitle.status).toBe(SubtitleStatus.SYNCED);
+    expect(subtitle.synced).toBe(true);
+  });
+});

--- a/backend/src/modules/subtitles/subtitle-sync.service.ts
+++ b/backend/src/modules/subtitles/subtitle-sync.service.ts
@@ -235,6 +235,11 @@ export class SubtitleSyncService {
       return args;
     };
 
+    // A fresh attempt owns the outcome: a success below has to clear what the
+    // last failure recorded.
+    subtitle.syncFailed = false;
+    subtitle.errorMessage = null;
+
     try {
       await execFileAsync(
         'ffsubsync',
@@ -296,9 +301,13 @@ export class SubtitleSyncService {
         subtitle.synced = true;
         subtitle.status = SubtitleStatus.SYNCED;
       } catch (alassErr: any) {
-        this.logger.error(
-          `Subtitle sync failed for #${id}:\n  ffsubsync stderr: ${err.stderr || '(none)'}\n  alass stderr: ${alassErr.stderr || '(none)'}\n  alass stdout: ${alassErr.stdout || '(none)'}\n  alass message: ${alassErr.message || alassErr}`,
-        );
+        const detail = `ffsubsync stderr: ${err.stderr || '(none)'}\nalass stderr: ${alassErr.stderr || '(none)'}\nalass stdout: ${alassErr.stdout || '(none)'}\nalass message: ${alassErr.message || alassErr}`;
+        this.logger.error(`Subtitle sync failed for #${id}:\n${detail}`);
+        // Saved before the throw: the caller only reports the failure to the
+        // in-memory sync queue, which no page outlives.
+        subtitle.syncFailed = true;
+        subtitle.errorMessage = detail.slice(0, 2000);
+        await this.repo.save(subtitle);
         throw new Error(`Sync failed: ${(alassErr as Error).message}`);
       }
     }

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1126,6 +1126,7 @@
     "add_to_list": "Zu Liste hinzufügen",
     "unlike": "Gefällt mir nicht mehr",
     "subtitle_failed": "Fehlgeschlagen",
+    "subtitle_sync_failed": "Sync fehlgeschlagen",
     "delete_no_folder": "Dieser Titel hat keinen eigenen Ordner: Nur der Bibliothekseintrag wird entfernt, die Datei bleibt auf der Festplatte."
   },
   "requests": {
@@ -1212,6 +1213,7 @@
     "status_upgraded": "Aktualisiert",
     "status_synced": "Synchronisiert",
     "status_failed": "Fehlgeschlagen",
+    "sync_failed": "Sync fehlgeschlagen",
     "error_detail_title": "Fehlerdetails",
     "subtitle_error_interrupted": "Die OCR wurde durch einen Serverneustart unterbrochen."
   },

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1134,6 +1134,7 @@
     "add_to_list": "Add to list",
     "unlike": "Unlike",
     "subtitle_failed": "Failed",
+    "subtitle_sync_failed": "Sync failed",
     "delete_no_folder": "This title has no folder of its own: only the library entry will be removed, the file stays on disk."
   },
   "requests": {
@@ -1220,6 +1221,7 @@
     "status_upgraded": "Upgraded",
     "status_synced": "Synced",
     "status_failed": "Failed",
+    "sync_failed": "Sync failed",
     "error_detail_title": "Failure detail",
     "subtitle_error_interrupted": "The OCR run was interrupted by a server restart."
   },

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1126,6 +1126,7 @@
     "add_to_list": "Añadir a una lista",
     "unlike": "Ya no me gusta",
     "subtitle_failed": "Error",
+    "subtitle_sync_failed": "Sincronización fallida",
     "delete_no_folder": "Este título no tiene una carpeta propia: solo se eliminará la entrada de la biblioteca, el archivo permanece en el disco."
   },
   "requests": {
@@ -1212,6 +1213,7 @@
     "status_upgraded": "Mejorado",
     "status_synced": "Sincronizado",
     "status_failed": "Fallido",
+    "sync_failed": "Sincronización fallida",
     "error_detail_title": "Detalle del fallo",
     "subtitle_error_interrupted": "El OCR se interrumpió por un reinicio del servidor."
   },

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1134,6 +1134,7 @@
     "add_to_list": "Ajouter à une liste",
     "unlike": "Je n’aime plus",
     "subtitle_failed": "Échec",
+    "subtitle_sync_failed": "Échec de la synchro",
     "delete_no_folder": "Ce titre n'a pas de dossier propre : seule l'entrée de la bibliothèque sera supprimée, le fichier reste sur le disque."
   },
   "requests": {
@@ -1220,6 +1221,7 @@
     "status_upgraded": "Mis à niveau",
     "status_synced": "Synchronisé",
     "status_failed": "Échec",
+    "sync_failed": "Échec de la synchro",
     "error_detail_title": "Détail de l'échec",
     "subtitle_error_interrupted": "L'OCR a été interrompu par un redémarrage du serveur."
   },

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1126,6 +1126,7 @@
     "add_to_list": "Aggiungi a un elenco",
     "unlike": "Non mi piace più",
     "subtitle_failed": "Non riuscito",
+    "subtitle_sync_failed": "Sincronizzazione non riuscita",
     "delete_no_folder": "Questo titolo non ha una cartella propria: verrà rimossa solo la voce della libreria, il file rimane sul disco."
   },
   "requests": {
@@ -1212,6 +1213,7 @@
     "status_upgraded": "Aggiornato",
     "status_synced": "Sincronizzato",
     "status_failed": "Fallito",
+    "sync_failed": "Sincronizzazione non riuscita",
     "error_detail_title": "Dettaglio dell'errore",
     "subtitle_error_interrupted": "L'OCR è stato interrotto da un riavvio del server."
   },

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1126,6 +1126,7 @@
     "add_to_list": "Adicionar a uma lista",
     "unlike": "Já não gosto",
     "subtitle_failed": "Falhou",
+    "subtitle_sync_failed": "Sincronização falhou",
     "delete_no_folder": "Este título não tem uma pasta própria: apenas a entrada da biblioteca será removida, o ficheiro permanece no disco."
   },
   "requests": {
@@ -1212,6 +1213,7 @@
     "status_upgraded": "Atualizado",
     "status_synced": "Sincronizado",
     "status_failed": "Falhou",
+    "sync_failed": "Sincronização falhou",
     "error_detail_title": "Detalhe da falha",
     "subtitle_error_interrupted": "O OCR foi interrompido por um reinício do servidor."
   },

--- a/client/src/app/core/services/api/subtitles-api.service.ts
+++ b/client/src/app/core/services/api/subtitles-api.service.ts
@@ -18,6 +18,9 @@ export interface SubtitleFileRow {
   status: string;
   score: number;
   synced: boolean;
+  syncFailed: boolean;
+  /** Set when `syncFailed`: the ffsubsync/alass output of the last attempt. */
+  errorMessage?: string | null;
   syncOffset?: number;
   streamIndex?: number | null;
   codec?: string | null;
@@ -235,6 +238,7 @@ export interface SubtitleHistoryEntry {
   forced: boolean;
   hearingImpaired: boolean;
   synced: boolean;
+  syncFailed: boolean;
   /** Why a failed entry failed: a raw engine error, or a translation key. */
   errorMessage: string | null;
   createdAt: string;

--- a/client/src/app/features/settings/subtitles-activity/subtitles-activity.html
+++ b/client/src/app/features/settings/subtitles-activity/subtitles-activity.html
@@ -66,7 +66,7 @@
             <td class="text-sm">{{ entry.providerType }}</td>
             <td class="text-center tabular-nums">{{ entry.score }}</td>
             <td class="text-center">
-              @if (errorText(entry)) {
+              @if (entry.status === 'failed' && errorText(entry)) {
                 <button
                   type="button"
                   class="link link-hover"
@@ -83,6 +83,20 @@
               @if (entry.forced) { <span class="badge badge-sm badge-outline mr-1">F</span> }
               @if (entry.hearingImpaired) { <span class="badge badge-sm badge-outline">HI</span> }
               @if (entry.synced) { <span class="badge badge-sm badge-info ml-1">Synced</span> }
+              @if (entry.syncFailed) {
+                @if (errorText(entry)) {
+                  <button
+                    type="button"
+                    class="link link-hover ml-1"
+                    (click)="openError(entry)"
+                    [attr.aria-label]="'activity.error_detail_title' | translate"
+                  >
+                    <span class="badge badge-sm badge-warning">{{ 'activity.sync_failed' | translate }}</span>
+                  </button>
+                } @else {
+                  <span class="badge badge-sm badge-warning ml-1">{{ 'activity.sync_failed' | translate }}</span>
+                }
+              }
             </td>
           </tr>
         }

--- a/client/src/app/features/settings/subtitles-activity/subtitles-activity.spec.ts
+++ b/client/src/app/features/settings/subtitles-activity/subtitles-activity.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../core/services/api/subtitles-api.service';
 
 const entry = (errorMessage: string | null): SubtitleHistoryEntry =>
-  ({ id: 1, status: 'failed', errorMessage }) as SubtitleHistoryEntry;
+  ({ id: 1, status: 'failed', syncFailed: false, errorMessage }) as SubtitleHistoryEntry;
 
 function setup() {
   TestBed.configureTestingModule({

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -174,6 +174,13 @@
                       @if (sub.synced) {
                         <span class="badge badge-sm badge-info ml-1">Synced</span>
                       }
+                      @if (sub.syncFailed) {
+                        <span
+                          class="badge badge-sm badge-warning ml-1"
+                          [title]="sub.errorMessage ?? ''"
+                          >{{ 'media_detail.subtitle_sync_failed' | translate }}</span
+                        >
+                      }
                       @if (sub.codec) {
                         <span class="badge badge-sm badge-ghost ml-1">{{ sub.codec }}</span>
                       }


### PR DESCRIPTION
Replaces #1295, which modelled this as a `sync_failed` status.

## Why a flag, not a status

`synced` is already a boolean on `SubtitleFile`, beside the acquisition status rather than inside it — so the sync outcome is an axis of its own, and its failure belongs on that same axis. A status value would have overwritten `downloaded` / `upgraded`, erasing where the file came from; and `failed` specifically means *the row has no servable file*, which is what tells `hasCoveringSub`, `/subtitles/missing` and the upgrade sweep to go fetch the language again. A subtitle whose timing sync failed is a perfectly playable file.

The flag also costs less: a plain boolean column, reversible, instead of an irreversible Postgres enum value, and no guard anywhere has to learn a new status.

## What it does

- `syncFailed` boolean on `SubtitleFile`, next to `synced`, plus its migration.
- The alass fallback composes its detail once, logs it, and saves it on the row as `syncFailed` + `errorMessage` (capped at 2000 chars) **before** rethrowing, so the in-memory queue still reports the failure to its caller.
- Each attempt clears the flag and the message on entry, so a later success leaves the row `synced` with nothing recorded.
- The status stays untouched: a row that failed to sync keeps reading `downloaded` or `upgraded`.

## UI

- Activity page: an amber `Sync failed` badge in the flags column next to Synced (the file plays, only its timing is off), and it opens the ffsubsync/alass output in the dialog #1294 added.
- The status badge now opens its dialog only when the status *itself* is the failure, so an acquired row carrying a sync message cannot render a clickable "downloaded".
- The media-detail subtitle modal shows the same badge, where the re-sync action already lives, with the cause on hover.

## Checks

- `tsc --noEmit` green on both projects, `ng build` green.
- `jest src/modules/subtitles src/modules/scheduler src/common --runInBand`: 48 suites, 451 tests. New spec mocks `child_process` and pins both directions: a failed sync saves the flag and the cause while leaving the status alone, and a later successful attempt clears both and lands on `synced`.
- Exercised against the dev database: `/subtitles/history` returns a `downloaded` row with `syncFailed: true` and its message, alongside the OCR `failed` rows from #1294.
