### PR TITLE
fix(card-actions): keep the long-press menu open on iOS and drop its touch focus

### DIFF
--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -99,6 +99,10 @@ export class App implements OnInit, OnDestroy {
     document.addEventListener('visibilitychange', this.visibilityListener);
 
     if (Capacitor.isNativePlatform()) {
+      // On <html> as well as <body>: overlays (sheets, popovers) are
+      // reparented under <html> to escape stacking contexts, and a
+      // body-scoped selector never reaches them.
+      document.documentElement.classList.add('native');
       document.body.classList.add('native');
 
       // Hide the native splash on the first NavigationEnd. The splash sits in

--- a/client/src/app/shared/directives/card-actions.directive.ts
+++ b/client/src/app/shared/directives/card-actions.directive.ts
@@ -47,6 +47,7 @@ export class CardActionsDirective implements OnDestroy {
   readonly actionsSubtitle = input<string>('');
 
   private longPressTimer: number | null = null;
+  private longPressFired = false;
   private touchStartX = 0;
   private touchStartY = 0;
   private boundHandlers: { type: string; fn: (e: Event) => void }[] = [];
@@ -104,6 +105,7 @@ export class CardActionsDirective implements OnDestroy {
   private onTouchStart(e: TouchEvent) {
     const actions = this.currentActions();
     if (!actions.length) return;
+    this.longPressFired = false;
     const t = e.touches[0];
     this.touchStartX = t?.clientX ?? 0;
     this.touchStartY = t?.clientY ?? 0;
@@ -118,6 +120,7 @@ export class CardActionsDirective implements OnDestroy {
       });
       this.service.show();
       this.longPressTimer = null;
+      this.longPressFired = true;
     }, 500);
   }
 
@@ -130,8 +133,35 @@ export class CardActionsDirective implements OnDestroy {
     }
   }
 
