### PR TITLE
test(client): give the TranslateService stubs their locale signals

### DIFF
--- a/client/src/app/core/utils/language-utils.spec.ts
+++ b/client/src/app/core/utils/language-utils.spec.ts
@@ -7,7 +7,11 @@ const NAMES: Record<string, string> = {
   'language.en': 'Anglais',
   'language.de': 'Allemand',
 };
-const translate = { instant: (key: string) => NAMES[key] ?? key } as TranslateService;
+const translate = {
+  instant: (key: string) => NAMES[key] ?? key,
+  currentLang: signal('fr'),
+  fallbackLang: signal('en'),
+} as unknown as TranslateService;
 
 describe('sortByLanguageName', () => {
   it('sorts by name and pushes unnamed tracks last', () => {

--- a/client/src/app/core/utils/subtitle-label-format.spec.ts
+++ b/client/src/app/core/utils/subtitle-label-format.spec.ts
@@ -1,8 +1,14 @@
 import { formatSubtitleLabel, formatSubtitleParts } from './player.utils';
+import { signal } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 
-/** The formatters only ever call `instant`, so a key-echoing stub is enough. */
-const translate = { instant: (key: string) => key } as TranslateService;
+/** Key-echoing stub. An unresolved key falls through to the platform's own
+ *  language name, so the locale signals have to be there too. */
+const translate = {
+  instant: (key: string) => key,
+  currentLang: signal('en'),
+  fallbackLang: signal('en'),
+} as unknown as TranslateService;
 
 const srt = { language: 'fra', codec: 'subrip', forced: true };
 


### PR DESCRIPTION
## Why

Six cases failed on `main` with `TypeError: translate.currentLang is not a function`:

- `subtitle-label-format.spec.ts` — 5 cases
- `language-utils.spec.ts` — 1 case (`sorts by name and pushes unnamed tracks last`)

#1282 turned `currentLang` and `fallbackLang` into signals. `localizeLanguage` reads them on its fallback path: when a `language.*` key resolves to nothing, it asks `Intl.DisplayNames` for the language's own name in the UI locale.

```ts
const t = translate.instant(key);
if (typeof t === 'string' && t !== key) return t;
const locale = translate.currentLang() || translate.fallbackLang() || 'en';
```

A key-echoing stub always takes that branch, so both stubs that carried only `instant` blew up. In `language-utils.spec.ts` the private-use tag `qaa` in the sort fixture is what reached it; the localizeLanguage cases in that same file were already updated by #1282 and passed.

## What changed

Both stubs get `currentLang` and `fallbackLang` signals, matching the idiom the updated cases in `language-utils.spec.ts` already use. No production code touched, and no assertion changed: every case here checks the format suffix, the flag keys or the track numbering, never the language name itself.

The subtitle stub's comment also claimed the formatters "only ever call `instant`", which is what made the omission read as deliberate. It now says why the locale signals are needed.

## Tests

Full client suite: **828 passing, 90 files, 0 failures** (was 822 passing / 6 failing). `tsc -p tsconfig.spec.json` clean.
