### PR TITLE
feat(setup): show the logo and a per-server switch spinner

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -578,7 +578,7 @@
     "sub_col_date": "Datum"
   },
   "setup": {
-    "subtitle": "Konfigurieren Sie die Adresse Ihres Fliks-Servers",
+    "subtitle": "Konfigurieren Sie die Adresse Ihres Servers",
     "server_url": "Serveradresse",
     "server_url_hint": "Die vollständige Adresse Ihres Servers (z. B.: http://192.168.1.10:3000)",
     "test": "Testen",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -583,7 +583,7 @@
     "sub_col_date": "Date"
   },
   "setup": {
-    "subtitle": "Configure the address of your Fliks server",
+    "subtitle": "Configure the address of your server",
     "server_url": "Server address",
     "server_url_hint": "The full address of your server (e.g. http://192.168.1.10:3000)",
     "test": "Test",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -578,7 +578,7 @@
     "sub_col_date": "Fecha"
   },
   "setup": {
-    "subtitle": "Configure la dirección de su servidor Fliks",
+    "subtitle": "Configure la dirección de su servidor",
     "server_url": "Dirección del servidor",
     "server_url_hint": "La dirección completa de su servidor (ej.: http://192.168.1.10:3000)",
     "test": "Probar",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -583,7 +583,7 @@
     "sub_col_date": "Date"
   },
   "setup": {
-    "subtitle": "Configurez l'adresse de votre serveur Fliks",
+    "subtitle": "Configurez l'adresse de votre serveur",
     "server_url": "Adresse du serveur",
     "server_url_hint": "L'adresse complète de votre serveur (ex: http://192.168.1.10:3000)",
     "test": "Tester",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -578,7 +578,7 @@
     "sub_col_date": "Data"
   },
   "setup": {
-    "subtitle": "Configura l'indirizzo del tuo server Fliks",
+    "subtitle": "Configura l'indirizzo del tuo server",
     "server_url": "Indirizzo del server",
     "server_url_hint": "L'indirizzo completo del tuo server (es: http://192.168.1.10:3000)",
     "test": "Testa",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -578,7 +578,7 @@
     "sub_col_date": "Data"
   },
   "setup": {
-    "subtitle": "Configure o endereço do seu servidor Fliks",
+    "subtitle": "Configure o endereço do seu servidor",
     "server_url": "Endereço do servidor",
     "server_url_hint": "O endereço completo do seu servidor (ex.: http://192.168.1.10:3000)",
     "test": "Testar",

--- a/client/src/app/features/setup/setup.html
+++ b/client/src/app/features/setup/setup.html
@@ -2,12 +2,16 @@
   <div class="card bg-base-100 shadow-xl w-full max-w-md" (click)="closeMenu()">
     <div class="card-body gap-6">
       <div class="text-center">
-        <h1 class="text-2xl font-bold">Fliks</h1>
-        <p class="text-base-content/60 mt-1">{{ 'setup.subtitle' | translate }}</p>
+        <img
+          src="/fliks-logo-ondark.svg"
+          alt="{{ 'app.name' | translate }}"
+          class="h-12 w-auto mx-auto"
+        />
+        <p class="text-base-content/60 pt-4">{{ 'setup.subtitle' | translate }}</p>
       </div>
 
       @if (knownServers().length > 0) {
-        <section class="flex flex-col gap-2">
+        <section class="flex flex-col gap-2 pt-2">
           <div class="text-xs font-semibold uppercase tracking-wider text-base-content/60">
             {{ 'server_history.section_title' | translate }}
           </div>
@@ -16,7 +20,8 @@
               <button
                 type="button"
                 class="flex-1 min-w-0 text-left"
-                [attr.aria-busy]="switching()"
+                [disabled]="!!switchingTo()"
+                [attr.aria-busy]="switchingTo() === server.url"
                 (click)="useKnown(server)"
               >
                 <div class="font-medium truncate flex items-center gap-1.5">
@@ -33,6 +38,9 @@
                   }
                 </div>
               </button>
+              @if (switchingTo() === server.url) {
+                <span class="loading loading-spinner loading-sm text-primary"></span>
+              }
               <div class="dropdown dropdown-end" [class.dropdown-open]="openMenuFor() === server.url">
                 <button type="button" class="btn btn-ghost btn-sm btn-square" (click)="toggleMenu(server.url, $event)" [attr.aria-label]="'server_history.actions' | translate">⋯</button>
                 <ul class="dropdown-content menu bg-base-100 rounded-box shadow z-10 w-48 p-2">
@@ -88,9 +96,12 @@
           #saveBtn
           type="button"
           class="btn btn-primary flex-1"
-          [disabled]="!testResult()?.ok"
+          [disabled]="!testResult()?.ok || !!switchingTo()"
           (click)="save()"
         >
+          @if (saving()) {
+            <span class="loading loading-spinner loading-sm"></span>
+          }
           {{ 'setup.save' | translate }}
         </button>
       </div>

--- a/client/src/app/features/setup/setup.ts
+++ b/client/src/app/features/setup/setup.ts
@@ -38,8 +38,12 @@ export class SetupComponent {
   readonly testing = signal(false);
   readonly testResult = signal<{ ok: boolean; message: string } | null>(null);
   readonly knownServers = this.serverConfig.knownServers;
-  /** The app restarts on a server switch, so this only has to hold until then. */
-  readonly switching = signal(false);
+  /** URL being switched to, or null. The app restarts on a server switch, so
+   *  this only has to hold until then. */
+  readonly switchingTo = signal<string | null>(null);
+  /** True only for a switch started by the save button, so the recent-server
+   *  rows don't spin its spinner. */
+  readonly saving = signal(false);
   /** URL of the entry whose ⋯ menu is open, or null. */
   readonly openMenuFor = signal<string | null>(null);
   private readonly saveBtn = viewChild<ElementRef<HTMLButtonElement>>('saveBtn');
@@ -80,7 +84,12 @@ export class SetupComponent {
   async save() {
     const result = this.testResult();
     if (!result?.ok) return;
-    await this.switchTo(this.url().trim());
+    this.saving.set(true);
+    try {
+      await this.switchTo(this.url().trim());
+    } finally {
+      this.saving.set(false);
+    }
   }
 
   /** One-tap "use this server" — already known, skip the test step. Its stored
@@ -90,12 +99,12 @@ export class SetupComponent {
   }
 
   private async switchTo(url: string) {
-    if (this.switching()) return;
-    this.switching.set(true);
+    if (this.switchingTo()) return;
+    this.switchingTo.set(url);
     try {
       await this.auth.switchToServer(url);
     } finally {
-      this.switching.set(false);
+      this.switchingTo.set(null);
     }
   }
 


### PR DESCRIPTION
## What

Server-selection page (`/setup`):

- Replaced the `Fliks` text heading with the `fliks-logo-ondark.svg` logo, matching the login page.
- Dropped the product name from `setup.subtitle` in all 6 locales (the logo says it) and loosened the spacing (`mt-1` → `pt-4`, `pt-2` on the recent-servers section).
- `switching` became `switchingTo`, holding the URL being switched to: the clicked recent-server row shows a spinner while the request is in flight, and every other row is disabled meanwhile.
- The save button keeps its own spinner, driven by a separate `saving` flag, so picking a recent server does not make it spin.

## Why

Clicking a recent server fired `switchToServer` with no visual feedback at all, so the page looked frozen until the app restarted on the new server.