### PR TITLE
fix(client): keep the background crossfade from collapsing into a cut

### DIFF
--- a/client/src/app/core/services/background.service.ts
+++ b/client/src/app/core/services/background.service.ts
@@ -16,8 +16,7 @@ export class BackgroundService {
   /** Current target URL. `null` means "fade out, no background". */
   readonly url = signal<string | null>(null);
 
-  /** Pool the current pick came from. Used to detect equivalent
-   *  calls so we don't re-randomise on every signal re-emit. */
+  /** Pool the current pick came from, so a re-emit doesn't re-randomise. */
   private pool: string[] = [];
 
   setBackground(url: string | null): void {
@@ -26,9 +25,9 @@ export class BackgroundService {
   }
 
   /**
-   * Pick one image at random from `urls`. Re-calling with an
-   * identical pool is a no-op so the displayed image doesn't
-   * change while the user is on the page.
+   * Pick one image at random from `urls`. The pick then holds for as long as
+   * it stays in the pool, so a page keeps its image while its data streams in
+   * and the pool grows underneath.
    */
   setBackgrounds(urls: string[]): void {
     const next = urls.filter((u): u is string => !!u);
@@ -36,10 +35,14 @@ export class BackgroundService {
       this.clear();
       return;
     }
-    const samePool =
-      next.length === this.pool.length &&
-      next.every((u, i) => u === this.pool[i]);
-    if (samePool) return;
+    // Keep the current pick while it is still on offer. The pool grows as a
+    // page's data streams in, and re-rolling on every growth swaps the image
+    // again within the same frame, which collapses the crossfade into a cut.
+    const current = this.url();
+    if (current && next.includes(current)) {
+      this.pool = next;
+      return;
+    }
 
     this.pool = next;
     this.url.set(next[Math.floor(Math.random() * next.length)]);

--- a/client/src/app/shared/components/background/background.html
+++ b/client/src/app/shared/components/background/background.html
@@ -9,7 +9,7 @@
       loading="lazy"
       decoding="async"
       fetchpriority="low"
-      class="absolute inset-0 w-full h-full object-cover object-[50%_25%] transition-opacity duration-1500"
+      class="absolute inset-0 w-full h-full object-cover object-[50%_25%] app-bg-layer transition-opacity duration-1500"
       [class.opacity-100]="activeLayer() === 'A' && imageVisible()"
       [class.opacity-0]="activeLayer() !== 'A' || !imageVisible()"
     />
@@ -21,7 +21,7 @@
       loading="lazy"
       decoding="async"
       fetchpriority="low"
-      class="absolute inset-0 w-full h-full object-cover object-[50%_25%] transition-opacity duration-1500"
+      class="absolute inset-0 w-full h-full object-cover object-[50%_25%] app-bg-layer transition-opacity duration-1500"
       [class.opacity-100]="activeLayer() === 'B' && imageVisible()"
       [class.opacity-0]="activeLayer() !== 'B' || !imageVisible()"
     />

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -132,6 +132,16 @@ html.tv-webos .table-zebra tbody tr.row-hover:where(:nth-child(2n)):hover {
   background-color: rgba(29, 35, 42, 0.95);
 }
 
+/* Background crossfade — a layer is written and activated in the same tick, so
+   its <img> enters the DOM already at the target opacity and has no previous
+   value to transition from. @starting-style supplies one. Engines without it
+   fall back to today's instant swap. */
+.app-bg-layer {
+  @starting-style {
+    opacity: 0;
+  }
+}
+
 /* Home library pill. The tint and border are an overlay dimmed by `opacity`
    rather than a `color-mix()` alpha, which the TV WebView can't parse. */
 .library-card {


### PR DESCRIPTION
The page background swapped instantly instead of crossfading, but only sometimes, which is what made it hard to place.

## What the instrumentation showed

Logging every URL change, layer flip and transition event on a media-detail → home round trip:

```
9381  url -> media/19/fanart      active B → A
9447  url -> media/19/fanart-2    active A → B     (66 ms later)
9547  img load opacity=1                            ← no transition at all
```

The background changes two to four times within a few tens of milliseconds, and each change flips which of the two stacked layers is active. Two flips land before the browser paints, so the visible layer's opacity never changes: only its `src` is replaced. No `transitionstart` is emitted for those swaps, while an isolated change does produce one.

## Where the churn came from

`setBackgrounds` re-rolled its random pick whenever the pool differed by strict array equality, and a page's fanart pool grows as its data streams in. Every growth therefore drew a new image, mid-fade. The pick now holds for as long as it is still in the pool, so the roll only happens on a genuinely different pool. That is what the service's own doc comment already promised.

## Second, smaller cause

An entering layer has no opacity to transition from: its `<img>` is created in the same tick that activates it, so it renders at the target value. `@starting-style` supplies the missing start, following the pattern already used for `.bottom-sheet-backdrop`. Engines without it, the Chromium 85 TV WebView, keep today's instant swap rather than breaking.

## Verification

Three round trips across three different media, with the diagnostics still in place: transitions now start and run to completion, `transitionstart` through `transitionend` at `elapsed=1.5`, where before those swaps emitted no transition event at all. Confirmed by hand in the browser as well.

The logs also settled two suspicions that turned out to be wrong, and are recorded here so they are not re-investigated: `duration-1500` does emit `1.5s` under Tailwind v4, and `@starting-style` does apply, entering layers reaching `load` at opacity 0.
