### PR TITLE
feat(desktop): let the .deb install its own updates

### DIFF
--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -12,3 +12,6 @@ vendor/
 native/vendor/*
 !native/vendor/libmpv.so.2
 *.log
+flatpak/fliks.deb
+flatpak/build/
+flatpak/.flatpak-builder/

--- a/desktop/flatpak/media.fliks.desktop.yml
+++ b/desktop/flatpak/media.fliks.desktop.yml
@@ -5,12 +5,14 @@
 # a noble build and the runtime is not Ubuntu, so it is dropped and mpv is
 # built here against the runtime instead.
 #
-# That makes this the test of the open question. mpv links the runtime's SHARED
-# FFmpeg, while Electron's own libffmpeg.so exports 678 av_* symbols into the
-# same process, which is exactly the clash the vendored static build avoids. If
-# playback works, the static libmpv and its bundle can go for good.
+# FFmpeg is built static and linked into libmpv, which is what the committed
+# blob is, except from a recipe and against the runtime. Nothing here may use
+# the runtime's shared FFmpeg: Electron hard-links its own libffmpeg.so and a
+# second shared copy in the process kills mpv_initialize.
 #
 # Build: scripts/flatpak-poc.sh <path-to .deb>
+# Install for the desktop session, not the snap's private XDG_DATA_HOME:
+#   env -u XDG_DATA_HOME flatpak install ...
 app-id: media.fliks.desktop
 runtime: org.freedesktop.Platform
 runtime-version: '24.08'
@@ -52,6 +54,7 @@ modules:
       - --enable-gpl
       - --enable-version3
       - --enable-vaapi
+      - --enable-gnutls
     cleanup: ['/include', '/lib/pkgconfig', '/lib/*.a', '/share/ffmpeg']
     sources:
       - type: archive

--- a/desktop/flatpak/media.fliks.desktop.yml
+++ b/desktop/flatpak/media.fliks.desktop.yml
@@ -37,8 +37,29 @@ finish-args:
   - --talk-name=org.freedesktop.portal.Flatpak
 
 modules:
-  # The runtime already carries FFmpeg 61, SDL2, EGL, libdrm and Vulkan; only
-  # mpv's own two are missing.
+  # Static, and NOT the runtime's shared FFmpeg. Electron hard-links its own
+  # libffmpeg.so (NEEDED, 678 av_* exports); a second shared FFmpeg in the same
+  # process kills mpv_initialize, and RTLD_DEEPBIND only moves the crash into
+  # the render path. Linking it into libmpv and hiding the symbols is the one
+  # configuration measured to work.
+  - name: ffmpeg
+    config-opts:
+      - --disable-shared
+      - --enable-static
+      - --enable-pic
+      - --disable-programs
+      - --disable-doc
+      - --enable-gpl
+      - --enable-version3
+      - --enable-vaapi
+    cleanup: ['/include', '/lib/pkgconfig', '/lib/*.a', '/share/ffmpeg']
+    sources:
+      - type: archive
+        url: https://ffmpeg.org/releases/ffmpeg-7.1.1.tar.xz
+        sha256: 733984395e0dbbe5c046abda2dc49a5544e7e0e1e2366bba849222ae9e3a03b1
+
+  # The runtime already carries SDL2, EGL, libdrm and Vulkan; only mpv's own
+  # two are missing.
   - name: libass
     buildsystem: meson
     cleanup: [/include, /lib/pkgconfig]
@@ -81,10 +102,20 @@ modules:
       - -Dvaapi=enabled
       - -Dvaapi-x11=enabled
     cleanup: [/include, /lib/pkgconfig, /share/applications, /share/icons]
+    # mpv already builds libmpv with hidden visibility and -Bsymbolic, but that
+    # covers its own objects, not the symbols pulled out of the static FFmpeg
+    # archives. The script keeps av_* from being exported at all, which is what
+    # desktop-release.yml's kill-switch checks.
+    build-options:
+      ldflags: -Wl,--version-script=/run/build/libmpv/mpv.ver
     sources:
       - type: archive
         url: https://github.com/mpv-player/mpv/archive/v0.41.0.tar.gz
         sha256: ee21092a5ee427353392360929dc64645c54479aefdb5babc5cfbb5fad626209
+      - type: inline
+        dest-filename: mpv.ver
+        contents: |
+          { global: mpv_*; local: *; };
 
   - name: fliks
     buildsystem: simple

--- a/desktop/flatpak/media.fliks.desktop.yml
+++ b/desktop/flatpak/media.fliks.desktop.yml
@@ -1,15 +1,14 @@
 # Flatpak manifest, PROOF OF CONCEPT.
 #
-# Repackages the .deb that desktop-release.yml already produces, rather than
-# building Electron and the addon inside the sandbox. That is deliberate: the
-# open questions are whether the SDL/GLES compositor, GL and mpv work under the
-# sandbox, and whether a static ostree remote can drive in-app updates.
-# Building from source in the manifest is the next step, not this one.
+# Electron, the compositor addon and the Angular client still come from the
+# .deb that desktop-release.yml produces. libmpv does not: the vendored one is
+# a noble build and the runtime is not Ubuntu, so it is dropped and mpv is
+# built here against the runtime instead.
 #
-# The vendored libmpv keeps its statically linked, symbol-hidden FFmpeg here.
-# Using the org.freedesktop.Platform.ffmpeg-full extension instead needs the
-# Electron libffmpeg symbol clash solved first (it exports 678 av_* symbols),
-# which is a separate question from packaging.
+# That makes this the test of the open question. mpv links the runtime's SHARED
+# FFmpeg, while Electron's own libffmpeg.so exports 678 av_* symbols into the
+# same process, which is exactly the clash the vendored static build avoids. If
+# playback works, the static libmpv and its bundle can go for good.
 #
 # Build: scripts/flatpak-poc.sh <path-to .deb>
 app-id: media.fliks.desktop
@@ -38,6 +37,55 @@ finish-args:
   - --talk-name=org.freedesktop.portal.Flatpak
 
 modules:
+  # The runtime already carries FFmpeg 61, SDL2, EGL, libdrm and Vulkan; only
+  # mpv's own two are missing.
+  - name: libass
+    buildsystem: meson
+    cleanup: [/include, /lib/pkgconfig]
+    sources:
+      - type: archive
+        url: https://github.com/libass/libass/archive/0.17.4.tar.gz
+        sha256: c287d180d93dc9c9021872574b618ac49027e84cc90e1289318b1ee68bb42251
+
+  - name: libplacebo
+    buildsystem: meson
+    config-opts: [-Dvulkan=enabled, -Ddemos=false]
+    cleanup: [/include, /lib/pkgconfig]
+    sources:
+      - type: git
+        url: https://github.com/haasn/libplacebo.git
+        tag: v7.360.1
+
+  - name: libXpresent
+    buildsystem: autotools
+    cleanup: [/include, /lib/pkgconfig]
+    sources:
+      - type: git
+        url: https://gitlab.freedesktop.org/xorg/lib/libxpresent.git
+        tag: libXpresent-1.0.2
+
+  # Library only, no player. Wayland and CUDA are left out while the app is
+  # pinned to X11 and the addon does its own GL.
+  - name: libmpv
+    buildsystem: meson
+    config-opts:
+      - -Dbuild-date=false
+      - -Dcplayer=false
+      - -Dlibmpv=true
+      - -Dmanpage-build=disabled
+      - -Dx11=enabled
+      - -Dgl=enabled
+      - -Degl=enabled
+      - -Degl-x11=enabled
+      - -Dvulkan=enabled
+      - -Dvaapi=enabled
+      - -Dvaapi-x11=enabled
+    cleanup: [/include, /lib/pkgconfig, /share/applications, /share/icons]
+    sources:
+      - type: archive
+        url: https://github.com/mpv-player/mpv/archive/v0.41.0.tar.gz
+        sha256: ee21092a5ee427353392360929dc64645c54479aefdb5babc5cfbb5fad626209
+
   - name: fliks
     buildsystem: simple
     sources:
@@ -48,6 +96,7 @@ modules:
         commands:
           # appendSwitch('ozone-platform') in the main script does not survive
           # zypak's re-exec; Chromium reads the platform from argv first.
+          - export FLIKS_MPV_PATH=/app/lib/libmpv.so.2
           - exec zypak-wrapper /app/fliks/fliks --ozone-platform=x11 "$@"
     build-commands:
       # dpkg-deb is not in the SDK; ar and tar are.
@@ -57,6 +106,9 @@ modules:
       # zypak redirects Chromium's sandbox onto the flatpak one, so the SUID
       # helper cannot work and is dead weight.
       - rm -f /app/fliks/chrome-sandbox
+      # The noble libmpv and the libs bundled beside it for Ubuntu hosts; the
+      # module below supersedes both.
+      - rm -rf /app/fliks/resources/app.asar.unpacked/native/vendor
       - install -Dm755 fliks.sh /app/bin/fliks
       # flatpak keys the desktop entry and the icon on the app-id, and rejects
       # anything above 512x512, so the 1024 master stays out.

--- a/desktop/flatpak/media.fliks.desktop.yml
+++ b/desktop/flatpak/media.fliks.desktop.yml
@@ -1,0 +1,68 @@
+# Flatpak manifest, PROOF OF CONCEPT.
+#
+# Repackages the .deb that desktop-release.yml already produces, rather than
+# building Electron and the addon inside the sandbox. That is deliberate: the
+# open questions are whether the SDL/GLES compositor, GL and mpv work under the
+# sandbox, and whether a static ostree remote can drive in-app updates.
+# Building from source in the manifest is the next step, not this one.
+#
+# The vendored libmpv keeps its statically linked, symbol-hidden FFmpeg here.
+# Using the org.freedesktop.Platform.ffmpeg-full extension instead needs the
+# Electron libffmpeg symbol clash solved first (it exports 678 av_* symbols),
+# which is a separate question from packaging.
+#
+# Build: scripts/flatpak-poc.sh <path-to .deb>
+app-id: media.fliks.desktop
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '24.08'
+command: fliks
+
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=x11
+  - --socket=pulseaudio
+  # Ozone's auto hint reads XDG_SESSION_TYPE and picks Wayland, then exits when
+  # the socket is absent instead of falling back. The compositor is only
+  # validated on X11 (XWayland).
+  - --env=ELECTRON_OZONE_PLATFORM_HINT=x11
+  # The visible window is an SDL2/GLES surface, so it needs the GPU itself.
+  - --device=dri
+  - --filesystem=xdg-download
+  - --talk-name=org.freedesktop.Notifications
+  # Lets the app drive its own update through the portal; electron-updater has
+  # no flatpak provider.
+  - --talk-name=org.freedesktop.portal.Flatpak
+
+modules:
+  - name: fliks
+    buildsystem: simple
+    sources:
+      - type: file
+        path: fliks.deb
+      - type: script
+        dest-filename: fliks.sh
+        commands:
+          # appendSwitch('ozone-platform') in the main script does not survive
+          # zypak's re-exec; Chromium reads the platform from argv first.
+          - exec zypak-wrapper /app/fliks/fliks --ozone-platform=x11 "$@"
+    build-commands:
+      # dpkg-deb is not in the SDK; ar and tar are.
+      - ar x fliks.deb
+      - mkdir -p tree && tar -xf data.tar.xz -C tree
+      - mkdir -p /app/fliks && cp -a tree/opt/Fliks/. /app/fliks/
+      # zypak redirects Chromium's sandbox onto the flatpak one, so the SUID
+      # helper cannot work and is dead weight.
+      - rm -f /app/fliks/chrome-sandbox
+      - install -Dm755 fliks.sh /app/bin/fliks
+      # flatpak keys the desktop entry and the icon on the app-id, and rejects
+      # anything above 512x512, so the 1024 master stays out.
+      - install -Dm644 tree/usr/share/applications/fliks.desktop /app/share/applications/media.fliks.desktop.desktop
+      - desktop-file-edit --set-key=Exec --set-value="fliks %U" --set-key=Icon --set-value=media.fliks.desktop /app/share/applications/media.fliks.desktop.desktop
+      - for s in 128 256 512; do install -Dm644 "tree/usr/share/icons/hicolor/${s}x${s}/apps/fliks.png" "/app/share/icons/hicolor/${s}x${s}/apps/media.fliks.desktop.png"; done
+      - install -Dm644 tree/usr/share/metainfo/media.fliks.desktop.metainfo.xml /app/share/metainfo/media.fliks.desktop.metainfo.xml
+      # The shipped metainfo names the .deb's launchable and stock icon; both are app-id prefixed here.
+      - sed -i -e 's|>fliks.desktop<|>media.fliks.desktop.desktop<|' -e 's|"stock">fliks<|"stock">media.fliks.desktop<|' /app/share/metainfo/media.fliks.desktop.metainfo.xml

--- a/desktop/scripts/flatpak-poc.sh
+++ b/desktop/scripts/flatpak-poc.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Build the PoC flatpak from a released .deb and install it for the current
+# user. With a second argument the build is also exported into an ostree repo,
+# which is what a static host (GitHub Pages, any bucket) would serve as a
+# flatpak remote.
+#
+# Requires: flatpak, flatpak-builder, and the flathub remote for the runtime,
+# SDK and org.electronjs.Electron2.BaseApp.
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")/.." && pwd)"
+deb="${1:?usage: flatpak-poc.sh <path-to .deb> [repo-dir]}"
+repo="${2:-}"
+
+test -f "$deb" || { echo "no such .deb: $deb" >&2; exit 1; }
+cp -f "$deb" "$here/flatpak/fliks.deb"
+
+# rofiles-fuse needs /dev/fuse, which containers and restricted shells rarely have.
+args=(--user --force-clean --disable-rofiles-fuse --install-deps-from=flathub --install)
+[ -n "$repo" ] && args+=(--repo="$repo")
+
+cd "$here/flatpak"
+flatpak-builder "${args[@]}" build media.fliks.desktop.yml
+
+echo
+echo "installed: flatpak run media.fliks.desktop"
+[ -n "$repo" ] && echo "exported to $repo (serve it over HTTP to use as a remote)"

--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow, ipcMain, shell } from 'electron';
-import { appendFileSync, mkdirSync } from 'node:fs';
+import { appendFileSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import electronUpdater from 'electron-updater';
 import {
@@ -18,8 +18,6 @@ const RELEASES_URL = `https://github.com/${GITHUB_REPO}/releases`;
 const INITIAL_CHECK_DELAY_MS = 10_000;
 const PERIODIC_CHECK_MS = 6 * 60 * 60 * 1000;
 
-/** electron-updater self-installs only from an NSIS exe, a signed .app zip, or
- *  an AppImage. A .deb (dpkg needs root) and dev runs fall back to a download. */
 /** Opt out of the update check entirely (no outbound api.github.com request),
  *  matching the backend's FLIKS_DISABLE_UPDATE_CHECK. */
 function updateCheckDisabled(): boolean {
@@ -57,10 +55,22 @@ function fileUpdaterLogger(): {
   };
 }
 
