### PR TITLE
feat(desktop): play the player-close transition, and keep the backdrop off the video

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -80,6 +80,12 @@ const POSTER_IN_CLASS = 'vt-poster-in';
 const POSTER_OUT_CLASS = 'vt-poster-out';
 const NATIVE_PLAYER_CLASS = 'native-player-active';
 const IS_TV = detectDevice().formFactor === 'tv';
+// The desktop shell composites the video under its own UI bitmap, so an empty
+// snapshot reveals the frame; a phone or a TV surface sits behind the WebView
+// and reveals black instead.
+const IS_DESKTOP_SHELL =
+  typeof window !== 'undefined' &&
+  (!!window.fliksDesktop || /\bElectron\//.test(navigator.userAgent));
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -114,6 +120,7 @@ export const appConfig: ApplicationConfig = {
                 // the destination.
                 if (
                   closingPlayer &&
+                  !IS_DESKTOP_SHELL &&
                   document.documentElement.classList.contains(NATIVE_PLAYER_CLASS)
                 ) {
                   transition.skipTransition();

--- a/client/src/app/shared/components/background/background.ts
+++ b/client/src/app/shared/components/background/background.ts
@@ -11,8 +11,8 @@ import { CachedSrcDirective } from '../../directives/cached-src.directive';
 /**
  * Page-wide background renderer. Mounted at the app root, above the outlet
  * every route swaps through, so the image covers everything — including under
- * the sidebar — and survives a trip to the player, which is a top-level route
- * and would otherwise take the whole layout, and this, down with it.
+ * the sidebar. It has to sit above the outlet rather than in the layout: the
+ * player is a top-level route and would take the layout, and this, with it.
  *
  * Crossfade strategy: a ring of layers, one visible at a time. A new url is
  * written into the next one, which then fades in over the others. Two would be

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -239,6 +239,13 @@ html.native-player-active router-outlet + *,
 html.native-player-active app-player {
   background: transparent !important;
 }
+/* The backdrop reaches the player route from the app root, and its veil paints
+   an opaque tint the video would sit behind. Hidden rather than undisplayed:
+   coming back from `display: none` counts as entering, which replays the
+   layers' `@starting-style` and fades in an image that never left. */
+html.native-player-active app-background {
+  visibility: hidden !important;
+}
 /* Pages with hero fanart — content extends behind status bar */
 body.native.hero-page {
   padding-top: 0 !important;


### PR DESCRIPTION
Three pieces of the same trip through the player, all confirmed by hand on the Linux client.

## The close transition never played on desktop

`onViewTransitionCreated` drops the transition whenever a native player is up:

> A native surface renders outside the WebView, and the class that lets it through has made every layer transparent — the old snapshot is an empty rectangle, so animating it paints black over the destination.

True where the video surface sits *behind* the WebView, as on a phone or a TV: the empty snapshot exposes the black window underneath. The desktop shell composites the video itself, under the UI bitmap, so the same snapshot reveals the frame. It keeps the transition; Tizen and Capacitor still skip it.

An earlier attempt at this was closed as the suspected cause of unstable poster morphs. It was not: that was the stamp the player wiped, fixed in #1343, and this is the same one-condition change on top of a repaired base.

## The backdrop covered the video

The backdrop is mounted at the app root so a trip to the player does not destroy and rebuild it, which is what made the image reload on the way back. That also puts it on the player route, where its veil paints `rgba(29, 35, 42, 0.95)` across the viewport, and on Linux the compositor draws the video *under* the UI bitmap, so the veil sat between the viewer and the picture.

It is hidden while a native player is up, next to the rules that already make every other layer transparent there. Transparency is not enough, since it is the veil itself that paints.

## visibility, not display

`display: none` fixed the video and broke the return: leaving `display: none` counts as entering, so the layers' `@starting-style` replays and fades in an image that never left. `visibility: hidden` stops the painting without being an entry, and does not destroy the component, so the url and the loaded images survive the round trip.

## Verification

On the Linux client, from this branch: the player shows its picture, closing it plays the shrink, the backdrop is unchanged on return with no reload and no fade, and ordinary navigation still crossfades.

macOS and Windows take the desktop branch too and are not verified. They embed mpv through the three-window `PlayerSession` rather than compositing it, so if the black-snapshot premise does hold there, the symptom is a flash on close and the revert is one token: replace `IS_DESKTOP_SHELL` with a Linux-only check.
