### PR TITLE
feat(desktop): crop black bars locally on the linux client too

### DIFF
--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -514,17 +514,18 @@ export class BrowserDeviceProfileService {
       supportsHdr = hdrDisplay && has10bitCodec;
     }
 
-    // Backends whose mpv renders through a real video output: Windows vo=gpu
-    // and the macOS layer. The Linux shell draws through the x11 software VO,
-    // which neither tone-maps nor crops, so it stays on the server-side paths.
-    const mpvVideoOutput =
+    // Windows vo=gpu and the macOS CAOpenGLLayer present HDR themselves. The
+    // Linux shell composites libmpv's render API into its own FBO and has no
+    // HDR path, so HDR there stays server-side.
+    const mpvHdrOutput =
       this.device.isDesktopNative() && /Windows|Mac OS X/.test(navigator.userAgent);
     // mpv tone-maps HDR down to an SDR display on its own (the macOS layer does
     // it whenever the screen has no EDR headroom).
-    const tonemapsHdrLocally = mpvVideoOutput && !supportsHdr;
-    // `video-crop` cuts the bars at the VO — free, and hwdec-safe unlike a
-    // lavfi crop.
-    const cropsBlackBarsLocally = mpvVideoOutput;
+    const tonemapsHdrLocally = mpvHdrOutput && !supportsHdr;
+    // `video-crop` cuts the bars at the VO: free, and hwdec-safe unlike a lavfi
+    // crop. Every mpv backend qualifies, the Linux render API included, since
+    // they all run the gl_video renderer that applies the rectangle.
+    const cropsBlackBarsLocally = this.device.isDesktopNative();
 
     // Dolby Vision passthrough capability, gated under supportsHdr (DV ⊆ HDR, so
     // it never outlives HDR and the forceDisableHdr override stays consistent).

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -438,6 +438,9 @@ app.whenReady().then(async () => {
   // Route the renderer's player IPC to the addon (control via mpv properties).
   ipcMain.handle(IPC.load, (_e, opts) => {
     console.log('[ipc] load', opts?.url, 'start=', opts?.startTime, 'headers=', Object.keys(opts?.headers ?? {}).join(','));
+    // Global property, so it is always written — otherwise the previous file's
+    // rectangle would crop the next one.
+    addon.setProperty('video-crop', opts?.videoCrop ?? '');
     return addon.load(opts);
   });
   ipcMain.handle(IPC.play, () => addon.setProperty('pause', 'no'));


### PR DESCRIPTION
Cropping black bars server-side forces a re-encode of a file that would otherwise Direct Play, which is why `cropsBlackBarsLocally` exists in the device profile. Windows and macOS use it; Linux did not.

## Why Linux was excluded, and why that does not hold

The profile restricted the capability to `/Windows|Mac OS X/` with this reason:

> The Linux shell draws through the x11 software VO, which neither tone-maps nor crops, so it stays on the server-side paths.

That sentence describes Chromium's OSR presenter, not mpv's output. The Linux compositor feeds **libmpv's render API**, which runs the same `gl_video` renderer as Windows' `vo=gpu`, and that renderer is exactly where the crop rectangle is applied:

```c
// video/out/gpu/video.c
if (mp_image_crop_valid(&p->image_params))
    src = p->image_params.crop;
```

mpv's manual documents no VO restriction on `--video-crop` and notes it works with hwdec, unlike a `lavfi` crop.

## The change

`cropsBlackBarsLocally` now covers every desktop-native build. The condition was split rather than widened, because the same boolean also drove `tonemapsHdrLocally`, and HDR is a different question: the Linux shell has no HDR presentation path, so that flag stays on Windows and macOS.

The rest of the plumbing was already platform-agnostic. `player.ts` pushes the rectangle whenever the stream is copied, and the desktop engine carries it into the load options; only the Linux main process ignored it. It now writes `video-crop` the way the Windows and macOS backends do, unconditionally, so one file's rectangle cannot survive into the next. No addon change: it is an mpv property.

## Verification

`tsc --noEmit` is green for both the client and the desktop bundle, and the app was built and launched locally from this branch (local main bundle and Angular build injected into the CI-built tree, since the native addon needs build deps this machine does not have): mpv comes up, the render context initialises, the renderer loads.

What is **not** verified is the pixel result: confirming that the bars actually disappear and that the session stays on Direct Play instead of transcoding needs a 2.35:1 film played on a Linux desktop client. The reasoning above is read from mpv's source and from the fact that the path is shared with Windows, where it works.
