### PR TITLE
build(desktop): build the vendored libmpv from source with mpv-build

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -82,7 +82,21 @@ is ignored; the Linux `.so` is the one committed exception). It must be
 clashes with libmpv's FFmpeg and crashes (`free(): invalid pointer` / abort).
 Override the path with `FLIKS_MPV_PATH`.
 
-**Linux** — `native/vendor/libmpv.so.2` (~38 MB self-contained static).
+**Linux** — `native/vendor/libmpv.so.2` (~31 MB self-contained static). Build it
+with the build script, which drives mpv-build in a container and runs the
+kill-switches itself:
+```bash
+desktop/scripts/build-libmpv-linux.sh           # ubuntu:24.04 → glibc 2.39 floor
+BASE=ubuntu:22.04 desktop/scripts/build-libmpv-linux.sh
+```
+The base image is the minimum glibc every user of the `.deb` / AppImage then needs,
+so it is an LTS rather than the newest release. Anything whose soname churns between
+distro releases (libass, libplacebo, libunibreak) is linked statically and the
+features that dragged in the rest (bluray, rubberband, drm/wayland EDID) are off —
+a dynamic dep on one of those is what breaks the blob on a distro upgrade.
+`vendor-libmpv-linux.sh` is the other half, at release time: it bundles next to the
+lib the two SONAMEs a stock desktop still lacks. It guards on the exact `DT_NEEDED`
+set, so a rebuilt libmpv means re-deriving its list.
 Kill-switch (MUST print nothing):
 ```bash
 nm -D native/vendor/libmpv.so.2 | grep ' av_'

--- a/desktop/scripts/build-libmpv-linux.sh
+++ b/desktop/scripts/build-libmpv-linux.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Build desktop/native/vendor/libmpv.so.2 — the runtime libmpv for the Linux
+# desktop client. Counterpart of vendor-libmpv-mac.sh.
+#
+# The build itself is mpv-build, the mpv project's own out-of-tree builder.
+# Two constraints drive what we ask of it:
+#   • FFmpeg is linked statically with its symbols hidden. Electron ships its own
+#     libffmpeg.so; a libmpv that resolves av_* through the process would bind to
+#     Chromium's networkless build ("Protocol not found" on every https stream).
+#   • Everything whose soname churns between distro releases (libass, libplacebo,
+#     libunibreak) is linked statically too, and the features that dragged in the
+#     rest (bluray, rubberband, drm/wayland EDID) are off. What stays dynamic is
+#     the stable base only: glibc, X11/GL, libva/libdrm, GnuTLS, freetype,
+#     fribidi, harfbuzz, alsa, pulse.
+#
+# Builds in a container, so the host needs nothing but docker. The base image
+# sets the glibc floor every user of the .deb / AppImage then needs, which is why
+# it is an LTS rather than the newest release; everything that matters is built
+# from source on top of it.
+#
+# Usage:
+#   desktop/scripts/build-libmpv-linux.sh
+#   BASE=ubuntu:22.04 desktop/scripts/build-libmpv-linux.sh   # lower the floor
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT="$ROOT/desktop/native/vendor"
+BASE="${BASE:-ubuntu:24.04}"
+
+UNIBREAK_VERSION=6.1
+LIBASS_VERSION=0.17.4
+LIBPLACEBO_VERSION=v7.351.0
+FFMPEG_VERSION=n7.1.1
+MPV_VERSION=v0.41.0
+
+echo "==> building libmpv (mpv $MPV_VERSION, ffmpeg $FFMPEG_VERSION) on $BASE"
+docker build \
+  --file "$ROOT/desktop/scripts/libmpv-linux.Dockerfile" \
+  --tag "fliks-libmpv:${MPV_VERSION}-${BASE//[:.]/-}" \
+  --build-arg "BASE=$BASE" \
+  --build-arg "JOBS=$(nproc)" \
+  --build-arg "UNIBREAK_VERSION=$UNIBREAK_VERSION" \
+  --build-arg "LIBASS_VERSION=$LIBASS_VERSION" \
+  --build-arg "LIBPLACEBO_VERSION=$LIBPLACEBO_VERSION" \
+  --build-arg "FFMPEG_VERSION=$FFMPEG_VERSION" \
+  --build-arg "MPV_VERSION=$MPV_VERSION" \
+  "$ROOT/desktop/scripts"
+
+mkdir -p "$OUT"
+cid="$(docker create "fliks-libmpv:${MPV_VERSION}-${BASE//[:.]/-}")"
+trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+docker cp "$cid:/libmpv.so.2" "$OUT/libmpv.so.2.new"
+
+echo "==> verifying"
+fail=0
+if nm -D "$OUT/libmpv.so.2.new" | grep -q ' av_'; then
+  echo "REJECTED: exports FFmpeg symbols — they would clash with Electron's libffmpeg" >&2; fail=1
+fi
+if ldd "$OUT/libmpv.so.2.new" | grep -q 'not found'; then
+  echo "REJECTED: unresolved dependencies on this host:" >&2
+  ldd "$OUT/libmpv.so.2.new" | grep 'not found' >&2; fail=1
+fi
+[ "$fail" = 0 ] || { rm -f "$OUT/libmpv.so.2.new"; exit 1; }
+
+mv "$OUT/libmpv.so.2.new" "$OUT/libmpv.so.2"
+chmod 755 "$OUT/libmpv.so.2"
+echo "==> $OUT/libmpv.so.2 ($(du -h "$OUT/libmpv.so.2" | cut -f1)), dynamic deps:"
+objdump -p "$OUT/libmpv.so.2" | awk '/NEEDED/ {print "    " $2}'

--- a/desktop/scripts/dev-linux.sh
+++ b/desktop/scripts/dev-linux.sh
@@ -67,9 +67,23 @@ echo "==> [2/3] desktop main + preload"
 ( cd "$ROOT/desktop" && npm run build )
 
 echo "==> [3/3] relaunch Electron"
+# Wait for the old instance to let go of ~/.config/Fliks: starting while it still
+# holds the IndexedDB lock loses the stored session, so every relaunch would ask
+# for a login again.
 pkill -x electron 2>/dev/null || true
+for _ in $(seq 50); do pgrep -x electron >/dev/null || break; sleep 0.2; done
+if pgrep -x electron >/dev/null; then
+  echo "dev-linux: previous instance still up after 10s, killing it" >&2
+  pkill -9 -x electron 2>/dev/null || true
+  sleep 1
+fi
 
 cd "$ROOT/desktop"
 # DISPLAY=:0 forces XWayland — the OSR compositor doesn't run on native Wayland.
+# env -u: a terminal inside an Electron host (VS Code) exports
+# ELECTRON_RUN_AS_NODE=1, which makes the binary run the app as plain node.
+# FLIKS_DEBUG_PORT=9223 exposes the UI page over CDP for inspection.
+dbg_port=""
+[ -n "${FLIKS_DEBUG_PORT:-}" ] && dbg_port="--remote-debugging-port=$FLIKS_DEBUG_PORT"
 FLIKS_WEB_DIR="$OUT/browser" DISPLAY="${DISPLAY:-:0}" \
-  exec ./node_modules/.bin/electron . --no-sandbox
+  exec env -u ELECTRON_RUN_AS_NODE ./node_modules/.bin/electron . --no-sandbox $dbg_port

--- a/desktop/scripts/libmpv-linux.Dockerfile
+++ b/desktop/scripts/libmpv-linux.Dockerfile
@@ -1,0 +1,67 @@
+# Builds the vendored Linux libmpv with mpv-build, the mpv project's own
+# out-of-tree builder: it links FFmpeg, libass and libplacebo statically into
+# libmpv, which is what keeps Electron's libffmpeg from hijacking av_*.
+# Driven by vendor-libmpv-linux.sh, which explains why.
+ARG BASE=ubuntu:24.04
+FROM ${BASE}
+
+ARG JOBS=4
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
+      build-essential autoconf automake libtool ca-certificates curl git \
+      pkg-config python3-pip nasm \
+      libfreetype-dev libfribidi-dev libharfbuzz-dev libfontconfig-dev \
+      libgnutls28-dev libx11-dev libxext-dev libxrandr-dev libxpresent-dev \
+      libxss-dev libgl-dev libegl-dev libva-dev libdrm-dev zlib1g-dev \
+      libasound2-dev libpulse-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# --break-system-packages is unknown to pip < 23 and mandatory from 24.04 on.
+RUN pip3 install --quiet --upgrade --break-system-packages meson ninja \
+ || pip3 install --quiet --upgrade meson ninja
+
+# libass and libplacebo are built static, and a plain `pkg-config --libs` hides
+# the Libs.private they need (libunibreak, stdc++): libmpv would otherwise link
+# with those symbols left undefined.
+RUN printf '#!/bin/sh\nexec /usr/bin/pkg-config --static "$@"\n' > /usr/local/bin/pkg-config-static \
+ && chmod +x /usr/local/bin/pkg-config-static
+ENV PKG_CONFIG=/usr/local/bin/pkg-config-static \
+    PKG_CONFIG_PATH=/build/deps/lib/pkgconfig
+
+# The one dependency mpv-build leaves to the distro, and the one whose soname
+# bumped between LTS releases. Its own prefix: mpv-build wipes build_libs.
+ARG UNIBREAK_VERSION
+RUN mkdir -p /build/src && cd /build/src \
+ && curl -sL "https://github.com/adah1972/libunibreak/releases/download/libunibreak_$(echo "$UNIBREAK_VERSION" | tr . _)/libunibreak-$UNIBREAK_VERSION.tar.gz" | tar xz \
+ && cd "libunibreak-$UNIBREAK_VERSION" \
+ && ./configure --prefix=/build/deps --enable-static --disable-shared --with-pic \
+ && make -j"$JOBS" && make install
+
+RUN git clone -q https://github.com/mpv-player/mpv-build.git /build/mpv-build
+WORKDIR /build/mpv-build
+ARG FFMPEG_VERSION
+ARG LIBASS_VERSION
+ARG LIBPLACEBO_VERSION
+ARG MPV_VERSION
+RUN ./use-ffmpeg-custom "$FFMPEG_VERSION" \
+ && ./use-libass-custom "$LIBASS_VERSION" \
+ && ./use-libplacebo-custom "$LIBPLACEBO_VERSION" \
+ && ./use-mpv-custom "$MPV_VERSION"
+
+# FFmpeg: lean on purpose — every codec library would add a dynamic dependency
+# whose soname can churn. VAAPI and libdrm are the exceptions (hwdec), both
+# stable, and GnuTLS carries https (OpenSSL would force --enable-nonfree here).
+RUN printf '%s\n' \
+      --disable-programs --disable-autodetect --enable-version3 \
+      --enable-gnutls --enable-zlib --enable-vaapi --enable-libdrm \
+      > ffmpeg_options \
+ && printf '%s\n' \
+      -Dlibmpv=true -Dcplayer=false -Dgpl=true \
+      -Dlibbluray=disabled -Drubberband=disabled -Ddrm=disabled -Dwayland=disabled \
+      -Dlua=disabled -Djavascript=disabled -Dlibarchive=disabled -Duchardet=disabled \
+      -Dvapoursynth=disabled -Dzimg=disabled -Djpeg=disabled \
+      -Dx11=enabled -Degl=enabled -Dgl=enabled -Dvaapi=enabled \
+      -Dalsa=enabled -Dpulse=enabled \
+      > mpv_options
+
+RUN ./rebuild -j"$JOBS" && cp -L mpv/build/libmpv.so.2 /libmpv.so.2

--- a/desktop/scripts/vendor-libmpv-linux.sh
+++ b/desktop/scripts/vendor-libmpv-linux.sh
@@ -2,10 +2,10 @@
 # Bundle the shared libraries the committed libmpv.so.2 links against but a
 # stock Ubuntu desktop has no package for, and point every RUNPATH at $ORIGIN.
 #
-# Only FFmpeg is static inside that libmpv (av_* hidden); it still carries 50
-# DT_NEEDED entries. Shipping the gap as deb `depends:` is not an option: the
-# lib is built on noble, and four of its SONAMEs (unibreak.so.5, rubberband.so.2,
-# bluray.so.2, display-info.so.1) are packaged by no later Ubuntu.
+# FFmpeg, libass and libplacebo are static inside that libmpv (av_* hidden) and
+# the features that pulled the rest in are off, so only two of its DT_NEEDED
+# entries are missing from a stock desktop. See build-libmpv-linux.sh, which
+# builds it.
 #
 # The .debs are downloaded and unpacked, never installed: libjack-jackd2-0
 # displaces libjack0 on the runner and takes libmpv-dev out with it, which
@@ -20,31 +20,14 @@
 # Requires patchelf. FLIKS_LIBS_DIR skips the download and resolves from there.
 set -euo pipefail
 
-NEEDED_SHA256=3c2b1487fd5105b0c02ec86fc2847cedae584574c1469866ec8ab7562ccbe804
+NEEDED_SHA256=0c4cfe086268fa6c89c6907107bb4cb57b06a0faf08ce4a7058585b343a5e607
 
-# Direct DT_NEEDED of libmpv.so.2 that a stock desktop lacks, plus what those
-# drag in (dvdnav to dvdread to udfread, bluray to xml2 to icu, rubberband to
-# fftw3). Regenerate on a clean machine: ldd libmpv.so.2 | grep 'not found',
-# unpack the providers, repeat until it comes back empty.
+# Direct DT_NEEDED of libmpv.so.2 that a stock desktop lacks. Regenerate on a
+# clean machine: ldd libmpv.so.2 | grep 'not found', unpack the providers,
+# repeat until it comes back empty.
 LIBS=(
-  libunibreak.so.5=libunibreak5
   libva-x11.so.2=libva-x11-2
-  libvdpau.so.1=libvdpau1
-  libdvdnav.so.4=libdvdnav4
-  libsndio.so.7=libsndio7.0
-  libbluray.so.2=libbluray2
-  librubberband.so.2=librubberband2
-  libzimg.so.2=libzimg2
-  libjack.so.0=libjack-jackd2-0
-  libdisplay-info.so.1=libdisplay-info1
-  libsixel.so.1=libsixel1
   libXpresent.so.1=libxpresent1
-  libdvdread.so.8=libdvdread8t64
-  libudfread.so.0=libudfread0
-  libxml2.so.2=libxml2
-  libfftw3.so.3=libfftw3-double3
-  libicuuc.so.74=libicu74
-  libicudata.so.74=libicu74
 )
 
 if [ "${1:-}" = "--print-sonames" ]; then


### PR DESCRIPTION
## Why

The committed `libmpv.so.2` stopped loading on Ubuntu 26.04 — `dlopen libmpv failed: libunibreak.so.5` — and playback died with it. Only FFmpeg was static inside that lib; `libunibreak.so.5`, `libbluray.so.2`, `librubberband.so.2` and `libdisplay-info.so.1` were dynamic and the distro moved all four to a new soname. Every other dependency was one upgrade away from the same fate, and the release job already carried eighteen libraries to paper over the gap.

## What

- **`desktop/scripts/build-libmpv-linux.sh` + `libmpv-linux.Dockerfile`** (new) build the lib with [mpv-build](https://github.com/mpv-player/mpv-build), the mpv project's own out-of-tree builder, in a container. Pinned: mpv `v0.41.0`, FFmpeg `n7.1.1`, libass `0.17.4`, libplacebo `v7.351.0`, libunibreak `6.1`.
- **FFmpeg, libass and libplacebo are static**, `av_*` stays hidden. That is the load-bearing property: Electron ships its own networkless `libffmpeg.so`, and a libmpv resolving `av_*` through the process binds to it and fails every https stream with `Protocol not found`. The build script refuses to install a lib that exports `av_*` or that has an unresolved dependency.
- **libunibreak is built static** beside them — mpv-build leaves it to the distro, and it is the soname that broke.
- **bluray, rubberband, drm and wayland EDID are off**; they only ever pulled in churny libraries. GnuTLS rather than OpenSSL, which FFmpeg marks non-redistributable under GPL.
- What stays dynamic is the stable base: glibc, X11/GL, libva/libdrm, GnuTLS, freetype, fribidi, harfbuzz, alsa, pulse. The base image is the glibc floor every user of the `.deb` / AppImage inherits, hence an LTS (`ubuntu:24.04`, glibc 2.39); `BASE=` lowers it.
- **`vendor-libmpv-linux.sh`** keeps its guard on the exact `DT_NEEDED` set and now bundles two libraries instead of eighteen (`libva-x11.so.2`, `libXpresent.so.1`).
- The dev launcher stops lying about the app: it drops `ELECTRON_RUN_AS_NODE` (inherited from an IDE terminal, it ran the app as plain node and crashed inside electron-updater), waits for the profile lock before relaunching (otherwise every iteration lost the stored session), and can expose the UI page over CDP with `FLIKS_DEBUG_PORT`.

## Test

Built and installed locally: 31 MB, `nm -D | grep ' av_'` empty, no unresolved dependency. Direct play over https works again on the Linux desktop client — stream opens, video renders, audio plays. `vendor-libmpv-linux.sh --print-sonames` lists the two remaining libraries; its `DT_NEEDED` checksum is re-derived for the new lib.

The release job's own verification (bare-container `ldd` against the bundled SONAMEs) has not run yet — it will on this PR.