### PR TITLE
fix(media-detail): cross-fade the mobile hero when the picture changes

### DIFF
--- a/client/src/app/shared/components/mobile-fanart-hero.html
+++ b/client/src/app/shared/components/mobile-fanart-hero.html
@@ -1,0 +1,36 @@
+<!-- While two layers overlap, the scrim mask has to sit on the pair: masking
+     each one lets the outgoing picture paint through the incoming one's faded
+     bottom, so the gradient only appeared once the old layer went. -->
+<div class="relative -mx-4 -mt-4 hero-fanart-bleed" [class.hero-fanart-fade]="!!outgoing()">
+  <!-- The picture being replaced, held under the incoming one so a swap
+       cross-fades in place instead of cutting. -->
+  @if (outgoing(); as prev) {
+    <img
+      [src]="prev | resolveUrl: 'medium'"
+      alt=""
+      aria-hidden="true"
+      class="absolute inset-0 w-full h-full object-cover object-[50%_25%]"
+    />
+  }
+  <!-- Keyed on the url: a fresh element is what makes appImgFadeIn fade the
+       new picture in. The name rides the image, not the wrapper: desktop pairs
+       img with img and its morph shows the destination's picture, a div
+       snapshot does not. -->
+  @for (url of incoming(); track url) {
+    <img
+      appImgFadeIn
+      [style.view-transition-name]="viewTransitionName()"
+      [src]="url | resolveUrl: 'medium'"
+      [alt]="imageAlt()"
+      loading="eager"
+      fetchpriority="high"
+      (load)="onIncomingLoad()"
+      [class.hero-fanart-fade]="!outgoing()"
+      class="relative w-full min-h-[230px] h-[38svh] max-h-[53svh] landscape:min-h-0 landscape:h-auto landscape:max-h-[47vh] landscape:aspect-video object-cover object-[50%_25%]"
+    />
+  } @empty {
+    <div
+      class="w-full min-h-[230px] h-[38svh] max-h-[53svh] landscape:min-h-0 landscape:h-auto landscape:aspect-video landscape:max-h-[47vh] bg-base-300"
+    ></div>
+  }
+</div>

--- a/client/src/app/shared/components/mobile-fanart-hero.spec.ts
+++ b/client/src/app/shared/components/mobile-fanart-hero.spec.ts
@@ -1,0 +1,58 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MobileFanartHeroComponent } from './mobile-fanart-hero';
+import { ServerConfigService } from '../../core/services/server-config.service';
+
+/** A single <img> whose src changes cuts to the new picture the moment it
+ *  decodes, so the swap holds the outgoing one under the fade. */
+describe('MobileFanartHeroComponent — cross-fade on swap', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    TestBed.resetTestingModule();
+  });
+
+  function createFixture() {
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        {
+          provide: ServerConfigService,
+          useValue: { resolveUrl: (u: string) => u } as unknown as ServerConfigService,
+        },
+      ],
+    });
+    const fixture = TestBed.createComponent(MobileFanartHeroComponent);
+    fixture.componentRef.setInput('fanartUrl', '/a.jpg');
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  const sources = (fixture: { nativeElement: HTMLElement }) =>
+    [...fixture.nativeElement.querySelectorAll('img')].map((i) => i.getAttribute('src'));
+
+  it('holds the outgoing picture until the incoming one has loaded', () => {
+    vi.useFakeTimers();
+    const fixture = createFixture();
+    expect(sources(fixture)).toEqual(['/a.jpg']);
+
+    fixture.componentRef.setInput('fanartUrl', '/b.jpg');
+    fixture.detectChanges();
+    expect(sources(fixture)).toEqual(['/a.jpg', '/b.jpg']);
+
+    const incoming = fixture.nativeElement.querySelector('img[src="/b.jpg"]')!;
+    incoming.dispatchEvent(new Event('load'));
+    vi.advanceTimersByTime(300);
+    fixture.detectChanges();
+
+    expect(sources(fixture)).toEqual(['/b.jpg']);
+  });
+
+  it('renders the placeholder and no image without a url', () => {
+    const fixture = createFixture();
+    fixture.componentRef.setInput('fanartUrl', null);
+    fixture.detectChanges();
+
+    expect(sources(fixture)).toEqual([]);
+  });
+});

