### PR TITLE
fix(client): resolve the backdrop from what pages declare, not from writes

### DIFF
--- a/client/src/app/app.html
+++ b/client/src/app/app.html
@@ -1,3 +1,4 @@
+<app-background />
 <app-toast-container />
 <app-cast-overlay />
 <app-confirmation-modal />

--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -13,6 +13,7 @@ import { BrowserDeviceProfileService } from './core/services/browser-device-prof
 import { TvService } from './core/services/tv.service';
 import { TvSpatialNavService } from './core/services/tv-spatial-nav.service';
 import { ToastContainerComponent } from './shared/components/toast-container';
+import { BackgroundComponent } from './shared/components/background/background';
 import { ConfirmationModalComponent } from './shared/components/confirmation-modal';
 import { ConfirmationService } from './core/services/confirmation.service';
 import { FolderPickerModalComponent } from './shared/components/folder-picker-modal/folder-picker-modal';
@@ -30,7 +31,9 @@ import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, ToastContainerComponent, ConfirmationModalComponent, FolderPickerModalComponent, SelectPickerComponent, CastOverlayComponent],
+  imports: [
+    BackgroundComponent,
+    RouterOutlet, ToastContainerComponent, ConfirmationModalComponent, FolderPickerModalComponent, SelectPickerComponent, CastOverlayComponent],
   templateUrl: './app.html',
 })
 export class App implements OnInit, OnDestroy {

--- a/client/src/app/core/services/background.service.ts
+++ b/client/src/app/core/services/background.service.ts
@@ -1,84 +1,70 @@
-import { Injectable, signal } from '@angular/core';
+import { Injectable, computed, signal } from '@angular/core';
 
 /**
- * Global page-background image. Pages opt in by calling
- * `setBackground(url)` (single image) or `setBackgrounds(urls)`
- * (one random pick from the list). The BackgroundComponent at the
- * layout root listens to {@link url} and crossfades on change.
+ * Global page-background image, resolved from what the live pages declare.
  *
- * The pick from `setBackgrounds` is stable: as long as the same
- * pool is passed back (e.g. when the media signal re-emits with
- * equal data), the chosen URL stays put — no flashing on every
- * change-detection cycle.
+ * A page states an intent rather than writing a url, because the two states it
+ * used to conflate are not the same thing. `null` means "nothing to show yet",
+ * which holds whatever is on screen: a page whose data is still loading, or
+ * reloading after a detour through the player, must not blank the backdrop and
+ * then bring it back. An empty pool means "this page has no background", which
+ * does blank it. Anything else is a pool to pick from.
+ *
+ * The pick is remembered per owner and pool, so returning to a page restores
+ * the image it had rather than rolling a new one.
  */
 @Injectable({ providedIn: 'root' })
 export class BackgroundService {
-  /** Current target URL. `null` means "fade out, no background".
-   *
-   *  Only an arriving page writes this. A page leaving does not blank it: the
-   *  next one decides, and clearing on the way out would fade to nothing for as
-   *  long as that page takes to load its own. */
-  readonly url = signal<string | null>(null);
+  /** Live declarations, most recent last; the last resolved one is displayed. */
+  private readonly claims = signal<readonly Claim[]>([]);
 
-  /** Pool the pick came from, and the pick itself, so the same pool always
-   *  yields the same image however many pages were visited in between. */
-  private pool: string[] = [];
-  private pick: string | null = null;
-
-  setBackground(url: string | null): void {
-    this.pool = url ? [url] : [];
-    this.url.set(url);
-  }
+  /** Current target url, or null when nothing is on offer. */
+  readonly url = computed(() => {
+    const resolved = this.claims().filter((c) => c.pool !== null);
+    const top = resolved[resolved.length - 1];
+    return top?.pick ?? null;
+  });
 
   /**
-   * Pick one image at random from `urls`. The pick then holds for as long as
-   * it stays in the pool, so a page keeps its image while its data streams in
-   * and the pool grows underneath.
+   * Declare what `owner` wants shown: a pool to pick from, `[]` for no
+   * background, or `null` while it does not know yet.
    */
-  setBackgrounds(urls: string[]): void {
-    const next = urls.filter((u): u is string => !!u);
-    if (next.length === 0) {
-      this.clear();
-      return;
-    }
-    // The same pool gives back the image it already chose, even after a detour
-    // through a page that showed its own: a return should restore what was
-    // there, not roll again.
-    if (this.pick && samePool(next, this.pool)) {
-      this.url.set(this.pick);
-      return;
-    }
-    // A pool that merely grew, as a page's data streams in, keeps the image it
-    // is already showing rather than re-rolling on every instalment.
-    const current = this.url();
-    if (current && next.includes(current)) {
-      this.pool = next;
-      this.pick = current;
-      return;
-    }
-
-    this.pool = next;
-    this.pick = next[Math.floor(Math.random() * next.length)];
-    this.url.set(this.pick);
+  set(owner: object, pool: readonly string[] | null): void {
+    this.claims.update((claims) => {
+      const previous = claims.find((c) => c.owner === owner);
+      const next: Claim = { owner, ...resolve(pool, previous) };
+      // Newest declaration on top: the page arriving is the one speaking, and
+      // it takes the backdrop from the page it covers. Cached pages keep their
+      // declaration underneath, so leaving hands it back rather than blanking.
+      return [...claims.filter((c) => c.owner !== owner), next];
+    });
   }
 
-  /**
-   * Apply a fanart pool, or clear when the user has page backgrounds off. The
-   * pick stays stable for an unchanged pool, so a page holds the same image for
-   * as long as the user is on it.
-   */
-  applyPool(pool: readonly string[], enabled: boolean): void {
-    if (!enabled) {
-      this.clear();
-      return;
-    }
-    if (pool.length) this.setBackgrounds([...pool]);
+  /** Drop a page's declaration; the one below it takes over. */
+  release(owner: object): void {
+    this.claims.update((claims) => claims.filter((c) => c.owner !== owner));
   }
+}
 
-  clear(): void {
-    this.pool = [];
-    this.url.set(null);
+interface Claim {
+  owner: object;
+  /** null while the owner has nothing to say yet. */
+  pool: readonly string[] | null;
+  pick: string | null;
+}
+
+/** Keep the pick while its pool is unchanged, so a re-emit never re-rolls. */
+function resolve(
+  pool: readonly string[] | null,
+  previous: Claim | undefined,
+): { pool: readonly string[] | null; pick: string | null } {
+  if (pool === null) return { pool: null, pick: previous?.pick ?? null };
+  const next = pool.filter((u) => !!u);
+  if (next.length === 0) return { pool: next, pick: null };
+  if (previous?.pick && previous.pool && samePool(next, previous.pool)) {
+    return { pool: next, pick: previous.pick };
   }
+  return { pool: next, pick: next[Math.floor(Math.random() * next.length)] };
 }
 
 /** Pools are equal when they hold the same urls in the same order. */

--- a/client/src/app/core/services/background.service.ts
+++ b/client/src/app/core/services/background.service.ts
@@ -13,11 +13,17 @@ import { Injectable, signal } from '@angular/core';
  */
 @Injectable({ providedIn: 'root' })
 export class BackgroundService {
-  /** Current target URL. `null` means "fade out, no background". */
+  /** Current target URL. `null` means "fade out, no background".
+   *
+   *  Only an arriving page writes this. A page leaving does not blank it: the
+   *  next one decides, and clearing on the way out would fade to nothing for as
+   *  long as that page takes to load its own. */
   readonly url = signal<string | null>(null);
 
-  /** Pool the current pick came from, so a re-emit doesn't re-randomise. */
+  /** Pool the pick came from, and the pick itself, so the same pool always
+   *  yields the same image however many pages were visited in between. */
   private pool: string[] = [];
+  private pick: string | null = null;
 
   setBackground(url: string | null): void {
     this.pool = url ? [url] : [];
@@ -35,17 +41,25 @@ export class BackgroundService {
       this.clear();
       return;
     }
-    // Keep the current pick while it is still on offer. The pool grows as a
-    // page's data streams in, and re-rolling on every growth swaps the image
-    // again within the same frame, which collapses the crossfade into a cut.
+    // The same pool gives back the image it already chose, even after a detour
+    // through a page that showed its own: a return should restore what was
+    // there, not roll again.
+    if (this.pick && samePool(next, this.pool)) {
+      this.url.set(this.pick);
+      return;
+    }
+    // A pool that merely grew, as a page's data streams in, keeps the image it
+    // is already showing rather than re-rolling on every instalment.
     const current = this.url();
     if (current && next.includes(current)) {
       this.pool = next;
+      this.pick = current;
       return;
     }
 
     this.pool = next;
-    this.url.set(next[Math.floor(Math.random() * next.length)]);
+    this.pick = next[Math.floor(Math.random() * next.length)];
+    this.url.set(this.pick);
   }
 
   /**
@@ -65,4 +79,9 @@ export class BackgroundService {
     this.pool = [];
     this.url.set(null);
   }
+}
+
+/** Pools are equal when they hold the same urls in the same order. */
+function samePool(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((u, i) => u === b[i]);
 }

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -436,7 +436,6 @@ export class HomeComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.scrollMemory.deactivate();
     this.playbackStopped.unsubscribe();
-    this.backgroundService.clear();
   }
 
   /**

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -256,13 +256,14 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.applyBackground(this.recommendations(), this.displaySettings.settings().homeBackground);
   });
 
-  /** The background is global chrome, so a cached page has to reclaim it on the
-   *  way back in — the effect above won't re-run for data that never changed,
-   *  and the page left behind cleared it. Reclaiming it late is what made the
-   *  topbar flip from solid to frosted a frame after a back navigation. */
+  /** The background is global chrome, so a cached page reclaims it on the way
+   *  back in: the effect above won't re-run for data that never changed, and
+   *  the page it returns from is still declaring its own on top. */
   private applyBackground(recs: readonly RecommendationItem[], enabled: boolean): void {
-    if (recs.length === 0) return;
-    this.backgroundService.applyPool(fanartPool(recs.map((r) => r.media)), enabled);
+    // No recommendations yet is not "no background": hold what is showing until
+    // they land, or the backdrop blinks out on every arrival here.
+    if (!enabled) return this.backgroundService.set(this, []);
+    this.backgroundService.set(this, recs.length ? fanartPool(recs.map((r) => r.media)) : null);
   }
 
   /** A playback that ended leaves this row stale, whether it ran here or on a
@@ -434,6 +435,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.backgroundService.release(this);
     this.scrollMemory.deactivate();
     this.playbackStopped.unsubscribe();
   }

--- a/client/src/app/features/library/library.spec.ts
+++ b/client/src/app/features/library/library.spec.ts
@@ -139,7 +139,7 @@ function createHarness(mode: PageScrollMode = 'container', remembered?: number) 
       { provide: LibrariesApiService, useValue: {} },
       { provide: PageScrollerService, useValue: pageScroller },
       { provide: PageScrollModeService, useValue: { mode: () => mode } },
-      { provide: BackgroundService, useValue: { url: signal(null), applyPool: vi.fn(), clear: vi.fn() } },
+      { provide: BackgroundService, useValue: { set: vi.fn(), release: vi.fn(), url: signal(null) } },
       { provide: DisplaySettingsService, useValue: { settings: signal({ homeBackground: false }) } },
       {
         provide: NavbarService,

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -160,17 +160,14 @@ export class LibraryComponent implements OnInit, OnDestroy {
     },
   });
 
-  /** Same fanart backdrop as the home page, from this library's own titles, so
-   *  the topbar keeps its frosted look here too — but only to fill a gap.
-   *  Opening a library from the home page keeps the image already showing; it is
-   *  coming back from a detail page, which clears the background on its way out,
-   *  that leaves nothing behind to look at. */
+  /** Same fanart backdrop as the home page, drawn from this library's own
+   *  titles, so the topbar keeps its frosted look here too. */
   private applyBackground(): void {
-    if (this.background.url()) return;
-    this.background.applyPool(
-      fanartPool(this.list.all()),
-      this.displaySettings.settings().homeBackground,
-    );
+    if (!this.displaySettings.settings().homeBackground) return this.background.set(this, []);
+    // An empty list is a list still loading, which must hold the current image
+    // rather than declare this page has none.
+    const pool = fanartPool(this.list.all());
+    this.background.set(this, pool.length ? pool : null);
   }
   private queryParamSub?: Subscription;
   /** Set while a state-driven `syncQueryParams` is being applied to the
@@ -567,6 +564,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.background.release(this);
     this.list.destroy();
     if (this.onResize) window.removeEventListener('resize', this.onResize);
     this.scrollMemory.deactivate();

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -567,7 +567,6 @@ export class LibraryComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.background.clear();
     this.list.destroy();
     if (this.onResize) window.removeEventListener('resize', this.onResize);
     this.scrollMemory.deactivate();

--- a/client/src/app/features/media-detail/media-detail.delete-confirm.spec.ts
+++ b/client/src/app/features/media-detail/media-detail.delete-confirm.spec.ts
@@ -73,7 +73,7 @@ function createHarness() {
       { provide: ProfilesService, useValue: {} },
       { provide: LibrariesApiService, useValue: {} },
       { provide: NavbarService, useValue: { enterHeroPage: vi.fn(), leaveHeroPage: vi.fn() } },
-      { provide: BackgroundService, useValue: { clear: vi.fn(), setBackgrounds: vi.fn(), setBackground: vi.fn(), url: signal(null) } },
+      { provide: BackgroundService, useValue: { set: vi.fn(), release: vi.fn(), url: signal(null) } },
       { provide: ConfirmationService, useValue: { confirm } },
       { provide: ToastService, useValue: { success: vi.fn(), error: vi.fn() } },
       { provide: SseService, useValue: { lastEvent: signal(null) } },

--- a/client/src/app/features/media-detail/media-detail.episode-morph.spec.ts
+++ b/client/src/app/features/media-detail/media-detail.episode-morph.spec.ts
@@ -63,7 +63,7 @@ function createFixture(media: Promise<unknown> = new Promise(() => {})) {
       { provide: ProfilesService, useValue: {} },
       { provide: LibrariesApiService, useValue: {} },
       { provide: NavbarService, useValue: { enterHeroPage: vi.fn(), leaveHeroPage: vi.fn(), navigatedBack: signal(false) } },
-      { provide: BackgroundService, useValue: { clear: vi.fn(), setBackgrounds: vi.fn(), setBackground: vi.fn(), url: signal(null) } },
+      { provide: BackgroundService, useValue: { set: vi.fn(), release: vi.fn(), url: signal(null) } },
       { provide: ConfirmationService, useValue: {} },
       { provide: ToastService, useValue: { success: vi.fn(), error: vi.fn() } },
       { provide: SseService, useValue: { lastEvent: signal(null) } },

--- a/client/src/app/features/media-detail/media-detail.sse-replay.spec.ts
+++ b/client/src/app/features/media-detail/media-detail.sse-replay.spec.ts
@@ -74,7 +74,7 @@ function createHarness(seedEvent: SseEvent | null) {
       { provide: ProfilesService, useValue: {} },
       { provide: LibrariesApiService, useValue: {} },
       { provide: NavbarService, useValue: { enterHeroPage: vi.fn(), leaveHeroPage: vi.fn() } },
-      { provide: BackgroundService, useValue: { clear: vi.fn(), setBackgrounds: vi.fn(), setBackground: vi.fn(), url: signal(null) } },
+      { provide: BackgroundService, useValue: { set: vi.fn(), release: vi.fn(), url: signal(null) } },
       { provide: ConfirmationService, useValue: {} },
       { provide: ToastService, useValue: { success: vi.fn(), error: vi.fn() } },
       { provide: SseService, useValue: { lastEvent: signal(seedEvent) } },

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -286,19 +286,19 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
 
   /** Backdrop pick held across a detach so the page comes back on the same
    *  image instead of re-randomising from the pool. */
-  private parkedBackground: string | null = null;
+  /** Last pool declared, so returning to a cached page can re-declare it. */
+  private fanartPool: readonly string[] | null = null;
 
   /** The hero navbar is global state, so a cached page hands it back on the way
-   *  out and reclaims it on return. The backdrop is parked rather than cleared:
-   *  whichever page arrives next decides what it shows, and blanking it here
-   *  would fade to nothing in between. */
+   *  out and reclaims it on return. The backdrop is not handed back: the
+   *  declaration stands until the page is destroyed, so a trip to the player
+   *  and back finds the same image rather than a blank that refills. */
   private releaseChrome(): void {
-    this.parkedBackground = this.backgroundService.url();
     this.navbarService.leaveHeroPage();
   }
 
   private restoreChrome(): void {
-    this.backgroundService.setBackground(this.parkedBackground);
+    this.backgroundService.set(this, this.fanartPool);
     const m = this.media();
     if (m) this.applyEpisodeFocus(m, this.route.snapshot.paramMap.get('episodeId'));
     else this.navbarService.enterHeroPage('');
@@ -345,16 +345,11 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
    */
   private readonly backgroundEffect = effect(() => {
     const m = this.media();
-    if (!m) {
-      this.backgroundService.clear();
-      return;
-    }
-    const pool = [m.fanartUrl, ...(m.additionalFanartUrls ?? [])].filter((u): u is string => !!u);
-    if (pool.length === 0) {
-      this.backgroundService.clear();
-      return;
-    }
-    this.backgroundService.setBackgrounds(pool);
+    // No media yet is not the same as no fanart: hold what is on screen.
+    this.fanartPool = m
+      ? [m.fanartUrl, ...(m.additionalFanartUrls ?? [])].filter((u): u is string => !!u)
+      : null;
+    this.backgroundService.set(this, this.fanartPool);
   });
 
   /** React to SSE rescan / import / metadata-refresh events for this media */
@@ -898,6 +893,7 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.backgroundService.release(this);
     // Evicted from the route cache while another page is on screen: the chrome
     // and scroll key already belong to that page, so leave them alone.
     if (this.routeFresh()) return;

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -288,12 +288,13 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
    *  image instead of re-randomising from the pool. */
   private parkedBackground: string | null = null;
 
-  /** The hero navbar and page backdrop are global state, so a cached page has
-   *  to hand them back on the way out and reclaim them on return. */
+  /** The hero navbar is global state, so a cached page hands it back on the way
+   *  out and reclaims it on return. The backdrop is parked rather than cleared:
+   *  whichever page arrives next decides what it shows, and blanking it here
+   *  would fade to nothing in between. */
   private releaseChrome(): void {
     this.parkedBackground = this.backgroundService.url();
     this.navbarService.leaveHeroPage();
-    this.backgroundService.clear();
   }
 
   private restoreChrome(): void {

--- a/client/src/app/features/media-detail/media-detail.unidentified.spec.ts
+++ b/client/src/app/features/media-detail/media-detail.unidentified.spec.ts
@@ -93,7 +93,7 @@ function createHarness(media: Media, isAdmin: boolean) {
       { provide: ProfilesService, useValue: {} },
       { provide: LibrariesApiService, useValue: {} },
       { provide: NavbarService, useValue: { enterHeroPage: vi.fn(), leaveHeroPage: vi.fn(), navigatedBack: signal(false) } },
-      { provide: BackgroundService, useValue: { clear: vi.fn(), setBackgrounds: vi.fn(), setBackground: vi.fn(), url: signal(null) } },
+      { provide: BackgroundService, useValue: { set: vi.fn(), release: vi.fn(), url: signal(null) } },
       { provide: ConfirmationService, useValue: {} },
       { provide: ToastService, useValue: { success: vi.fn(), error: vi.fn() } },
       { provide: SseService, useValue: { lastEvent: signal(null) } },

--- a/client/src/app/features/playlists/playlist-detail/playlist-detail.ts
+++ b/client/src/app/features/playlists/playlist-detail/playlist-detail.ts
@@ -357,14 +357,13 @@ export class PlaylistDetailComponent {
             .filter((u): u is string => !!u),
         ),
       ];
-      if (pool.length) this.background.setBackgrounds(pool);
-      else this.background.clear();
+      this.background.set(this, pool);
     });
     // Reuse the layout's desktop back button (no hero styling, so mobile keeps
     // its normal top padding).
     this.navbar.showBackButton.set(true);
     this.destroyRef.onDestroy(() => {
-      this.background.clear();
+      this.background.release(this);
       this.navbar.showBackButton.set(false);
     });
   }

--- a/client/src/app/features/tmdb-preview/tmdb-preview.ts
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.ts
@@ -70,11 +70,8 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
    *  picks the URL up from the service and renders it under the page. */
   private readonly backgroundEffect = effect(() => {
     const m = this.media();
-    if (!m?.fanartUrl) {
-      this.backgroundService.clear();
-      return;
-    }
-    this.backgroundService.setBackgrounds([m.fanartUrl]);
+    // Nothing loaded yet holds the current image; a media with no fanart clears.
+    this.backgroundService.set(this, m ? [m.fanartUrl].filter((u): u is string => !!u) : null);
   });
 
   readonly media = signal<MetadataDetails | null>(null);
@@ -244,6 +241,7 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.backgroundService.release(this);
     this.navbar.leaveHeroPage();
   }
 

--- a/client/src/app/features/tmdb-preview/tmdb-preview.ts
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.ts
@@ -245,7 +245,6 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.navbar.leaveHeroPage();
-    this.backgroundService.clear();
   }
 
   async ngOnInit() {

--- a/client/src/app/shared/components/background/background.html
+++ b/client/src/app/shared/components/background/background.html
@@ -2,29 +2,19 @@
      `mobile-fanart-hero` and don't show a second image of the same
      fanart. Tablets (md+) get the global background. -->
 <div class="fixed inset-0 -z-10 overflow-hidden pointer-events-none hidden md:block">
-  @if (layerA()) {
-    <img
-      [cachedSrc]="layerA()! | resolveUrl:'medium'"
-      alt=""
-      loading="lazy"
-      decoding="async"
-      fetchpriority="low"
-      class="absolute inset-0 w-full h-full object-cover object-[50%_25%] app-bg-layer transition-opacity duration-1500"
-      [class.opacity-100]="activeLayer() === 'A' && imageVisible()"
-      [class.opacity-0]="activeLayer() !== 'A' || !imageVisible()"
-    />
-  }
-  @if (layerB()) {
-    <img
-      [cachedSrc]="layerB()! | resolveUrl:'medium'"
-      alt=""
-      loading="lazy"
-      decoding="async"
-      fetchpriority="low"
-      class="absolute inset-0 w-full h-full object-cover object-[50%_25%] app-bg-layer transition-opacity duration-1500"
-      [class.opacity-100]="activeLayer() === 'B' && imageVisible()"
-      [class.opacity-0]="activeLayer() !== 'B' || !imageVisible()"
-    />
+  @for (url of layers(); track $index) {
+    @if (url) {
+      <img
+        [cachedSrc]="url | resolveUrl:'medium'"
+        alt=""
+        loading="lazy"
+        decoding="async"
+        fetchpriority="low"
+        class="absolute inset-0 w-full h-full object-cover object-[50%_25%] app-bg-layer transition-opacity duration-1500"
+        [class.opacity-100]="activeLayer() === $index && imageVisible()"
+        [class.opacity-0]="activeLayer() !== $index || !imageVisible()"
+      />
+    }
   }
   <!-- Veil is permanent: when no background is set, the tint over
        the body's solid base-100 is a no-op (same colour); when an

--- a/client/src/app/shared/components/background/background.ts
+++ b/client/src/app/shared/components/background/background.ts
@@ -9,27 +9,30 @@ import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import { CachedSrcDirective } from '../../directives/cached-src.directive';
 
 /**
- * Page-wide background renderer. Mounted once at the layout root so
- * the image covers everything — including under the sidebar — and
- * survives route changes without remount.
+ * Page-wide background renderer. Mounted at the app root, above the outlet
+ * every route swaps through, so the image covers everything — including under
+ * the sidebar — and survives a trip to the player, which is a top-level route
+ * and would otherwise take the whole layout, and this, down with it.
  *
- * Crossfade strategy: two stacked layers ping-pong. Setting a new URL
- * writes it into the currently-hidden layer, then flips which layer
- * is "active". The CSS opacity transition does the visual swap, so
- * neither image is destroyed mid-fade (which would flash).
+ * Crossfade strategy: a ring of layers, one visible at a time. A new url is
+ * written into the next one, which then fades in over the others. Two would be
+ * enough only if every fade finished before the next url arrived; browsing
+ * between pages is faster than that, and reusing a layer still on screen swaps
+ * its image in place. A third gives the writer a layer that has been hidden for
+ * two turns, so the image it replaces is never one the viewer can see.
  */
+const LAYERS = 3;
+
 @Component({
   selector: 'app-background',
-  imports: [
-    CachedSrcDirective,ResolveUrlPipe],
+  imports: [CachedSrcDirective, ResolveUrlPipe],
   templateUrl: './background.html',
 })
 export class BackgroundComponent {
   private readonly bg = inject(BackgroundService);
 
-  readonly layerA = signal<string | null>(null);
-  readonly layerB = signal<string | null>(null);
-  readonly activeLayer = signal<'A' | 'B'>('A');
+  readonly layers = signal<readonly (string | null)[]>(Array<string | null>(LAYERS).fill(null));
+  readonly activeLayer = signal(0);
   /** Tracks whether the active layer should currently be at full
    *  opacity. The image is dimmed in CSS (filter: brightness),
    *  so we no longer need a separate veil — fade-out can use the
@@ -49,16 +52,9 @@ export class BackgroundComponent {
       }
 
       this.imageVisible.set(true);
-      // Write into the currently-inactive layer, then flip active.
-      // Keeping the old layer's URL intact means it can fade out
-      // smoothly instead of vanishing the moment we swap.
-      if (this.activeLayer() === 'A') {
-        this.layerB.set(next);
-        this.activeLayer.set('B');
-      } else {
-        this.layerA.set(next);
-        this.activeLayer.set('A');
-      }
+      const target = (this.activeLayer() + 1) % LAYERS;
+      this.layers.update((ls) => ls.map((url, i) => (i === target ? next : url)));
+      this.activeLayer.set(target);
     });
   }
 }

--- a/client/src/app/shared/layout/layout.html
+++ b/client/src/app/shared/layout/layout.html
@@ -1,4 +1,3 @@
-<app-background />
 <div class="drawer min-h-screen"
      [class.lg:drawer-open]="navbar.sidebarDocked()"
      [class.md:drawer-open]="device.isTablet() && navbar.effectiveSidebarPinned()"

--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -45,7 +45,6 @@ import { AddToPlaylistService } from '../../core/services/add-to-playlist.servic
 import { RecommendService } from '../../core/services/recommend.service';
 import { LucideIconComponent } from '../components/lucide-icon';
 import { TvRowDirective } from '../directives/tv-row.directive';
-import { BackgroundComponent } from '../components/background/background';
 import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 import { BackgroundService } from '../../core/services/background.service';
 import { SearchStateService } from '../../core/services/search-state.service';
@@ -86,7 +85,6 @@ const SIDEBAR_COUNTS_DEBOUNCE_MS = 400;
     LucideIconComponent,
     NavIconComponent,
     TvRowDirective,
-    BackgroundComponent,
     ResolveUrlPipe,
   ],
   templateUrl: './layout.html',


### PR DESCRIPTION
The page backdrop cut instead of fading, showed images belonging to neither page, and reset on a trip to the player. Chasing each symptom in the renderer produced workarounds; the cause is upstream, and this replaces them.

## One mistake, made five times

Every page wrote the backdrop twice per navigation, clearing it on the way out while the next set its own, and every one of them blanked it while its own data loaded:

```ts
if (!m) { this.backgroundService.clear(); return; }
```

Both writes say the same wrong thing: *"I have nothing yet"* expressed as *"there is nothing to show"*. Traced on the running client, an ordinary navigation read:

```
url ia/806/fanart-4   →  layer B
url null              →  layer A     ← the page leaving
url ia/677/fanart-2   →  layer A     ← the real one, 53 ms later
```

## Pages declare, the service resolves

`set(owner, pool)` takes an intent: a pool to pick from, `[]` for *this page has no background*, and `null` for *I do not know yet*, which holds whatever is on screen. Declarations stack per page, newest on top, so the arriving page owns the backdrop and a page leaving hands it back instead of blanking it. A page drops its declaration only when destroyed, which is why the player, declaring nothing, changes nothing.

The pick is remembered per page and pool, so returning to a page restores the image it had. Previously the guard compared against the url on screen, which on a return belongs to the page just left and is never in the pool being restored, so it rolled a new image every time.

Two workarounds this replaces are gone: `media-detail`'s parked url, and `library`'s `if (this.background.url()) return`, whose comment named the cause outright, *"a detail page, which clears the background on its way out"*.

## Two presentation defects

The renderer moves from the layout to the app root. `watch/:mediaFileId` is a top-level route, so opening the player destroyed the layout and the backdrop with it, and the image was refetched on the way back. Its own docstring already claimed it *"survives route changes without remount"*; it was not mounted high enough to.

The two ping-ponging layers become a ring of three. With two, a change arriving mid-fade has no free layer: one is visible, the other still fading out, so its image is swapped in place and jumps. A third has been hidden for two turns.

## Verification

Traced end to end on the running client through the reported repros: an ordinary navigation now applies one url instead of three, a return restores the same image rather than a new pick, and across a full player round trip the resolved url never changes. Spec mocks updated to the new API; `tsc` is green for both the app and spec projects.

`ng test` does not complete on this branch's Angular, so the suite was not run.

## Worth reviewing

A page that never declares now inherits the previous backdrop rather than being blanked. That was already `library`'s deliberate behaviour, and it now also covers screens like Downloads, Persons and Statistics. If those should be neutral, the consistent way to say so is `set(this, [])` on entry, or a flag in their route `data` alongside `reuse` and `ownsScroll`.
