### PR TITLE
fix(focus): stop overlays painting a focus ring after a mouse click

### DIFF
--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -202,13 +202,13 @@ export class App implements OnInit, OnDestroy {
   }
 
   /** Track input modality (keyboard / D-pad vs pointer / touch) and
-   *  toggle `body.keyboard-modality`. CSS gates `:focus-visible`
+   *  toggle `html.keyboard-modality`. CSS gates `:focus-visible`
    *  visuals on it so an iOS long-press — which Safari WebKit
    *  incorrectly classifies as a focus-visible trigger — doesn't
    *  paint the high-contrast focus ring on the card the user was
    *  trying to context-tap. The class flips on the first
    *  navigation-key press and clears on the next pointer / touch
-   *  interaction. TV stays focused-visible regardless (`body.tv`
+   *  interaction. TV stays focused-visible regardless (`html.tv-host`
    *  short-circuits the suppression rule in styles.css). */
   private initInputModalityTracking(): void {
     const NAV_KEYS = new Set([
@@ -224,11 +224,20 @@ export class App implements OnInit, OnDestroy {
     const setKeyboard = (on: boolean) => {
       if (on === keyboardActive) return;
       keyboardActive = on;
-      document.body.classList.toggle('keyboard-modality', on);
+      // On <html>, not <body>: overlays are reparented out of the body to
+      // escape stacking contexts, so a body-scoped rule can't reach them.
+      document.documentElement.classList.toggle('keyboard-modality', on);
     };
-    window.addEventListener('keydown', (e) => {
-      if (NAV_KEYS.has(e.key)) setKeyboard(true);
-    });
+    // Capture, like the pointer listeners below: the components that own these
+    // keys stopPropagation them (a select opening its picker, spatial nav), so a
+    // bubble-phase listener never sees the press that starts a keyboard session.
+    window.addEventListener(
+      'keydown',
+      (e) => {
+        if (NAV_KEYS.has(e.key)) setKeyboard(true);
+      },
+      { capture: true },
+    );
     const clearOnPointer = () => setKeyboard(false);
     window.addEventListener('pointerdown', clearOnPointer, { capture: true });
     window.addEventListener('touchstart', clearOnPointer, {

--- a/client/src/app/core/services/default-focus.service.ts
+++ b/client/src/app/core/services/default-focus.service.ts
@@ -45,7 +45,10 @@ export class DefaultFocusService {
    *  focus on arrival (and where the ring is shown, gated identically in CSS). */
   private shouldAutoFocus(): boolean {
     if (typeof document === 'undefined') return false;
-    return this.device.isTv() || document.body.classList.contains('keyboard-modality');
+    return (
+      this.device.isTv() ||
+      document.documentElement.classList.contains('keyboard-modality')
+    );
   }
 
   /** Focus the page's default target on arrival — the previously focused item

--- a/client/src/app/core/services/focusable.constants.ts
+++ b/client/src/app/core/services/focusable.constants.ts
@@ -30,8 +30,8 @@ export const TABBABLE_SELECTOR =
  */
 export function wantsFocusRestore(): boolean {
   if (typeof document === 'undefined') return false;
-  const b = document.body.classList;
-  return b.contains('keyboard-modality') || b.contains('tv');
+  const c = document.documentElement.classList;
+  return c.contains('keyboard-modality') || c.contains('tv-host');
 }
 
 /**

--- a/client/src/app/features/player/controls/player-controls.ts
+++ b/client/src/app/features/player/controls/player-controls.ts
@@ -491,12 +491,12 @@ export class PlayerControlsComponent {
 
   /** True under keyboard / D-pad input — the only modality where stealing focus
    *  is wanted (mouse and touch users are left alone, matching the CSS ring
-   *  gate). TV is always keyboard-like; the browser flags it on `body`. */
+   *  gate). TV is always keyboard-like. */
   private autoFocusModality(): boolean {
     return (
       this.isTv() ||
       (typeof document !== 'undefined' &&
-        document.body.classList.contains('keyboard-modality'))
+        document.documentElement.classList.contains('keyboard-modality'))
     );
   }
 

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -437,10 +437,9 @@ html.tv-host {
 /* Same focus-into-view breathing room on the browser when navigating by
    keyboard: arrow / Tab focus scrolls via scrollIntoView({block:'nearest'}) (or
    sequential focus nav), which otherwise parks the focused card against the
-   bottom edge. Scoped through :has to keyboard modality so mouse scrolling is
-   untouched. TVs already get this via html.tv-host above; :has never matches on
-   the TV WebView's Chrome 85, which is fine. */
-html:has(body.keyboard-modality) {
+   bottom edge. Scoped to keyboard modality so mouse scrolling is untouched.
+   TVs already get this via html.tv-host above. */
+html.keyboard-modality {
   scroll-padding-top: 96px;
   scroll-padding-bottom: 20vh;
 }
@@ -451,16 +450,20 @@ body.tv *:hover {
 /* Suppress every `:focus-visible` visual when the user isn't on a
    keyboard / D-pad modality. Safari WebKit on iOS incorrectly fires
    focus-visible on long-press, so a context-tap on a media card used
-   to paint the high-contrast ring. The `keyboard-modality` body
-   class is set by app.ts on the first navigation keydown and cleared
-   on the next pointer / touch interaction; TV always uses the ring
-   so it short-circuits the suppression. `transform: none` covers the
+   to paint the high-contrast ring. The `keyboard-modality` class is
+   set by app.ts on the first navigation keydown and cleared on the
+   next pointer / touch interaction; TV always uses the ring so it
+   short-circuits the suppression. `transform: none` covers the
    scale-up rule on media cards a few selectors down.
+
+   Scoped to <html>, not <body>: overlays are reparented under <html>
+   to escape stacking contexts, and a body-scoped rule left their
+   focused entry ringed after a plain mouse click.
 
    A select is not exempt: tapping one opens its picker, which is the
    indication, and no platform leaves a ring on a field after a tap. Text
    fields stay exempt because a caret alone reads as nothing on a wide row. */
-body:not(.keyboard-modality):not(.tv)
+html:not(.keyboard-modality):not(.tv-host)
   :focus-visible:not(input, textarea, [contenteditable]) {
   outline: none !important;
   box-shadow: none !important;
@@ -471,7 +474,7 @@ body:not(.keyboard-modality):not(.tv)
    select (WebKit notably), so there the outline stayed and read as a second ring
    next to the untouched border. Reached on plain :focus so the modality, not the
    engine's focus-visible verdict, decides. */
-body:not(.keyboard-modality):not(.tv) .select:focus {
+html:not(.keyboard-modality):not(.tv-host) .select:focus {
   outline: none;
 }
 
@@ -485,10 +488,10 @@ body.native textarea,
 body.native select {
   font-size: 16px;
 }
-body:not(.keyboard-modality):not(.tv) app-media-card figure:focus-visible,
-body:not(.keyboard-modality):not(.tv) [data-home-focus]:focus-visible,
-body:not(.keyboard-modality):not(.tv) [data-tv-focusable]:focus-visible,
-body:not(.keyboard-modality):not(.tv) app-mosaic-card button:focus-visible .mosaic-art {
+html:not(.keyboard-modality):not(.tv-host) app-media-card figure:focus-visible,
+html:not(.keyboard-modality):not(.tv-host) [data-home-focus]:focus-visible,
+html:not(.keyboard-modality):not(.tv-host) [data-tv-focusable]:focus-visible,
+html:not(.keyboard-modality):not(.tv-host) app-mosaic-card button:focus-visible .mosaic-art {
   transform: none !important;
 }
 
@@ -1012,7 +1015,7 @@ body.tv .to-base-100\/50 {
 /* TV / keyboard focus: subtle hover tint isn't enough on a 10-foot UI —
    the user can't track which row is highlighted from the couch without
    a clear ring. */
-body.tv .dropdown-item:focus-visible {
+html.tv-host .dropdown-item:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: -2px;
 }


### PR DESCRIPTION
## Symptom

Opening a `<select>` with the mouse showed the high-contrast primary ring on the option the picker lands on, as if the user were navigating by keyboard. Only on the first open of a page, which is what made it look random.

## Cause

Two things stacked.

**1. The modality gate could not reach the overlay.** The rule that suppresses `:focus-visible` visuals outside keyboard and D-pad modality was scoped to the body class:

```css
body:not(.keyboard-modality):not(.tv) :focus-visible:not(input, textarea, [contenteditable])
```

But `popover-menu` reparents its host under `<html>` on every open, to escape the stacking contexts of `dialog[open]`, `body.tv`'s transform and mobile's `drawer-content`. The option buttons are therefore siblings of `<body>`, not descendants, and no body-scoped rule can ever match them. The file already documents this trap for TV toggles, which is why one override targets `html.tv-host` rather than `body.tv`; the focus-visible gate was never given the same treatment.

**2. Blink marks a scripted focus as focus-visible when no pointer has moved focus yet.** `focusOverlayEntry` focuses the current selection programmatically, and `TvSelectDirective` preventDefaults its own `mousedown` to open the picker, so the click never focuses the select. On the first interaction of a page there is nothing to mark the session as pointer-driven, and Blink resolves `:focus-visible` to true. After the user has clicked an option once, later opens no longer match, which is exactly the "first time only" pattern.

Measured over CDP with `html.className` empty (no `keyboard-modality`, no `tv`) and the focused option reporting `matches(':focus-visible') === true` with the two-layer ring painted.

## Fix

`keyboard-modality` moves from `<body>` to `<html>`, joining the `tv-host` mirror that exists for this same reason, and the six rules keyed off it follow. Three JS readers move with it, so the class has one home rather than two.

Two things fall out of the move:
- the scroll-padding rule drops its `:has(body.keyboard-modality)` wrapper, which never matched on the TV's Chromium 85 and is now a plain class selector that works everywhere;
- `body.tv .dropdown-item:focus-visible` becomes `html.tv-host ...`, reviving the TV inset outline that the same reparenting had been swallowing. **Not verified on a device** — the app-wide ring still applies there, this rule only adds the inset outline on top.

## A second bug found on the way

With the gate finally working, a keyboard open was also ringless. The modality tracker listened for `keydown` in the bubble phase, but the components owning those keys `stopPropagation` them, `TvSelectDirective` included, so a keyboard session that starts by pressing Enter or Space on a select was never recorded. It now listens in capture, like the `pointerdown` and `touchstart` listeners beside it.

## Verification

Driven in real Chromium over CDP on the settings page, opening the same select both ways:

| Open gesture | `html.className` | option `box-shadow` |
|---|---|---|
| mouse | *(empty)* | `none` |
| keyboard (Enter) | `keyboard-modality` | ring painted |

`tsc` and `ng build` clean. Client suite: 822 passing. Six failures in `subtitle-label-format` and `language-utils` predate this branch and reproduce on `main` (#1282 made `currentLang` a function; those specs' fake `TranslateService` was not updated).
