### PR TITLE
fix(library): halve the alphabet-column clearance on TV

### DIFF
--- a/client/src/app/features/library/library.html
+++ b/client/src/app/features/library/library.html
@@ -74,7 +74,7 @@
          of the cards and the search input never runs under the sticky
          alphabet column it passes through while scrolling. -->
     <div
-      class="flex flex-wrap items-center gap-2"
+      class="flex flex-wrap items-center gap-2 tv:pr-4"
       [class.pr-8]="sortBy() === 'title' && sortOrder() === 'ASC'"
       [class.pr-2]="sortBy() !== 'title' || sortOrder() !== 'ASC'"
     >
@@ -323,7 +323,7 @@
     @if (loading()) {
       <!-- Same grid as the real one below, so the cards land where the
            placeholders sat instead of replacing a centred spinner. -->
-      <div class="grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-6 gap-1.5 sm:gap-4 tv:gap-8 pt-2"
+      <div class="grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-6 gap-1.5 sm:gap-4 tv:gap-8 pt-2 tv:pr-4"
         [class.pr-8]="sortBy() === 'title' && sortOrder() === 'ASC'"
         [class.pr-2]="sortBy() !== 'title' || sortOrder() !== 'ASC'">
         @for (i of skeletonCards; track i) {
@@ -397,7 +397,7 @@
                #cardRow
                [class.pr-8]="sortBy() === 'title' && sortOrder() === 'ASC'"
                [class.pr-2]="sortBy() !== 'title' || sortOrder() !== 'ASC'"
-               class="grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-6 gap-1.5 sm:gap-4 tv:gap-8"
+               class="grid content-start grid-cols-3 sm:grid-cols-3 md:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 3xl:grid-cols-10 4xl:grid-cols-14 5xl:grid-cols-18 tv:grid-cols-6 gap-1.5 sm:gap-4 tv:gap-8 tv:pr-4"
                [style.height.px]="rowHeight()">
             @for (item of row.items; track item.id) {
               <ng-container [ngTemplateOutlet]="cardCell" [ngTemplateOutletContext]="{ $implicit: item }" />


### PR DESCRIPTION
## Problem

On TV, the library grid sat visibly off-centre: too much empty space on the right compared to the left.

There is no TV-specific padding rule on the grid — the imbalance comes from three desktop assumptions that stop holding on a 10-foot layout:

- The grid and its toolbar reserve `pr-8` on the right whenever the alphabet column is shown (`sort=title` ASC), so the cards don't run under it.
- `--page-p` goes from `1rem` on desktop to `4vw` on TV (`body.tv`), i.e. ~77px of page gutter on a 1920 viewport.
- The root font scales to `24px` above a 1900px viewport (`html.tv-host`), so the rem-based `pr-8` inflates from 32px to 48px.

The alphabet column is `fixed right-4` with `w-4`. On desktop it occupies 16→32px from the edge against a 16px gutter, so it really does overlap the content and the reserve is justified. On TV it occupies 24→48px, entirely inside the 77px gutter — the 48px reserve is stacked on top of space that was already empty. Net result: ~125px on the right against ~77px on the left.

## Fix

`tv:pr-4` on the three elements carrying the conditional `pr-8` — the toolbar row, the skeleton grid, and the virtualised card rows. That keeps a small clearance without the desktop-sized reserve.

The `tv` variant is declared as `@custom-variant tv (body.tv &)`, so it compiles to `body.tv .tv\:pr-4` (specificity 0,2,0) and outranks the `[class.pr-8]` binding without needing to touch the binding itself. No other form factor is affected.

## Testing

Built and deployed to the Samsung QE85Q80BATXXC test panel (`tizen package -s fliks` + `tizen install`), checked the library in `sort=title` ASC. Also verified the rule reaches the bundle: `body.tv .tv\:pr-4{padding-right:calc(var(--spacing) * 4)}` in the built stylesheet.

`pr-0` and `pr-2` were tried on the panel first; `pr-4` reads best from the couch.