### PR TITLE
feat(search): badge the provider cards as a movie or a series

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2438,6 +2438,8 @@
     "unreleased": "Nicht veröffentlicht",
     "queued": "In Warteschlange",
     "missing_files": "Fehlende Dateien",
+    "type_movie": "Film",
+    "type_series": "Serie",
     "play": "Abspielen",
     "open_detail": "Details ansehen",
     "mark_watched": "Als gesehen markieren",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2465,6 +2465,8 @@
     "unreleased": "Unreleased",
     "queued": "Queued",
     "missing_files": "Missing files",
+    "type_movie": "Movie",
+    "type_series": "Series",
     "play": "Play",
     "open_detail": "View details",
     "mark_watched": "Mark as watched",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2438,6 +2438,8 @@
     "unreleased": "No estrenado",
     "queued": "En cola",
     "missing_files": "Archivos faltantes",
+    "type_movie": "Película",
+    "type_series": "Serie",
     "play": "Reproducir",
     "open_detail": "Ver la ficha",
     "mark_watched": "Marcar como visto",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2465,6 +2465,8 @@
     "unreleased": "Non sorti",
     "queued": "En file",
     "missing_files": "Fichiers manquants",
+    "type_movie": "Film",
+    "type_series": "Série",
     "play": "Lire",
     "open_detail": "Voir la fiche",
     "mark_watched": "Marquer comme vu",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2438,6 +2438,8 @@
     "unreleased": "Non uscito",
     "queued": "In coda",
     "missing_files": "File mancanti",
+    "type_movie": "Film",
+    "type_series": "Serie",
     "play": "Riproduci",
     "open_detail": "Vedi la scheda",
     "mark_watched": "Segna come visto",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2438,6 +2438,8 @@
     "unreleased": "Não estreado",
     "queued": "Na fila",
     "missing_files": "Ficheiros em falta",
+    "type_movie": "Filme",
+    "type_series": "Série",
     "play": "Reproduzir",
     "open_detail": "Ver a ficha",
     "mark_watched": "Marcar como visto",

--- a/client/src/app/features/search/search.html
+++ b/client/src/app/features/search/search.html
@@ -97,7 +97,7 @@
             } @else if (state.discoverResults().length) {
               <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 3xl:grid-cols-8 gap-3 sm:gap-4">
                 @for (row of state.discoverResults(); track row.mediaType + ':' + row.tmdbId) {
-                  <app-media-card [imageUrl]="row.posterUrl" [title]="row.title" [subtitle]="'' + (row.year ?? '')" [rating]="row.rating" [badge]="cardStatus(row)" (clicked)="onExternalCardClick(row)" />
+                  <app-media-card [imageUrl]="row.posterUrl" [title]="row.title" [subtitle]="'' + (row.year ?? '')" [rating]="row.rating" [badge]="cardStatus(row)" [mediaTypeBadge]="row.mediaType" (clicked)="onExternalCardClick(row)" />
                 }
               </div>
             } @else {
@@ -136,21 +136,21 @@
                     <button type="button" class="btn btn-xs join-item" [class.btn-primary]="state.trendingWindow() === 'week'" (click)="setTrendingWindow('week')">{{ 'search.trending_week' | translate }}</button>
                   </div>
                   @for (row of state.discoveryTrending(); track row.mediaType + ':' + row.tmdbId) {
-                    <app-media-card class="shrink-0 w-28 sm:w-32 lg:w-40" [imageUrl]="row.posterUrl" [title]="row.title" [subtitle]="'' + (row.year ?? '')" [rating]="row.rating" [badge]="cardStatus(row)" (clicked)="onExternalCardClick(row)" />
+                    <app-media-card class="shrink-0 w-28 sm:w-32 lg:w-40" [imageUrl]="row.posterUrl" [title]="row.title" [subtitle]="'' + (row.year ?? '')" [rating]="row.rating" [badge]="cardStatus(row)" [mediaTypeBadge]="row.mediaType" (clicked)="onExternalCardClick(row)" />
                   }
                 </app-horizontal-scroller>
               }
               @if (state.discoveryPopular().length) {
                 <app-horizontal-scroller [title]="'search.discover_popular' | translate" class="block">
                   @for (row of state.discoveryPopular(); track row.mediaType + ':' + row.tmdbId) {
-                    <app-media-card class="shrink-0 w-28 sm:w-32 lg:w-40" [imageUrl]="row.posterUrl" [title]="row.title" [subtitle]="'' + (row.year ?? '')" [rating]="row.rating" [badge]="cardStatus(row)" (clicked)="onExternalCardClick(row)" />
+                    <app-media-card class="shrink-0 w-28 sm:w-32 lg:w-40" [imageUrl]="row.posterUrl" [title]="row.title" [subtitle]="'' + (row.year ?? '')" [rating]="row.rating" [badge]="cardStatus(row)" [mediaTypeBadge]="row.mediaType" (clicked)="onExternalCardClick(row)" />
                   }
                 </app-horizontal-scroller>
               }
               @if (state.discoverySuggestions().length) {
                 <app-horizontal-scroller [title]="'search.discover_suggestions' | translate" class="block">
                   @for (row of state.discoverySuggestions(); track row.mediaType + ':' + row.tmdbId) {
-                    <app-media-card class="shrink-0 w-28 sm:w-32 lg:w-40" [imageUrl]="row.posterUrl" [title]="row.title" [subtitle]="'' + (row.year ?? '')" [rating]="row.rating" [badge]="cardStatus(row)" (clicked)="onExternalCardClick(row)" />
+                    <app-media-card class="shrink-0 w-28 sm:w-32 lg:w-40" [imageUrl]="row.posterUrl" [title]="row.title" [subtitle]="'' + (row.year ?? '')" [rating]="row.rating" [badge]="cardStatus(row)" [mediaTypeBadge]="row.mediaType" (clicked)="onExternalCardClick(row)" />
                   }
                 </app-horizontal-scroller>
               }
