### PR TITLE
fix(desktop): repair caret, cursor and clicks on the linux shell

### DIFF
--- a/client/src/app/core/plugins/desktop-player.bridge.ts
+++ b/client/src/app/core/plugins/desktop-player.bridge.ts
@@ -93,6 +93,9 @@ export interface FliksDesktopApi {
   setSubtitleStyle(style: DesktopSubtitleStyle): Promise<void>;
   /** Crop the video to fill the window (mpv `panscan`) instead of letterboxing. */
   setFillScreen(fill: boolean): Promise<void>;
+  /** Show or hide the pointer over the native window; on Linux the visible
+   *  surface is the compositor's, so the page's CSS cursor never reaches it. */
+  setCursorVisible(visible: boolean): Promise<void>;
   resize(rect: DesktopRect): Promise<void>;
   setFullscreen(enabled: boolean): Promise<void>;
   destroy(): Promise<void>;

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -53,6 +53,7 @@ import {
 } from '../../core/services/player-settings.service';
 import { Capacitor, registerPlugin } from '@capacitor/core';
 
+import { desktopBridgeOrNull } from '../../core/plugins/desktop-player.bridge';
 import { PlaybackEngine } from '../../core/services/playback-engine/playback-engine';
 import { ShakaEngine } from '../../core/services/playback-engine/shaka-engine';
 import { TizenEngine, isTizenAvplayAvailable } from '../../core/services/playback-engine/tizen-engine';
@@ -493,6 +494,14 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     const delay = this.device.isTv() ? 5000 : 3000;
     const id = setTimeout(() => this.hideControls(), delay);
     onCleanup(() => clearTimeout(id));
+  });
+
+  /** The CSS cursor above only covers the page. Where the visible surface is
+   *  the native compositor's window (Linux), the pointer belongs to it, so the
+   *  same visibility has to be pushed down to it. */
+  private readonly nativeCursorEffect = effect(() => {
+    const visible = this.controlsVisible();
+    void desktopBridgeOrNull()?.setCursorVisible(visible).catch(() => {});
   });
 
   // ── Skip-intro state ──

