### PR TITLE
fix(client): keep the poster morph alive across a player visit

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -129,6 +129,14 @@ export const appConfig: ApplicationConfig = {
                   transition.skipTransition();
                   return;
                 }
+                // Opening the player animates itself, and the root pair is off,
+                // so there is nothing to capture. Skipping keeps the stamp the
+                // eventual back morph pairs with, which clearing below would
+                // drop, leaving the returning page with only half a pair.
+                if (leafRoutePath(to) === WATCH_PATH) {
+                  transition.skipTransition();
+                  return;
+                }
                 // A stamp outlives its navigation so the back morph can pair it.
                 clearStalePosterStamps(from, to);
                 // Leaving the player is the one navigation that re-enables the


### PR DESCRIPTION
Navigating home → media detail → player → back → back cut instead of morphing on that last leg, and on every one after it. It looked intermittent because the first round trip works: the breakage starts once the player has been visited. Present on web today, and not specific to the desktop client.

## What the traces showed

Logging the inline `view-transition-name` stamps at the hook and again at `transition.ready`, when the new DOM is in place:

```
episode → watch   CLEARS media-poster-ep-8102 ×2   at clearStalePosterStamps ← onViewTransitionCreated
episode → home    atHook  = none
                  atReady = media-poster-ep-8102, media-card-overlay
```

The arriving card is named, the outgoing hero is not. Chromium has half a pair and nothing to morph.

`clearStalePosterStamps` drops the stamp on any leg touching the player, guarding against a lone named image being snapshotted out of the figure that rounds it. The stamp is what the eventual back navigation pairs with, and the file's own header says as much: *"the back transition reads it again"*.

## The change

Opening the player has nothing to capture. The root pair is disabled globally, neither poster trip claims a leg to `watch` (both explicitly exclude `WATCH_PATH`), and the player animates itself from `player.ts`. Skipping the transition there removes the artefact the clearing existed to prevent, so the clearing is no longer reached and the stamp survives.

## Verification

Same traces after the change, on the same repro:

```
episode → watch   READY REJECTED AbortError: Transition was skipped
episode → home    atHook  = media-poster-ep-199, media-poster-ep-199
                  atReady = media-poster-ep-199, media-card-overlay
```

The outgoing side now carries its name where it previously reported none. Confirmed by hand on the client as well, across the full repro and the legs that follow it.
