### PR TITLE
feat(desktop): tone-map HDR locally on linux, on a desktop GL compositor

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -131,7 +131,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-electron42-
 
-      # Linux-only: build deps for the native compositor addon (SDL2 + GLES/EGL
+      # Linux-only: build deps for the native compositor addon (SDL2 + GL/EGL
       # + libmpv headers). macOS/Windows don't build the addon (they embed mpv
       # natively), so they need no extra build deps here.
       - name: Install Linux build deps
@@ -140,7 +140,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential python3 pkg-config patchelf \
-            libsdl2-dev libgles2-mesa-dev libegl1-mesa-dev libmpv-dev
+            libsdl2-dev libgl1-mesa-dev libegl1-mesa-dev libmpv-dev
 
       # macOS embeds in-process libmpv (no SDL/GLES addon). `mpv` provides the
       # libmpv headers the addon compiles against + the dylib the vendor script

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -514,14 +514,10 @@ export class BrowserDeviceProfileService {
       supportsHdr = hdrDisplay && has10bitCodec;
     }
 
-    // Windows vo=gpu and the macOS CAOpenGLLayer present HDR themselves. The
-    // Linux shell composites libmpv's render API into its own FBO and has no
-    // HDR path, so HDR there stays server-side.
-    const mpvHdrOutput =
-      this.device.isDesktopNative() && /Windows|Mac OS X/.test(navigator.userAgent);
     // mpv tone-maps HDR down to an SDR display on its own (the macOS layer does
-    // it whenever the screen has no EDR headroom).
-    const tonemapsHdrLocally = mpvHdrOutput && !supportsHdr;
+    // it whenever the screen has no EDR headroom), so the server can copy the
+    // bitstream instead of re-encoding it.
+    const tonemapsHdrLocally = this.device.isDesktopNative() && !supportsHdr;
     // `video-crop` cuts the bars at the VO: free, and hwdec-safe unlike a lavfi
     // crop. Every mpv backend qualifies, the Linux render API included, since
     // they all run the gl_video renderer that applies the rectangle.

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -8,13 +8,13 @@ it is NOT the menu-bar server host under `macos/`.
 
 - **Electron** loads the Angular client **offscreen** (`offscreen: true,
   transparent: true`) and paints it to a BGRA bitmap.
