### PR TITLE
fix(i18n): use vu for the French watched label in media info

### DIFF
--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -852,7 +852,7 @@
     "audio": "Audio :",
     "subtitles": "Sous-titres :",
     "directors": "Réalisateurs",
-    "watched": "Lu",
+    "watched": "Vu",
     "ends_at": "Se termine à {{time}}",
     "remaining": "restantes",
     "genres": "Genres",


### PR DESCRIPTION
## What

`media_info.watched` in `client/public/i18n/fr.json` was translated as "Lu", while every other French watched-state string ("Vu récemment", "Marquer comme vu", the library filter "Vu") uses "Vu". The same state was therefore named two different ways in the UI.

## Change

One string: `"watched": "Lu"` → `"watched": "Vu"`.

The other "lu/lue" occurrences in the file describe media playback ("la vidéo est de nouveau lue", "ce sous-titre n'a pas pu être lu") and are unrelated, so they are left as-is. The other locales were already consistent (Visto / Gesehen).