### PR TITLE
fix(scroll): stop the scroll fighting itself across a cached-route return

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -89,7 +89,17 @@ export const appConfig: ApplicationConfig = {
     { provide: LOCALE_ID, useFactory: resolveInitialLocale },
     provideRouter(
       routes,
-      withInMemoryScrolling({ scrollPositionRestoration: 'top' }),
+      // ScrollMemoryService owns the scroll, so the router must not also drive
+      // it: its own scroll runs a frame after NavigationEnd, which lands in the
+      // middle of the poster morph and is then undone by the restore. On device
+      // that read as the grid blinking to bare background (or, before the
+      // rendered range was preserved, as the A-Z index flashing `A`) a couple of
+      // frames into every back transition. `disabled` also stops Angular
+      // setting `history.scrollRestoration`, so the service sets it instead.
+      withInMemoryScrolling({
+        scrollPositionRestoration: 'disabled',
+        anchorScrolling: 'disabled',
+      }),
       // A route reads its own params only; an ancestor's are not inherited.
       withRouterConfig({ paramsInheritanceStrategy: 'emptyOnly' }),
       // Poster→hero morph. On TV the root snapshot costs ~400 ms on a Tizen 9

--- a/client/src/app/core/services/keep-route-fresh.spec.ts
+++ b/client/src/app/core/services/keep-route-fresh.spec.ts
@@ -1,4 +1,4 @@
-import { provideZonelessChangeDetection, runInInjectionContext, Injector } from '@angular/core';
+import { provideZonelessChangeDetection, runInInjectionContext, Injector, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { Subject } from 'rxjs';
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { keepRouteFresh } from './keep-route-fresh';
 import { AppResumeService } from './app-resume.service';
 import { CachingReuseStrategy } from './route-reuse.strategy';
+import { NavbarService } from './navbar.service';
 import { ScrollMemoryService } from './scroll-memory.service';
 
 const OWN_KEY = 'route-7::id=1';
@@ -16,12 +17,15 @@ describe('keepRouteFresh', () => {
   let resume$: Subject<void>;
   let calls: string[];
   let scrollMemory: { activate: ReturnType<typeof vi.fn>; restoreSticky: ReturnType<typeof vi.fn>; deactivateIf: ReturnType<typeof vi.fn> };
+  /** Every reattach in these specs is a return unless the spec says otherwise. */
+  let navigatedBack: ReturnType<typeof signal<boolean>>;
 
   beforeEach(() => {
     attached$ = new Subject<string>();
     detached$ = new Subject<string>();
     resume$ = new Subject<void>();
     calls = [];
+    navigatedBack = signal(true);
     scrollMemory = {
       activate: vi.fn((k: string) => calls.push(`activate:${k}`)),
       restoreSticky: vi.fn((k: string) => calls.push(`restore:${k}`)),
@@ -34,6 +38,7 @@ describe('keepRouteFresh', () => {
         { provide: ScrollMemoryService, useValue: scrollMemory },
         { provide: AppResumeService, useValue: { resume$ } },
         { provide: ActivatedRoute, useValue: { snapshot: {} } },
+        { provide: NavbarService, useValue: { navigatedBack } as unknown as NavbarService },
       ],
     });
   });
@@ -116,6 +121,19 @@ describe('keepRouteFresh', () => {
 
     attached$.next(OWN_KEY);
     expect(calls).toEqual(['forced', 'refresh']);
+  });
+
+  it('leaves a page opened fresh at the top, cached instance or not', () => {
+    // Tapping a card for a title still in the reuse cache reattaches its
+    // instance, and restoring the offset it was left at dropped the user at the
+    // bottom of the page they had just opened.
+    navigatedBack.set(false);
+    bind({ refresh: () => calls.push('refresh'), scrollKey: 'home' });
+
+    attached$.next(OWN_KEY);
+
+    expect(calls).toEqual(['activate:home', 'refresh']);
+    expect(scrollMemory.restoreSticky).not.toHaveBeenCalled();
   });
 
   it('skips scroll handling while a computed key is still unknown', () => {

--- a/client/src/app/core/services/keep-route-fresh.ts
+++ b/client/src/app/core/services/keep-route-fresh.ts
@@ -2,6 +2,7 @@ import { DestroyRef, inject, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { AppResumeService } from './app-resume.service';
+import { NavbarService } from './navbar.service';
 import { CachingReuseStrategy } from './route-reuse.strategy';
 import { ScrollMemoryService } from './scroll-memory.service';
 
@@ -48,6 +49,7 @@ export function keepRouteFresh(
   const route = inject(ActivatedRoute);
   const scrollMemory = inject(ScrollMemoryService);
   const appResume = inject(AppResumeService);
+  const navbar = inject(NavbarService);
   const destroyRef = inject(DestroyRef);
 
   const detached = signal(false);
@@ -68,7 +70,11 @@ export function keepRouteFresh(
     if (sk) scrollMemory.activate(sk);
     opts.onAttach?.();
     opts.refresh?.();
-    if (sk) scrollMemory.restoreSticky(sk);
+    // Only a return restores the offset. A page opened fresh whose instance is
+    // still in the reuse cache (a card tapped for a title visited earlier) has
+    // to land at the top like any other, and the sticky restore otherwise spent
+    // its whole window dragging the page back down against the router's scroll.
+    if (sk && navbar.navigatedBack()) scrollMemory.restoreSticky(sk);
   });
 
   reuse.detached$.pipe(takeUntilDestroyed(destroyRef)).subscribe((key) => {

--- a/client/src/app/core/services/scroll-memory.service.ts
+++ b/client/src/app/core/services/scroll-memory.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Injector, afterNextRender, inject } from '@angular/core';
-import { NavigationStart, Router, Scroll } from '@angular/router';
+import { NavigationEnd, NavigationStart, Router, Scroll } from '@angular/router';
 
 @Injectable({ providedIn: 'root' })
 export class ScrollMemoryService {
@@ -9,13 +9,43 @@ export class ScrollMemoryService {
   /** False between NavigationStart and the router's own scroll. */
   private routerScrolled = true;
   private queued: (() => void)[] = [];
+  private stickFrame: number | null = null;
 
   constructor() {
+    // Angular sets this itself for every mode but `disabled`, and the router is
+    // on `disabled` precisely so it keeps its hands off the scroll. Without it
+    // the browser restores its own offsets on popstate, on top of ours.
+    if (typeof history !== 'undefined') history.scrollRestoration = 'manual';
+
     this.router.events.subscribe((event) => {
       // Save scroll position BEFORE navigation starts (scroll is still intact)
       if (event instanceof NavigationStart) {
         if (this.currentKey) this.positions.set(this.currentKey, window.scrollY);
         this.routerScrolled = false;
+        // A restore still in flight belongs to the page being left. Left alone
+        // it keeps calling scrollTo for the rest of its window, on a document
+        // that is now the next page — which lands wherever the outgoing offset
+        // clamps to, and fights the router's scroll-to-top all the way there.
+        this.cancelStick();
+        this.queued = [];
+      }
+      // Every navigation lands at the top from here: in the same frame as the
+      // DOM swap, and a return then has its offset put back by `restoreSticky`
+      // later in that same frame. The router used to do this a frame after
+      // NavigationEnd, which fell in the middle of the poster morph.
+      //
+      // NavigationStart is too early — the view transition captures the
+      // outgoing page after it, and scrolling the list away first left the
+      // morphing poster with no card to grow out of.
+      //
+      // `nav-back` is NavbarService's verdict on the navigation in flight,
+      // published on <html> at NavigationStart, so it is set by the time this
+      // runs whichever order the two services subscribed in. Read from the
+      // class rather than injected: this service is constructed early enough
+      // that importing NavbarService reorders module init, and `app.config`
+      // resolves the device at module scope.
+      if (event instanceof NavigationEnd) {
+        this.toTop(!document.documentElement.classList.contains('nav-back'));
       }
       if (event instanceof Scroll) {
         this.routerScrolled = true;
@@ -84,17 +114,58 @@ export class ScrollMemoryService {
     // would scroll the page being left, be overwritten by the scroll-to-top,
     // and then correct itself — three jumps, the first of them on the outgoing
     // page. Wait for the router to have had its turn.
-    if (this.routerScrolled) this.stick(target);
-    else this.queued.push(() => this.stick(target));
+    if (this.routerScrolled) this.stick(key, target);
+    else this.queued.push(() => this.stick(key, target));
   }
 
-  private stick(target: number): void {
+  private stick(key: string, target: number): void {
+    this.cancelStick();
     const deadline = performance.now() + 600;
     const tick = () => {
+      this.stickFrame = null;
+      // The page this restore was for is no longer the one on screen.
+      if (this.currentKey !== key) return;
       if (Math.abs(window.scrollY - target) < 1) return;
       window.scrollTo({ top: target, left: 0, behavior: 'instant' });
-      if (performance.now() < deadline) requestAnimationFrame(tick);
+      if (performance.now() < deadline) this.stickFrame = requestAnimationFrame(tick);
     };
     tick();
+  }
+
+  /**
+   * Take the incoming page to the top. `hold` keeps it there for a moment: one
+   * scrollTo is not enough on an opening, because WebKit drops it while
+   * WKWebView is still settling the scroll view's contentSize and then keeps
+   * adjusting the offset for a few frames as the page's height lands. The hold
+   * ends on the first touch so it never fights a user who scrolls straight
+   * away, and a return does not take one at all — its offset is restored right
+   * after this.
+   */
+  private toTop(hold: boolean): void {
+    if (typeof window === 'undefined') return;
+    window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+    if (!hold) return;
+    const deadline = performance.now() + 400;
+    let released = false;
+    const release = () => {
+      released = true;
+      window.removeEventListener('touchstart', release);
+    };
+    window.addEventListener('touchstart', release, { passive: true, once: true });
+    const tick = () => {
+      this.stickFrame = null;
+      if (released) return;
+      if (window.scrollY !== 0) window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+      if (performance.now() < deadline) this.stickFrame = requestAnimationFrame(tick);
+      else release();
+    };
+    this.stickFrame = requestAnimationFrame(tick);
+  }
+
+  private cancelStick(): void {
+    if (this.stickFrame !== null) {
+      cancelAnimationFrame(this.stickFrame);
+      this.stickFrame = null;
+    }
   }
 }

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -131,13 +131,55 @@ export class LibraryComponent implements OnInit, OnDestroy {
       const lib = this.library();
       return lib ? `library-${lib.id}` : null;
     },
+    onDetach: () => this.suspendRanging(),
     onAttach: () => {
       const lib = this.library();
       if (lib) this.navbar.setPageTitle(lib.name);
       if (lib) this.prerenderRestoredRows(`library-${lib.id}`);
       this.applyBackground();
+      // After the prerender: the scroll is back on the offset the rows were
+      // rendered for, so the first scroll event CDK sees again agrees with them.
+      this.resumeRanging();
     },
   });
+
+  /**
+   * The grid scrolls the window, and this page's DOM leaves the document while
+   * it waits in the reuse cache — but its viewport keeps that subscription. The
+   * document shrinks to the page navigated to, the scroll clamps to 0, and CDK
+   * re-ranges the detached grid onto the top of the list, dropping every row
+   * that was on screen. They are rebuilt on the way back, which reads as the
+   * whole grid reloading its artwork and the A-Z index flashing `A` before the
+   * real letter. Nothing about that scroll concerns a page nobody is looking at,
+   * so the strategy's reaction to it is muted for the trip. `onDataLengthChanged`
+   * and the rest stay live, so a list that changes meanwhile still re-lays out.
+   */
+  private suspendRanging(): void {
+    const strategy = this.scrollStrategy();
+    if (strategy) strategy.onContentScrolled = () => {};
+    // Same reason, same trip: the alphabet highlight is derived from the window
+    // offset too, so the clamp to 0 left it reading the list's first letter
+    // until a real scroll corrected it after the page was back.
+    window.removeEventListener('scroll', this.onLetterScroll);
+  }
+
+  private resumeRanging(): void {
+    const strategy = this.scrollStrategy();
+    // Back to the prototype method rather than a copy captured on the way out.
+    if (strategy) delete strategy.onContentScrolled;
+    window.addEventListener('scroll', this.onLetterScroll, { passive: true });
+    // The offset moved while nothing was listening, so nothing will announce
+    // it: recompute once, off the offset the rows were just rendered for.
+    this.onLetterScroll();
+  }
+
+  private scrollStrategy(): { onContentScrolled?: () => void } | null {
+    return (
+      (this.viewport as unknown as {
+        _scrollStrategy?: { onContentScrolled?: () => void };
+      } | undefined)?._scrollStrategy ?? null
+    );
+  }
 
   /** Renders the rows for the offset the scroll is about to be restored to —
    *  see {@link renderRowsForOffset}. The flush is CDK's own: `ApplicationRef
@@ -148,6 +190,12 @@ export class LibraryComponent implements OnInit, OnDestroy {
     const y = this.scrollMemory.remembered(key);
     const vp = this.viewport;
     if (y == null || !vp) return;
+    // The router retrieves a cached route twice per return, and on the first
+    // pass this page is not back in the document: CDK measures a zero-height
+    // viewport, collapses the rendered range onto the top of the list, and
+    // destroys every row on screen — which the second pass rebuilds, reloading
+    // all of their artwork. Only the pass that can measure may lay rows out.
+    if (!vp.elementRef.nativeElement.clientHeight) return;
     const render = (vp as unknown as { _doChangeDetection?: () => void })._doChangeDetection;
     renderRowsForOffset(vp, y, () => render?.call(vp));
   }

--- a/client/src/app/shared/utils/restore-virtual-rows.spec.ts
+++ b/client/src/app/shared/utils/restore-virtual-rows.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { renderRowsForOffset } from './restore-virtual-rows';
 
 describe('renderRowsForOffset', () => {
-  it('lays the viewport out at the target offset and hands the scroll back', () => {
+  it('lays the viewport out at the target offset and keeps it', () => {
     const order: string[] = [];
     const applied: number[] = [];
     let scrollY = 4200;
@@ -20,9 +20,9 @@ describe('renderRowsForOffset', () => {
     // Both happen while the offset is the one the rows are needed for: CDK reads
     // it to choose the range, and the flush is what renders that range.
     expect(order).toEqual(['measure@27274', 'flush@27274']);
-    // And the page is left exactly where it was, or the page being navigated
-    // away from visibly jumps before the transition has snapshotted it.
-    expect(applied).toEqual([27274, 4200]);
-    expect(scrollY).toBe(4200);
+    // The offset stays: handing it back let CDK re-pick its range from a scroll
+    // of 0 on the next frame, dropping the rows this call just rendered.
+    expect(applied).toEqual([27274]);
+    expect(scrollY).toBe(27274);
   });
 });

--- a/client/src/app/shared/utils/restore-virtual-rows.ts
+++ b/client/src/app/shared/utils/restore-virtual-rows.ts
@@ -5,11 +5,13 @@
  *
  * The offset has to be real: CDK derives the rows AND their placement from it,
  * and a range set by hand against a scroll of 0 lands every row thousands of
- * pixels off screen. It also has to be given straight back — this runs before
- * the transition has captured the page it is leaving, so a scroll left behind
- * shows as that page jumping to its end. The rows survive the round trip
- * because CDK only revisits the range on its next frame, by which time the
- * restore proper has landed.
+ * pixels off screen. And it is kept, not handed back: the restore proper only
+ * lands on the router's own scroll event a frame later, and CDK revisits its
+ * range on the frame in between — from a scroll handed back to 0 it picks the
+ * top of the list, throwing away every row on screen for the restore to build
+ * again. On device that showed as the whole grid reloading its artwork and the
+ * A-Z index reading `A` for a moment. The caller restores this same offset
+ * immediately after, so keeping it is also where the page is headed.
  *
  * `flush` renders the range CDK has just chosen; the placement only lands in a
  * change-detection pass, and CDK asks for one rather than running it.
@@ -20,11 +22,9 @@ export function renderRowsForOffset(
   flush: () => void,
   scroller: Scroller = window,
 ): void {
-  const held = scroller.scrollY;
   scroller.scrollTo({ top: offset, left: 0, behavior: 'instant' });
   viewport.checkViewportSize();
   flush();
-  scroller.scrollTo({ top: held, left: 0, behavior: 'instant' });
 }
 
 interface Scroller {


### PR DESCRIPTION
Follow-up to #1321, same device session. Opening a media page from a library sometimes landed at its **bottom**, and every return to the library **rebuilt the grid it had just left** — 36 posters reloading their artwork and the A-Z index flashing `A`.

Everything here was traced on a physical iPhone XS by streaming the WebView console through `devicectl --console`, not reasoned from the source. Each fix below quotes the measurement that motivated it.

## 1. The cache restored an offset on an opening

`keepRouteFresh` called `restoreSticky` on *every* reattach. `movies/:id` and `series/:id` are `reuse: true`, cached per id in a 10-entry LRU, so tapping a card for a title visited earlier reattached its instance and dropped the user where they had last left that page. That is the "sometimes": a first-ever open was always fine. Gated on `navigatedBack()` — the signal `horizontal-scroller` already uses for its own restore, and the one the non-cached path in `media-detail` already had.

## 2. WKWebView drops the router's scroll-to-top

With that fixed the bottom-landing still happened, and the trace shows why — a cached page reattaches at full height, so the outgoing offset is still a valid one on it and survives the swap:

```
NavigationStart | y=32102
ActivationEnd   | y=1447          <- clamped to the cached page's bottom, not to 0
scrollTo({0,0}) | y=1422 max=1422 <- the router calls it, and WebKit ignores it
y=1422 -> 1372 -> 1397            <- drifts as contentSize settles, rests at max
```

Angular's scroll runs a frame after `NavigationEnd` (and omits `behavior: 'instant'` on a forward nav), landing while the scroll view is still settling. `withInMemoryScrolling` is now `disabled` and `ScrollMemoryService` takes the page to the top **in the same frame as the DOM swap**, holding it briefly because a single call is the one WebKit drops. The hold releases on the first touch, and a return does not take one — its offset is restored right after.

`NavigationStart` would be the obvious place and is wrong: `onViewTransitionCreated` runs *before* the old-state capture, so scrolling the list away there left the morphing poster with no card to grow out of. That regression was seen and fixed within the session.

Since `disabled` also stops Angular setting `history.scrollRestoration`, the service sets it — otherwise the browser restores its own offsets on popstate on top of ours.

## 3. A restore in flight kept scrolling the next page

`stick()` re-applies its target every frame for 600 ms. Returning to a library and tapping a card inside that window left the loop scrolling the *detail* page to the library's offset. Cancelled on navigation, and each loop now checks its key is still the page on screen.

## 4. The detached library grid re-ranged itself

The grid scrolls the window (`scrollWindow`), and its viewport keeps that subscription while the page sits in the cache. The document shrinks to the page navigated to, the offset clamps to 0, and CDK re-ranges a grid nobody is looking at:

```
RANGE before  0-7     off=0        <- already collapsed on arrival: the collapse happened on the way OUT
RANGE after   165-177 off=32841    <- the prerender rebuilds it -> 36 new <img>, 36 loads
```

Its reaction to scroll is muted for the trip (`onDataLengthChanged` and the rest stay live, so a list that changes meanwhile still re-lays out). The alphabet highlight is derived from the same window offset and was wrong for the same reason — the clamp to 0 had it computing row 0 — so it is muted too and recomputed once on return. After:

```
RANGE before 145-157 -> after 145-157   <- survives the trip, zero churn
```

Reloads on the return path: **none**. The ones left in the trace all fall after a `NavigationStart /movies/...` and are the detail page's own artwork.

Two earlier passes fed the same bug and are also fixed: `retrieve()` is called twice per return and the first pass ran before the page was back in the document (`vpH=0`), so CDK measured a zero-height viewport — the prerender now requires a measurable one; and `renderRowsForOffset` handed the offset back to 0, from which CDK re-picked the top of the list on the frame before the restore landed.

## Verification

- 849/849 specs green, plus a new one for the opening-vs-return gate and an updated one for the offset no longer being handed back.
- On device: the bottom-landing, the double prerender, the grid reload and the range collapse are each confirmed gone in the trace.
- **The A-Z fix (part of 4) is reasoned from the measured mechanism but its user-visible effect was not separately confirmed** — a remaining unrelated artifact (below) makes the return transition hard to judge by eye.

## Known, out of scope

- **A blank frame early in the back transition.** The per-frame trace clears the live DOM completely: from `updateCallbackDone` onward the scroll is already restored and 15 cards sit in the viewport, constant across all 20 sampled frames. So the blank is in the view-transition pseudo-tree, not the page. Cause not established; a plausible-looking `mix-blend-mode` hypothesis was tested on device and disproved, so nothing speculative was kept here. Next test is the same return from a small library, to confirm or clear the 47 500 px document.
- **`attached$` fires twice per return**, so `refresh()` and its HTTP revalidation run twice on all six cached pages. Untouched.
- Part 4 writes over `_scrollStrategy.onContentScrolled`, a CDK internal. Surgical and measured, but it can break quietly on an Angular upgrade. The structural fix is for the grid to scroll its own container instead of the window — that would delete this hack, the prerender, the alphabet mute and this page's whole scroll-memory dance, since the offset would live on the element and survive the detach untouched. Discussed and deliberately deferred: it is an architecture change, and `window` is currently the shared scroll API for `layout`'s topbar and for `infinite-scroll-list` on five other pages.

## Review focus

`scrollPositionRestoration` moving to `disabled` affects **every** page, not just the library. Worth checking that openings land at the top and returns keep their position on settings, search, persons, playlists, watch-history and home — that is the risk surface of this PR and it has not been walked through on device.