### PR TITLE
fix(confirmation-modal): keep the dialog content during the closing animation

### DIFF
--- a/client/src/app/shared/components/confirmation-modal.ts
+++ b/client/src/app/shared/components/confirmation-modal.ts
@@ -4,6 +4,7 @@ import {
   computed,
   effect,
   viewChild,
+  linkedSignal,
   ElementRef,
 } from '@angular/core';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -23,20 +24,30 @@ export class ConfirmationModalComponent {
   private readonly dialog = viewChild<ElementRef<HTMLDialogElement>>('dialog');
 
   readonly isOpen = computed(() => !!this.confirmService.state());
-  readonly title = computed(() => this.confirmService.state()?.title ?? '');
-  readonly message = computed(() => this.confirmService.state()?.message ?? '');
+
+  /** Last non-null state, so the content survives the closing animation. */
+  private readonly view = linkedSignal<
+    ReturnType<ConfirmationService['state']>,
+    ReturnType<ConfirmationService['state']>
+  >({
+    source: this.confirmService.state,
+    computation: (state, previous) => state ?? previous?.value ?? null,
+  });
+
+  readonly title = computed(() => this.view()?.title ?? '');
+  readonly message = computed(() => this.view()?.message ?? '');
   readonly confirmLabel = computed(
-    () => this.confirmService.state()?.confirmLabel ?? this.translate.instant('common.confirm'),
+    () => this.view()?.confirmLabel ?? this.translate.instant('common.confirm'),
   );
   readonly cancelLabel = computed(
-    () => this.confirmService.state()?.cancelLabel ?? this.translate.instant('common.cancel'),
+    () => this.view()?.cancelLabel ?? this.translate.instant('common.cancel'),
   );
-  readonly variant = computed(() => this.confirmService.state()?.variant ?? 'default');
+  readonly variant = computed(() => this.view()?.variant ?? 'default');
 
-  readonly alertOnly = computed(() => this.confirmService.state()?.alertOnly ?? false);
-  readonly toggleLabel = computed(() => this.confirmService.state()?.toggleLabel ?? null);
-  readonly toggleHint = computed(() => this.confirmService.state()?.toggleHint ?? null);
-  readonly dismissLabel = computed(() => this.confirmService.state()?.dismissLabel ?? null);
+  readonly alertOnly = computed(() => this.view()?.alertOnly ?? false);
+  readonly toggleLabel = computed(() => this.view()?.toggleLabel ?? null);
+  readonly toggleHint = computed(() => this.view()?.toggleHint ?? null);
+  readonly dismissLabel = computed(() => this.view()?.dismissLabel ?? null);
 
   readonly confirmBtnClass = computed(() => {
     const map: Record<string, string> = {


### PR DESCRIPTION
## Problem

Closing a confirmation dialog visibly reset its content mid-animation: a `danger` confirm lost its red styling and its custom button labels reverted to the generic confirm/cancel strings while the dialog was still fading out.

The component derived every displayed value (`title`, `message`, `confirmLabel`, `cancelLabel`, `variant`, `alertOnly`, toggle label/hint, `dismissLabel`) directly from `ConfirmationService.state()`, which is set to `null` as soon as `accept()`/`cancel()`/`dismiss()` resolves the promise. The native `<dialog>` is still animating out at that moment, so every computed fell back to its default for the duration of the transition.

## Fix

A `linkedSignal` retains the last non-null state and all the display computeds read from it. `isOpen` still tracks the live service signal, so the dialog closes at exactly the same instant as before, only the rendered content stops resetting. The retained copy is overwritten on the next open.

## Testing

`tsc -p client/tsconfig.app.json --noEmit` clean.