### PR TITLE
test(imports): hand the media-import specs their ImageService dependency

### DIFF
--- a/backend/src/modules/media/media-service/media-import.library-provider.spec.ts
+++ b/backend/src/modules/media/media-service/media-import.library-provider.spec.ts
@@ -85,6 +85,7 @@ describe('MediaImportService — the destination library owns the provider', () 
       } as never,
       { onMediaImported: jest.fn().mockResolvedValue(undefined) } as never,
       { emitDomain: jest.fn() } as never,
+      { storeFromDisk: jest.fn().mockResolvedValue(null) } as never,
     );
     Object.assign(svc, {
       log: { log: jest.fn(), warn: jest.fn((m: string) => warnings.push(m)) },

--- a/backend/src/modules/media/media-service/media-import.season-scope.spec.ts
+++ b/backend/src/modules/media/media-service/media-import.season-scope.spec.ts
@@ -55,6 +55,7 @@ describe('MediaImportService — season monitoring scope on import', () => {
       } as any,
       { onMediaImported: jest.fn().mockResolvedValue(undefined) } as any,
       { emitDomain: jest.fn() } as any,
+      { storeFromDisk: jest.fn().mockResolvedValue(null) } as any,
     );
     jest.spyOn(svc as any, 'resolveImportTarget').mockResolvedValue({
       libraryId: 7,


### PR DESCRIPTION
## Why

`tsc -p tsconfig.json` (the spec-inclusive config) reported two errors on `main`:

```
media-import.library-provider.spec.ts(65,17): error TS2554: Expected 15 arguments, but got 14.
media-import.season-scope.spec.ts(26,17): error TS2554: Expected 15 arguments, but got 14.
```

Both specs build `MediaImportService` by hand rather than through the Nest injector. #1265 added `ImageService` as its 15th dependency — to store sibling artwork found next to an unidentified title — and the two hand-rolled constructions were not updated.

The production build was never affected: `tsconfig.build.json` excludes `**/*spec.ts`. Jest compiles per-file without whole-program type checking, so both specs kept passing while the typecheck was red.

## What changed

Each construction gains the 15th argument: a stub carrying `storeFromDisk`, the only method `MediaImportService` calls on the service, resolving `null` so the artwork loop stores nothing.

Neither spec exercises that path today, so `{}` would have compiled equally well. Giving it the real method means a spec that later reaches the artwork branch fails on its assertion instead of on a missing function.

Cast style follows each file's local idiom (`as never` in one, `as any` in the other).

## Verification

- `tsc -p tsconfig.json --noEmit`: **clean**, which it was not before this branch.
- `tsc -p tsconfig.build.json --noEmit`: clean.
- `media-import` specs: 3 suites, 13 tests passing.
- Full backend suite: **200 suites, 2130 tests, 29 snapshots, all passing**.

One note on that full run: jest exits non-zero on an rxjs `Unexpected end of JSON input` thrown *after* the summary, with "Jest did not exit one second after the test run has completed". It is an unclosed handle at teardown, downstream of the results, and it reproduces without this change. Not addressed here.
