### PR TITLE
fix(media-detail): fade the outgoing hero picture instead of the incoming one

### DIFF
--- a/client/src/app/shared/components/mobile-fanart-hero.html
+++ b/client/src/app/shared/components/mobile-fanart-hero.html
@@ -2,16 +2,6 @@
      each one lets the outgoing picture paint through the incoming one's faded
      bottom, so the gradient only appeared once the old layer went. -->
 <div class="relative -mx-4 -mt-4 hero-fanart-bleed" [class.hero-fanart-fade]="!!outgoing()">
-  <!-- The picture being replaced, held under the incoming one so a swap
-       cross-fades in place instead of cutting. -->
-  @if (outgoing(); as prev) {
-    <img
-      [src]="prev | resolveUrl: 'medium'"
-      alt=""
-      aria-hidden="true"
-      class="absolute inset-0 w-full h-full object-cover object-[50%_25%]"
-    />
-  }
   <!-- Keyed on the url: a fresh element is what makes appImgFadeIn fade the
        new picture in. The name rides the image, not the wrapper: desktop pairs
        img with img and its morph shows the destination's picture, a div
@@ -19,6 +9,7 @@
   @for (url of incoming(); track url) {
     <img
       appImgFadeIn
+      [instant]="!!outgoing()"
       [style.view-transition-name]="viewTransitionName()"
       [src]="url | resolveUrl: 'medium'"
       [alt]="imageAlt()"
@@ -32,5 +23,18 @@
     <div
       class="w-full min-h-[230px] h-[38svh] max-h-[53svh] landscape:min-h-0 landscape:h-auto landscape:aspect-video landscape:max-h-[47vh] bg-base-300"
     ></div>
+  }
+  <!-- The picture being replaced, held OVER the incoming one and faded out once
+       that has loaded. The other way round the fade rode on the incoming image,
+       which a cached picture skips entirely — no animation on most swaps. -->
+  @if (outgoing(); as prev) {
+    <img
+      [src]="prev | resolveUrl: 'medium'"
+      alt=""
+      aria-hidden="true"
+      [class.hero-swap-out]="fadingOut()"
+      (animationend)="outgoing.set(null)"
+      class="absolute inset-0 w-full h-full object-cover object-[50%_25%] pointer-events-none"
+    />
   }
 </div>

