### PR TITLE
fix(card-actions): request the thumb variant for the panel preview

### DIFF
--- a/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
+++ b/client/src/app/shared/components/card-actions-panel/card-actions-panel.html
@@ -21,7 +21,7 @@
              crowding the top edge. -->
         <div class="flex items-start gap-3 px-2 pt-2 pb-3 mb-1 border-b border-base-content/10">
           @if (imageUrl(); as img) {
-            <img [cachedSrc]="img | resolveUrl" alt="" loading="lazy"
+            <img [cachedSrc]="img | resolveUrl: 'thumb'" alt="" loading="lazy"
               class="shrink-0 rounded object-cover bg-base-300"
               [style.width.px]="imageAspect() === 'landscape' ? 80 : 60"
               [style.aspect-ratio]="imageAspect() === 'landscape' ? '16 / 9' : '2 / 3'" />


### PR DESCRIPTION
## Problem

The card actions panel (long-press on a media card) renders its preview at 60 px wide for a
portrait poster, 80 px for a landscape still:

```html
<img [cachedSrc]="img | resolveUrl" ... [style.width.px]="imageAspect() === 'landscape' ? 80 : 60" />
```

`resolveUrl` only appends `?size=` when it is given a size argument. Without it the request
reaches the image controller with no `size` query param, and the controller falls back to `full`:

```ts
const size: ImageSize = (VALID_SIZES as string[]).includes(sizeRaw ?? '')
  ? (sizeRaw as ImageSize)
  : 'full';
```

`full` is TMDB's `original`, stored verbatim on disk — 1.7 MB for a typical 2000x3000 poster,
up to 5 MB for a 4K backdrop. So every long-press on a card pulled a multi-megabyte original to
paint a 60 px thumbnail, which is the worst place in the client for it: the panel is a
mobile-first affordance.

This was the only sizeless `resolveUrl` in the codebase that resolves to a local image. The
other bare call site (`media-detail-identify-modal`) passes a remote TMDB URL, which the pipe
leaves untouched.

## Fix

Ask for `thumb`, the variant the pipeline already generates: w185 for posters, w300 for
stills. At a 3x device pixel ratio a 60 px slot needs 180 px, so `thumb` is the correct rung —
`medium` would still be 3x more bytes than the element can show.

## Not included

The image controller also falls back to `full` when a requested variant is missing on disk
(images stored before multi-size support, or from non-TMDB sources). That path is already
flagged in a comment there and needs a variant backfill, not a client change.