### PR TITLE
feat(layout): animate the dock's more menu and outline both bars

### DIFF
--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -22,6 +22,8 @@
       [class.backdrop-blur-sm]="!navbarTransparent() && !tv.isTv()"
       [class.shadow-sm]="!navbarTransparent() && !background.url() && !tv.isTv()"
       [class.bg-transparent]="navbarTransparent()"
+      [class.border-b]="!navbarTransparent() && !tv.isTv()"
+      [class.border-base-100/20]="!navbarTransparent() && !tv.isTv()"
       [class.text-white]="navbarTransparent()"
       [class.nav-hero-icons]="navbarTransparent()"
     >
@@ -231,9 +233,10 @@
              since the .dock is no longer the parent stacking context). -->
         @if (bottomMenuOpen()) {
           <div class="fixed inset-0 z-40" (click)="bottomMenuOpen.set(false)"></div>
-          <div class="fixed bottom-20 right-2 mb-2 bg-base-100 rounded-box shadow-xl border border-base-200 min-w-48 z-50"
-               style="bottom: calc(4rem + env(safe-area-inset-bottom, 0px) + 0.5rem)">
-            <ul class="menu p-2 gap-0.5">
+          <div animate.leave="popover-pop-leaving"
+               class="popover-pop-in fixed bottom-20 right-2 mb-2 bg-base-100/70 backdrop-blur-sm rounded-box shadow-xl border border-base-200 min-w-48 z-50"
+               style="bottom: calc(4rem + env(safe-area-inset-bottom, 0px) + 0.5rem); transform-origin: bottom right">
+            <ul class="menu w-full p-2 gap-0.5">
               @for (lib of customLibraries(); track lib.id) {
                 <li>
                   <a [routerLink]="libraryUrl(lib)" routerLinkActive="menu-active" class="justify-between" (click)="resetNavHistory()">

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1149,7 +1149,27 @@ body.tablet [data-touch-only] {
    `overflow: visible` is required so the pseudo can extend past the dock's
    own bounding box (DaisyUI's .dock would otherwise clip it). */
 .dock-with-fab-cradle {
+  --dock-edge: color-mix(in oklab, var(--color-base-100) 20%, transparent);
   overflow: visible !important;
+  /* Drawn by ::after instead, which leaves the cradle's chord out. */
+  border-top-color: transparent;
+}
+/* The dock's top edge, interrupted where the cradle's outline takes over. The
+   gap is the cradle's chord at its clip line: r 32, cut 12px down. */
+.dock-with-fab-cradle::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(
+    to right,
+    var(--dock-edge) calc(50% - 25px),
+    transparent calc(50% - 25px),
+    transparent calc(50% + 25px),
+    var(--dock-edge) calc(50% + 25px)
+  );
 }
 .dock-with-fab-cradle::before {
   content: '';
@@ -1164,6 +1184,7 @@ body.tablet [data-touch-only] {
   top: -12px;
   transform: translateX(-50%);
   background: color-mix(in oklab, var(--color-base-100) 70%, transparent);
+  border: 1px solid var(--dock-edge);
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
   /* Only the protruding cap is drawn: over the bar it would stack a second


### PR DESCRIPTION
Follow-up to #1299, which gave the mobile topbar and dock their blur.

## Changes

**More menu (dock)**
- Reuses the `popover-pop-in` / `animate.leave="popover-pop-leaving"` pair already used by `popover-menu` and `searchable-select`, instead of appearing and vanishing instantly. Its transform origin moves to `bottom right`: the class ships `transform-origin: top`, which would grow the panel downward while it opens upward.
- Same tint and blur as the dock, which is what it sits against.
- Rows now fill the panel. `.menu` is `width: fit-content` and the panel carries `min-w-48`, so the hover band stopped at the width of the longest label. `w-full` on the list is the whole fix; the rows keep daisyUI's radius and the list keeps its `p-2`.

**Edges**
- The blurred topbar gets a `base-100/20` bottom border, on the same condition as the blur, so the transparent hero state stays clean.
- The dock gets the same edge on top, including around the FAB cradle. Its own `border-top` could not be reused: it crosses the cradle's chord and reads as a barred half-circle. The line is drawn by a pseudo-element with a gap in the middle, and the cradle carries a matching border that `clip-path` reduces to the visible arc. The gap is the cradle's chord at the clip line (r 32, cut 12px down → ±25px), so the arc's ends meet the line's with no hole or overlap.

## Test

Production build clean; `--dock-edge` and `border-base-100/20` both ship with the opaque `color-mix` fallback. Not checked on a device: the dock renders only under Capacitor.