--- a/desktop/native/compositor/addon.cc
+++ b/desktop/native/compositor/addon.cc
@@ -114,6 +114,8 @@ struct GlState {
   std::string iconPath;  // BMP loaded onto the window via SDL_SetWindowIcon
   std::atomic<bool> run{false};
   std::atomic<int> fsRequest{-1};  // -1 none, 0 windowed, 1 fullscreen-desktop
+  std::atomic<int> cursorRequest{-1};  // -1 none, 0 hidden, 1 shown
+  std::atomic<int> cursorShape{-1};    // -1 none, else an index into kCursors
   std::thread renderThread;
   std::thread eventThread;
 
@@ -250,11 +252,20 @@ void MpvRenderInit(GlState* s) {
   fprintf(stderr, "[compositor] mpv render context ready\n");
 }
 
+// Indexed by the shape ids main/index.ts maps Chromium's cursor names onto.
+const SDL_SystemCursor kCursors[] = {SDL_SYSTEM_CURSOR_ARROW, SDL_SYSTEM_CURSOR_HAND,
+                                     SDL_SYSTEM_CURSOR_IBEAM, SDL_SYSTEM_CURSOR_SIZEALL};
+constexpr int kCursorCount = static_cast<int>(sizeof(kCursors) / sizeof(kCursors[0]));
+
 void RenderThreadMain(GlState* s) {
+  SDL_Cursor* cursorCache[kCursorCount] = {};
   // Name the X11 WM_CLASS so the window isn't grouped under "electron" (argv0).
   // GNOME/Ubuntu key the dock entry on this; default to "fliks" but let an
   // explicit launch-time SDL_VIDEO_X11_WMCLASS win (overwrite=0).
   setenv("SDL_VIDEO_X11_WMCLASS", "fliks", 0);
+  // Without this SDL swallows the click that refocuses the window, so the first
+  // click back into the app lands on nothing and everything needs clicking twice.
+  SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
   if (SDL_Init(SDL_INIT_VIDEO) != 0) {
     fprintf(stderr, "[compositor] SDL_Init failed: %s\n", SDL_GetError());
     return;
@@ -354,6 +365,17 @@ void RenderThreadMain(GlState* s) {
     int fs = s->fsRequest.exchange(-1, std::memory_order_acq_rel);
     if (fs >= 0)
       SDL_SetWindowFullscreen(s->window, fs == 1 ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
+    // The page's CSS cursor only covers the offscreen bitmap; the pointer the
+    // user sees belongs to this window.
+    int cur = s->cursorRequest.exchange(-1, std::memory_order_acq_rel);
+    if (cur >= 0) SDL_ShowCursor(cur == 1 ? SDL_ENABLE : SDL_DISABLE);
+    // Chromium resolves the CSS cursor for the page; only this window can show
+    // it. Built on demand and kept, since a shape recurs on every hover.
+    int shape = s->cursorShape.exchange(-1, std::memory_order_acq_rel);
+    if (shape >= 0 && shape < kCursorCount) {
+      if (!cursorCache[shape]) cursorCache[shape] = SDL_CreateSystemCursor(kCursors[shape]);
+      if (cursorCache[shape]) SDL_SetCursor(cursorCache[shape]);
+    }
 
     int w, h;
     SDL_GL_GetDrawableSize(s->window, &w, &h);
@@ -642,6 +664,18 @@ Napi::Value SetFullscreen(const Napi::CallbackInfo& info) {
   return info.Env().Undefined();
 }
 
+Napi::Value SetCursorShape(const Napi::CallbackInfo& info) {
+  int shape = info.Length() > 0 ? info[0].ToNumber().Int32Value() : 0;
+  g_state.cursorShape.store(shape, std::memory_order_release);
+  return info.Env().Undefined();
+}
+
+Napi::Value SetCursorVisible(const Napi::CallbackInfo& info) {
+  bool on = info.Length() > 0 && info[0].ToBoolean().Value();
+  g_state.cursorRequest.store(on ? 1 : 0, std::memory_order_release);
+  return info.Env().Undefined();
+}
+
 Napi::Value UploadUi(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   if (info.Length() < 3 || !info[0].IsBuffer()) return env.Undefined();
@@ -683,6 +717,8 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("getProperty", Napi::Function::New(env, GetProperty));
   exports.Set("setProperty", Napi::Function::New(env, SetProperty));
   exports.Set("setFullscreen", Napi::Function::New(env, SetFullscreen));
+  exports.Set("setCursorVisible", Napi::Function::New(env, SetCursorVisible));
+  exports.Set("setCursorShape", Napi::Function::New(env, SetCursorShape));
   exports.Set("stop", Napi::Function::New(env, Stop));
   return exports;
 }

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -62,6 +62,8 @@ type Addon = {
   getProperty(name: string): string | null;
   setProperty(name: string, value: string): void;
   setFullscreen(enabled: boolean): void;
+  setCursorVisible(visible: boolean): void;
+  setCursorShape(shape: number): void;
   stop(): void;
 };
 
@@ -171,6 +173,22 @@ const KEYMAP: Record<string, string> = {
   Home: 'Home',
   End: 'End',
 };
+
+// Chromium cursor name → index into the addon's SDL system-cursor table. These
+// are Blink's legacy names, where "pointer" is the plain arrow and "hand" is
+// what CSS calls cursor:pointer. Anything unlisted falls back to the arrow;
+// SDL has no grab cursor, so the hand stands in for the drag handles.
+const CURSOR_SHAPES: Record<string, number> = {
+  hand: 1,
+  grab: 1,
+  grabbing: 1,
+  text: 2,
+  move: 3,
+};
+
+// SDL reports wheel notches, Chromium wants pixels. GTK's own convention is
+// about 53px a notch, which reads sluggish against a browser's smooth scroll.
+const WHEEL_PIXELS_PER_NOTCH = 100;
 
 let uiWin: BrowserWindow | null = null;
 const inputCounts: Record<string, number> = {};
@@ -316,6 +334,20 @@ app.whenReady().then(async () => {
     },
   });
   uiWin.webContents.setFrameRate(60);
+  // The window is never shown, so Electron's focus() is a no-op on it and
+  // Chromium keeps the widget unfocused: no blinking caret in any text field.
+  // Focus emulation is the one switch that sets it without a visible window.
+  try {
+    uiWin.webContents.debugger.attach('1.3');
+    void uiWin.webContents.debugger.sendCommand('Emulation.setFocusEmulationEnabled', {
+      enabled: true,
+    });
+  } catch (e) {
+    console.error('[main] focus emulation unavailable, the caret will not blink', e);
+  }
+  // Chromium resolves the CSS cursor for the offscreen page and reports it
+  // here; the pointer it applies to belongs to the compositor's window.
+  uiWin.webContents.on('cursor-changed', (_e, type) => addon.setCursorShape(CURSOR_SHAPES[type] ?? 0));
   uiWin.webContents.on('paint', (_e, _dirty, image) => {
     const s = image.getSize();
     if (s.width > 0) addon.uploadUi(image.toBitmap(), s.width, s.height);
@@ -427,7 +459,14 @@ app.whenReady().then(async () => {
     else if (i.kind === 'button')
       wc.sendInputEvent({ type: i.down ? 'mouseDown' : 'mouseUp', x: i.x, y: i.y, button: i.button, clickCount: i.clicks || 1 } as any);
     else if (i.kind === 'wheel')
-      wc.sendInputEvent({ type: 'mouseWheel', x: i.x, y: i.y, deltaX: i.dx * 40, deltaY: i.dy * 40, canScroll: true } as any);
+      wc.sendInputEvent({
+        type: 'mouseWheel',
+        x: i.x,
+        y: i.y,
+        deltaX: i.dx * WHEEL_PIXELS_PER_NOTCH,
+        deltaY: i.dy * WHEEL_PIXELS_PER_NOTCH,
+        canScroll: true,
+      } as any);
     else if (i.kind === 'text') wc.sendInputEvent({ type: 'char', keyCode: i.text } as any);
     else if (i.kind === 'key') {
       const k = KEYMAP[i.key];
@@ -480,6 +519,7 @@ app.whenReady().then(async () => {
   ipcMain.handle(IPC.setFillScreen, (_e, fill: boolean) =>
     addon.setProperty('panscan', fill ? '1.0' : '0.0'),
   );
+  ipcMain.handle(IPC.setCursorVisible, (_e, visible: boolean) => addon.setCursorVisible(visible));
   ipcMain.handle(IPC.setFullscreen, (_e, enabled: boolean) => addon.setFullscreen(enabled));
   ipcMain.handle(IPC.setSubtitleStyle, (_e, s: DesktopSubtitleStyle) => {
     if (!s) return;

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -40,6 +40,8 @@ export function registerPlayerIpc(session: PlayerSession): void {
     session.player.setSubtitleStyle(style),
   );
   ipcMain.handle(IPC.setFillScreen, (_e, fill: boolean) => session.player.setFillScreen(fill));
+  // The page is the visible surface here, so its CSS cursor already applies.
+  ipcMain.handle(IPC.setCursorVisible, () => {});
   ipcMain.handle(IPC.setFullscreen, (_e, enabled: boolean) => session.setFullscreen(enabled));
   ipcMain.handle(IPC.resize, (_e, rect: DesktopRect) => session.resize(rect));
   ipcMain.handle(IPC.destroy, () => session.destroy());

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -43,6 +43,7 @@ const api: FliksDesktopApi = {
   setSubtitleStyle: (style: DesktopSubtitleStyle) =>
     ipcRenderer.invoke(IPC.setSubtitleStyle, style),
   setFillScreen: (fill: boolean) => ipcRenderer.invoke(IPC.setFillScreen, fill),
+  setCursorVisible: (visible: boolean) => ipcRenderer.invoke(IPC.setCursorVisible, visible),
   resize: (rect: DesktopRect) => ipcRenderer.invoke(IPC.resize, rect),
   destroy: () => ipcRenderer.invoke(IPC.destroy),
   getSystemInfo: () => ipcRenderer.invoke(IPC.getSystemInfo),

--- a/desktop/src/shared/contract.ts
+++ b/desktop/src/shared/contract.ts
@@ -106,6 +106,7 @@ export const IPC = {
   subAdd: 'player:subAdd',
   setSubtitleStyle: 'player:setSubtitleStyle',
   setFillScreen: 'player:setFillScreen',
+  setCursorVisible: 'player:setCursorVisible',
   resize: 'player:resize',
   destroy: 'player:destroy',
   /** Host OS identity (name + version), resolved natively. */
@@ -243,6 +244,9 @@ export interface FliksDesktopApi {
   setSubtitleStyle(style: DesktopSubtitleStyle): Promise<void>;
   /** Crop the video to fill the window (mpv `panscan`) instead of letterboxing. */
   setFillScreen(fill: boolean): Promise<void>;
+  /** Show or hide the pointer over the native window, which the page's CSS
+   *  cursor cannot reach where the visible surface is not the page. */
+  setCursorVisible(visible: boolean): Promise<void>;
   resize(rect: DesktopRect): Promise<void>;
   destroy(): Promise<void>;
   /** Native host OS identity (e.g. { systemName: "macOS 26" }). */


### PR DESCRIPTION
On Linux the visible surface is the compositor's SDL window, while every interaction is resolved by a Chromium page that is never shown. Four user-visible consequences had been left to the page, which cannot reach the real window, plus one unrelated input constant.

## The caret never blinked

Not throttling, which was the first guess and was wrong: repaints were flowing normally. Instrumenting showed the widget was simply never focused, and that asking for focus changed nothing:

```
focusedBefore= false   afterFocus()= false   winVisible= false
```

Electron's `focus()` short-circuits on an invisible window, so Chromium kept the widget unfocused and hid the caret, while injected events still inserted text, which is why typing worked and only the caret was missing. `Emulation.setFocusEmulationEnabled` over CDP is the one switch that sets it without showing a window; `document.hasFocus()` flips to `true`.

## The pointer never hid, and never changed shape

The player hides the cursor with a transparent image cursor in CSS, and buttons use `cursor: pointer`. Both only paint into the offscreen bitmap.

Rather than reimplement an idle timer in C++ that would drift from the player's own, the visibility the player already computes (`controlsVisible()`) is forwarded to `SDL_ShowCursor`. Shapes come from `webContents`'s `cursor-changed`, mapped onto SDL system cursors. Both cross to the render thread through the atomic-request pattern `setFullscreen` already uses.

One trap worth the comment left in the code: these are Blink's legacy names, where **`pointer` is the plain arrow** and **`hand`** is what CSS calls `cursor: pointer`. Mapping them the intuitive way inverts every cursor in the app.

## The first click back into the window did nothing

SDL swallows the click that restores focus unless `SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH` says otherwise, so everything needed clicking twice after visiting another app.

## Scrolling

The wheel step moves from 40px a notch to 100px, named rather than inline. GTK's own convention is about 53px, and 40 read sluggish next to a browser.

## Verification

Each was built and exercised by hand on the Linux client, against builds made from this branch (locally compiled addon, main bundle and Angular client): caret, cursor hiding during playback and its return afterwards, cursor shapes over buttons, text fields and the rest of the UI, and scroll feel. The click-through fix is the one confirmed only by its mechanism and a launch, not by a reported round-trip.