+/** electron-builder's marker, absent outside a distro package. */
+function packageType(): string {
+  try {
+    return readFileSync(join(process.resourcesPath, 'package-type'), 'utf8').trim();
+  } catch {
+    return '';
+  }
+}
+
+/** An AppImage self-replaces; a distro package is reinstalled through the
+ *  package manager under pkexec. electron-updater keys its Linux updater on
+ *  the marker above, and only these three have one. */
 function canSelfInstall(): boolean {
   if (!app.isPackaged) return false;
-  if (process.platform === 'linux') return !!process.env.APPIMAGE;
-  return true;
+  if (process.platform !== 'linux') return true;
+  return !!process.env.APPIMAGE || ['deb', 'rpm', 'pacman'].includes(packageType());
 }
 
 function capability(): DesktopUpdateCapability {
@@ -85,7 +95,7 @@ function normalizeNotes(notes: unknown): string | null {
 }
 
 /** Wires the in-app updater: renderer-invokable channels + status broadcasts.
- *  Installable builds use electron-updater (autoDownload off); .deb/dev do a
+ *  Installable builds use electron-updater (autoDownload off); dev runs do a
  *  GitHub release lookup to surface availability + a download link. */
 export function setupUpdater(): void {
   const installable = canSelfInstall();
@@ -148,7 +158,7 @@ export function setupUpdater(): void {
       }),
     );
   } else {
-    // .deb / dev: detect-only via the public GitHub release, install = open page.
+    // Dev runs: detect-only via the public GitHub release, install = open page.
     ipcMain.handle(UPDATE_IPC.check, () => githubFallbackCheck(broadcast));
     ipcMain.handle(UPDATE_IPC.install, () => shell.openExternal(RELEASES_URL));
   }


