### PR TITLE
fix(media-detail): land on home after deleting a title, and say so

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1142,7 +1142,8 @@
     "unlike": "Gefällt mir nicht mehr",
     "subtitle_failed": "Fehlgeschlagen",
     "subtitle_sync_failed": "Sync fehlgeschlagen",
-    "delete_no_folder": "Dieser Titel hat keinen eigenen Ordner: Nur der Bibliothekseintrag wird entfernt, die Datei bleibt auf der Festplatte."
+    "delete_no_folder": "Dieser Titel hat keinen eigenen Ordner: Nur der Bibliothekseintrag wird entfernt, die Datei bleibt auf der Festplatte.",
+    "delete_success": "Titel aus der Bibliothek entfernt."
   },
   "requests": {
     "title": "Anfragen",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1150,7 +1150,8 @@
     "unlike": "Unlike",
     "subtitle_failed": "Failed",
     "subtitle_sync_failed": "Sync failed",
-    "delete_no_folder": "This title has no folder of its own: only the library entry will be removed, the file stays on disk."
+    "delete_no_folder": "This title has no folder of its own: only the library entry will be removed, the file stays on disk.",
+    "delete_success": "Title removed from the library."
   },
   "requests": {
     "title": "Requests",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1142,7 +1142,8 @@
     "unlike": "Ya no me gusta",
     "subtitle_failed": "Error",
     "subtitle_sync_failed": "Sincronización fallida",
-    "delete_no_folder": "Este título no tiene una carpeta propia: solo se eliminará la entrada de la biblioteca, el archivo permanece en el disco."
+    "delete_no_folder": "Este título no tiene una carpeta propia: solo se eliminará la entrada de la biblioteca, el archivo permanece en el disco.",
+    "delete_success": "Título eliminado de la biblioteca."
   },
   "requests": {
     "title": "Solicitudes",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1150,7 +1150,8 @@
     "unlike": "Je n’aime plus",
     "subtitle_failed": "Échec",
     "subtitle_sync_failed": "Échec de la synchro",
-    "delete_no_folder": "Ce titre n'a pas de dossier propre : seule l'entrée de la bibliothèque sera supprimée, le fichier reste sur le disque."
+    "delete_no_folder": "Ce titre n'a pas de dossier propre : seule l'entrée de la bibliothèque sera supprimée, le fichier reste sur le disque.",
+    "delete_success": "Titre supprimé de la bibliothèque."
   },
   "requests": {
     "title": "Demandes",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1142,7 +1142,8 @@
     "unlike": "Non mi piace più",
     "subtitle_failed": "Non riuscito",
     "subtitle_sync_failed": "Sincronizzazione non riuscita",
-    "delete_no_folder": "Questo titolo non ha una cartella propria: verrà rimossa solo la voce della libreria, il file rimane sul disco."
+    "delete_no_folder": "Questo titolo non ha una cartella propria: verrà rimossa solo la voce della libreria, il file rimane sul disco.",
+    "delete_success": "Titolo rimosso dalla libreria."
   },
   "requests": {
     "title": "Richieste",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1142,7 +1142,8 @@
     "unlike": "Já não gosto",
     "subtitle_failed": "Falhou",
     "subtitle_sync_failed": "Sincronização falhou",
-    "delete_no_folder": "Este título não tem uma pasta própria: apenas a entrada da biblioteca será removida, o ficheiro permanece no disco."
+    "delete_no_folder": "Este título não tem uma pasta própria: apenas a entrada da biblioteca será removida, o ficheiro permanece no disco.",
+    "delete_success": "Título removido da biblioteca."
   },
   "requests": {
     "title": "Pedidos",

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -1415,6 +1415,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     this.deleteLoading.set(true);
     try {
       await this.mediaService.delete(m.id);
+      this.toast.success(this.translate.instant('media_detail.delete_success'));
       // Home, not /movies or /series: those redirect through the
       // __default_movies__/__default_series__ sentinel, which the user then sees in the URL.
       void this.router.navigate(['/']);

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -1415,7 +1415,9 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     this.deleteLoading.set(true);
     try {
       await this.mediaService.delete(m.id);
-      void this.router.navigate(['/', m.type === 'movie' ? 'movies' : 'series']);
+      // Home, not /movies or /series: those redirect through the
+      // __default_movies__/__default_series__ sentinel, which the user then sees in the URL.
+      void this.router.navigate(['/']);
     } finally {
       this.deleteLoading.set(false);
     }


### PR DESCRIPTION
## Why

Deleting a series from its detail page left the user on `/libraries/__default_series__`, with
nothing said about the deletion having worked.

`deleteMedia` navigated to `/movies` or `/series`, and both are `redirectTo` routes pointing at
the `__default_movies__` / `__default_series__` sentinels, which `LibraryComponent` resolves to
whichever library carries the default flag. The redirect is by design, but it is not meant to be
seen: the user ends up staring at an internal sentinel in the address bar.

## What changed

- The post-delete navigation goes to `/`. This is the only place in the client that navigates
  after a media delete; the library page's bulk delete stays where it is.
- A success toast fires before the navigation, so the page change is not the only signal that
  anything happened. The wording carries no participle agreeing with the title, so it reads
  correctly for a movie and a series alike in all six locales.

## Not tested

No spec assertion added. The client vitest suite does not run on `main` at all: 96 of 98 test
files fail before reaching a single assertion, on `@lucide/angular` being partially compiled
without the Angular Linker in the test build. `media-detail.delete-confirm.spec.ts` is among
them. That is a separate problem from this fix.

Client build is clean.