-  private onTouchEnd() {
+  private onTouchEnd(e: TouchEvent) {
     this.cancelLongPress();
+    if (!this.longPressFired) return;
+    this.longPressFired = false;
+    // WebKit hit-tests the compatibility click at the release point, which is
+    // now the sheet backdrop the hold just mounted — it would dismiss the panel
+    // the same gesture opened. preventDefault on touchend suppresses that
+    // click; the capture-phase swallower covers the WebView that fires it
+    // anyway.
+    if (e.cancelable) e.preventDefault();
+    this.swallowNextClick();
+  }
+
+  /** Eat the one click that closes out the long-press gesture. Self-disarms on
+   *  the first click or after 300 ms, so a deliberate tap is never lost. */
+  private swallowNextClick() {
+    if (typeof window === 'undefined') return;
+    let timer = 0;
+    const swallow = (ev: Event) => {
+      ev.stopPropagation();
+      ev.preventDefault();
+      disarm();
+    };
+    const disarm = () => {
+      window.clearTimeout(timer);
+      window.removeEventListener('click', swallow, true);
+    };
+    timer = window.setTimeout(disarm, 300);
+    window.addEventListener('click', swallow, { capture: true });
   }
 
   private onContextMenu(e: Event) {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -145,20 +145,24 @@ body.native.immersive {
    hold a media card. Inputs, textareas and explicit `[contenteditable]`
    regions are re-enabled below so forms and dialogs still work. The
    `.select-text` opt-in lets specific surfaces (e.g. release notes,
-   stack traces in the debug panel) keep selection if we want it. */
-body.native,
-body.native * {
+   stack traces in the debug panel) keep selection if we want it.
+
+   Scoped to <html>, not <body>: overlays are reparented under <html> to
+   escape stacking contexts, so a body-scoped rule never reaches a sheet's
+   own poster and title. */
+html.native,
+html.native * {
   -webkit-user-select: none;
   user-select: none;
   -webkit-touch-callout: none;
   -webkit-user-drag: none;
 }
-body.native input,
-body.native textarea,
-body.native [contenteditable="true"],
-body.native [contenteditable=""],
-body.native .select-text,
-body.native .select-text * {
+html.native input,
+html.native textarea,
+html.native [contenteditable="true"],
+html.native [contenteditable=""],
+html.native .select-text,
+html.native .select-text * {
   -webkit-user-select: text;
   user-select: text;
   -webkit-touch-callout: default;
@@ -483,16 +487,25 @@ html:not(.keyboard-modality):not(.tv-host) .select:focus {
    reads as "the page suddenly grows" when tapping the search bar.
    Lock the in-app form fields at 16 px on the Capacitor build so
    focus never triggers the zoom. Desktop / web is untouched. */
-body.native input,
-body.native textarea,
-body.native select {
+html.native input,
+html.native textarea,
+html.native select {
   font-size: 16px;
 }
 html:not(.keyboard-modality):not(.tv-host) app-media-card figure:focus-visible,
 html:not(.keyboard-modality):not(.tv-host) [data-home-focus]:focus-visible,
 html:not(.keyboard-modality):not(.tv-host) [data-tv-focusable]:focus-visible,
-html:not(.keyboard-modality):not(.tv-host) app-mosaic-card button:focus-visible .mosaic-art {
+html:not(.keyboard-modality):not(.tv-host) app-mosaic-card button:focus-visible .mosaic-art,
+html:not(.keyboard-modality):not(.tv-host) app-media-card figure:focus-visible + div,
+html:not(.keyboard-modality):not(.tv-host) app-mosaic-card button:focus-visible .mosaic-art + div {
   transform: none !important;
+}
+
+/* Same modality gate for a menu row's focus tint: the panel focuses its first
+   entry on open, and on a long-press-opened sheet that row read as already
+   selected. */
+html:not(.keyboard-modality):not(.tv-host) .dropdown-item:focus-visible {
+  background-color: transparent;
 }
 
 /* High-contrast primary focus ring — applies on every form factor so


### PR DESCRIPTION
Three iOS-only bugs on the media-card long-press, all rooted in WebKit behaviour the Android WebView does not share.

## The panel dismissed itself on release

WebKit hit-tests the compatibility click at the release point, which by then is the bottom sheet's full-screen backdrop — mounted under the finger by the hold that just opened the panel. The backdrop's `(click)="dismiss()"` fired immediately, so the menu closed as soon as the user let go, unless they had dragged the finger onto the sheet first.

`CardActionsDirective` now tracks whether the 500 ms hold actually fired, and on the terminating `touchend` / `touchcancel` it calls `preventDefault()` (which suppresses the compat mouse events) plus arms a one-shot capture-phase `click` swallower as a belt for the WebView that dispatches it anyway. The swallower self-disarms on the first click or after 300 ms, so a deliberate tap is never lost, and a plain tap is untouched because the long-press flag is false.

Side effect worth having: releasing over a menu row no longer activates it by accident.

## Focus visuals on a touch-opened menu

WebKit matches `:focus-visible` on a tap and on a programmatic `focus()`; Chromium only does when the focus came from keyboard-like input. That is why none of this ever showed on Android.

The modality gate (`html:not(.keyboard-modality):not(.tv-host)`) already reset `outline`, `box-shadow` and the card's own `transform`, but two visuals sat outside its reach:

- the caption slide is written against the **sibling** (`figure:focus-visible + div`), so an element-scoped reset never touched it — the card title slid down on every context-tap;
- `.dropdown-item` carries `focus-visible:bg-white/10` and the gate resets no `background-color`, so the entry the panel auto-focuses on open read as already selected.

Both are now covered by the same gate. Keyboard, D-pad and TV keep the lift, the slide and the tint.

## Text / image selection inside the sheet

The Capacitor selection suppression (`user-select: none`, `-webkit-touch-callout: none`) was scoped `body.native, body.native *`, but `PopoverMenuComponent` reparents its host to `document.documentElement` on open to escape stacking contexts. The sheet is therefore a sibling of `<body>`, so its poster and title still offered iOS's "Copy / Save Image" callout.

Rescoped to `html.native` (the class is now set on both elements), together with the 16 px anti-zoom rule for form fields, which had the same reach problem for a text input inside a sheet.

## Testing

Built and run on a physical iPhone XS (Debug, `devicectl` install): long-press holds the menu open on release, no title slide, no tinted first row, no selection callout on the poster or title. Plain taps still open the media detail.