### PR TITLE
feat(media-detail): offer the episode list view on TV too

### DIFF
--- a/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
+++ b/client/src/app/features/media-detail/components/media-detail-seasons/media-detail-seasons.component.ts
@@ -244,13 +244,12 @@ export class MediaDetailSeasonsComponent {
 
   /**
    * Card row or detail list. Kept local: nothing outside this component reacts
-   * to it, unlike the on-disk filter the parent owns. Cards only on a TV, where
-   * a vertical list has no idiom and the d-pad row does.
+   * to it, unlike the on-disk filter the parent owns. A TV gets the choice too:
+   * each list row is an `appTvRow`, and the page's vertical `appTvSection`
+   * steps between them, which is the shape the home rows already use.
    */
   readonly episodeView = signal<EpisodeView>(readEpisodeViewFromStorage());
-  readonly canSwitchEpisodeView = computed(
-    () => !this.hideControls() && !this.tv.isTv(),
-  );
+  readonly canSwitchEpisodeView = computed(() => !this.hideControls());
   readonly showEpisodeList = computed(
     () => this.canSwitchEpisodeView() && this.episodeView() === 'list',
   );


### PR DESCRIPTION
The grid/list toggle for episodes was hidden on every TV form factor, so a TV only ever got the
card row — and the synopsis, the one thing a viewer reads before picking an episode, was
unreachable there.

#826 hid it deliberately: "a vertical list has no d-pad idiom and the card row does". That
premise no longer holds against the code. The list is already wired for spatial navigation:
every row is an `appTvRow` horizontal container, and the page's vertical `appTvSection` at
`media-detail.html:1` steps between them. That is the same structure the home screen rows use,
so nothing new had to be built — only the gate removed.

`hideControls` still gates the toggle, so the episode page's "more from this season" block keeps
its row, which is a row by intent.

## Scope

Enabled on all TV form factors, per an explicit call. Only the LG panel was exercised on
hardware; Tizen and Android TV inherit the change untested.

## Checks

- `tsc -p tsconfig.app.json --noEmit` clean; the 8 existing `media-detail-seasons` specs pass.
- Confirmed on the LG webOS panel after deploying the built ipk: the toggle appears and the list
  view renders.
- My scripted d-pad walk did not produce a result — driving an in-app route by synthesising a
  click on a `routerLink` anchor hard-navigates under the `file://` scheme and lands the WebView
  on `loaderror.html` instead of routing. The on-device confirmation above is manual.
