### PR TITLE
fix(styles): restore the TV focus ring on the active sidebar entry

### DIFF
--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -14,6 +14,9 @@
   --radius-selector: 1rem;
   --radius-field: 1rem;
   --radius-box: 0.5rem;
+  --focus-ring:
+    0 0 0 2px var(--color-base-100, #1d232a),
+    0 0 0 4px var(--color-primary, #7a3ff2);
 }
 
 /* Active menu item styled like the hover state. daisyUI's neutral default is
@@ -502,9 +505,7 @@ body:not(.keyboard-modality):not(.tv) app-mosaic-card button:focus-visible .mosa
    because the second shadow shows through it. */
 :is(a, button, select, input, [role="button"], [tabindex]):focus-visible {
   outline: none;
-  box-shadow:
-    0 0 0 2px var(--color-base-100, #1d232a),
-    0 0 0 4px var(--color-primary, #7a3ff2);
+  box-shadow: var(--focus-ring);
   z-index: 1;
   /* Never set `position` here: it would re-anchor an absolutely placed
      focusable (a modal ✕, a floating cue) and make it jump on focus. */
@@ -516,6 +517,14 @@ body:not(.keyboard-modality):not(.tv) app-mosaic-card button:focus-visible .mosa
    ring is 4px and these rows carry a gap, so nothing overlaps without it. */
 body.tv :is(a, button, select, input, [role="button"], [tabindex]):focus-visible {
   z-index: auto;
+}
+
+/* daisyUI keeps its active menu item's own box-shadow at low specificity behind
+   a `:where()`. The TV downlevel unwraps that wrapper — Chromium 85 can't parse
+   it — which lifts the rule above the ring and swallows it, so the focused
+   sidebar entry you are already on shows no ring at all. */
+body.tv .menu li > .menu-active:focus-visible {
+  box-shadow: var(--focus-ring) !important;
 }
 
 /* Over the video, the ring's inner `--color-base-100` layer has nothing to


### PR DESCRIPTION
On a settings / account / admin shell, the sidebar entry for the route you are already on showed **no focus ring** under the D-pad — only its active background — so there was no way to tell it held focus. Desktop keyboard navigation was unaffected, which is what pointed at the TV stylesheet rather than the markup.

## Cause

daisyUI keeps its active menu item's own `box-shadow` behind a `:where()` wrapper, which holds the rule's specificity below the app's focus ring. Chromium 85 cannot parse `:where()`, so the TV downlevel (`client/postcss/tv-fallbacks.cjs`, run from `client/tizen/downlevel-css.mjs`) unwraps it — and the rule lands well above the ring:

| Rule | Non-downlevelled | Downlevelled |
|---|---|---|
| daisyUI active item | `.menu :where(li) > :not(ul, .menu-title, details, .btn).menu-active` | `.menu li>*:not(ul):not(.menu-title):not(details):not(.btn).menu-active` → **(0,4,3)** |
| app focus ring | `:is(a, button, …):focus-visible` | `a:not(.does-not-exist):focus` → **(0,2,1)** |

daisyUI then wins `box-shadow` and replaces the ring with its own 2px depth shadow. Only the *active* entry has a competing `box-shadow`, which is why every other entry rings correctly.

## Verification

Matched rules dumped for the focused active entry via `CSS.getMatchedStylesForNode`, real app DOM, each of the two stylesheets swapped in — same two rules, opposite order:

```
dev (not downlevelled)     daisyUI active, then the ring   -> ring wins
downlevelled for Tizen     the ring, then daisyUI active   -> ring swallowed
```

Computed `box-shadow` on the focused active entry:

```
before  rgba(243, 248, 255, 0.1) 0px 2px 3px -2px                            <- daisyUI only
after   oklch(0.2533 0.016 252.42) 0px 0px 0px 2px, rgb(96, 93, 255) 0px 0px 0px 4px
```

Desktop re-checked with real arrow-key navigation: ring unchanged, `z-index: 1` still applied, inactive entries unchanged.

## Choices

- Scoped to `body.tv` and to the active menu entry, so it cannot reach the player-controls or media-card ring overrides.
- `!important` rather than a specificity race: matching (0,4,3) would leave the outcome resting on source order, which the next daisyUI bump could silently win back.
- The ring value moves to a `--focus-ring` custom property so the override cannot drift from the rule it restores.