### PR TITLE
fix(subtitles): translate the subtitle status labels

### DIFF
--- a/client/src/app/core/pipes/subtitle-status.pipe.spec.ts
+++ b/client/src/app/core/pipes/subtitle-status.pipe.spec.ts
@@ -1,0 +1,38 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { TranslateLoader, provideTranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { SubtitleStatusPipe } from './subtitle-status.pipe';
+
+const table = {
+  activity: { status_downloaded: 'Téléchargé', status_synced: 'Synchronisé' },
+  requests: { status: { processing: 'En traitement' } },
+};
+
+function pipe() {
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideTranslateService({
+        lang: 'fr',
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of(table) } },
+      }),
+      SubtitleStatusPipe,
+    ],
+  });
+  return TestBed.inject(SubtitleStatusPipe);
+}
+
+describe('SubtitleStatusPipe', () => {
+  it('resolves a status to the label its own feature already ships', () => {
+    const p = pipe();
+    expect(p.transform('downloaded')).toBe('Téléchargé');
+    expect(p.transform('processing')).toBe('En traitement');
+  });
+
+  it('falls through to the raw value rather than emptying the cell', () => {
+    const p = pipe();
+    expect(p.transform('something_new')).toBe('something_new');
+    expect(p.transform(null)).toBe('');
+  });
+});

--- a/client/src/app/core/pipes/subtitle-status.pipe.ts
+++ b/client/src/app/core/pipes/subtitle-status.pipe.ts
@@ -1,0 +1,31 @@
+import { Pipe, PipeTransform, inject } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+
+/** Every label already shipped for these states, wherever it lives. */
+const STATUS_KEYS: Record<string, string> = {
+  downloaded: 'activity.status_downloaded',
+  upgraded: 'activity.status_upgraded',
+  synced: 'activity.status_synced',
+  failed: 'activity.status_failed',
+  processing: 'requests.status.processing',
+  embedded: 'media_detail.embedded',
+  missing: 'media_detail.subtitle_missing',
+};
+
+/**
+ * Resolve a subtitle row's stored status to its display label. An unmapped
+ * status falls through to its raw value rather than an empty cell.
+ *
+ * Impure because the translation table loads asynchronously and changes when
+ * the user switches locale.
+ */
+@Pipe({ name: 'subtitleStatus', pure: false })
+export class SubtitleStatusPipe implements PipeTransform {
+  private readonly translate = inject(TranslateService);
+
+  transform(status: string | null | undefined): string {
+    if (!status) return '';
+    const key = STATUS_KEYS[status];
+    return key ? this.translate.instant(key) : status;
+  }
+}

--- a/client/src/app/features/settings/subtitles-activity/subtitles-activity.html
+++ b/client/src/app/features/settings/subtitles-activity/subtitles-activity.html
@@ -73,16 +73,16 @@
                   (click)="openError(entry)"
                   [attr.aria-label]="'activity.error_detail_title' | translate"
                 >
-                  <span class="badge badge-sm" [ngClass]="subStatusClass(entry.status)">{{ entry.status }}</span>
+                  <span class="badge badge-sm" [ngClass]="subStatusClass(entry.status)">{{ entry.status | subtitleStatus }}</span>
                 </button>
               } @else {
-                <span class="badge badge-sm" [ngClass]="subStatusClass(entry.status)">{{ entry.status }}</span>
+                <span class="badge badge-sm" [ngClass]="subStatusClass(entry.status)">{{ entry.status | subtitleStatus }}</span>
               }
             </td>
             <td class="text-center text-sm">
               @if (entry.forced) { <span class="badge badge-sm badge-outline mr-1">F</span> }
               @if (entry.hearingImpaired) { <span class="badge badge-sm badge-outline">HI</span> }
