### PR TITLE
fix(tv): give the card rails real room after the last card

### DIFF
--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -678,6 +678,13 @@ html.vt-player-close body.tv main.page-enter {
 body.tv [data-scroller] {
   will-change: scroll-position;
 }
+/* End room for the last card, matching what the first one gets at scrollLeft 0.
+   The negative margin cancels the rail's gap, so this adds 16px, not 40. */
+body.tv [data-scroller]::after {
+  content: '';
+  flex: 0 0 1rem;
+  margin-left: -1.5rem;
+}
 
 /* Run the focus lift on the compositor. The scale itself is cheap; animating it
    on an unpromoted element is not — the TV WebView repaints the card and


### PR DESCRIPTION
## Problem

On the TV, D-padding to the right end of a card rail never cleared the last card: it parked against the rail's clip edge with its focus lift (`scale(1.06)`) and its 4px ring cut off.

The rails carry `scroll-px-16`, so `scrollRowToFocus` places a focused card 64px from either edge. At the end of the scroll the only room available is the rail's own `px-4`, so the `scrollTo` clamps and the last card lands where no other card ever does. Same asymmetry at the left end, where `scrollLeft` cannot go below 0.

## Fix

A flex pseudo-item at the end of the rail supplies scrollable room the container's end padding cannot. Its negative margin cancels the rail's `gap`, so the contribution is 16px: the last card stops level with the page content edge, exactly where the first card sits at `scrollLeft: 0`. Sized to 40px first, which overshot to the full scroll-padding and read as a void.

TV only — no other form factor scrolls these rails one focus step at a time.

## Test

Built, signed and installed on the Samsung QE85Q80B; both ends of the home and library rails check out.