### PR TITLE
fix(backup): read the database settings the rest of the app uses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # RPU tone-map) — that stays, amd64-only. The jellyfin-ffmpeg deb is per-arch;
 # on arm64 there's no Intel HW so the image is CPU-only (libx264) + ffsubsync.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  postgresql-client \
   procps \
   python3 \
   python3-pip \
@@ -72,6 +71,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc \
   python3-dev \
   libc6-dev \
+  # postgres client tools from PGDG: Ubuntu ships 16 and pg_dump refuses a
+  # server newer than itself, which is every supported deployment.
+  && wget -q -O /usr/share/keyrings/pgdg.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+  && echo "deb [signed-by=/usr/share/keyrings/pgdg.asc] http://apt.postgresql.org/pub/repos/apt noble-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends postgresql-client \
   && if [ "$TARGETARCH" = "amd64" ]; then \
        apt-get install -y --no-install-recommends \
          intel-opencl-icd; \

--- a/backend/src/modules/scheduler/backup.service.spec.ts
+++ b/backend/src/modules/scheduler/backup.service.spec.ts
@@ -1,0 +1,57 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { BackupService } from './backup.service';
+
+describe('BackupService', () => {
+  let dir: string;
+  let backups: string;
+  let service: BackupService;
+
+  beforeAll(() => {
+    // getDataDir() caches its probe process-wide, so the env has to be set
+    // before the first instance and the directory reused after that.
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fliks-backup-spec-'));
+    process.env.FLIKS_DATA_DIR = dir;
+    service = new BackupService(new ConfigService());
+    backups = path.join(dir, 'backups');
+  });
+
+  beforeEach(() => {
+    fs.rmSync(backups, { recursive: true, force: true });
+    fs.mkdirSync(backups, { recursive: true });
+  });
+
+  afterAll(() => {
+    delete process.env.FLIKS_DATA_DIR;
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function write(name: string) {
+    fs.writeFileSync(path.join(backups, name), '-- dump');
+  }
+
+  describe('getBackupPath', () => {
+    it('resolves a backup that exists', () => {
+      write('fliks-backup-1.sql');
+      expect(service.getBackupPath('fliks-backup-1.sql')).toBe(
+        path.join(backups, 'fliks-backup-1.sql'),
+      );
+    });
+
+    it.each(['../../etc/passwd', '/etc/passwd', 'sub/dir.sql', 'dump.sql.gz'])(
+      'rejects %s',
+      (name) => {
+        expect(() => service.getBackupPath(name)).toThrow(BadRequestException);
+      },
+    );
+
+    it('reports a missing backup as not found', () => {
+      expect(() => service.getBackupPath('absent.sql')).toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/backend/src/modules/scheduler/backup.service.ts
+++ b/backend/src/modules/scheduler/backup.service.ts
@@ -1,20 +1,31 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { spawn } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { exec } from 'child_process';
-import { promisify } from 'util';
+import { getDataDir } from '../../common/constants/paths';
 
-const execAsync = promisify(exec);
-
+/**
+ * Whole-database dump and restore through the postgres client tools.
+ *
+ * Connection settings come from the same `DB_*` variables TypeORM reads, so the
+ * two can never point at different databases. The password travels in
+ * `PGPASSWORD` and the tools are spawned without a shell: no quoting of
+ * credentials, nothing for a value to escape into.
+ */
 @Injectable()
 export class BackupService {
   private readonly log = new Logger(BackupService.name);
-  private readonly backupDir: string;
+  /** Under the data dir, so backups survive an image upgrade. */
+  private readonly backupDir = path.join(getDataDir(), 'backups');
 
-  constructor(private readonly config: ConfigService) {
-    this.backupDir = path.join(process.cwd(), 'backups');
-  }
+  constructor(private readonly config: ConfigService) {}
 
   async createBackup(): Promise<{ filename: string; size: number }> {
     fs.mkdirSync(this.backupDir, { recursive: true });
@@ -22,13 +33,21 @@ export class BackupService {
     const filename = `fliks-backup-${timestamp}.sql`;
     const filePath = path.join(this.backupDir, filename);
 
-    const dbUrl = this.config.get<string>('DATABASE_URL', '');
-    if (!dbUrl) {
-      throw new Error('DATABASE_URL not configured');
-    }
-
     this.log.log(`Creating backup: ${filename}`);
-    await execAsync(`pg_dump "${dbUrl}" > "${filePath}"`);
+    const fd = fs.openSync(filePath, 'w');
+    try {
+      // --clean --if-exists: the restore runs against a populated database.
+      await this.run(
+        'pg_dump',
+        [...this.connectionArgs(), '--clean', '--if-exists', '--no-owner'],
+        fd,
+      );
+    } catch (err) {
+      fs.closeSync(fd);
+      fs.rmSync(filePath, { force: true });
+      throw err;
+    }
+    fs.closeSync(fd);
 
     const stat = fs.statSync(filePath);
     this.log.log(`Backup created: ${filename} (${stat.size} bytes)`);
@@ -48,26 +67,79 @@ export class BackupService {
   }
 
   async restore(filename: string): Promise<void> {
-    const filePath = path.join(this.backupDir, filename);
-    if (!fs.existsSync(filePath)) {
-      throw new NotFoundException(`Backup "${filename}" not found`);
-    }
-
-    const dbUrl = this.config.get<string>('DATABASE_URL', '');
-    if (!dbUrl) {
-      throw new Error('DATABASE_URL not configured');
-    }
-
+    const filePath = this.getBackupPath(filename);
     this.log.warn(`Restoring backup: ${filename}`);
-    await execAsync(`psql "${dbUrl}" < "${filePath}"`);
+    // ON_ERROR_STOP: without it psql reports success after skipping every
+    // statement that failed, leaving a half-restored database.
+    await this.run('psql', [
+      ...this.connectionArgs(),
+      '-v',
+      'ON_ERROR_STOP=1',
+      '-f',
+      filePath,
+    ]);
     this.log.log(`Backup restored: ${filename}`);
   }
 
+  /** Resolved inside the backup dir: the name reaches here from a request. */
   getBackupPath(filename: string): string {
+    if (!/^[\w.-]+\.sql$/.test(filename)) {
+      throw new BadRequestException(`Invalid backup name "${filename}"`);
+    }
     const filePath = path.join(this.backupDir, filename);
     if (!fs.existsSync(filePath)) {
       throw new NotFoundException(`Backup "${filename}" not found`);
     }
     return filePath;
+  }
+
+  private connectionArgs(): string[] {
+    return [
+      '-h',
+      this.config.get<string>('DB_HOST', 'localhost'),
+      '-p',
+      String(this.config.get<number>('DB_PORT', 5432)),
+      '-U',
+      this.config.get<string>('DB_USERNAME', 'fliks'),
+      '-d',
+      this.config.get<string>('DB_NAME', 'fliks'),
+    ];
+  }
+
+  /** Spawn a postgres tool, optionally writing its stdout to `outFd`. Rejects
+   *  with the tool's own last stderr line, which is what the UI shows. */
+  private run(cmd: string, args: string[], outFd?: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(cmd, args, {
+        stdio: ['ignore', outFd ?? 'ignore', 'pipe'],
+        env: {
+          ...process.env,
+          PGPASSWORD: this.config.get<string>('DB_PASSWORD', ''),
+        },
+      });
+      let stderr = '';
+      child.stderr?.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+      child.on('error', (err: NodeJS.ErrnoException) => {
+        reject(
+          new InternalServerErrorException(
+            err.code === 'ENOENT'
+              ? `${cmd} is not available on this server`
+              : `${cmd} failed: ${err.message}`,
+          ),
+        );
+      });
+      child.on('close', (code) => {
+        if (code === 0) return resolve();
+        const detail = stderr.trim().split('\n').filter(Boolean).pop();
+        this.log.error(`${cmd} exited with ${code}: ${stderr.trim()}`);
+        reject(
+          new InternalServerErrorException(
+            detail ?? `${cmd} exited with code ${code}`,
+          ),
+        );
+      });
+    });
   }
 }


### PR DESCRIPTION
## Problem

`POST /api/system/backup` answered **500 Internal Server Error** in every deployment, and had since the feature landed.

Two independent causes, both reproduced on the dev stack:

1. The service read `DATABASE_URL`, which nothing sets. TypeORM, `data-source.ts` and both compose files configure the database through `DB_HOST` / `DB_PORT` / `DB_USERNAME` / `DB_PASSWORD` / `DB_NAME`. `createBackup()` threw `Error('DATABASE_URL not configured')` before spawning anything.
2. The image ships Ubuntu 24.04's `postgresql-client` (16) against a PostgreSQL 18.3 server: `pg_dump: aborting because of server version mismatch`. A client older than the server is refused outright.

## Changes

- Connection arguments come from the same `DB_*` variables TypeORM reads, so the two can never diverge.
- Client tools come from the PGDG repo, unpinned: a newer `pg_dump` reads an older server, never the reverse.
- Backups move from `process.cwd()/backups` to `<dataDir>/backups`. The old path sits outside every volume (lost on upgrade) and is not writable at a non-root container uid.
- The filename in `restore` and the download route went into `path.join` straight from the request. It is now matched against `^[\w.-]+\.sql$`, so nothing walks out of the backup directory.
- `pg_dump --clean --if-exists`: without it a restore onto a populated database fails on every `CREATE`.
- `psql -v ON_ERROR_STOP=1`: psql was exiting 0 after skipping every failed statement, reporting success on a half-restored database.
- `spawn` without a shell, password in `PGPASSWORD`. The old `exec` interpolated credentials into a shell string.
- Errors carry the tool's own stderr, so the UI shows the cause instead of a bare 500.

## Test

On the dev stack (PostgreSQL 18.3, PGDG client 18.6 installed in the container to match this Dockerfile):

- `POST /api/system/backup` → 201, 4 MB dump in the data volume.
- That dump restored into a throwaway database → exit 0, 46 tables, users intact; restored a second time onto the now-populated database → exit 0, which is what `--clean --if-exists` buys.
- `restore` with `../../etc/passwd` → 400; with an absent name → 404.
- New spec covers the name guard (6 tests). Full image build not run; the PGDG lines were validated verbatim in a container on the same noble base.