### PR TITLE
fix(tv): six webOS-only defects found on an LG panel

### DIFF
--- a/client/src/app/core/services/device.service.ts
+++ b/client/src/app/core/services/device.service.ts
@@ -223,10 +223,13 @@ export class DeviceService {
     html.classList.toggle('tv-host', this.formFactor() === 'tv');
 
     // Per-platform hook so CSS can target a specific TV OS without
-    // duplicating the formFactor check in every selector.
+    // duplicating the formFactor check in every selector. Mirrored on <html>
+    // because overlays are reparented there, out of <body>'s reach.
     const platforms: TvPlatform[] = ['androidtv', 'tizen', 'webos'];
     for (const p of platforms) {
-      body.classList.toggle(`tv-${p}`, this.tvPlatform() === p);
+      const on = this.tvPlatform() === p;
+      body.classList.toggle(`tv-${p}`, on);
+      html.classList.toggle(`tv-${p}`, on);
     }
   }
 

--- a/client/src/app/core/services/playback-engine/subtitle-overlay.util.spec.ts
+++ b/client/src/app/core/services/playback-engine/subtitle-overlay.util.spec.ts
@@ -1,0 +1,28 @@
+import { SubtitleOverlay } from './subtitle-overlay.util';
+import { NATIVE_SUBTITLE_SIZE_SCALE, WEBOS_CUE_SIZE_BOOST } from '../../utils/subtitle-presets';
+import { domCueFontSize } from '../player-settings.service';
+
+describe('SubtitleOverlay', () => {
+  afterEach(() => {
+    document.getElementById('fliks-tv-subtitle')?.remove();
+    document.querySelector('.player-container')?.remove();
+  });
+
+  it('mounts in .player-container, re-parenting once it exists', () => {
+    const overlay = new SubtitleOverlay();
+    overlay.setStyle({ color: 'white' });
+    expect(document.getElementById('fliks-tv-subtitle')?.parentElement).toBe(document.body);
+
+    const container = document.createElement('div');
+    container.className = 'player-container';
+    document.body.appendChild(container);
+    overlay.setStyle({ color: 'white' });
+    expect(document.getElementById('fliks-tv-subtitle')?.parentElement).toBe(container);
+  });
+
+  it('shifts the webOS ladder up one notch', () => {
+    expect(domCueFontSize(NATIVE_SUBTITLE_SIZE_SCALE['normal'] * WEBOS_CUE_SIZE_BOOST)).toBe(
+      domCueFontSize(NATIVE_SUBTITLE_SIZE_SCALE['xlarge']),
+    );
+  });
+});

--- a/client/src/app/core/services/playback-engine/subtitle-overlay.util.ts
+++ b/client/src/app/core/services/playback-engine/subtitle-overlay.util.ts
@@ -1,16 +1,17 @@
 import {
-  SUBTITLE_SIZE_MAP,
   SUBTITLE_COLOR_MAP,
   SUBTITLE_SHADOW_MAP,
   SUBTITLE_BG_MAP,
+  domCueFontSize,
 } from '../player-settings.service';