-- A **native N-API addon** (`native/compositor/addon.cc`, SDL2 + GLES 3.2) owns
+- A **native N-API addon** (`native/compositor/addon.cc`, SDL2 + GL 4.3 core) owns
   the single visible window. It composites **mpv video** (rendered into a GL FBO
   via libmpv's render API) under the **Angular UI bitmap**.
 - Embedded **mpv** comes from a self-contained static **libmpv** (render API).
 - ⚠️ **Three mpv backends — know which one you're debugging.**
   1. **Linux** — mpv runs **inside the native C++ addon** (`native/compositor/
-     addon.cc`, libmpv render API, self-compositing SDL/GLES window); its
+     addon.cc`, libmpv render API, self-compositing SDL/GL window); its
      property/event plumbing (`time-pos`, `demuxer-cache-time`,
      `paused-for-cache`, `timeUpdate`, `stateChanged`) lives in addon.cc + the
      `addon.onEvent` / `emitPosition` wiring in `src/main/index.ts`.
@@ -59,11 +59,12 @@ System packages (Debian/Ubuntu) — the C++ addon compiles against these via
 `pkg-config` and node-gyp needs a C++17 toolchain:
 ```bash
 sudo apt install -y build-essential python3 pkg-config \
-  libsdl2-dev libgles2-mesa-dev libegl1-mesa-dev libmpv-dev
+  libsdl2-dev libgl1-mesa-dev libegl1-mesa-dev libmpv-dev
 ```
 - `build-essential` + `python3` → node-gyp.
-- `pkg-config` + `libsdl2-dev` + `libgles2-mesa-dev` + `libegl1-mesa-dev` →
-  the addon links SDL2 / GLESv2 / EGL.
+- `pkg-config` + `libsdl2-dev` + `libgl1-mesa-dev` + `libegl1-mesa-dev` →
+  the addon links SDL2 / desktop GL / EGL. Desktop GL, not GLES: mpv drops
+  compute shaders on any GLES context, and they drive its HDR peak detection.
 - `libmpv-dev` → addon **compiles** against mpv's headers (`client.h`,
   `render_gl.h`). Runtime uses the vendored self-contained libmpv below, not the
   system one.

--- a/desktop/native/binding.gyp
+++ b/desktop/native/binding.gyp
@@ -1,7 +1,7 @@
 {
   # One native unit per desktop OS, selected by top-level conditions so the
   # wrong-OS target (and its toolchain probes) never even resolve:
-  #   - linux → fliks_compositor: SDL2/GLES/EGL self-compositor (pkg-config).
+  #   - linux → fliks_compositor: SDL2 + desktop GL self-compositor (pkg-config).
   #     Its `<!@(pkg-config sdl2 …)` would FAIL at gyp time on macOS, hence the
   #     condition gate rather than a per-target no-op.
   #   - mac   → fliks_player_mac: in-process libmpv rendering offscreen via GL
@@ -19,10 +19,10 @@
           ],
           "include_dirs": [
             "<!@(node -p \"require('node-addon-api').include_dir\")",
-            "<!@(pkg-config --cflags-only-I sdl2 glesv2 egl mpv | sed 's/-I//g')"
+            "<!@(pkg-config --cflags-only-I sdl2 gl egl mpv | sed 's/-I//g')"
           ],
           "libraries": [
-            "<!@(pkg-config --libs sdl2 glesv2 egl)",
+            "<!@(pkg-config --libs sdl2 gl egl)",
             "-ldl"
           ],
           "cflags_cc": [ "-std=c++17", "-fexceptions" ],

--- a/desktop/native/compositor/addon.cc
+++ b/desktop/native/compositor/addon.cc
@@ -1,6 +1,6 @@
 // fliks_compositor — native single-window GL compositor (Electron+mpv, Option C).
 //
-// One SDL2/GLES window. mpv (self-contained libmpv, plain dlopen — FFmpeg
+// One SDL2/GL window. mpv (self-contained libmpv, plain dlopen — FFmpeg
 // statically linked + symbols hidden, so no clash with Electron's libffmpeg)
 // renders video via the RENDER API into a GL FBO; the Electron OSR UI bitmap is
 // uploaded to a GL texture; both are composited (video then UI, premult-alpha)
@@ -11,7 +11,12 @@
 #include <napi.h>
 
 #include <SDL.h>
-#include <GLES3/gl32.h>
+// Desktop GL, not GLES: mpv drops RA_CAP_COMPUTE on any GLES context (ra_gl.c
+// disables it unconditionally), which costs HDR peak detection. Mesa's libGL
+// exports the 2.0+ entry points, so glext's prototypes are enough, no loader.
+#define GL_GLEXT_PROTOTYPES
+#include <GL/gl.h>
+#include <GL/glext.h>
 
 #include <mpv/client.h>
 #include <mpv/render.h>
@@ -133,7 +138,7 @@ struct GlState {
 
 GlState g_state;
 
-const char* kVert = R"(#version 320 es
+const char* kVert = R"(#version 430 core
 out vec2 v_uv;
 uniform float u_flipY;
 void main() {
@@ -145,8 +150,7 @@ void main() {
 }
 )";
 
-const char* kFrag = R"(#version 320 es
-precision mediump float;
+const char* kFrag = R"(#version 430 core
 in vec2 v_uv;
 uniform sampler2D u_tex;
 uniform int u_bgra;
@@ -255,9 +259,11 @@ void RenderThreadMain(GlState* s) {
     fprintf(stderr, "[compositor] SDL_Init failed: %s\n", SDL_GetError());
     return;
   }
-  SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
-  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+  // 4.3 core: mpv gates compute shaders on GLSL >= 420, and they drive its HDR
+  // peak detection. The compositor's own GL surface is core-clean already.
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
   s->window = SDL_CreateWindow(
       s->title.c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, s->width,


### PR DESCRIPTION
Tone-mapping server-side re-encodes the whole file, the most expensive path the transcoder has. `tonemapsHdrLocally` exists so a client can take the bitstream verbatim and render it in SDR itself; Windows and macOS use it, Linux did not, even though `desktop/CLAUDE.md` already states that the Linux render API tone-maps.

## Why the flag could not simply be flipped

Enabling it alone would have shipped a visibly coarser picture than Windows. mpv drops `RA_CAP_COMPUTE` on **any** GLES context:

```c
// video/out/opengl/ra_gl.c
// While we can handle compute shaders on GLES the spec (intentionally) does not
// support binding textures for writing, which all uses inside mpv would require.
// So disable it unconditionally anyway.
if (ra->glsl_es)
    ra->caps &= ~RA_CAP_COMPUTE;
```

and without compute there is no HDR peak detection, only a static peak. GLES 3.2 does have compute shaders; mpv refuses them regardless of version. The compositor was asking for GLES 3.2.

## The change

The compositor now asks for a **4.3 core** context, which satisfies mpv's `glsl_version >= 420` gate for compute. The addon's own GL surface turned out to be core-clean already, no GLES-only call or enum in it, so the port is narrow:

- SDL context attributes → `PROFILE_CORE` 4.3
- `<GLES3/gl32.h>` → `<GL/gl.h>` + `<GL/glext.h>` under `GL_GLEXT_PROTOTYPES`; Mesa's libGL exports the 2.0+ entry points, so no loader is needed
- both shaders → `#version 430 core`, `precision mediump float;` dropped
- `pkg-config glesv2` → `gl`, in `binding.gyp` **and** in the release workflow, otherwise the Linux job stops building
- `desktop/CLAUDE.md` realigned, including the first-time install command

`tonemapsHdrLocally` then widens to every desktop-native build.

## Verification

Built and run on an Intel/Mesa box, from this branch (locally built addon, main bundle and Angular client):

```
before   [compositor] GL OpenGL ES 3.2 Mesa …
         [mpv] libmpv_render: Disabling HDR peak computation (compute shaders=0, SSBO=1)

after    [compositor] GL 4.6 (Core Profile) Mesa …
         (no such line)
```

The addon links `libGL`/`libGLX` with no unresolved dependency, and playback, rendering and input were exercised by hand on the running app.