### PR DESCRIPTION
The `.deb` reported "an update is available" and then sent the user to the releases page to download and install it by hand. It turns out nothing was missing for a real in-app update; the pieces were already shipping and simply were not wired together.

## What was already there

- electron-builder writes `resources/package-type` into the `.deb`, and it contains `deb`.
- electron-updater reads exactly that marker to choose its Linux updater, and instantiates `DebUpdater` when it says `deb`.
- `DebUpdater` downloads the `.deb` and hands it to `dpkg` through `pkexec`.
- `latest-linux.yml` already lists the `.deb` alongside the AppImage, so the file the updater looks for is published.

The only thing standing in the way was the app's own gate in `desktop/src/main/updater.ts`, which treated every Linux build that is not an AppImage as unable to self-install. Its comment stated `a .deb (dpkg needs root)`, which is true as an observation but does not follow as a conclusion: needing root is what `pkexec` is for.

## The change

`canSelfInstall()` now accepts a packaged Linux build when it is an AppImage **or** when `resources/package-type` names a format electron-updater has an updater for. Nothing else moves: the same `checkForUpdates` / `downloadUpdate` / `quitAndInstall` wiring, the same events, the same file logger.

## Verification

Run against a local `generic` feed advertising a 99.0.0, with the built main bundle repacked into a real packaged tree, so the whole chain executed rather than being reasoned about:

```
14:07:39  GET /latest-linux.yml           update resolved
14:08:04  GET /Fliks-Client-99.0.0.deb    downloaded
14:08:08  pkexec: session opened for root  dpkg installed it
```

`dpkg -l fliks-desktop` moved to the advertised build on disk, so the update was genuinely applied and not merely attempted.

`tsc --noEmit` and the esbuild bundle are green.

## What this changes for users

An update now applies from inside the app, at the cost of one polkit authentication per update. That is the honest trade-off of this route.

An apt repository would remove the prompt entirely, since updates would arrive through the system updater, and can be added later without undoing any of this: it would simply make `canSelfInstall()` moot on Linux rather than contradict it.
