### PR TITLE
feat(desktop): keep the player-close transition on the desktop shell

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -80,6 +80,11 @@ const POSTER_IN_CLASS = 'vt-poster-in';
 const POSTER_OUT_CLASS = 'vt-poster-out';
 const NATIVE_PLAYER_CLASS = 'native-player-active';
 const IS_TV = detectDevice().formFactor === 'tv';
+// The desktop shell composites the video itself, so a transparent snapshot
+// reveals it rather than the black an OS-level surface would show through.
+const IS_DESKTOP_SHELL =
+  typeof window !== 'undefined' &&
+  (!!window.fliksDesktop || /\bElectron\//.test(navigator.userAgent));
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -114,6 +119,7 @@ export const appConfig: ApplicationConfig = {
                 // the destination.
                 if (
                   closingPlayer &&
+                  !IS_DESKTOP_SHELL &&
                   document.documentElement.classList.contains(NATIVE_PLAYER_CLASS)
                 ) {
                   transition.skipTransition();


### PR DESCRIPTION
Closing the player cut straight to the page behind it on desktop, with none of the 200 ms shrink the web client plays.

## Why it was skipped

Not an oversight. `onViewTransitionCreated` drops the transition whenever a native player is up:

> A native surface renders outside the WebView, and the class that lets it through has made every layer transparent — the old snapshot is an empty rectangle, so animating it paints black over the destination.

`html.native-player-active` forces `background: transparent` down the whole chain, `html`, `body`, `app-root`, `app-layout`, `main`, `app-player`, so the native video shows through. On a phone or a TV the video surface sits *behind* the WebView, so what an empty snapshot exposes is the black window underneath.

## Why the desktop shell is different

It composites the video **itself**: the addon draws the mpv frame and lays the UI bitmap over it. A transparent snapshot there reveals the video, not a hole, so the premise behind the skip does not hold. The condition is narrowed rather than removed; Tizen and Capacitor keep skipping.

## Verification, and what is not verified

Confirmed on the Linux client, built and run from this branch: the shrink plays, with no black flash over the destination and a correct page at the end.

**macOS and Windows are not verified.** They embed mpv through the three-window `PlayerSession` rather than compositing it, which is architecturally closer to the mobile case this skip was written for. If the premise does hold there, the symptom is a ~200 ms black or background-coloured flash on every player close, and the revert is one token: replace `IS_DESKTOP_SHELL` with a Linux-only check. Worth a look from anyone who runs those builds.