-              @if (entry.synced) { <span class="badge badge-sm badge-info ml-1">Synced</span> }
+              @if (entry.synced) { <span class="badge badge-sm badge-info ml-1">{{ 'activity.status_synced' | translate }}</span> }
               @if (entry.syncFailed) {
                 @if (errorText(entry)) {
                   <button

--- a/client/src/app/features/settings/subtitles-activity/subtitles-activity.ts
+++ b/client/src/app/features/settings/subtitles-activity/subtitles-activity.ts
@@ -20,12 +20,13 @@ import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 import { LocaleDatePipe } from '../../../core/pipes/locale-date.pipe';
 import { LocalizeLanguagePipe } from '../../../core/pipes/localize-language.pipe';
+import { SubtitleStatusPipe } from '../../../core/pipes/subtitle-status.pipe';
 import { SUBTITLE_LANGUAGE_CODES } from '../../../core/constants/subtitle-languages';
 import { episodeLabel } from '../../../shared/utils/episode-label';
 
 @Component({
   selector: 'app-subtitles-activity',
-  imports: [TvSelectDirective, TranslatePipe, LocaleDatePipe, LocalizeLanguagePipe, NgClass, RouterLink, FormsModule, PaginationComponent, ModalHeaderComponent, ModalFooterComponent],
+  imports: [TvSelectDirective, TranslatePipe, LocaleDatePipe, LocalizeLanguagePipe, NgClass, RouterLink, FormsModule, PaginationComponent, ModalHeaderComponent, ModalFooterComponent, SubtitleStatusPipe],
   templateUrl: './subtitles-activity.html',
 })
 export class SubtitlesActivityComponent implements OnInit {

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.html
@@ -172,7 +172,9 @@
                         <span class="badge badge-sm badge-outline">HI</span>
                       }
                       @if (sub.synced) {
-                        <span class="badge badge-sm badge-info ml-1">Synced</span>
+                        <span class="badge badge-sm badge-info ml-1">{{
+                          'activity.status_synced' | translate
+                        }}</span>
                       }
                       @if (sub.syncFailed) {
                         <span
@@ -290,7 +292,9 @@
             <optgroup [label]="'media_detail.sync_external_subtitles' | translate">
               @for (s of externalSubtitleRefs(); track s.id) {
                 <option [value]="'file:' + s.relativePath">
-                  {{ s.language | localizeLanguage }} — {{ s.providerType }} ({{ s.status }})
+                  {{ s.language | localizeLanguage }} — {{ s.providerType }} ({{
+                    s.status | subtitleStatus
+                  }})
                 </option>
               }
             </optgroup>

--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -16,6 +16,7 @@ import {
   LucideUpload,
 } from '@lucide/angular';
 import { LocalizeLanguagePipe } from '../../../core/pipes/localize-language.pipe';
+import { SubtitleStatusPipe } from '../../../core/pipes/subtitle-status.pipe';
 import { formatSubtitleLabel, formatSubtitleParts } from '../../../core/utils/player.utils';
 import { guessLanguageFromFilename, localizeLanguage } from '../../../core/utils/language.utils';
 import {
@@ -74,6 +75,7 @@ interface SubtitleRow {
     FormsModule,
     TranslatePipe,
     LocalizeLanguagePipe,
+    SubtitleStatusPipe,
     SubtitleFilenamePipe,
     PaginationComponent,
     MediaDetailSubtitleSearchModalComponent,


### PR DESCRIPTION
## What was wrong

The activity table printed `entry.status` straight from the database, so a French UI read `downloaded` / `failed` next to a translated `Échec de la synchro`. The `Synced` badge was English in the markup in two places (activity table and the media-detail subtitle modal), and the sync-reference dropdown in that modal printed the raw status as well.

## Reusing what already ships

No new i18n keys. Every one of these states already has a label somewhere:

| status | key |
| --- | --- |
| `downloaded` / `upgraded` / `synced` / `failed` | `activity.status_*` — the four the status filter already offers |
| `processing` | `requests.status.processing` |
| `embedded` | `media_detail.embedded` |
| `missing` | `media_detail.subtitle_missing` |

A `subtitleStatus` pipe maps the stored value onto them, in the shape `localizeLanguage` already uses for language codes: impure, so switching locale repaints, and falling through to the raw value so a status nobody mapped yet leaves a readable cell rather than an empty one. The `Synced` badges reuse `activity.status_synced`.

## Checks

- `tsc --noEmit` and `ng build` green.
- New pipe spec: resolution for a mapped status, and the raw-value fallthrough for an unmapped one; the activity page spec still passes.
