### PR TITLE
feat(desktop): navigate with the mouse thumb buttons on linux

### DIFF
--- a/desktop/native/compositor/addon.cc
+++ b/desktop/native/compositor/addon.cc
@@ -322,8 +322,12 @@ void RenderThreadMain(GlState* s) {
           break;
         case SDL_MOUSEBUTTONDOWN:
         case SDL_MOUSEBUTTONUP: {
-          const char* btn = ev.button.button == SDL_BUTTON_RIGHT  ? "right"
+          // Thumb buttons are navigation, not clicks; the main process turns
+          // them into history moves rather than forwarding them to the page.
+          const char* btn = ev.button.button == SDL_BUTTON_RIGHT    ? "right"
                             : ev.button.button == SDL_BUTTON_MIDDLE ? "middle"
+                            : ev.button.button == SDL_BUTTON_X1     ? "back"
+                            : ev.button.button == SDL_BUTTON_X2     ? "forward"
                                                                     : "left";
           snprintf(ib, sizeof(ib),
                    "{\"kind\":\"button\",\"down\":%s,\"x\":%d,\"y\":%d,\"button\":\"%s\",\"clicks\":%d}",

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -456,8 +456,19 @@ app.whenReady().then(async () => {
     const wc = uiWin.webContents;
     if (i.kind !== 'move' && i.kind !== 'wheel') wc.focus();
     if (i.kind === 'move') wc.sendInputEvent({ type: 'mouseMove', x: i.x, y: i.y } as any);
-    else if (i.kind === 'button')
-      wc.sendInputEvent({ type: i.down ? 'mouseDown' : 'mouseUp', x: i.x, y: i.y, button: i.button, clickCount: i.clicks || 1 } as any);
+    else if (i.kind === 'button') {
+      // sendInputEvent only knows left/middle/right, so the thumb buttons are
+      // history moves here. Chromium's session history is what the router
+      // listens to, so this behaves like a browser's back button.
+      const history = wc.navigationHistory;
+      if (i.button === 'back') {
+        if (i.down && history.canGoBack()) history.goBack();
+      } else if (i.button === 'forward') {
+        if (i.down && history.canGoForward()) history.goForward();
+      } else {
+        wc.sendInputEvent({ type: i.down ? 'mouseDown' : 'mouseUp', x: i.x, y: i.y, button: i.button, clickCount: i.clicks || 1 } as any);
+      }
+    }
     else if (i.kind === 'wheel')
       wc.sendInputEvent({
         type: 'mouseWheel',


### PR DESCRIPTION
The mouse thumb buttons did nothing useful on the Linux client, and the reason turned out to be worse than "not wired up".

## What they actually did

The compositor mapped buttons like this:

```c
ev.button.button == SDL_BUTTON_RIGHT ? "right" : ev.button.button == SDL_BUTTON_MIDDLE ? "middle" : "left"
```

Everything that was not right or middle fell through to `"left"`. Pressing the back button therefore sent a **left click at the pointer**, activating whatever card or control happened to sit under it. `SDL_BUTTON_X1` and `X2` are now reported for what they are.

## Where the navigation happens

`sendInputEvent` only accepts `left`, `middle` and `right`, so the thumb buttons cannot be forwarded to the page at all. The main process turns them into history moves instead, guarded by `canGoBack()` / `canGoForward()` and acting on press only.

It goes through Chromium's session history rather than calling the Angular router directly. That history is what the router already listens to, so back behaves exactly as a browser's does, view transitions included, instead of becoming a second navigation path that would drift out of sync with the real history.

## Verification

Built and run on the Linux client from this branch: back and forward move through history, and a normal left click still works, which matters here because the shared button path was touched.