@@ -206,6 +206,7 @@
                   [title]="row.title"
                   [subtitle]="'' + (row.year ?? '')"
                   [rating]="row.rating"
+                  [mediaTypeBadge]="row.mediaType"
                   (clicked)="onExternalCardClick(row)"
                 />
               }
@@ -229,6 +230,7 @@
                   [subtitle]="'' + (row.year ?? '')"
                   [rating]="row.rating"
                   [badge]="cardStatus(row)"
+                  [mediaTypeBadge]="row.mediaType"
                   (clicked)="onExternalCardClick(row)"
                 />
               }

--- a/client/src/app/shared/components/media-card/media-card.html
+++ b/client/src/app/shared/components/media-card/media-card.html
@@ -67,9 +67,14 @@
       </div>
     }
 
-    <!-- Top-left: missing-files indicator (auto), status badge, episode number -->
-    @if (_resolvedStatus() === 'missing' || statusBadge() || topLeftBadge()) {
+    <!-- Top-left: missing-files indicator (auto), media type, status badge, episode number -->
+    @if (_resolvedStatus() === 'missing' || statusBadge() || topLeftBadge() || typeBadge()) {
       <div class="absolute top-2 left-2 z-10 flex items-center gap-1">
+        @if (typeBadge()) {
+          <span class="badge badge-sm badge-soft" [ngClass]="typeBadge()!.class">{{
+            typeBadge()!.text
+          }}</span>
+        }
         @if (_resolvedStatus() === 'missing') {
           <svg
             lucideCircleX

--- a/client/src/app/shared/components/media-card/media-card.ts
+++ b/client/src/app/shared/components/media-card/media-card.ts
@@ -4,6 +4,7 @@ import { NgClass, DecimalPipe } from '@angular/common';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { LucideFilm, LucidePlay, LucideStar, LucideCheck, LucideClock, LucideEllipsisVertical, LucideCircleX, LucideHeart } from '@lucide/angular';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
+import { MediaType } from '../../../core/enums/media-type.enum';
 import { Media } from '../../../core/services/api/media.service';
 import { computeMediaBarStatus } from '../../utils/media-status.util';
 import { MediaService } from '../../../core/services/api/media.service';
@@ -117,6 +118,9 @@ export class MediaCardComponent {
 
   // Badges
   readonly topLeftBadge = input<string | undefined>(undefined);
+  /** Marks a card as a movie or a series, for the mixed provider results where
+   *  the poster alone does not say which. */
+  readonly mediaTypeBadge = input<MediaType | null>(null);
   readonly badge = input<CardBadge>(null);
   readonly status = input<CardStatus>(null);
 
@@ -636,6 +640,22 @@ export class MediaCardComponent {
   });
 
   /** Status badge shown in the top-left corner of the poster. */
+  /** Blue for a movie, pink for a series: `info` and `secondary` are the theme's
+   *  blue and pink hues. */
+  protected readonly typeBadge = computed((): { text: string; class: string } | null => {
+    switch (this.mediaTypeBadge()) {
+      case 'movie':
+        return { text: this.translate.instant('media_card.type_movie'), class: 'badge-info' };
+      case 'series':
+        return {
+          text: this.translate.instant('media_card.type_series'),
+          class: 'badge-secondary',
+        };
+      default:
+        return null;
+    }
+  });
+
   protected readonly statusBadge = computed((): { text: string; class: string } | null => {
     const s = this._barStatus();
     if (!s) return null;


### PR DESCRIPTION
## Why

The provider sections on Search mix movies and series in a single grid, and a poster does not
say which is which. Picking a result meant clicking it to find out.

## What changed

`media-card` gains an optional `mediaTypeBadge` input, typed with the app's `MediaType`. It
renders in the top-left slot the card already keeps for episode numbers and status badges, so no
new corner is introduced and it sits alongside whatever is already there.

Blue for a movie, pink for a series, as `badge-soft badge-info` and `badge-soft badge-secondary`:
the theme's `info` and `secondary` are its blue and pink hues, so no raw colour is hardcoded.

The input is set on the six provider-backed call sites in `search.html` (the discover grid, the
three discovery rows, the owned-external matches, and the external results). Library cards do
not get it: they are reached from a typed route, and their top-left corner already carries
monitoring and missing-file state.

Two keys added to the `media_card` namespace in all six locales. `requests.type_movie` /
`requests.type_series` already existed with the same wording, but reaching into the requests
namespace from a shared card is the wrong dependency.

## Verified

Rendered the built stylesheet in headless Chromium and read the computed styles back: the movie
badge resolves to `oklch(0.74 0.16 232.661)` (hue 232, blue) and the series badge to
`oklch(0.65 0.241 354.308)` (hue 354, pink), both with the soft translucent fill. Screenshot
confirms the top-left placement.

Client build is clean. No spec: the client vitest suite does not run on `main` (96 of 98 files
fail on `@lucide/angular` partial compilation), and `media-card.spec.ts` is among them.

## Drive-by note, not fixed here

`shared/components/discover-card` has no callers anywhere in the client. It looks like the
predecessor of these provider cards, superseded by `media-card`. Worth deleting, but not in this
PR.
