### PR TITLE
fix(select-user): keep D-pad focus alive on the account picker

### DIFF
--- a/client/src/app/features/select-user/select-user.html
+++ b/client/src/app/features/select-user/select-user.html
@@ -23,7 +23,7 @@
           <button
             type="button"
             class="flex flex-col items-center gap-2 p-2 rounded-lg hover:bg-base-100 focus-visible:bg-base-100 transition-colors"
-            [attr.data-select-user-focus]="hasSession(user) ? '' : null"
+            [attr.data-select-user-focus]="user.id === focusTileId() ? '' : null"
             [attr.aria-busy]="resuming() === user.id"
             (click)="selectUser(user); $event.stopPropagation()"
           >
@@ -46,7 +46,12 @@
     }
 
     <div class="flex flex-col items-center gap-2">
-      <button type="button" class="btn btn-ghost btn-sm gap-2" (click)="goToOtherUser(); $event.stopPropagation()">
+      <button
+        type="button"
+        class="btn btn-ghost btn-sm gap-2"
+        [attr.data-select-user-focus]="!loading() && !users().length ? '' : null"
+        (click)="goToOtherUser(); $event.stopPropagation()"
+      >
         <svg lucideUserRoundPen class="h-4 w-4"></svg>
         {{ 'select_user.other_user' | translate }}
       </button>

--- a/client/src/app/features/select-user/select-user.ts
+++ b/client/src/app/features/select-user/select-user.ts
@@ -12,6 +12,7 @@ import { Router } from '@angular/router';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { AuthService, PublicUserSummary } from '../../core/services/auth.service';
 import { DismissableStackService } from '../../core/services/dismissable-stack.service';
+import { restoreOpenerFocus } from '../../core/services/focusable.constants';
 import { ServerConfigService } from '../../core/services/server-config.service';
 import { ToastService } from '../../core/services/toast.service';
 import { UserAvatarComponent } from '../../shared/components/user-avatar/user-avatar';
@@ -77,6 +78,14 @@ export class SelectUserComponent {
     () => this.users().find((u) => u.id === this.openSheetFor()) ?? null,
   );
 
+  /** Tile the default-focus pass lands on: an account with a stored session
+   *  when there is one, else the first. A session-only marker would match
+   *  nothing on a fresh device and leave the boot screen unfocused until
+   *  `DefaultFocusService` times out. */
+  readonly focusTileId = computed(
+    () => this.users().find((u) => this.hasSession(u))?.id ?? this.users()[0]?.id ?? null,
+  );
+
   /** Default-focus target inside the sheet (password button). Captured as a
    *  view child so the effect below can pull focus to it the moment the
    *  sheet opens — `data-tv-modal` on the sheet container already traps
@@ -88,6 +97,9 @@ export class SelectUserComponent {
    *  fires multiple times (open → cancel → reopen). */
   private readonly dismissCallback = () => this.closeSheet();
   private dismissRegistered = false;
+  /** Tile the sheet was opened from, so closing hands focus back to it
+   *  instead of dropping it on `<body>`. */
+  private opener: HTMLElement | null = null;
 
   constructor() {
     void this.loadUsers();
@@ -106,7 +118,15 @@ export class SelectUserComponent {
         this.dismissStack.remove(this.dismissCallback);
         this.dismissRegistered = false;
       }
-      if (!open) return;
+      if (!open) {
+        const opener = this.opener;
+        this.opener = null;
+        // rAF for the same reason as the open path: the sheet's focused button
+        // is still in the DOM until Angular's commit pass lands, and its
+        // removal would blur whatever we restored.
+        if (opener) requestAnimationFrame(() => restoreOpenerFocus(opener));
+        return;
+      }
       requestAnimationFrame(() => {
         this.passwordBtn()?.nativeElement.focus({ preventScroll: true });
       });
@@ -144,6 +164,7 @@ export class SelectUserComponent {
    *  anything else opens the password / quick-connect sheet. */
   async selectUser(user: PublicUserSummary) {
     if (this.resuming() !== null) return;
+    this.opener = document.activeElement as HTMLElement | null;
     if (!this.hasSession(user)) {
       this.openSheetFor.set(user.id);
       return;


### PR DESCRIPTION
Two TV navigation holes on the account picker, both found and then re-verified by driving `/select-user?tv=1` in headless Chromium over CDP with real dispatched D-pad key events (9-account roster stubbed via `Fetch.fulfillRequest`).

## 1. Focus dropped on `<body>` every time the sheet closed

All three exits from the password / quick-connect sheet left the page with nothing focused:

| Close via | Focus after | Next D-pad press |
|---|---|---|
| OK on Cancel | `BODY (nothing focused)` | jumped to the **first** tile |
| Escape | `BODY (nothing focused)` | jumped to the **first** tile |
| Tizen return key (10009) | `BODY (nothing focused)` | jumped to the **first** tile |

No focus ring anywhere on screen, and the next press teleported to the top-left tile instead of returning to the account whose sheet had just been dismissed. `restoreOpenerFocus()` exists for exactly this and is already used by `bottom-sheet`, `popover-menu`, `dropdown-menu`, `dropdown-toggle` and `select-picker` — this hand-rolled sheet was the only overlay in the app that skipped it.

Fixed by recording the opener in `selectUser()` (before the sheet's rAF steals focus) and handing it back through `restoreOpenerFocus` when `openSheetFor` clears. The restore runs inside a rAF for the same reason the open path does: the sheet's focused button is still in the DOM until Angular's commit pass lands, and its removal would blur whatever we restored.

After the fix, all three exits return focus to the originating tile with the ring painted.

## 2. ~3.5 s with nothing focused on a fresh device

Timeline before, roster served in 300 ms:

```
  252ms  body | tiles=0
 1320ms  body | tiles=5     <- tiles painted, nothing focusable
 4867ms  A alice [NO RING]  <- the 4000ms fallback timeout
```

`appDefaultFocus="[data-select-user-focus]"` and the attribute was set only on accounts with a stored session. On a fresh install — the exact state where this screen is the first thing the TV shows — nobody has a session, the selector never matched, and `DefaultFocusService` burnt its whole `WAIT_FOR_TARGET_MS = 4000` before falling back to the first focusable.

The marker is now picked in the component: the first account with a session when there is one, else the first account. A comma selector would not work here — `firstVisibleMatch` iterates `querySelectorAll` in DOM order, not selector order, so the session preference would be lost.

After: focus lands at **1717 ms**, as soon as the tiles render. Verified with a seeded session that the session account still wins the marker over the first tile.

The empty-roster case (server unreachable, no stored session) used to wait out the same 4 s; the marker now moves to the other-user button, gated on `!loading()` so the boot focus still prefers a tile once the roster arrives. Measured 1272 ms with the roster request failed.

## Not touched here

- **No focus ring on the very first programmatic focus.** `:focus-visible` does not match a `focus()` with no prior keyboard interaction, so the first D-pad press both reveals the ring and moves focus — the user silently skips a tile. Tizen is immune (`postcss/tv-fallbacks.cjs` rewrites `:focus-visible` to `:focus`), but that plugin only runs in the Tizen downlevel pass, so Android TV and webOS are affected on **every** cold-loaded page. Global, deserves its own change.
- **Last partial grid row skipped.** With 9 accounts (4/4/1), pressing down from row 2 lands on the other-user button from columns 2-4; the row-3 account stays reachable via column 1. Standard rect-nav behaviour, shared with the library grid.