### PR TITLE
feat(layout): blur the mobile topbar and dock on every page

### DIFF
--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -17,9 +17,9 @@
       [class.lg:hidden]="device.isDesktop() || (device.isTv() && navbar.effectiveSidebarPinned())"
       [class.md:hidden]="device.isTablet() && navbar.effectiveSidebarPinned()"
       [class.-translate-y-full]="navbarHidden()"
-      [class.bg-base-100]="!navbarTransparent() && !background.url() && !tv.isTv()"
+      [class.bg-base-100/70]="!navbarTransparent() && !background.url() && !tv.isTv()"
       [class.app-navbar-veil]="!navbarTransparent() && !!background.url()"
-      [class.backdrop-blur-sm]="!navbarTransparent() && !!background.url() && !tv.isTv()"
+      [class.backdrop-blur-sm]="!navbarTransparent() && !tv.isTv()"
       [class.shadow-sm]="!navbarTransparent() && !background.url() && !tv.isTv()"
       [class.bg-transparent]="navbarTransparent()"
       [class.text-white]="navbarTransparent()"
@@ -180,7 +180,7 @@
     <!-- Native bottom navigation bar — phones only.
          Tablets and TV use the drawer/sidebar instead. -->
     @if (isNative && device.isPhone() && !keyboardOpen()) {
-      <div class="dock z-40 dock-with-fab-cradle">
+      <div class="dock z-40 dock-with-fab-cradle bg-base-100/70 backdrop-blur-sm">
         @if (dockHome(); as item) {
           <a [routerLink]="item.route" routerLinkActive="dock-active" [routerLinkActiveOptions]="{ exact: item.exact }"
              (click)="resetNavHistory()">

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1156,7 +1156,12 @@ body.tablet [data-touch-only] {
      top: -12 puts the cradle's centre at the same y as the FAB. */
   top: -12px;
   transform: translateX(-50%);
-  background: var(--color-base-100);
+  background: color-mix(in oklab, var(--color-base-100) 70%, transparent);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  /* Only the protruding cap is drawn: over the bar it would stack a second
+     translucent layer and show as a lighter half-circle. */
+  clip-path: inset(0 0 52px 0);
 }
 
 /* Skip the full-page cross-fade. Rasterizing + compositing two viewport-sized


### PR DESCRIPTION
## Problem

On mobile the topbar was frosted only on pages that carry a fanart background. Everywhere else (watch history, settings, requests, …) it fell back to an opaque `bg-base-100`. The bottom dock was opaque on every page.

## Change

- The topbar keeps its transparent state on hero pages, but otherwise always gets `bg-base-100/70` + `backdrop-blur-sm`, dropping the `background.url()` condition on the blur.
- The dock gets the same tint and blur.
- The FAB cradle follows, with one constraint: only its protruding cap is painted (`clip-path`). Over the bar it would stack a second translucent layer and show as a lighter half-circle.

`bg-base-100/70` rather than the existing `.app-navbar-veil`: the veil is a hardcoded dark rgba, right over artwork but wrong on a light theme. TV keeps its own treatment, untouched.

## Test

Production build clean; the emitted CSS carries the opaque `color-mix` fallback, so engines without `color-mix` degrade to today's solid bar.

Known cosmetic residue: daisyUI's 0.5px / 5%-alpha `border-top` on the dock now crosses the cradle notch instead of being hidden under it.