### PR TITLE
feat(client): hold one ambient backdrop across the normal pages

### DIFF
--- a/client/src/app/core/services/background.service.ts
+++ b/client/src/app/core/services/background.service.ts
@@ -1,73 +1,93 @@
-import { Injectable, computed, signal } from '@angular/core';
+import { Injectable, computed, effect, inject, signal, untracked } from '@angular/core';
+import { Navigation, Router } from '@angular/router';
+import { AuthService } from './auth.service';
+import { DisplaySettingsService } from './display-settings.service';
+import { StreamingApiService } from './api/streaming-api.service';
+import { fanartPool } from '../../shared/utils/media-artwork.util';
+
+/** How long an ambient image stays before a navigation may replace it. */
+const AMBIENT_TTL = 5 * 60 * 1000;
+
+/** Settings and admin pages take no backdrop at all. */
+const BARE_ROUTES = ['/app-settings', '/account', '/admin'];
 
 /**
- * Global page-background image, resolved from what the live pages declare.
- *
- * A page states an intent rather than writing a url, because the two states it
- * used to conflate are not the same thing. `null` means "nothing to show yet",
- * which holds whatever is on screen: a page whose data is still loading, or
- * reloading after a detour through the player, must not blank the backdrop and
- * then bring it back. An empty pool means "this page has no background", which
- * does blank it. Anything else is a pool to pick from.
- *
- * The pick is remembered per owner and pool, so returning to a page restores
- * the image it had rather than rolling a new one.
+ * Global page-background image. A media page declares its own fanart and wins
+ * while it is on screen; every other page shows the ambient image, drawn from
+ * the viewer's recommendations and held across navigations.
  */
 @Injectable({ providedIn: 'root' })
 export class BackgroundService {
-  /** Live declarations, most recent last; the last resolved one is displayed. */
-  private readonly claims = signal<readonly Claim[]>([]);
+  private readonly router = inject(Router);
+  private readonly auth = inject(AuthService);
+  private readonly displaySettings = inject(DisplaySettingsService);
+  private readonly streamingApi = inject(StreamingApiService);
 
-  /** Current target url, or null when nothing is on offer. */
-  readonly url = computed(() => {
-    const resolved = this.claims().filter((c) => c.pool !== null);
-    const top = resolved[resolved.length - 1];
-    return top?.pick ?? null;
+  private readonly claim = signal<{ owner: object; url: string } | null>(null);
+  private readonly ambient = signal<string | null>(null);
+  private ambientAt = 0;
+  private rolling = false;
+
+  private readonly currentPath = computed(() => {
+    const nav = this.router.lastSuccessfulNavigation();
+    return nav ? this.pathOf(nav) : this.router.url;
   });
 
-  /**
-   * Declare what `owner` wants shown: a pool to pick from, `[]` for no
-   * background, or `null` while it does not know yet.
-   */
-  set(owner: object, pool: readonly string[] | null): void {
-    this.claims.update((claims) => {
-      const previous = claims.find((c) => c.owner === owner);
-      const next: Claim = { owner, ...resolve(pool, previous) };
-      // Newest declaration on top: the page arriving is the one speaking, and
-      // it takes the backdrop from the page it covers. Cached pages keep their
-      // declaration underneath, so leaving hands it back rather than blanking.
-      return [...claims.filter((c) => c.owner !== owner), next];
-    });
+  readonly url = computed(() => {
+    if (BARE_ROUTES.some((p) => this.currentPath().startsWith(p))) return null;
+    if (!this.auth.isAuthenticated()) return null;
+    return (
+      this.claim()?.url ?? (this.displaySettings.settings().homeBackground ? this.ambient() : null)
+    );
+  });
+
+  /** Declare the media page's fanart; `null` means not known yet, and holds. */
+  set(owner: object, url: string | null): void {
+    if (url) this.claim.set({ owner, url });
   }
 
-  /** Drop a page's declaration; the one below it takes over. */
   release(owner: object): void {
-    this.claims.update((claims) => claims.filter((c) => c.owner !== owner));
+    if (this.claim()?.owner === owner) this.claim.set(null);
+  }
+
+  /** A page leaving the screen hands the backdrop back — unless the player is
+   *  what covers it, which it has to come back from on the same image. */
+  suspend(owner: object): void {
+    const nav = this.router.currentNavigation();
+    if (!isPlayer(nav ? this.pathOf(nav) : this.router.url)) this.release(owner);
+  }
+
+  /** Each navigation may replace the ambient image, except a trip through the
+   *  player: however long the film ran, the viewer comes back to what they left. */
+  private readonly navigationEffect = effect(() => {
+    const nav = this.router.lastSuccessfulNavigation();
+    if (!nav) return;
+    const from = nav.previousNavigation;
+    if (isPlayer(this.pathOf(nav)) || (from && isPlayer(this.pathOf(from)))) return;
+    untracked(() => void this.rollAmbient());
+  });
+
+  private async rollAmbient(): Promise<void> {
+    if (this.rolling || Date.now() - this.ambientAt < AMBIENT_TTL) return;
+    if (!this.auth.isAuthenticated() || !this.displaySettings.settings().homeBackground) return;
+    this.rolling = true;
+    try {
+      // Same request as the home page, so this is served from its cache.
+      const recs = await this.streamingApi.getRecommendations().catch(() => []);
+      const pool = fanartPool(recs.map((r) => r.media)).filter((u) => u !== this.ambient());
+      if (!pool.length) return;
+      this.ambientAt = Date.now();
+      this.ambient.set(pool[Math.floor(Math.random() * pool.length)]);
+    } finally {
+      this.rolling = false;
+    }
+  }
+
+  private pathOf(nav: Navigation): string {
+    return this.router.serializeUrl(nav.finalUrl ?? nav.extractedUrl);
   }
 }
 
-interface Claim {
-  owner: object;
-  /** null while the owner has nothing to say yet. */
-  pool: readonly string[] | null;
-  pick: string | null;
-}
-
-/** Keep the pick while its pool is unchanged, so a re-emit never re-rolls. */
-function resolve(
-  pool: readonly string[] | null,
-  previous: Claim | undefined,
-): { pool: readonly string[] | null; pick: string | null } {
-  if (pool === null) return { pool: null, pick: previous?.pick ?? null };
-  const next = pool.filter((u) => !!u);
-  if (next.length === 0) return { pool: next, pick: null };
-  if (previous?.pick && previous.pool && samePool(next, previous.pool)) {
-    return { pool: next, pick: previous.pick };
-  }
-  return { pool: next, pick: next[Math.floor(Math.random() * next.length)] };
-}
-
-/** Pools are equal when they hold the same urls in the same order. */
-function samePool(a: readonly string[], b: readonly string[]): boolean {
-  return a.length === b.length && a.every((u, i) => u === b[i]);
+function isPlayer(url: string): boolean {
+  return url.startsWith('/watch');
 }

--- a/client/src/app/features/home/home.ts
+++ b/client/src/app/features/home/home.ts
@@ -23,7 +23,6 @@ import { PlayableMediaService } from '../../core/services/playable-media.service
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
 import { DefaultFocusDirective } from '../../shared/directives/default-focus.directive';
 import { NavbarService } from '../../core/services/navbar.service';
-import { BackgroundService } from '../../core/services/background.service';
 import { DisplaySettingsService } from '../../core/services/display-settings.service';
 import { HomeSettingsService, HomeSectionType, ResolvedHomeSection } from '../../core/services/home-settings.service';
 import { LibraryPrefsService } from '../../core/services/library-prefs.service';
@@ -41,7 +40,7 @@ import { RequestCardComponent } from '../requests/request-card/request-card';
 import { RequestDeclineModalComponent } from '../requests/request-decline-modal/request-decline-modal.component';
 import { libraryColorVar } from '../../core/constants/library-appearance';
 import { StorageScopeService } from '../../core/services/storage-scope.service';
-import { fanartPool, itemArtwork } from '../../shared/utils/media-artwork.util';
+import { itemArtwork } from '../../shared/utils/media-artwork.util';
 
 /**
  * # Home page
@@ -113,7 +112,6 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly scrollMemory = inject(ScrollMemoryService);
   private readonly navbar = inject(NavbarService);
   private readonly translate = inject(TranslateService);
-  private readonly backgroundService = inject(BackgroundService);
   private readonly displaySettings = inject(DisplaySettingsService);
   private readonly home = inject(HomeSettingsService);
   private readonly libraryPrefs = inject(LibraryPrefsService);
@@ -134,11 +132,6 @@ export class HomeComponent implements OnInit, OnDestroy {
     // repaint nothing.
     refreshOnResume: () => void this.loadAllSections({ force: true }),
     scrollKey: HomeComponent.SCROLL_KEY,
-    onAttach: () =>
-      this.applyBackground(
-        this.recommendations(),
-        this.displaySettings.settings().homeBackground,
-      ),
   });
   private readonly declineModal = viewChild(RequestDeclineModalComponent);
   private readonly detailModal = viewChild(DownloadDetailModalComponent);
@@ -246,24 +239,6 @@ export class HomeComponent implements OnInit, OnDestroy {
   languageProfileDisplay(id: number | null): string {
     if (id == null) return '—';
     return this.languageProfileNames().get(id) ?? `#${id}`;
-  }
-
-  /** Once the recommendations land, randomise the page background
-   *  using their fanarts (primary + extras). One pick per visit;
-   *  the BackgroundService keeps it stable while the user stays on
-   *  the home — same contract as media-detail. */
-  private readonly recommendationsBackgroundEffect = effect(() => {
-    this.applyBackground(this.recommendations(), this.displaySettings.settings().homeBackground);
-  });
-
-  /** The background is global chrome, so a cached page reclaims it on the way
-   *  back in: the effect above won't re-run for data that never changed, and
-   *  the page it returns from is still declaring its own on top. */
-  private applyBackground(recs: readonly RecommendationItem[], enabled: boolean): void {
-    // No recommendations yet is not "no background": hold what is showing until
-    // they land, or the backdrop blinks out on every arrival here.
-    if (!enabled) return this.backgroundService.set(this, []);
-    this.backgroundService.set(this, recs.length ? fanartPool(recs.map((r) => r.media)) : null);
   }
 
   /** A playback that ended leaves this row stale, whether it ran here or on a
@@ -435,7 +410,6 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.backgroundService.release(this);
     this.scrollMemory.deactivate();
     this.playbackStopped.unsubscribe();
   }

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -34,8 +34,6 @@ import type {
 import { PageScrollerService } from '../../core/services/page-scroller.service';
 import { PageScrollModeService } from '../../core/services/page-scroll-mode.service';
 import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
-import { BackgroundService } from '../../core/services/background.service';
-import { DisplaySettingsService } from '../../core/services/display-settings.service';
 import { DefaultFocusDirective } from '../../shared/directives/default-focus.directive';
 import { TvRowDirective } from '../../shared/directives/tv-row.directive';
 import { NavbarService } from '../../core/services/navbar.service';
@@ -46,7 +44,7 @@ import { MosaicCardComponent } from '../../shared/components/mosaic-card/mosaic-
 import { CardSkeletonComponent } from '../../shared/components/card-skeleton';
 import { ImportProgressBannerComponent } from '../../shared/components/import-progress-banner/import-progress-banner';
 import { NgTemplateOutlet } from '@angular/common';
-import { fanartPool, itemArtwork } from '../../shared/utils/media-artwork.util';
+import { itemArtwork } from '../../shared/utils/media-artwork.util';
 import { PlayableMediaService } from '../../core/services/playable-media.service';
 import {
   CdkVirtualScrollViewport,
@@ -120,8 +118,6 @@ export class LibraryComponent implements OnInit, OnDestroy {
   private readonly scrollMode = inject(PageScrollModeService);
   private readonly scrollMemory = inject(ScrollMemoryService);
   private readonly injector = inject(Injector);
-  private readonly background = inject(BackgroundService);
-  private readonly displaySettings = inject(DisplaySettingsService);
   readonly navbar = inject(NavbarService);
   private readonly translate = inject(TranslateService);
   protected readonly itemArtwork = itemArtwork;
@@ -153,22 +149,12 @@ export class LibraryComponent implements OnInit, OnDestroy {
         this.holdLetter();
         this.renderRangeForRememberedOffset();
       }
-      this.applyBackground();
     },
     onDetach: () => {
       if (!this.windowScroll()) this.pageScroller.release(this.shellRef.nativeElement);
     },
   });
 
-  /** Same fanart backdrop as the home page, drawn from this library's own
-   *  titles, so the topbar keeps its frosted look here too. */
-  private applyBackground(): void {
-    if (!this.displaySettings.settings().homeBackground) return this.background.set(this, []);
-    // An empty list is a list still loading, which must hold the current image
-    // rather than declare this page has none.
-    const pool = fanartPool(this.list.all());
-    this.background.set(this, pool.length ? pool : null);
-  }
   private queryParamSub?: Subscription;
   /** Set while a state-driven `syncQueryParams` is being applied to the
    *  URL, so the `queryParamMap` subscription that fires right after
@@ -564,7 +550,6 @@ export class LibraryComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.background.release(this);
     this.list.destroy();
     if (this.onResize) window.removeEventListener('resize', this.onResize);
     this.scrollMemory.deactivate();
@@ -916,7 +901,6 @@ export class LibraryComponent implements OnInit, OnDestroy {
         this.streamingApi.getWatchedMediaIds().catch(() => [] as number[]),
       ]);
       this.list.setItems(res.data, (m) => m.title);
-      this.applyBackground();
       this.watchedIds.set(new Set(watchedIds));
     } finally {
       if (!silent) this.loading.set(false);
@@ -932,10 +916,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
         this.streamingApi.getWatchedMediaIds({ force: true }).catch(() => null),
       ]).then(([res, watchedIds]) => {
         if (gen !== this.loadGen) return;
-        if (res) {
-          this.list.setItems(res.data, (m) => m.title);
-          this.applyBackground();
-        }
+        if (res) this.list.setItems(res.data, (m) => m.title);
         if (watchedIds) this.watchedIds.set(new Set(watchedIds));
       });
     });

--- a/client/src/app/features/media-detail/media-detail.delete-confirm.spec.ts
+++ b/client/src/app/features/media-detail/media-detail.delete-confirm.spec.ts
@@ -73,7 +73,7 @@ function createHarness() {
       { provide: ProfilesService, useValue: {} },
       { provide: LibrariesApiService, useValue: {} },
       { provide: NavbarService, useValue: { enterHeroPage: vi.fn(), leaveHeroPage: vi.fn() } },
-      { provide: BackgroundService, useValue: { set: vi.fn(), release: vi.fn(), url: signal(null) } },
+      { provide: BackgroundService, useValue: { set: vi.fn(), release: vi.fn(), suspend: vi.fn(), url: signal(null) } },
       { provide: ConfirmationService, useValue: { confirm } },
       { provide: ToastService, useValue: { success: vi.fn(), error: vi.fn() } },
       { provide: SseService, useValue: { lastEvent: signal(null) } },

--- a/client/src/app/features/media-detail/media-detail.episode-morph.spec.ts
+++ b/client/src/app/features/media-detail/media-detail.episode-morph.spec.ts
@@ -63,7 +63,7 @@ function createFixture(media: Promise<unknown> = new Promise(() => {})) {
       { provide: ProfilesService, useValue: {} },
       { provide: LibrariesApiService, useValue: {} },
       { provide: NavbarService, useValue: { enterHeroPage: vi.fn(), leaveHeroPage: vi.fn(), navigatedBack: signal(false) } },
-      { provide: BackgroundService, useValue: { set: vi.fn(), release: vi.fn(), url: signal(null) } },
+      { provide: BackgroundService, useValue: { set: vi.fn(), release: vi.fn(), suspend: vi.fn(), url: signal(null) } },
       { provide: ConfirmationService, useValue: {} },
       { provide: ToastService, useValue: { success: vi.fn(), error: vi.fn() } },
       { provide: SseService, useValue: { lastEvent: signal(null) } },

--- a/client/src/app/features/media-detail/media-detail.sse-replay.spec.ts
+++ b/client/src/app/features/media-detail/media-detail.sse-replay.spec.ts
@@ -74,7 +74,7 @@ function createHarness(seedEvent: SseEvent | null) {
       { provide: ProfilesService, useValue: {} },
       { provide: LibrariesApiService, useValue: {} },
       { provide: NavbarService, useValue: { enterHeroPage: vi.fn(), leaveHeroPage: vi.fn() } },
-      { provide: BackgroundService, useValue: { set: vi.fn(), release: vi.fn(), url: signal(null) } },
+      { provide: BackgroundService, useValue: { set: vi.fn(), release: vi.fn(), suspend: vi.fn(), url: signal(null) } },
       { provide: ConfirmationService, useValue: {} },
       { provide: ToastService, useValue: { success: vi.fn(), error: vi.fn() } },
       { provide: SseService, useValue: { lastEvent: signal(seedEvent) } },

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -42,6 +42,7 @@ import { ProfilesService, LanguageProfile } from '../../core/services/api/profil
 import { LibrariesApiService, LibrarySummary } from '../../core/services/api/libraries-api.service';
 import { NavbarService } from '../../core/services/navbar.service';
 import { BackgroundService } from '../../core/services/background.service';
+import { pickFanart } from '../../shared/utils/media-artwork.util';
 import {
   StreamingApiService,
   MediaResumeInfo,
@@ -284,21 +285,18 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     onAttach: () => this.restoreChrome(),
   });
 
-  /** Backdrop pick held across a detach so the page comes back on the same
-   *  image instead of re-randomising from the pool. */
-  /** Last pool declared, so returning to a cached page can re-declare it. */
-  private fanartPool: readonly string[] | null = null;
+  /** Last fanart declared, so returning to a cached page can re-declare it. */
+  private fanartUrl: string | null = null;
 
-  /** The hero navbar is global state, so a cached page hands it back on the way
-   *  out and reclaims it on return. The backdrop is not handed back: the
-   *  declaration stands until the page is destroyed, so a trip to the player
-   *  and back finds the same image rather than a blank that refills. */
+  /** The hero navbar and the backdrop are global state, so a cached page hands
+   *  them back on the way out and reclaims them on return. */
   private releaseChrome(): void {
     this.navbarService.leaveHeroPage();
+    this.backgroundService.suspend(this);
   }
 
   private restoreChrome(): void {
-    this.backgroundService.set(this, this.fanartPool);
+    this.backgroundService.set(this, this.fanartUrl);
     const m = this.media();
     if (m) this.applyEpisodeFocus(m, this.route.snapshot.paramMap.get('episodeId'));
     else this.navbarService.enterHeroPage('');
@@ -334,22 +332,12 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     this.applyEpisodeFocus(m, params.get('episodeId'));
   });
 
-  /**
-   * Drive the global page background from the currently-focused media.
-   *
-   * We always pull from the *series / movie* fanart pool (never the
-   * episode still): TMDB stills cap at ~780×438 and look mushy when
-   * stretched fullscreen. The pool is `[fanartUrl,
-   * ...additionalFanartUrls]`; one entry is picked at random when the
-   * page loads and stays put — no auto-rotation.
-   */
+  /** Series / movie fanart, never the episode still: TMDB stills cap at
+   *  ~780×438 and look mushy stretched fullscreen. */
   private readonly backgroundEffect = effect(() => {
     const m = this.media();
-    // No media yet is not the same as no fanart: hold what is on screen.
-    this.fanartPool = m
-      ? [m.fanartUrl, ...(m.additionalFanartUrls ?? [])].filter((u): u is string => !!u)
-      : null;
-    this.backgroundService.set(this, this.fanartPool);
+    this.fanartUrl = m ? pickFanart(m) : null;
+    this.backgroundService.set(this, this.fanartUrl);
   });
 
   /** React to SSE rescan / import / metadata-refresh events for this media */

--- a/client/src/app/features/media-detail/media-detail.unidentified.spec.ts
+++ b/client/src/app/features/media-detail/media-detail.unidentified.spec.ts
@@ -93,7 +93,7 @@ function createHarness(media: Media, isAdmin: boolean) {
       { provide: ProfilesService, useValue: {} },
       { provide: LibrariesApiService, useValue: {} },
       { provide: NavbarService, useValue: { enterHeroPage: vi.fn(), leaveHeroPage: vi.fn(), navigatedBack: signal(false) } },
-      { provide: BackgroundService, useValue: { set: vi.fn(), release: vi.fn(), url: signal(null) } },
+      { provide: BackgroundService, useValue: { set: vi.fn(), release: vi.fn(), suspend: vi.fn(), url: signal(null) } },
       { provide: ConfirmationService, useValue: {} },
       { provide: ToastService, useValue: { success: vi.fn(), error: vi.fn() } },
       { provide: SseService, useValue: { lastEvent: signal(null) } },

--- a/client/src/app/features/playlists/playlist-detail/playlist-detail.ts
+++ b/client/src/app/features/playlists/playlist-detail/playlist-detail.ts
@@ -43,7 +43,6 @@ import { DropdownMenuComponent } from '../../../shared/components/dropdown-menu'
 import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import { StreamingApiService } from '../../../core/services/api/streaming-api.service';
-import { BackgroundService } from '../../../core/services/background.service';
 import { AutoDownloadService } from '../../../core/services/auto-download.service';
 import { NavbarService } from '../../../core/services/navbar.service';
 import { PlayableMediaService } from '../../../core/services/playable-media.service';
@@ -119,7 +118,6 @@ export class PlaylistDetailComponent {
   readonly tv = inject(TvService);
   readonly navbar = inject(NavbarService);
   private readonly streamingApi = inject(StreamingApiService);
-  private readonly background = inject(BackgroundService);
   private readonly autoDownload = inject(AutoDownloadService);
   private readonly playable = inject(PlayableMediaService);
   private readonly social = inject(SocialApiService);
@@ -347,23 +345,10 @@ export class PlaylistDetailComponent {
       const id = this.playlistId();
       if (Number.isFinite(id) && id > 0) void this.load(id);
     });
-    // Drive the global page background from the playlist's media, like the
-    // media-detail pages.
-    effect(() => {
-      const pool = [
-        ...new Set(
-          this.items()
-            .map((i) => i.media.fanartUrl)
-            .filter((u): u is string => !!u),
-        ),
-      ];
-      this.background.set(this, pool);
-    });
     // Reuse the layout's desktop back button (no hero styling, so mobile keeps
     // its normal top padding).
     this.navbar.showBackButton.set(true);
     this.destroyRef.onDestroy(() => {
-      this.background.release(this);
       this.navbar.showBackButton.set(false);
     });
   }

--- a/client/src/app/features/tmdb-preview/tmdb-preview.ts
+++ b/client/src/app/features/tmdb-preview/tmdb-preview.ts
@@ -70,8 +70,7 @@ export class TmdbPreviewComponent implements OnInit, OnDestroy {
    *  picks the URL up from the service and renders it under the page. */
   private readonly backgroundEffect = effect(() => {
     const m = this.media();
-    // Nothing loaded yet holds the current image; a media with no fanart clears.
-    this.backgroundService.set(this, m ? [m.fanartUrl].filter((u): u is string => !!u) : null);
+    this.backgroundService.set(this, m?.fanartUrl ?? null);
   });
 
   readonly media = signal<MetadataDetails | null>(null);

--- a/client/src/app/shared/utils/media-artwork.util.ts
+++ b/client/src/app/shared/utils/media-artwork.util.ts
@@ -11,11 +11,7 @@ export function itemArtwork(item: {
   return item.stillUrl ?? item.fanartUrl ?? item.posterUrl ?? null;
 }
 
-/**
- * Fanart URLs for a page-background pool: the primary plus every extra. The
- * BackgroundService keeps one stable pick per pool, so the page holds the same
- * image for as long as the user stays on it.
- */
+/** Fanart URLs for a page-background pool: the primary plus every extra. */
 export function fanartPool(
   items: readonly { fanartUrl?: string | null; additionalFanartUrls?: string[] | null }[],
 ): string[] {
@@ -25,4 +21,14 @@ export function fanartPool(
     pool.push(...(item.additionalFanartUrls ?? []));
   }
   return pool;
+}
+
+/** One fanart per title, the same on every visit. */
+export function pickFanart(m: {
+  id: number;
+  fanartUrl?: string | null;
+  additionalFanartUrls?: string[] | null;
+}): string | null {
+  const pool = fanartPool([m]);
+  return pool.length ? pool[m.id % pool.length] : null;
 }


### PR DESCRIPTION
## Why

Every page declared its own backdrop pool, so walking the app reshuffled the image on each arrival: the home drew from its recommendations, a library from its own titles, a playlist from its items. The backdrop is chrome, not page content, and it read as a slideshow.

## What

- **Normal pages** share one *ambient* image drawn from the viewer's recommendations. A navigation may only replace it once the previous pick is five minutes old; the page itself declares nothing (home, library and playlist-detail lost all their backdrop code).
- **Media pages** (`media-detail`, `tmdb-preview`) declare their title's fanart and win while they are on screen. The pick is derived from the media id, so the same title always comes back on the same image.
- **Player round-trip changes nothing**: navigations to and from `/watch` never roll the ambient, and `suspend()` keeps a media claim alive while the player is what covers the page (a claim is only handed back when another page takes over).
- **Settings and admin pages** (`/app-settings`, `/account`, `/admin`) take no backdrop.

`BackgroundService` owns the whole decision — recommendations pool, timer, current route — and reads the router through its signals (`lastSuccessfulNavigation`, `currentNavigation`) instead of an event subscription. The recommendations request carries no options, so it is the same URL the home page asks for and is served from its cache.

## Trade-offs

- A library and a playlist no longer get a backdrop built from their own titles; that is what "the image does not change between normal pages" implies.
- A media with no fanart keeps the ambient behind its hero instead of clearing the backdrop.

## Test

`tsc --noEmit` clean, eslint clean, `ng test` 891/891 green. Exercised in the Linux desktop client.