--- a/client/src/app/shared/components/mobile-fanart-hero.spec.ts
+++ b/client/src/app/shared/components/mobile-fanart-hero.spec.ts
@@ -1,16 +1,15 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { MobileFanartHeroComponent } from './mobile-fanart-hero';
 import { ServerConfigService } from '../../core/services/server-config.service';
 
 /** A single <img> whose src changes cuts to the new picture the moment it
- *  decodes, so the swap holds the outgoing one under the fade. */
+ *  decodes, so a swap fades the outgoing one out over the incoming one. The
+ *  fade rides the OUTGOING layer on purpose: on the incoming one an
+ *  already-cached picture skips it, which is most swaps. */
 describe('MobileFanartHeroComponent — cross-fade on swap', () => {
-  afterEach(() => {
-    vi.useRealTimers();
-    TestBed.resetTestingModule();
-  });
+  afterEach(() => TestBed.resetTestingModule());
 
   function createFixture() {
     TestBed.configureTestingModule({
@@ -28,27 +27,35 @@ describe('MobileFanartHeroComponent — cross-fade on swap', () => {
     return fixture;
   }
 
+  const images = (fixture: { nativeElement: HTMLElement }) => [
+    ...fixture.nativeElement.querySelectorAll('img'),
+  ];
   const sources = (fixture: { nativeElement: HTMLElement }) =>
-    [...fixture.nativeElement.querySelectorAll('img')].map((i) => i.getAttribute('src'));
+    images(fixture).map((i) => i.getAttribute('src'));
 
-  it('holds the outgoing picture until the incoming one has loaded', () => {
-    vi.useFakeTimers();
+  it('fades the outgoing picture out over an incoming one shown at once', () => {
     const fixture = createFixture();
     expect(sources(fixture)).toEqual(['/a.jpg']);
 
     fixture.componentRef.setInput('fanartUrl', '/b.jpg');
     fixture.detectChanges();
-    expect(sources(fixture)).toEqual(['/a.jpg', '/b.jpg']);
+    const [incoming, outgoing] = images(fixture);
+    expect(sources(fixture)).toEqual(['/b.jpg', '/a.jpg']);
+    // Nothing in jsdom ever loads: the incoming layer is opaque because the
+    // swap asks for it, not because the picture happened to be cached.
+    expect(incoming.style.opacity).toBe('1');
+    expect(outgoing.classList).not.toContain('hero-swap-out');
 
-    const incoming = fixture.nativeElement.querySelector('img[src="/b.jpg"]')!;
     incoming.dispatchEvent(new Event('load'));
-    vi.advanceTimersByTime(300);
     fixture.detectChanges();
+    expect(outgoing.classList).toContain('hero-swap-out');
 
+    outgoing.dispatchEvent(new Event('animationend'));
+    fixture.detectChanges();
     expect(sources(fixture)).toEqual(['/b.jpg']);
   });
 
-  it('renders the placeholder and no image without a url', () => {
+  it('renders no image without a url', () => {
     const fixture = createFixture();
     fixture.componentRef.setInput('fanartUrl', null);
     fixture.detectChanges();

--- a/client/src/app/shared/components/mobile-fanart-hero.ts
+++ b/client/src/app/shared/components/mobile-fanart-hero.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, computed, inject, input, linkedSignal } from '@angular/core';
+import { Component, computed, input, linkedSignal } from '@angular/core';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 import { ImgFadeInDirective } from '../directives/img-fade-in.directive';
 
@@ -31,17 +31,14 @@ export class MobileFanartHeroComponent {
     computation: (next, previous) => (previous?.source && next ? previous.source : null),
   });
 
-  private timer?: ReturnType<typeof setTimeout>;
+  /** Reset by its source, so a swap landing mid-fade starts its own. */
+  protected readonly fadingOut = linkedSignal<string | null | undefined, boolean>({
+    source: () => this.fanartUrl(),
+    computation: () => false,
+  });
 
-  constructor() {
-    inject(DestroyRef).onDestroy(() => clearTimeout(this.timer));
-  }
-
-  /** Drop the old layer once the fade has covered it: its mask leaves the
-   *  bottom translucent, so keeping it would ghost through. */
+  /** Nothing is faded out before the picture underneath can be seen. */
   protected onIncomingLoad() {
-    if (!this.outgoing()) return;
-    clearTimeout(this.timer);
-    this.timer = setTimeout(() => this.outgoing.set(null), 250);
+    if (this.outgoing()) this.fadingOut.set(true);
   }
 }

--- a/client/src/app/shared/directives/img-fade-in.directive.ts
+++ b/client/src/app/shared/directives/img-fade-in.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, OnInit } from '@angular/core';
+import { Directive, ElementRef, inject, input, OnInit } from '@angular/core';
 import { viewTransitionRunning } from '../utils/view-transition';
 
 /**
@@ -23,9 +23,12 @@ export class ImgFadeInDirective implements OnInit {
   private readonly host = inject<ElementRef<HTMLImageElement>>(ElementRef);
   protected opacity = '0';
 
+  /** Show the picture at once: the caller runs its own transition over it. */
+  readonly instant = input(false);
+
   ngOnInit() {
     const img = this.host.nativeElement;
-    if (viewTransitionRunning() || (img.complete && img.naturalWidth > 0)) {
+    if (this.instant() || viewTransitionRunning() || (img.complete && img.naturalWidth > 0)) {
       this.opacity = '1';
     }
   }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1290,6 +1290,24 @@ html.vt-poster-in app-media-info-header [data-hero-lead] {
 .hero-fanart-fade {
   mask-image: linear-gradient(to top, transparent 0, #000 38%);
 }
+/* The hero's outgoing picture fading out over the incoming one. An animation
+   rather than a transition: the layer is inserted and flagged in the same
+   navigation, so a transition has no rendered start value to run from. */
+@keyframes hero-swap-out {
+  to {
+    opacity: 0;
+  }
+}
+.hero-swap-out {
+  animation: hero-swap-out 320ms ease-out forwards;
+}
+@media (prefers-reduced-motion: reduce) {
+  /* Not `none`: `animationend` is what drops the layer. */
+  .hero-swap-out {
+    animation-duration: 1ms;
+  }
+}
+
 /* The dock and the search button sit inside the root snapshot, so lifting the
    lead block above root also lifted the overview — "voir plus" and all — in
    front of them. They have to come along, ordered as they are on the settled


### PR DESCRIPTION
Follow-up to #1316, which put the cross-fade on the *incoming* layer. `ImgFadeInDirective` deliberately shows an already-decoded picture at once, so the swap animated only when the still was cold — most episode swaps hit the cache and cut exactly as before. Reported as "parfois il y a, parfois non".

The old picture is now held **over** the new one and faded out once that has loaded, so the animation no longer depends on the cache. The incoming layer opts out of the directive's own fade (`[instant]`) — it sits underneath, covered, until the fade uncovers it.

- An animation rather than a transition: the layer is inserted and flagged within the same navigation, so a transition has no rendered start value to run from. Under `prefers-reduced-motion` the duration drops to 1 ms rather than to `none`, because `animationend` is what drops the layer.
- 320 ms, up from 200: the swap happens in place, and the shorter duration still read as a cut.

Verified locally: `ng build` green, 310 shared specs green, the hero spec now asserts the incoming layer is opaque without ever loading (the cache-independence) and that the layer is dropped on `animationend`.