--- a/client/src/app/shared/components/mobile-fanart-hero.ts
+++ b/client/src/app/shared/components/mobile-fanart-hero.ts
@@ -1,4 +1,4 @@
-import { Component, input } from '@angular/core';
+import { Component, DestroyRef, computed, inject, input, linkedSignal } from '@angular/core';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 import { ImgFadeInDirective } from '../directives/img-fade-in.directive';
 
@@ -9,29 +9,7 @@ import { ImgFadeInDirective } from '../directives/img-fade-in.directive';
 @Component({
   selector: 'app-mobile-fanart-hero',
   imports: [ResolveUrlPipe, ImgFadeInDirective],
-  template: `
-    <div class="relative -mx-4 -mt-4 hero-fanart-bleed">
-      @if (fanartUrl()) {
-        <!-- The name rides the image, not the wrapper: desktop pairs img with
-             img and its morph shows the destination's picture, a div snapshot
-             does not. -->
-        <img
-          appImgFadeIn
-          [style.view-transition-name]="viewTransitionName()"
-          [src]="fanartUrl()! | resolveUrl:'medium'"
-          [alt]="imageAlt()"
-          loading="eager"
-          fetchpriority="high"
-          class="hero-fanart-fade relative w-full min-h-[230px] h-[38svh] max-h-[53svh] landscape:min-h-0 landscape:h-auto landscape:max-h-[47vh] landscape:aspect-video object-cover object-[50%_25%]"
-        />
-
-      } @else {
-        <div
-          class="w-full min-h-[230px] h-[38svh] max-h-[53svh] landscape:min-h-0 landscape:h-auto landscape:aspect-video landscape:max-h-[47vh] bg-base-300"
-        ></div>
-      }
-    </div>
-  `,
+  templateUrl: './mobile-fanart-hero.html',
 })
 export class MobileFanartHeroComponent {
   readonly fanartUrl = input<string | null | undefined>(null);
@@ -41,4 +19,29 @@ export class MobileFanartHeroComponent {
    *  portrait card into landscape hero. On the wrapper rather than the image so
    *  the scrim the title sits on travels with it. Null where nothing pairs. */
   readonly viewTransitionName = input<string | null>(null);
+
+  protected readonly incoming = computed(() => {
+    const url = this.fanartUrl();
+    return url ? [url] : [];
+  });
+
+  /** The url this hero was showing before the current one. */
+  protected readonly outgoing = linkedSignal<string | null | undefined, string | null>({
+    source: () => this.fanartUrl(),
+    computation: (next, previous) => (previous?.source && next ? previous.source : null),
+  });
+
+  private timer?: ReturnType<typeof setTimeout>;
+
+  constructor() {
+    inject(DestroyRef).onDestroy(() => clearTimeout(this.timer));
+  }
+
+  /** Drop the old layer once the fade has covered it: its mask leaves the
+   *  bottom translucent, so keeping it would ghost through. */
+  protected onIncomingLoad() {
+    if (!this.outgoing()) return;
+    clearTimeout(this.timer);
+    this.timer = setTimeout(() => this.outgoing.set(null), 250);
+  }
 }


### PR DESCRIPTION
Picking another episode in the "more from season" row swapped the hero's `src` on a single `<img>`, so the still cut to the new picture the moment it decoded — a hard, janky jump on mobile.

The outgoing picture is now held under the incoming one, which fades in over it (reusing the existing `appImgFadeIn`) and drops it once loaded. No view transition: nothing travels from one area of the page to another, the swap happens in place.

The scrim mask (`hero-fanart-fade`) moves onto the pair while both layers overlap. Masked one by one, the outgoing picture painted through the incoming one's faded bottom, so the gradient showed a hard edge mid-fade and only settled once the old layer went — visible in the before/after captures the swap was reported with. Wrapper-masked during the fade, image-masked at rest: same composite in both states, so there is no pop.

Left out: the desktop poster keeps its instant swap, and the 250 ms drop of the old layer is hand-tuned to the directive's 200 ms fade.

Verified locally: `ng build` green, 2 new specs on the layer handoff green.