### PR TITLE
fix(client): crossfade the backdrop image to image, and never through a stale layer

### DIFF
--- a/client/src/app/shared/components/background/background.html
+++ b/client/src/app/shared/components/background/background.html
@@ -3,18 +3,16 @@
      fanart. Tablets (md+) get the global background. -->
 <div class="fixed inset-0 -z-10 overflow-hidden pointer-events-none hidden md:block">
   @for (url of layers(); track $index) {
-    @if (url) {
-      <img
-        [cachedSrc]="url | resolveUrl:'medium'"
-        alt=""
-        loading="lazy"
-        decoding="async"
-        fetchpriority="low"
-        class="absolute inset-0 w-full h-full object-cover object-[50%_25%] app-bg-layer transition-opacity duration-1500"
-        [class.opacity-100]="activeLayer() === $index && imageVisible()"
-        [class.opacity-0]="activeLayer() !== $index || !imageVisible()"
-      />
-    }
+    <img
+      [cachedSrc]="url | resolveUrl:'medium'"
+      alt=""
+      loading="lazy"
+      decoding="async"
+      fetchpriority="low"
+      (load)="onLoad($index, $event)"
+      class="absolute inset-0 w-full h-full object-cover object-[50%_25%]"
+      [class]="layerClass($index)"
+    />
   }
   <!-- Veil is permanent: when no background is set, the tint over
        the body's solid base-100 is a no-op (same colour); when an
@@ -25,5 +23,5 @@
        which Chromium 85 (Tizen TV) doesn't support — the preset-env
        fallback drops the alpha and the veil ends up 100% opaque,
        killing the fanart. Plain `rgba()` is universally supported. -->
-  <div class="absolute inset-0 app-bg-veil"></div>
+  <div class="absolute inset-0 z-30 app-bg-veil"></div>
 </div>

--- a/client/src/app/shared/components/background/background.ts
+++ b/client/src/app/shared/components/background/background.ts
@@ -1,9 +1,4 @@
-import {
-  Component,
-  effect,
-  inject,
-  signal,
-} from '@angular/core';
+import { Component, effect, inject, signal } from '@angular/core';
 import { BackgroundService } from '../../../core/services/background.service';
 import { ResolveUrlPipe } from '../../../core/pipes/resolve-url.pipe';
 import { CachedSrcDirective } from '../../directives/cached-src.directive';
@@ -14,12 +9,11 @@ import { CachedSrcDirective } from '../../directives/cached-src.directive';
  * the sidebar. It has to sit above the outlet rather than in the layout: the
  * player is a top-level route and would take the layout, and this, with it.
  *
- * Crossfade strategy: a ring of layers, one visible at a time. A new url is
- * written into the next one, which then fades in over the others. Two would be
- * enough only if every fade finished before the next url arrived; browsing
- * between pages is faster than that, and reusing a layer still on screen swaps
- * its image in place. A third gives the writer a layer that has been hidden for
- * two turns, so the image it replaces is never one the viewer can see.
+ * Crossfade: a ring of three layers. The next url is written into the layer
+ * nobody can see, brought up only once its image has decoded (an <img> keeps
+ * painting its old image until then), and fades in over the outgoing image,
+ * which stays fully opaque underneath so the fade goes image to image and
+ * never dips through the base colour. Only a fade to nothing dims a layer.
  */
 const LAYERS = 3;
 
