### PR TITLE
fix(layout): stop the topbar edge flashing white through the blur fade

### DIFF
--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -9,7 +9,7 @@
     <div #topSentinel aria-hidden="true" class="absolute top-0 left-0 h-5 w-px pointer-events-none"></div>
     <nav
       appTvRow
-      class="navbar fixed left-0 right-0 z-30 transition-all duration-300 tv:px-[var(--page-p)] tv:static"
+      class="navbar fixed left-0 right-0 z-30 transition-all duration-300 border-base-100/20 tv:px-[var(--page-p)] tv:static"
       [style.transition]="restorePending() ? 'none' : null"
       [style.padding-top]="tv.isTv() ? 'calc(env(safe-area-inset-top, 0px) + var(--page-p) / 2)' : 'calc(env(safe-area-inset-top, 0px) + 4px)'"
       [class.top-0]="!tv.isTv() || tv.isTizen()"
@@ -23,7 +23,6 @@
       [class.shadow-sm]="!navbarTransparent() && !background.url() && !tv.isTv()"
       [class.bg-transparent]="navbarTransparent()"
       [class.border-b]="!navbarTransparent() && !tv.isTv()"
-      [class.border-base-100/20]="!navbarTransparent() && !tv.isTv()"
       [class.text-white]="navbarTransparent()"
       [class.nav-hero-icons]="navbarTransparent()"
     >


### PR DESCRIPTION
## Symptom

On media-detail, scrolling slowly across the point where the topbar swaps between its
transparent hero state and its blurred state, the bottom border flashes white — in both scroll
directions.

## Cause

Tailwind v4's preflight resets every element to `border: 0 solid` — a width and a style, but
**no colour**, so `border-color` falls through to `currentColor`.

The topbar carries `text-white` while transparent. Its border colour was therefore already
white in that state; only `border-bottom-width: 0` kept it invisible. The colour class was
bound to the same condition as the width:

```html
[class.border-b]="!navbarTransparent() && !tv.isTv()"
[class.border-base-100/20]="!navbarTransparent() && !tv.isTv()"
```

So at the flip, `border-bottom-color` had a real before value (white) and a real after value
(`base-100/20`) — and the bar carries `transition-all duration-300`. The border colour
interpolated from white over 300 ms while the width grew 0 → 1px, i.e. a white line fading to
the intended edge. Symmetric on the way out. Scrolling slowly holds the viewport at the
threshold, which is why it reads as a solid white border rather than a blink.

## Fix

Move the colour into the static class list. It no longer has two values, so there is nothing
to interpolate; `transition-all` is left animating only the width, which fades the edge in at
its final colour.

The colour is harmless in the states that do not draw an edge: with no `border-b` the width
stays 0 on every side, transparent hero state and TV included.

## Related

The dock's edge added in #1303 is not affected — it uses an explicit `--dock-edge` custom
property on a pseudo-element and never inherits a white `currentColor`.