### PR TITLE
fix(client): let the arriving page own the background, and remember its pick

### DIFF
--- a/client/src/app/core/services/background.service.ts
+++ b/client/src/app/core/services/background.service.ts
@@ -13,11 +13,17 @@ import { Injectable, signal } from '@angular/core';
  */
 @Injectable({ providedIn: 'root' })
 export class BackgroundService {
-  /** Current target URL. `null` means "fade out, no background". */
+  /** Current target URL. `null` means "fade out, no background".
+   *
+   *  Only an arriving page writes this. A page leaving does not blank it: the
+   *  next one decides, and clearing on the way out would fade to nothing for as
+   *  long as that page takes to load its own. */
   readonly url = signal<string | null>(null);
 
-  /** Pool the current pick came from, so a re-emit doesn't re-randomise. */
+  /** Pool the pick came from, and the pick itself, so the same pool always
+   *  yields the same image however many pages were visited in between. */
   private pool: string[] = [];
+  private pick: string | null = null;
 
   setBackground(url: string | null): void {
     this.pool = url ? [url] : [];
@@ -35,17 +41,25 @@ export class BackgroundService {
       this.clear();
       return;
     }
-    // Keep the current pick while it is still on offer. The pool grows as a
-    // page's data streams in, and re-rolling on every growth swaps the image
-    // again within the same frame, which collapses the crossfade into a cut.
+    // The same pool gives back the image it already chose, even after a detour
+    // through a page that showed its own: a return should restore what was
+    // there, not roll again.
+    if (this.pick && samePool(next, this.pool)) {
+      this.url.set(this.pick);
+      return;
+    }
+    // A pool that merely grew, as a page's data streams in, keeps the image it
+    // is already showing rather than re-rolling on every instalment.
     const current = this.url();
     if (current && next.includes(current)) {
       this.pool = next;
+      this.pick = current;
       return;
     }
 
     this.pool = next;
-    this.url.set(next[Math.floor(Math.random() * next.length)]);
+    this.pick = next[Math.floor(Math.random() * next.length)];
+    this.url.set(this.pick);
   }
 
   /**
@@ -65,4 +79,9 @@ export class BackgroundService {
     this.pool = [];
     this.url.set(null);
   }
+}
+
+/** Pools are equal when they hold the same urls in the same order. */
+function samePool(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((u, i) => u === b[i]);
 }

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -436,7 +436,6 @@ export class HomeComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.scrollMemory.deactivate();
     this.playbackStopped.unsubscribe();
-    this.backgroundService.clear();
   }
 
   /**

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -567,7 +567,6 @@ export class LibraryComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.background.clear();
     this.list.destroy();
     if (this.onResize) window.removeEventListener('resize', this.onResize);
     this.scrollMemory.deactivate();

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -288,12 +288,13 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
    *  image instead of re-randomising from the pool. */
   private parkedBackground: string | null = null;
 
-  /** The hero navbar and page backdrop are global state, so a cached page has
-   *  to hand them back on the way out and reclaim them on return. */
+  /** The hero navbar is global state, so a cached page hands it back on the way
+   *  out and reclaims it on return. The backdrop is parked rather than cleared:
+   *  whichever page arrives next decides what it shows, and blanking it here
+   *  would fade to nothing in between. */
   private releaseChrome(): void {
     this.parkedBackground = this.backgroundService.url();
     this.navbarService.leaveHeroPage();
-    this.backgroundService.clear();
   }
 
   private restoreChrome(): void {

--- a/client/src/app/features/tmdb-preview/tmdb-preview.ts
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.ts
@@ -245,7 +245,6 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.navbar.leaveHeroPage();
-    this.backgroundService.clear();
   }
 
   async ngOnInit() {


### PR DESCRIPTION
Two problems on the page background, both traced on the running client with the applied urls logged per navigation.

## A parasite image mid-fade

Every navigation wrote the background twice: the page leaving cleared it, the page arriving set its own. The traces:

```
url ia/806/fanart-4   APPLY → layer B
url null              APPLY → layer A     ← clear() from the page leaving
url ia/677/fanart-2   APPLY → layer A     ← the real one, 53 ms later
```

So the crossfade played out to nothing and back, showing an image that belonged to neither page.

The pages already decide on entry, and two of them say so plainly: `library` keeps whatever is showing when it has no opinion of its own (`if (this.background.url()) return`), and `home` returns without touching it while its recommendations are still loading. Clearing on the way out contradicted both. It goes, and only an arriving page writes.

## A third image on the way back

Returning to home rolled a new random pick every time:

```
/695/fanart-4 … /787/fanart-3 … /954/fanart-5 … /806/fanart-4
```

The stability guard compared the pool against the url on screen, and on a return that url is the one the *other* page set, never a member of the pool being restored, so it always re-rolled. The pool now carries the pick it produced, so the same pool gives back the same image however many pages were crossed. The service's own doc promised this from the start: *"the pick from setBackgrounds is stable"*.

## What was thrown away

An earlier attempt used a 150 ms settle window plus a helper that stripped the inline transition and forced a reflow to end a fade early. Both were workarounds for the double write, one of them resting on a delay measured once on one machine. Neither survives here.

## Consequence worth reviewing

A page that never claims a background now inherits the previous one, rather than being blanked on the way in. That is already `library`'s deliberate behaviour, but it now also covers screens like Downloads, Persons and Statistics. If those should be neutral, the consistent way to say so is a flag in their route `data`, alongside `reuse` and `ownsScroll`, rather than restoring a blind clear.