@@ -32,12 +26,12 @@ export class BackgroundComponent {
   private readonly bg = inject(BackgroundService);
 
   readonly layers = signal<readonly (string | null)[]>(Array<string | null>(LAYERS).fill(null));
-  readonly activeLayer = signal(0);
-  /** Tracks whether the active layer should currently be at full
-   *  opacity. The image is dimmed in CSS (filter: brightness),
-   *  so we no longer need a separate veil — fade-out can use the
-   *  image opacity directly without showing un-tinted colour. */
-  readonly imageVisible = signal(false);
+  /** Layer fading in on top; `null` while the backdrop fades out to nothing. */
+  readonly active = signal<number | null>(null);
+  /** Layer held opaque under the fade: the image the viewer is leaving. */
+  readonly previous = signal<number | null>(null);
+  /** Layer whose image is still loading; promoted once it has decoded. */
+  private pending: number | null = null;
 
   constructor() {
     let last: string | null = null;
@@ -45,16 +39,51 @@ export class BackgroundComponent {
       const next = this.bg.url();
       if (next === last) return;
       last = next;
-
+      this.pending = null;
       if (next === null) {
-        this.imageVisible.set(false);
+        this.show(null);
         return;
       }
-
-      this.imageVisible.set(true);
-      const target = (this.activeLayer() + 1) % LAYERS;
+      const target = this.freeLayer();
+      // The same image already sits there, so no load event will come.
+      if (this.layers()[target] === next) {
+        this.show(target);
+        return;
+      }
+      this.pending = target;
       this.layers.update((ls) => ls.map((url, i) => (i === target ? next : url)));
-      this.activeLayer.set(target);
     });
+  }
+
+  onLoad(index: number, event: Event): void {
+    if (index !== this.pending) return;
+    const img = event.target as HTMLImageElement;
+    const src = img.currentSrc;
+    void img
+      .decode()
+      .catch(() => undefined)
+      .then(() => {
+        if (index !== this.pending || img.currentSrc !== src) return;
+        this.pending = null;
+        this.show(index);
+      });
+  }
+
+  layerClass(index: number): string {
+    const active = this.active();
+    if (index === active) return 'opacity-100 z-20 transition-opacity duration-1500';
+    if (index !== this.previous()) return 'opacity-0';
+    return active === null ? 'opacity-0 transition-opacity duration-1500' : 'opacity-100 z-10';
+  }
+
+  private show(index: number | null): void {
+    if (index === this.active()) return;
+    this.previous.set(this.active());
+    this.active.set(index);
+  }
+
+  private freeLayer(): number {
+    const busy = [this.active(), this.previous()];
+    return this.layers().findIndex((_, i) => !busy.includes(i));
   }
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -132,16 +132,6 @@ html.tv-webos .table-zebra tbody tr.row-hover:where(:nth-child(2n)):hover {
   background-color: rgba(29, 35, 42, 0.95);
 }
 
-/* Background crossfade — a layer is written and activated in the same tick, so
-   its <img> enters the DOM already at the target opacity and has no previous
-   value to transition from. @starting-style supplies one. Engines without it
-   fall back to today's instant swap. */
-.app-bg-layer {
-  @starting-style {
-    opacity: 0;
-  }
-}
-
 /* Home library pill. The tint and border are an overlay dimmed by `opacity`
    rather than a `color-mix()` alpha, which the TV WebView can't parse. */
 .library-card {


### PR DESCRIPTION
## Symptoms (Tizen TV)

- Walking home → media → home → media, the fanart of a media page visited earlier flashed on screen for an instant before the right image took over.
- Every backdrop change dipped through a step with no image, instead of fading from one image to the other.

## Causes

1. A layer was raised to full opacity in the same tick its `src` changed. An `<img>` keeps painting its previous image until the new one has decoded, so on a slow decode (TV, image not in cache) the layer came up showing the fanart it held two turns earlier. The ring of three only guaranteed the overwritten image was not the *visible* one; it exposed it at promotion.
2. The outgoing layer faded out while the incoming faded in. Two opposite linear fades cover only `1 - t(1 - t)` of the frame: a quarter of the base colour showed through at the midpoint.

## Fix

- The next url is written into the layer nobody can see, promoted only once its image has decoded (`load` + `decode()`), and fades in over the outgoing layer, which stays fully opaque underneath. A layer is only dimmed when the backdrop fades to nothing.
- Roles (`active` / `previous` / free) are stacked with `z-index` since the ring order is fixed in the DOM; the veil rides above them all.
- The three `<img>` are always mounted, so a first image fades in even on engines without `@starting-style`; that rule goes.

Validated on the Q80B (Tizen 6.5).
