### PR TITLE
fix(home): revalidate the social cards when the cached page returns

### DIFF
--- a/client/src/app/shared/components/follow-requests-card/follow-requests-card.ts
+++ b/client/src/app/shared/components/follow-requests-card/follow-requests-card.ts
@@ -10,6 +10,7 @@ import { RouterLink } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 import { LucideCheck, LucideX } from '@lucide/angular';
 import { SocialApiService, SocialUser } from '../../../core/services/api/social-api.service';
+import { keepRouteFresh } from '../../../core/services/keep-route-fresh';
 import { SseService } from '../../../core/services/sse.service';
 import { TvService } from '../../../core/services/tv.service';
 import { UserAvatarComponent } from '../user-avatar/user-avatar';
@@ -36,6 +37,8 @@ export class FollowRequestsCardComponent implements OnInit {
   readonly busyId = signal<number | null>(null);
 
   constructor() {
+    // Home is a cached route, so ngOnInit doesn't run again on return.
+    keepRouteFresh({ refresh: () => { if (!this.tv.isTv()) void this.load(); } });
     // Prepend a request the moment its SSE arrives, without a round-trip.
     effect(() => {
       if (this.sse.lastEvent()?.type === 'social.follow_request') void this.load();

--- a/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.ts
+++ b/client/src/app/shared/components/received-recommendations-card/received-recommendations-card.ts
@@ -18,6 +18,7 @@ import {
   ReceivedRecommendation,
   SocialApiService,
 } from '../../../core/services/api/social-api.service';
+import { keepRouteFresh } from '../../../core/services/keep-route-fresh';
 import { SseService } from '../../../core/services/sse.service';
 import { TvService } from '../../../core/services/tv.service';
 import { DropdownMenuComponent } from '../dropdown-menu';
@@ -84,6 +85,8 @@ export class ReceivedRecommendationsCardComponent implements OnInit {
   });
 
   constructor() {
+    // Home is a cached route, so ngOnInit doesn't run again on return.
+    keepRouteFresh({ refresh: () => { if (!this.tv.isTv()) void this.load(); } });
     // Refresh the moment a new recommendation SSE arrives, without waiting for
     // the next page load.
     effect(() => {


### PR DESCRIPTION
## Problem

The "recommended by a friend" card (and its sibling, the follow-requests card) never refreshed when coming back to the home page.

Both load only in `ngOnInit` plus their own SSE. Home is a `reuse: true` route, so the reuse strategy detaches it instead of destroying it: `ngOnInit` does not run again on return, and `HomeComponent`'s `keepRouteFresh` refresh only reloads the sections the page itself owns. The cards kept whatever they had on first mount, so anything changed elsewhere (a dismissal from another device, an SSE missed while the connection was down) stayed invisible for the rest of the session.

## Fix

Both cards call `keepRouteFresh({ refresh })`, the pattern the cached pages already use. The hook injects the same `ActivatedRoute` as `HomeComponent`, so its key matches home's cache key and the reload fires on every reattach. The TV guard from `ngOnInit` is kept: the template renders nothing there, so the request would only be discarded.

## Test

`tsc -p tsconfig.app.json --noEmit` clean.