+import { NATIVE_SUBTITLE_SIZE_SCALE } from '../../utils/subtitle-presets';
 
 /**
  * DOM-rendered subtitle overlay shared by the TV engines (Tizen AVPlay,
  * webOS native `<video>`). Those pipelines either reject HTTPS external
  * subtitle paths (AVPlay) or give no styleable cue API, so we fetch the
- * WebVTT ourselves, parse the cues, and paint the active one into a
- * fixed positioned div on top of the hardware video surface.
+ * WebVTT ourselves, parse the cues, and paint the active one into our own
+ * div inside the player container.
  */
 
 export interface VttCue {
@@ -28,6 +29,10 @@ export class SubtitleOverlay {
   private visible = false;
   private lastText = '';
   private disposed = false;
+
+  /** Multiplies every preset on the ladder, so a platform can shift the whole
+   *  scale without redefining the presets. */
+  constructor(private readonly sizeScale = 1) {}
 
   /** Parse a remote WebVTT file and arm it as the active track. */
   async show(url: string): Promise<void> {
@@ -92,7 +97,8 @@ export class SubtitleOverlay {
     const el = this.ensureEl();
     if (!el) return;
     if (style.size) {
-      el.style.fontSize = SUBTITLE_SIZE_MAP[style.size] ?? SUBTITLE_SIZE_MAP['normal'];
+      const scale = NATIVE_SUBTITLE_SIZE_SCALE[style.size] ?? NATIVE_SUBTITLE_SIZE_SCALE['normal'];
+      el.style.fontSize = domCueFontSize(scale * this.sizeScale);
     }
     if (style.color) {
       el.style.color = SUBTITLE_COLOR_MAP[style.color] ?? SUBTITLE_COLOR_MAP['white'];
@@ -119,12 +125,19 @@ export class SubtitleOverlay {
   }
 
   private ensureEl(): HTMLDivElement | null {
-    if (this.el?.isConnected) return this.el;
     if (typeof document === 'undefined') return null;
+    // Must live inside `.player-container` (like Shaka's own text container):
+    // it is a z-index 100 stacking context, and on webOS the hardware video
+    // surface erases anything painted below it.
+    const host = document.querySelector('.player-container') ?? document.body;
+    if (this.el?.isConnected) {
+      if (this.el.parentElement !== host) host.appendChild(this.el);
+      return this.el;
+    }
     const el = document.createElement('div');
     el.id = 'fliks-tv-subtitle';
     el.style.cssText = [
-      'position: fixed',
+      'position: absolute',
       'left: 50%',
       'bottom: 10vh',
       'transform: translateX(-50%)',
@@ -132,7 +145,7 @@ export class SubtitleOverlay {
       'padding: 6px 14px',
       'background: transparent',
       'color: #fff',
-      'font-size: 3vh',
+      `font-size: ${domCueFontSize(this.sizeScale)}`,
       'font-weight: 500',
       'line-height: 1.3',
       'text-align: center',
@@ -144,7 +157,7 @@ export class SubtitleOverlay {
       'white-space: pre-wrap',
       'display: none',
     ].join(';');
-    document.body.appendChild(el);
+    host.appendChild(el);
     this.el = el;
     return el;
   }

--- a/client/src/app/core/services/playback-engine/webos-engine.ts
+++ b/client/src/app/core/services/playback-engine/webos-engine.ts
@@ -5,6 +5,7 @@ import {
   PlaybackEngine,
 } from './playback-engine';
 import { SubtitleOverlay } from './subtitle-overlay.util';
+import { WEBOS_CUE_SIZE_BOOST } from '../../utils/subtitle-presets';
 
 /** Open HLS a few rungs up so the picture isn't a soft 256×144 while the
  *  native ABR ramps. ~8 Mbps suits a TV display. */
@@ -48,7 +49,7 @@ const SEEK_DEBOUNCE_MS = 280;
  */
 export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngine {
   private video: HTMLVideoElement | null = null;
-  private readonly subtitles = new SubtitleOverlay();
+  private readonly subtitles = new SubtitleOverlay(WEBOS_CUE_SIZE_BOOST);
   private _duration = 0;
   /** Last URL handed to `load()` — the base for reload-on-seek. */
   private loadedUrl = '';

--- a/client/src/app/core/services/player-settings.service.ts
+++ b/client/src/app/core/services/player-settings.service.ts
@@ -97,10 +97,14 @@ export interface AudioStreamChoice {
 /** The DOM cue sizes are the native ladder in `vmin` — the viewport's short
  *  side, so a rotation doesn't resize the cues (`vh` collapsed them to ~12px
  *  in landscape on a phone) — under the same floor the native renderers use. */
+export function domCueFontSize(scale: number): string {
+  return `max(${+(scale * SUBTITLE_MIN_TEXT_PX).toFixed(2)}px, ${+(scale * DOM_SUBTITLE_HEIGHT_FRACTION * 100).toFixed(2)}vmin)`;
+}
+
 export const SUBTITLE_SIZE_MAP: Record<string, string> = Object.fromEntries(
   Object.entries(NATIVE_SUBTITLE_SIZE_SCALE).map(([size, scale]) => [
     size,
-    `max(${+(scale * SUBTITLE_MIN_TEXT_PX).toFixed(2)}px, ${+(scale * DOM_SUBTITLE_HEIGHT_FRACTION * 100).toFixed(2)}vmin)`,
+    domCueFontSize(scale),
   ]),
 );
 

--- a/client/src/app/core/utils/subtitle-presets.ts
+++ b/client/src/app/core/utils/subtitle-presets.ts
@@ -36,6 +36,11 @@ export const DOM_SUBTITLE_HEIGHT_FRACTION = 0.03;
  *  (MIN_TEXT_SIZE_SP, minPointSize). */
 export const SUBTITLE_MIN_TEXT_PX = 18;
 
+/** webOS reads smaller than the other TV paths at the same preset, so LG gets
+ *  the whole ladder shifted up one notch: its `normal` equals the shared
+ *  `xlarge`. Only the DOM overlay honours it — no other platform is affected. */
+export const WEBOS_CUE_SIZE_BOOST = 1.3;
+
 export const NATIVE_SUBTITLE_SIZE_SCALE: Record<string, number> = {
   xsmall: 0.7,
   small: 0.85,

--- a/client/src/app/core/utils/ua-parser.spec.ts
+++ b/client/src/app/core/utils/ua-parser.spec.ts
@@ -1,0 +1,25 @@
+import { detectOs } from './ua-parser';
+
+describe('detectOs', () => {
+  it('names TV OSes that also claim Linux or Android', () => {
+    expect(
+      detectOs(
+        'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.270 Safari/537.36 WebAppManager',
+      ),
+    ).toBe('webOS');
+    expect(detectOs('Mozilla/5.0 (SMART-TV; Linux; Tizen 6.5) AppleWebKit/537.36')).toBe('Tizen');
+    expect(detectOs('Mozilla/5.0 (Linux; Android 13; AndroidTV/1.0) AppleWebKit/537.36')).toBe(
+      'Android TV',
+    );
+  });
+
+  it('still resolves the desktop and mobile cases', () => {
+    expect(detectOs('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36')).toBe('Linux');
+    expect(detectOs('Mozilla/5.0 (Linux; Android 13; Pixel 8) AppleWebKit/537.36')).toBe('Android');
+    expect(detectOs('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15')).toBe(
+      'macOS',
+    );
+    expect(detectOs('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36')).toBe('Windows');
+    expect(detectOs('irrelevant')).toBeNull();
+  });
+});

--- a/client/src/app/core/utils/ua-parser.ts
+++ b/client/src/app/core/utils/ua-parser.ts
@@ -13,6 +13,11 @@
 
 /** OS name from the UA (no version — see file header). Null if unknown. */
 export function detectOs(ua: string): string | null {
+  // TV OSes lead: each one also says Android or Linux further along, so a
+  // generic match would win. LG writes its token with a zero — "Web0S".
+  if (/Web0S|webOS/.test(ua)) return 'webOS';
+  if (/\bTizen\b|SMART-TV/i.test(ua)) return 'Tizen';
+  if (/AndroidTV|GoogleTV/i.test(ua)) return 'Android TV';
   if (/iPad/.test(ua)) return 'iPadOS';
   if (/iPhone|iPod/.test(ua)) return 'iOS';
   if (/Android/.test(ua)) return 'Android';

--- a/client/src/app/features/login/login.html
+++ b/client/src/app/features/login/login.html
@@ -2,7 +2,7 @@
   <div class="card w-96 bg-base-100 shadow-xl">
     <div class="card-body">
       <img
-        src="/fliks-logo-ondark.svg"
+        src="fliks-logo-ondark.svg"
         alt="{{ 'app.name' | translate }}"
         class="h-14 w-auto mx-auto mb-6"
       />

--- a/client/src/app/features/setup/setup.html
+++ b/client/src/app/features/setup/setup.html
@@ -3,7 +3,7 @@
     <div class="card-body gap-6">
       <div class="text-center">
         <img
-          src="/fliks-logo-ondark.svg"
+          src="fliks-logo-ondark.svg"
           alt="{{ 'app.name' | translate }}"
           class="h-12 w-auto mx-auto"
         />

--- a/client/src/app/shared/components/horizontal-scroller.css
+++ b/client/src/app/shared/components/horizontal-scroller.css
@@ -7,9 +7,9 @@
 }
 
 /* Large edge scroll affordances. Centred on the row, they fade in while the
-   row is hovered and scroll one viewport-width on click. Mouse-only — on
-   touch they get in the way of swiping, and on TV the row is driven by
-   spatial navigation. */
+   row is hovered and scroll one viewport-width on click. Pointer-only — on
+   touch they get in the way of swiping, and on a D-pad-only TV the row is
+   driven by spatial navigation. */
 .scroll-edge {
   position: absolute;
   top: 50%;
@@ -49,11 +49,14 @@
   transform: translateY(-50%) scale(0.97);
 }
 
-:host-context(body.tv) .scroll-edge {
+/* webOS is exempt from both gates: the Magic Remote is a real pointer, even
+   though the platform reports `(hover: none)`. The arrows stay `tabindex="-1"`
+   so D-pad navigation never lands on them. */
+:host-context(html.tv-host:not(.tv-webos)) .scroll-edge {
   display: none;
 }
 @media (hover: none) {
-  .scroll-edge {
+  :host-context(html:not(.tv-webos)) .scroll-edge {
     display: none;
   }
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -7,6 +7,50 @@
    range and Tailwind packs the same column count as a portrait tablet). */
 @custom-variant tv (body.tv &);
 
+/* webOS reports `(hover: none)` even though the Magic Remote is a real
+   pointer, so Tailwind's default gate leaves every `hover:` utility inert on
+   LG. Re-open the variant there — and only there, since a touch device that
+   reports no hover would latch the state after a tap. Scoped to <html>, not
+   <body>: dropdown-menu and popover-menu reparent their host to
+   `document.documentElement`, outside <body>. */
+@custom-variant hover {
+  @media (hover: hover) {
+    &:hover {
+      @slot;
+    }
+  }
+  html.tv-webos &:hover {
+    @slot;
+  }
+}
+
+/* daisyUI authors its component hover states in its own `@media (hover: hover)`
+   block, which the variant above can't reach — mirrored here so LG gets them
+   too. Re-check the list against the built CSS on a daisyUI upgrade. */
+html.tv-webos .btn:hover {
+  --btn-bg: var(--btn-color, var(--color-base-200));
+}
+html.tv-webos .tab:hover {
+  color: var(--color-base-content);
+}
+html.tv-webos .dock > *:hover {
+  opacity: 80%;
+}
+html.tv-webos .link-hover:hover {
+  text-decoration-line: underline;
+}
+html.tv-webos .link-primary:hover {
+  color: var(--color-primary);
+}
+html.tv-webos .table tr.row-hover:hover,
+html.tv-webos .table tr.row-hover:nth-child(2n):hover {
+  background-color: var(--color-base-200);
+}
+html.tv-webos .table-zebra tbody tr.row-hover:hover,
+html.tv-webos .table-zebra tbody tr.row-hover:where(:nth-child(2n)):hover {
+  background-color: var(--color-base-300);
+}
+
 /* Rounder corners for all DaisyUI components */
 :root, [data-theme] {
   /* Page padding — <main>, the topbars, and anything that bleeds out of them. */
@@ -447,9 +491,13 @@ html.keyboard-modality {
   scroll-padding-top: 96px;
   scroll-padding-bottom: 20vh;
 }
-/* Disable hover styles on TV — there is no pointer */
-body.tv *:hover {
-  background-color: revert;
+/* Pointerless TVs: neutralise daisyUI's two ungated `:hover` backgrounds, so a
+   latched hover can't leave a phantom highlight. Tailwind's own `hover:`
+   utilities need no help — they sit behind `@media (hover: hover)`. Narrow on
+   purpose: `*:hover` reverted base backgrounds too, not just hover ones. */
+html.tv-host:not(.tv-webos) .menu li > :hover,
+html.tv-host:not(.tv-webos) .select option:hover {
+  background-color: revert !important;
 }
 /* Suppress every `:focus-visible` visual when the user isn't on a
    keyboard / D-pad modality. Safari WebKit on iOS incorrectly fires
@@ -1134,6 +1182,11 @@ body.tv .to-base-100\/50 {
 html.tv-host .dropdown-item:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: -2px;
+}
+/* Same distance problem for the pointer: `hover:bg-white/5` is ~4 RGB levels,
+   invisible from a couch. Focus stays ahead of it thanks to the ring above. */
+html.tv-webos .dropdown-item:hover {
+  background-color: color-mix(in oklab, var(--color-white) 12%, transparent);
 }
 
 /* TV (Tizen 6.5 / webOS 6 — Chromium ~85): daisyUI v5's `.toggle` relies on

--- a/client/webos/appinfo.json
+++ b/client/webos/appinfo.json
@@ -14,5 +14,5 @@
   "uiRevision": 2,
   "disableBackHistoryAPI": true,
   "supportTouchMode": "none",
-  "handlesRelaunch": true
+  "handlesRelaunch": false
 }


### PR DESCRIPTION
Six webOS-only defects found while validating the LG build on a webOS TV 25 panel
(platform 10.3.1, Chromium 120). Each cause was measured on the device over CDP, not inferred.

## Subtitles were never painted

`SubtitleOverlay` appended its div to `document.body` at `z-index: 30`, but `.player-container`
is `position: fixed; z-index: 100` with a `translateZ(0)`, so it is its own stacking context.
The cue div was a sibling of that container, not a descendant, so it competed with 100 rather
than with the `z-40` controls row its comment named. On webOS the hardware video surface is
composited inside the container and erases whatever the web layer painted below it. Cues were
parsed, positioned and styled the whole time, just invisible. Tizen never showed this because
AVPlay puts no `<video>` over the page.

Proof: a marker at `z-index: 30` was invisible, the same marker at `z-index: 2147483647` was
visible, and the real cue appeared the moment its `z-index` went above 100.

The overlay now mounts inside `.player-container`, where Shaka's own text container already
lives, which makes the existing `z-index: 30` reasoning true as written.

## Subtitles were too small on LG

The same overlay takes a size multiplier, and webOS shifts the whole ladder up one notch, so its
`normal` equals the shared `xlarge`. `3.9vmin` is ~42px on a 1080p panel, which does not read
from a couch. No other platform is affected.

| preset | before | after (1080p) |
|---|---|---|
| xsmall | 22.7px | 29.5px |
| small | 27.5px | 35.8px |
| normal | 32.4px | 42.1px |
| large | 37.3px | 48.4px |
| xlarge | 42.1px | 54.8px |

## Hover was dead, and it took base backgrounds down with it

webOS reports `(hover: none)` and `(pointer: none)` while the Magic Remote is a real pointer
that fires `mousemove` and latches `:hover`. Two consequences:

- Every Tailwind `hover:` utility sits behind `@media (hover: hover)`, so none of them applied.
  The `hover` variant is re-opened for webOS; `@apply hover:*` picks the override up too, and
  `group-hover:` was never gated. daisyUI writes its component hover states in its own media
  block that no variant override can reach, so those are mirrored by hand.
- Anything gated on `(hover: none)` to mean "touch device" fired on LG, which is what hid the
  horizontal-scroller arrows.

Separately, `body.tv *:hover { background-color: revert }` was a landmine. At specificity 0-2-1
it beat every single-class utility, and `revert` drops to the UA value, so **any** hovered
element lost its own base background, not just a hover one. Player dropdown panels went
transparent as soon as the pointer crossed them. It only ever needed to cancel daisyUI's two
ungated rules, so it now names them and applies only to the pointerless TVs.

The webOS rules are scoped to `<html>` rather than `<body>` because `dropdown-menu` and
`popover-menu` reparent their host to `document.documentElement`, outside `<body>` — the same
reason the focus rules are already html-scoped. The platform class is mirrored onto `<html>`
for that. Verified on a node reparented out of `<body>`: `hover:bg-white/10` resolves.

`.dropdown-item` also gets a stronger tint on webOS: `hover:bg-white/5` is about four RGB
levels, invisible at three metres, and TV focus already carries both a 10% fill and a ring.

## The logo was broken on the server-selection screen

A leading slash bypasses `<base href>` and targets the origin root, which under the `file://`
scheme the webOS bundle runs from becomes `file:///fliks-logo-ondark.svg`. Measured on device:
the relative form loads at 300x118, the absolute one fails. Routes were fine because the router
goes through the base href. These were the only two absolute asset paths in the client.

## An LG TV called itself "Application Linux"

`detectOs` knew no TV OS, so `Web0S; Linux/SmartTV` matched the generic `Linux` branch and the
quick-connect waiting screen rendered it as "Application Linux". Tizen shared that fate through
`SMART-TV; Linux`, and Android TV resolved to plain `Android`. The three TV checks now lead,
because every one of those user agents also names Android or Linux further along. Only display
labels read `detectOs`, so no playback decision changes.

## The app would not reopen after the Home key

`appinfo.json` declared `handlesRelaunch: true`. Per LG that means the platform hands the app a
`webOSRelaunch` event and then waits for it to call `activate()` before showing anything — the
system deliberately does not foreground it. The client never listened for that event, so
backgrounding with the remote Home key and reopening from the LG launcher left the app running
and invisible. Confirmed on the device: `isActivated` stayed false after a relaunch while
`visibilityState` still read `visible`. Nothing needs to happen before the first paint here, so
the app no longer claims it handles its own relaunch.

## Checks

- `tsc -p tsconfig.app.json --noEmit` clean.
- New `subtitle-overlay.util.spec.ts` (mount point and re-parenting, the webOS ladder invariant)
  and `ua-parser.spec.ts` (TV OSes, and the desktop/mobile cases still resolving) pass, as does
  the existing `horizontal-scroller.spec.ts`.
- Every fix was confirmed on the LG panel after deploying the built ipk.
