### PR TITLE
fix(streaming): reach same-language audio renditions on webOS

### DIFF
--- a/backend/src/modules/streaming/dto/device-profile.dto.ts
+++ b/backend/src/modules/streaming/dto/device-profile.dto.ts
@@ -142,6 +142,17 @@ export class DeviceProfileDto {
   supportsHlsSubtitles?: boolean;
 
   /**
+   * Client can select an alternate `EXT-X-MEDIA:TYPE=AUDIO` rendition at
+   * runtime. LG webOS sends `false`: its native HLS pipeline exposes one
+   * entry in `audioTracks` whatever the group holds, and it ignores
+   * `DEFAULT=YES`, so the master publishes the picked rendition alone and an
+   * audio switch goes through a reload. Unset is treated as `true`.
+   */
+  @IsBoolean()
+  @IsOptional()
+  supportsHlsAudioRenditions?: boolean;
+
+  /**
    * Client accelerates HLS through an `EXT-X-I-FRAME-STREAM-INF` rendition
    * (Tizen AVPlay's `setSpeed`). Only clients that declare it get the tag: any
    * player that reads one will fetch the frames behind it, and each frame costs

--- a/backend/src/modules/streaming/dto/device-profile.dto.ts
+++ b/backend/src/modules/streaming/dto/device-profile.dto.ts
@@ -142,15 +142,16 @@ export class DeviceProfileDto {
   supportsHlsSubtitles?: boolean;
 
   /**
-   * Client can select an alternate `EXT-X-MEDIA:TYPE=AUDIO` rendition at
-   * runtime. LG webOS sends `false`: its native HLS pipeline exposes one
-   * entry in `audioTracks` whatever the group holds, and it ignores
-   * `DEFAULT=YES`, so the master publishes the picked rendition alone and an
-   * audio switch goes through a reload. Unset is treated as `true`.
+   * Client surfaces one audio track per LANGUAGE, not one per rendition. LG
+   * webOS sends `true`: a group of eng/eng/hin reaches `audioTracks` as two
+   * entries, so same-language renditions can never be picked client-side.
+   * The master then publishes one rendition per language, the track the user
+   * asked for winning its own, and a same-language switch goes through a
+   * reload. Unset is treated as `false`.
    */
   @IsBoolean()
   @IsOptional()
-  supportsHlsAudioRenditions?: boolean;
+  dedupesAudioByLanguage?: boolean;
 
   /**
    * Client accelerates HLS through an `EXT-X-I-FRAME-STREAM-INF` rendition

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -114,10 +114,10 @@ export interface LiveSession {
    *  cues show in PiP / AirPlay / lock-screen. Web (Shaka) leaves this false
    *  and keeps fetching sidecar VTT. Sourced from the device profile. */
   supportsHlsSubtitles: boolean;
-  /** Client can select an alternate `EXT-X-MEDIA:TYPE=AUDIO` rendition at
-   *  runtime. `false` (webOS) publishes the picked rendition alone. Sourced
-   *  from the device profile. */
-  supportsHlsAudioRenditions: boolean;
+  /** Client surfaces one audio track per language, not per rendition (webOS).
+   *  The master then publishes one rendition per language. Sourced from the
+   *  device profile. */
+  dedupesAudioByLanguage: boolean;
   /** Client drives HLS trick play from an `EXT-X-I-FRAME-STREAM-INF`
    *  rendition (Tizen AVPlay). Sourced from the device profile. */
   supportsIFrameTrickPlay: boolean;
@@ -186,7 +186,7 @@ export interface CreateLiveSessionInput {
   deviceType?: 'mobile' | 'desktop';
   hdrLadder?: boolean;
   supportsHlsSubtitles?: boolean;
-  supportsHlsAudioRenditions?: boolean;
+  dedupesAudioByLanguage?: boolean;
   supportsIFrameTrickPlay?: boolean;
   probesSegZero?: boolean;
   supportsAbr?: boolean;
@@ -297,9 +297,7 @@ export function buildLiveSession(
       deviceType: input.deviceType ?? 'desktop',
       hdrLadder: input.hdrLadder ?? false,
       supportsHlsSubtitles: input.supportsHlsSubtitles ?? false,
-      // Default true: only a client that declares it can't pick a rendition
-      // gets the collapsed audio group.
-      supportsHlsAudioRenditions: input.supportsHlsAudioRenditions ?? true,
+      dedupesAudioByLanguage: input.dedupesAudioByLanguage ?? false,
       supportsIFrameTrickPlay: input.supportsIFrameTrickPlay ?? false,
       // Default true: only a client that explicitly declares it seeks straight
       // to the resume segment opts out of the seg-0 companion. Pre-flag clients

--- a/backend/src/modules/streaming/live-session.service.ts
+++ b/backend/src/modules/streaming/live-session.service.ts
@@ -114,6 +114,10 @@ export interface LiveSession {
    *  cues show in PiP / AirPlay / lock-screen. Web (Shaka) leaves this false
    *  and keeps fetching sidecar VTT. Sourced from the device profile. */
   supportsHlsSubtitles: boolean;
+  /** Client can select an alternate `EXT-X-MEDIA:TYPE=AUDIO` rendition at
+   *  runtime. `false` (webOS) publishes the picked rendition alone. Sourced
+   *  from the device profile. */
+  supportsHlsAudioRenditions: boolean;
   /** Client drives HLS trick play from an `EXT-X-I-FRAME-STREAM-INF`
    *  rendition (Tizen AVPlay). Sourced from the device profile. */
   supportsIFrameTrickPlay: boolean;
@@ -182,6 +186,7 @@ export interface CreateLiveSessionInput {
   deviceType?: 'mobile' | 'desktop';
   hdrLadder?: boolean;
   supportsHlsSubtitles?: boolean;
+  supportsHlsAudioRenditions?: boolean;
   supportsIFrameTrickPlay?: boolean;
   probesSegZero?: boolean;
   supportsAbr?: boolean;
@@ -292,6 +297,9 @@ export function buildLiveSession(
       deviceType: input.deviceType ?? 'desktop',
       hdrLadder: input.hdrLadder ?? false,
       supportsHlsSubtitles: input.supportsHlsSubtitles ?? false,
+      // Default true: only a client that declares it can't pick a rendition
+      // gets the collapsed audio group.
+      supportsHlsAudioRenditions: input.supportsHlsAudioRenditions ?? true,
       supportsIFrameTrickPlay: input.supportsIFrameTrickPlay ?? false,
       // Default true: only a client that explicitly declares it seeks straight
       // to the resume segment opts out of the seg-0 companion. Pre-flag clients

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -996,7 +996,7 @@ export class StreamingController {
       deviceType,
       hdrLadder: useHdrLadder,
       supportsHlsSubtitles: !!deviceProfile.supportsHlsSubtitles,
-      supportsHlsAudioRenditions: deviceProfile.supportsHlsAudioRenditions,
+      dedupesAudioByLanguage: deviceProfile.dedupesAudioByLanguage,
       supportsIFrameTrickPlay: !!deviceProfile.supportsIFrameTrickPlay,
       probesSegZero: deviceProfile.probesSegZero,
       supportsAbr: deviceProfile.supportsAbr,
@@ -1302,7 +1302,7 @@ export class StreamingController {
       defaultAudioIndex: pickedIdx ?? 0,
       deviceType,
       supportsAbr,
-      supportsHlsAudioRenditions: live?.supportsHlsAudioRenditions ?? true,
+      dedupesAudioByLanguage: live?.dedupesAudioByLanguage ?? false,
       outputAudioCodec: masterAudioCodec,
       // Real output audio bitrate so the BANDWIDTH sum reflects the 640k
       // AC-3/E-AC-3 path, not the profile nominal; copy renditions fall back.

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -996,6 +996,7 @@ export class StreamingController {
       deviceType,
       hdrLadder: useHdrLadder,
       supportsHlsSubtitles: !!deviceProfile.supportsHlsSubtitles,
+      supportsHlsAudioRenditions: deviceProfile.supportsHlsAudioRenditions,
       supportsIFrameTrickPlay: !!deviceProfile.supportsIFrameTrickPlay,
       probesSegZero: deviceProfile.probesSegZero,
       supportsAbr: deviceProfile.supportsAbr,
@@ -1301,6 +1302,7 @@ export class StreamingController {
       defaultAudioIndex: pickedIdx ?? 0,
       deviceType,
       supportsAbr,
+      supportsHlsAudioRenditions: live?.supportsHlsAudioRenditions ?? true,
       outputAudioCodec: masterAudioCodec,
       // Real output audio bitrate so the BANDWIDTH sum reflects the 640k
       // AC-3/E-AC-3 path, not the profile nominal; copy renditions fall back.

--- a/backend/src/modules/streaming/transcoding/hls-variant-ladder.ts
+++ b/backend/src/modules/streaming/transcoding/hls-variant-ladder.ts
@@ -61,6 +61,23 @@ export function buildUniqueAudioNames(
  *  (issue #148). `outputChannels[i]` is the resolved per-track output count
  *  (copy keeps the source, transcode downmixes); falls back to a codec-derived
  *  guess when the plan isn't threaded. */
+/** Indices to publish when the client keeps one rendition per language: the
+ *  picked track wins its own language, every other language keeps its first.
+ *  webOS collapses the audio group that way on its own — the renditions it
+ *  drops are unreachable, so the group has to carry the chosen one. */
+function keepOnePerLanguage(
+  audioStreams: AudioStreamMeta[],
+  pickedIdx: number,
+): Set<number> {
+  const byLang = new Map<string, number>();
+  const langOf = (i: number) => audioStreams[i].language || 'und';
+  byLang.set(langOf(pickedIdx), pickedIdx);
+  for (let i = 0; i < audioStreams.length; i++) {
+    if (!byLang.has(langOf(i))) byLang.set(langOf(i), i);
+  }
+  return new Set(byLang.values());
+}
+
 export function emitAudioRenditions(
   lines: string[],
   audioStreams: AudioStreamMeta[],
@@ -69,17 +86,18 @@ export function emitAudioRenditions(
   mediaFileId: number,
   tokenParam: string,
   outputChannels?: (number | undefined)[],
-  onlyPicked = false,
+  dedupeByLanguage = false,
 ): void {
   const pickedIdx =
     defaultAudioIndex >= 0 && defaultAudioIndex < audioStreams.length
       ? defaultAudioIndex
       : 0;
   const names = buildUniqueAudioNames(audioStreams);
+  const publish = dedupeByLanguage
+    ? keepOnePerLanguage(audioStreams, pickedIdx)
+    : null;
   for (let i = 0; i < audioStreams.length; i++) {
-    // A player that can't select a rendition plays whichever it sees first,
-    // so publishing the others only pins it away from the picked track.
-    if (onlyPicked && i !== pickedIdx) continue;
+    if (publish && !publish.has(i)) continue;
     const a = audioStreams[i];
     const lang = a.language || 'und';
     const isDefault = i === pickedIdx ? 'YES' : 'NO';

--- a/backend/src/modules/streaming/transcoding/hls-variant-ladder.ts
+++ b/backend/src/modules/streaming/transcoding/hls-variant-ladder.ts
@@ -69,6 +69,7 @@ export function emitAudioRenditions(
   mediaFileId: number,
   tokenParam: string,
   outputChannels?: (number | undefined)[],
+  onlyPicked = false,
 ): void {
   const pickedIdx =
     defaultAudioIndex >= 0 && defaultAudioIndex < audioStreams.length
@@ -76,6 +77,9 @@ export function emitAudioRenditions(
       : 0;
   const names = buildUniqueAudioNames(audioStreams);
   for (let i = 0; i < audioStreams.length; i++) {
+    // A player that can't select a rendition plays whichever it sees first,
+    // so publishing the others only pins it away from the picked track.
+    if (onlyPicked && i !== pickedIdx) continue;
     const a = audioStreams[i];
     const lang = a.language || 'und';
     const isDefault = i === pickedIdx ? 'YES' : 'NO';

--- a/backend/src/modules/streaming/transcoding/hls-variant-ladder.ts
+++ b/backend/src/modules/streaming/transcoding/hls-variant-ladder.ts
@@ -61,10 +61,8 @@ export function buildUniqueAudioNames(
  *  (issue #148). `outputChannels[i]` is the resolved per-track output count
  *  (copy keeps the source, transcode downmixes); falls back to a codec-derived
  *  guess when the plan isn't threaded. */
-/** Indices to publish when the client keeps one rendition per language: the
- *  picked track wins its own language, every other language keeps its first.
- *  webOS collapses the audio group that way on its own — the renditions it
- *  drops are unreachable, so the group has to carry the chosen one. */
+/** One index per language: the picked track wins its own, every other
+ *  language keeps its first. */
 function keepOnePerLanguage(
   audioStreams: AudioStreamMeta[],
   pickedIdx: number,

--- a/backend/src/modules/streaming/transcoding/master-playlist.spec.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.spec.ts
@@ -95,32 +95,64 @@ describe('generateMasterPlaylist — audio rendition CHANNELS', () => {
   });
 });
 
-describe('generateMasterPlaylist — supportsHlsAudioRenditions', () => {
+describe('generateMasterPlaylist — dedupesAudioByLanguage', () => {
   const mediaLines = (m: string): string[] =>
     m.split('\n').filter((l) => l.startsWith('#EXT-X-MEDIA:TYPE=AUDIO'));
+  const uri = (l: string): string => (l.match(/\/audio\/(\d+)\//) || [])[1];
+  // Measured shape on webOS: eng/eng/hin surfaces two tracks, so the second
+  // English is only reachable if the group publishes it instead of the first.
   const base = {
     mediaFileId: 1,
     sourceWidth: 1920,
     sourceHeight: 1080,
     tokenParam: '',
-    audioStreams: [{ channels: 6 }, { channels: 6 }, { channels: 2 }],
-    defaultAudioIndex: 2,
+    audioStreams: [
+      { channels: 6, language: 'eng' },
+      { channels: 6, language: 'eng' },
+      { channels: 2, language: 'hin' },
+    ],
   };
 
-  it('publishes the picked rendition alone when the client cannot select one', () => {
+  it('keeps one rendition per language, the picked track winning its own', () => {
     const media = mediaLines(
-      generateMasterPlaylist({ ...base, supportsHlsAudioRenditions: false }),
+      generateMasterPlaylist({
+        ...base,
+        defaultAudioIndex: 1,
+        dedupesAudioByLanguage: true,
+      }),
     );
-    expect(media).toHaveLength(1);
-    expect(media[0]).toContain('/audio/2/');
+    expect(media.map(uri)).toEqual(['1', '2']);
     expect(media[0]).toContain('DEFAULT=YES');
   });
 
-  it('publishes every rendition when unset or true', () => {
-    expect(mediaLines(generateMasterPlaylist(base))).toHaveLength(3);
+  it('keeps the other languages when the picked track is not theirs', () => {
+    const media = mediaLines(
+      generateMasterPlaylist({
+        ...base,
+        defaultAudioIndex: 2,
+        dedupesAudioByLanguage: true,
+      }),
+    );
+    // hin picked, and English still reachable through its first rendition.
+    expect(media.map(uri)).toEqual(['0', '2']);
+  });
+
+  it('never drops a rendition when each language is already unique', () => {
+    const twoLangs = {
+      ...base,
+      audioStreams: [
+        { channels: 6, language: 'fre' },
+        { channels: 6, language: 'eng' },
+      ],
+      defaultAudioIndex: 1,
+    };
     expect(
-      generateMasterPlaylist({ ...base, supportsHlsAudioRenditions: true }),
-    ).toEqual(generateMasterPlaylist(base));
+      mediaLines(generateMasterPlaylist({ ...twoLangs, dedupesAudioByLanguage: true })),
+    ).toHaveLength(2);
+  });
+
+  it('publishes every rendition when unset', () => {
+    expect(mediaLines(generateMasterPlaylist({ ...base, defaultAudioIndex: 1 }))).toHaveLength(3);
   });
 });
 

--- a/backend/src/modules/streaming/transcoding/master-playlist.spec.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.spec.ts
@@ -95,6 +95,35 @@ describe('generateMasterPlaylist — audio rendition CHANNELS', () => {
   });
 });
 
+describe('generateMasterPlaylist — supportsHlsAudioRenditions', () => {
+  const mediaLines = (m: string): string[] =>
+    m.split('\n').filter((l) => l.startsWith('#EXT-X-MEDIA:TYPE=AUDIO'));
+  const base = {
+    mediaFileId: 1,
+    sourceWidth: 1920,
+    sourceHeight: 1080,
+    tokenParam: '',
+    audioStreams: [{ channels: 6 }, { channels: 6 }, { channels: 2 }],
+    defaultAudioIndex: 2,
+  };
+
+  it('publishes the picked rendition alone when the client cannot select one', () => {
+    const media = mediaLines(
+      generateMasterPlaylist({ ...base, supportsHlsAudioRenditions: false }),
+    );
+    expect(media).toHaveLength(1);
+    expect(media[0]).toContain('/audio/2/');
+    expect(media[0]).toContain('DEFAULT=YES');
+  });
+
+  it('publishes every rendition when unset or true', () => {
+    expect(mediaLines(generateMasterPlaylist(base))).toHaveLength(3);
+    expect(
+      generateMasterPlaylist({ ...base, supportsHlsAudioRenditions: true }),
+    ).toEqual(generateMasterPlaylist(base));
+  });
+});
+
 describe('generateMasterPlaylist — supportsAbr collapses the ladder', () => {
   const base = {
     mediaFileId: 1,

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -199,6 +199,12 @@ export interface MasterPlaylistOptions {
   /** Source video bitrate + codec; caps each rung's declared BANDWIDTH. */
   sourceVideoBitrateBps?: number;
   sourceVideoCodec?: string;
+  /** Client can select an alternate `EXT-X-MEDIA:TYPE=AUDIO` rendition at
+   *  runtime. `false` publishes the picked one alone: LG webOS exposes a
+   *  single entry in `audioTracks` whatever the group holds and ignores
+   *  `DEFAULT=YES`, so the extra renditions only pin it to the wrong track.
+   *  Missing/undefined defaults to `true`. */
+  supportsHlsAudioRenditions?: boolean;
   /** Client can switch HLS variants at runtime (real ABR). `false` collapses
    *  the ladder to {@link topFittingProfile} when there's no explicit
    *  `onlyQuality` pin — see {@link applyQualityPin}. Missing/undefined
@@ -244,6 +250,7 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
     sourceVideoBitrateBps,
     sourceVideoCodec,
     supportsAbr = true,
+    supportsHlsAudioRenditions = true,
     iFrameTrickPlaySegmentSeconds,
     remuxCodecs,
     remuxBandwidthBps,
@@ -318,6 +325,8 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
         outputAudioCodec,
         mediaFileId,
         tokenParam,
+        undefined,
+        !supportsHlsAudioRenditions,
       );
     }
     const hdrAudioAttr = multiAudio ? ',AUDIO="audio"' : '';
@@ -397,6 +406,7 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
       mediaFileId,
       tokenParam,
       audioOutputChannels,
+      !supportsHlsAudioRenditions,
     );
   }
 

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -199,12 +199,11 @@ export interface MasterPlaylistOptions {
   /** Source video bitrate + codec; caps each rung's declared BANDWIDTH. */
   sourceVideoBitrateBps?: number;
   sourceVideoCodec?: string;
-  /** Client can select an alternate `EXT-X-MEDIA:TYPE=AUDIO` rendition at
-   *  runtime. `false` publishes the picked one alone: LG webOS exposes a
-   *  single entry in `audioTracks` whatever the group holds and ignores
-   *  `DEFAULT=YES`, so the extra renditions only pin it to the wrong track.
-   *  Missing/undefined defaults to `true`. */
-  supportsHlsAudioRenditions?: boolean;
+  /** Client exposes one audio track per LANGUAGE rather than one per
+   *  rendition (measured on webOS: a group of eng/eng/hin surfaces two
+   *  tracks). The renditions it folds away are unreachable, so the group
+   *  publishes one per language with the picked track winning its own. */
+  dedupesAudioByLanguage?: boolean;
   /** Client can switch HLS variants at runtime (real ABR). `false` collapses
    *  the ladder to {@link topFittingProfile} when there's no explicit
    *  `onlyQuality` pin — see {@link applyQualityPin}. Missing/undefined
@@ -250,7 +249,7 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
     sourceVideoBitrateBps,
     sourceVideoCodec,
     supportsAbr = true,
-    supportsHlsAudioRenditions = true,
+    dedupesAudioByLanguage = false,
     iFrameTrickPlaySegmentSeconds,
     remuxCodecs,
     remuxBandwidthBps,
@@ -326,7 +325,7 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
         mediaFileId,
         tokenParam,
         undefined,
-        !supportsHlsAudioRenditions,
+        dedupesAudioByLanguage,
       );
     }
     const hdrAudioAttr = multiAudio ? ',AUDIO="audio"' : '';
@@ -406,7 +405,7 @@ export function generateMasterPlaylist(opts: MasterPlaylistOptions): string {
       mediaFileId,
       tokenParam,
       audioOutputChannels,
-      !supportsHlsAudioRenditions,
+      dedupesAudioByLanguage,
     );
   }
 

--- a/backend/src/modules/streaming/transcoding/master-playlist.ts
+++ b/backend/src/modules/streaming/transcoding/master-playlist.ts
@@ -199,10 +199,9 @@ export interface MasterPlaylistOptions {
   /** Source video bitrate + codec; caps each rung's declared BANDWIDTH. */
   sourceVideoBitrateBps?: number;
   sourceVideoCodec?: string;
-  /** Client exposes one audio track per LANGUAGE rather than one per
-   *  rendition (measured on webOS: a group of eng/eng/hin surfaces two
-   *  tracks). The renditions it folds away are unreachable, so the group
-   *  publishes one per language with the picked track winning its own. */
+  /** Client exposes one audio track per language rather than one per
+   *  rendition, so the group publishes one per language — the renditions it
+   *  would fold away are unreachable, and the picked track wins its own. */
   dedupesAudioByLanguage?: boolean;
   /** Client can switch HLS variants at runtime (real ABR). `false` collapses
    *  the ladder to {@link topFittingProfile} when there's no explicit

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -132,6 +132,13 @@ export interface DeviceProfile {
    *  VTT. True for phone/desktop (iOS, Android, web/Shaka); false for TVs,
    *  whose AVPlay/webOS cue APIs are limited so they keep a DOM overlay. */
   supportsHlsSubtitles?: boolean;
+
+  /** Engine can select an alternate `EXT-X-MEDIA:TYPE=AUDIO` rendition at
+   *  runtime. False only for webOS, whose native pipeline surfaces one entry
+   *  in `audioTracks` whatever the group holds; the backend then publishes
+   *  the picked rendition alone and a switch goes through a reload. */
+  supportsHlsAudioRenditions?: boolean;
+
   /** Engine accelerates HLS from an `EXT-X-I-FRAME-STREAM-INF` rendition. */
   supportsIFrameTrickPlay?: boolean;
 
@@ -571,6 +578,7 @@ export class BrowserDeviceProfileService {
       // AVPlay/webOS cue APIs are limited, so those engines drive a DOM
       // overlay fed by sidecar VTT instead of the HLS renditions.
       supportsHlsSubtitles: traits.supportsHlsSubtitles,
+      supportsHlsAudioRenditions: traits.supportsHlsAudioRenditions,
       supportsIFrameTrickPlay: traits.supportsIFrameTrickPlay,
       supportsImageSubtitles: traits.supportsImageSubtitles,
       // Only the web/Shaka path probes seg-0 on a load-then-seek; that is

--- a/client/src/app/core/services/browser-device-profile.service.ts
+++ b/client/src/app/core/services/browser-device-profile.service.ts
@@ -133,11 +133,10 @@ export interface DeviceProfile {
    *  whose AVPlay/webOS cue APIs are limited so they keep a DOM overlay. */
   supportsHlsSubtitles?: boolean;
 
-  /** Engine can select an alternate `EXT-X-MEDIA:TYPE=AUDIO` rendition at
-   *  runtime. False only for webOS, whose native pipeline surfaces one entry
-   *  in `audioTracks` whatever the group holds; the backend then publishes
-   *  the picked rendition alone and a switch goes through a reload. */
-  supportsHlsAudioRenditions?: boolean;
+  /** Engine surfaces one audio track per LANGUAGE rather than one per
+   *  rendition (webOS). The backend then publishes one rendition per
+   *  language, the picked track winning its own. */
+  dedupesAudioByLanguage?: boolean;
 
   /** Engine accelerates HLS from an `EXT-X-I-FRAME-STREAM-INF` rendition. */
   supportsIFrameTrickPlay?: boolean;
@@ -578,7 +577,7 @@ export class BrowserDeviceProfileService {
       // AVPlay/webOS cue APIs are limited, so those engines drive a DOM
       // overlay fed by sidecar VTT instead of the HLS renditions.
       supportsHlsSubtitles: traits.supportsHlsSubtitles,
-      supportsHlsAudioRenditions: traits.supportsHlsAudioRenditions,
+      dedupesAudioByLanguage: traits.dedupesAudioByLanguage,
       supportsIFrameTrickPlay: traits.supportsIFrameTrickPlay,
       supportsImageSubtitles: traits.supportsImageSubtitles,
       // Only the web/Shaka path probes seg-0 on a load-then-seek; that is

--- a/client/src/app/core/services/engine-traits.spec.ts
+++ b/client/src/app/core/services/engine-traits.spec.ts
@@ -48,6 +48,7 @@ const EXPECTED: Record<EngineKind, EngineTraits> = {
   [EngineKind.WEBOS]: {
     useTsOnSingleAudio: false,
     supportsHlsSubtitles: false,
+    dedupesAudioByLanguage: true,
     supportsImageSubtitles: false,
     probesSegZero: false,
     supportsDirectPlay: true,

--- a/client/src/app/core/services/engine-traits.ts
+++ b/client/src/app/core/services/engine-traits.ts
@@ -38,6 +38,9 @@ export interface EngineTraits {
   useTsOnSingleAudio?: boolean;
   /** Engine consumes HLS `SUBTITLES` renditions natively. */
   supportsHlsSubtitles?: boolean;
+  /** Engine can select an alternate `EXT-X-MEDIA:TYPE=AUDIO` rendition at
+   *  runtime. `false` makes the master publish the picked one alone. */
+  supportsHlsAudioRenditions?: boolean;
   /** Engine accelerates HLS from an `EXT-X-I-FRAME-STREAM-INF` rendition
    *  (Tizen AVPlay `setSpeed`). */
   supportsIFrameTrickPlay?: boolean;
@@ -124,9 +127,14 @@ export const ENGINE_TRAITS: Record<EngineKind, EngineTraits> = {
     supportsDirectPlay: true,
     supportsAbr: true,
   },
+  // webOS surfaces exactly one entry in `video.audioTracks` however many
+  // renditions the audio group holds, and picks it without honouring
+  // DEFAULT=YES — so the group must carry only the track the user asked for
+  // and a language switch goes through a backend reload.
   [EngineKind.WEBOS]: {
     useTsOnSingleAudio: false,
     supportsHlsSubtitles: false,
+    supportsHlsAudioRenditions: false,
     supportsImageSubtitles: false,
     probesSegZero: false,
     supportsDirectPlay: true,

--- a/client/src/app/core/services/engine-traits.ts
+++ b/client/src/app/core/services/engine-traits.ts
@@ -38,9 +38,9 @@ export interface EngineTraits {
   useTsOnSingleAudio?: boolean;
   /** Engine consumes HLS `SUBTITLES` renditions natively. */
   supportsHlsSubtitles?: boolean;
-  /** Engine can select an alternate `EXT-X-MEDIA:TYPE=AUDIO` rendition at
-   *  runtime. `false` makes the master publish the picked one alone. */
-  supportsHlsAudioRenditions?: boolean;
+  /** Engine surfaces one audio track per LANGUAGE rather than one per
+   *  rendition, so same-language renditions can't be picked client-side. */
+  dedupesAudioByLanguage?: boolean;
   /** Engine accelerates HLS from an `EXT-X-I-FRAME-STREAM-INF` rendition
    *  (Tizen AVPlay `setSpeed`). */
   supportsIFrameTrickPlay?: boolean;
@@ -127,14 +127,13 @@ export const ENGINE_TRAITS: Record<EngineKind, EngineTraits> = {
     supportsDirectPlay: true,
     supportsAbr: true,
   },
-  // webOS surfaces exactly one entry in `video.audioTracks` however many
-  // renditions the audio group holds, and picks it without honouring
-  // DEFAULT=YES — so the group must carry only the track the user asked for
-  // and a language switch goes through a backend reload.
+  // webOS folds the audio group by language: a group of eng/eng/hin reaches
+  // `audioTracks` as two entries, so a second English rendition is
+  // unreachable client-side and only a reload can swap it in.
   [EngineKind.WEBOS]: {
     useTsOnSingleAudio: false,
     supportsHlsSubtitles: false,
-    supportsHlsAudioRenditions: false,
+    dedupesAudioByLanguage: true,
     supportsImageSubtitles: false,
     probesSegZero: false,
     supportsDirectPlay: true,

--- a/client/src/app/core/services/playback-engine/webos-engine.ts
+++ b/client/src/app/core/services/playback-engine/webos-engine.ts
@@ -54,6 +54,7 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
   /** Last URL handed to `load()` — the base for reload-on-seek. */
   private loadedUrl = '';
   private boundListeners: Array<[keyof HTMLMediaElementEventMap, EventListener]> = [];
+  private audioTrackListeners: Array<[string, EventListener]> = [];
   private frameCbHandle: number | null = null;
   /** Suppress the persistent `error` handler while a (re)load is in flight —
    *  a mediaOption rejection is recovered via the fallback, not surfaced. */
@@ -85,6 +86,10 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
     const v = this.video;
     if (v) {
       for (const [event, fn] of this.boundListeners) v.removeEventListener(event, fn);
+      const audioList = (v as unknown as { audioTracks?: EventTarget }).audioTracks;
+      for (const [event, fn] of this.audioTrackListeners) {
+        audioList?.removeEventListener(event, fn);
+      }
       if (this.frameCbHandle != null && 'cancelVideoFrameCallback' in v) {
         (v as any).cancelVideoFrameCallback(this.frameCbHandle);
       }
@@ -95,6 +100,7 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
       } catch { /* element may already be detached */ }
     }
     this.boundListeners = [];
+    this.audioTrackListeners = [];
     this.frameCbHandle = null;
     this.video = null;
     this.subtitles.destroy();
@@ -168,6 +174,19 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
       });
       this.emit('stateChanged', { state: 'error' });
     });
+
+    // The native pipeline fills AudioTrackList as it opens the stream, well
+    // after `loadedmetadata`, and refills it on every reload-seek — a one-shot
+    // read after load would miss it.
+    const audioList = (v as unknown as { audioTracks?: EventTarget }).audioTracks;
+    if (audioList) {
+      const onAudioTracks = () =>
+        this.emit('audioTracksChanged', { tracks: this.getAudioTracks() });
+      for (const event of ['addtrack', 'removetrack', 'change'] as const) {
+        audioList.addEventListener(event, onAudioTracks);
+        this.audioTrackListeners.push([event, onAudioTracks]);
+      }
+    }
 
     // requestVideoFrameCallback fires once a frame is actually composited —
     // a tighter "first frame" signal than the `playing` DOM event.
@@ -403,21 +422,25 @@ export class WebOsEngine extends AbstractPlaybackEngine implements PlaybackEngin
     const tracks: AudioTrack[] = [];
     for (let i = 0; i < list.length; i++) {
       const t = list[i];
+      // Position, never `t.id`: webOS numbers tracks from the demuxer stream
+      // id (1-based), and the player reads this suffix as a streamInfo index.
       tracks.push({
-        id: 'audio-' + (t.id || i),
+        id: 'audio-' + i,
         language: t.language || 'und',
         label: t.label || t.language || 'Track ' + (i + 1),
+        selected: !!t.enabled,
       });
     }
     return tracks;
   }
 
+  /** LG's AudioTrack API is a mute/unmute switch: the picked track goes
+   *  `enabled = true`, every other one false (webOS TV 3.0+). */
   async selectAudioTrack(id: string): Promise<void> {
     const list = this.audioTrackList();
     if (!list) return;
     for (let i = 0; i < list.length; i++) {
-      const t = list[i];
-      t.enabled = 'audio-' + (t.id || i) === id;
+      list[i].enabled = 'audio-' + i === id;
     }
   }
 

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -3994,16 +3994,16 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       if (this.isNativeEngine() && this.availableAudioTracks().length > 1) return;
 
       const engineTracks = this.engine.getAudioTracks();
-      // An engine that folds renditions together (webOS keeps one per
-      // language) reports fewer tracks than the source has. Its positional
-      // map to streamInfo would then mislabel, and the folded-away tracks
-      // would be unreachable — so keep the streamInfo list, whose picks route
-      // through a reload the backend can honour.
+      // An engine that folds renditions by language enumerates fewer tracks
+      // than the source: keep streamInfo so none leaves the menu.
       const sourceAudioCount =
         (this.media?.files?.find((f: any) => f.id === this.mediaFileId)
           ?.streamInfo as any)?.audio?.length ?? 0;
+      const foldsTracks =
+        !!this.deviceProfileService.getProfile().dedupesAudioByLanguage &&
+        engineTracks.length < sourceAudioCount;
 
-      if (engineTracks.length <= 1 || engineTracks.length < sourceAudioCount) {
+      if (engineTracks.length <= 1 || foldsTracks) {
         // Offline: don't show si-* fallback tracks — they can't be switched
         // via the engine. Only real engine-detected tracks are switchable.
         if (this.isOfflinePlayback) return;

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -1839,6 +1839,7 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
     engine.on('firstFrame', () => {
       this.state.videoStarted.set(true);
     });
+    this.wireAudioTracks(engine);
     this.wireSessionExpiredRecovery(engine);
   }
 

--- a/client/src/app/features/player/player.ts
+++ b/client/src/app/features/player/player.ts
@@ -3994,8 +3994,16 @@ export class PlayerComponent implements AfterViewInit, OnDestroy {
       if (this.isNativeEngine() && this.availableAudioTracks().length > 1) return;
 
       const engineTracks = this.engine.getAudioTracks();
+      // An engine that folds renditions together (webOS keeps one per
+      // language) reports fewer tracks than the source has. Its positional
+      // map to streamInfo would then mislabel, and the folded-away tracks
+      // would be unreachable — so keep the streamInfo list, whose picks route
+      // through a reload the backend can honour.
+      const sourceAudioCount =
+        (this.media?.files?.find((f: any) => f.id === this.mediaFileId)
+          ?.streamInfo as any)?.audio?.length ?? 0;
 
-      if (engineTracks.length <= 1) {
+      if (engineTracks.length <= 1 || engineTracks.length < sourceAudioCount) {
         // Offline: don't show si-* fallback tracks — they can't be switched
         // via the engine. Only real engine-detected tracks are switchable.
         if (this.isOfflinePlayback) return;


### PR DESCRIPTION
## Symptom

On the LG TV, picking a different audio track does nothing when the file carries several tracks
in the same language (e.g. English TrueHD + English AC-3 + director commentary). A title with
distinct languages (fre + eng) switches fine.

## Cause, measured on the panel

Probed over CDP on the running app (webOS TV 25, platform 10.3.1, Chromium 120), reading
`video.audioTracks` against the master actually served:

| Master audio group | `audioTracks` |
|---|---|
| `eng`, `eng`, `eng` (TrueHD / AC-3 / commentary) | **1** entry |
| `eng`, `eng`, `hin` | **2** entries (`eng`, `hin`) |
| `fre`, `eng` | **2** entries (`fre`, `eng`) |

**webOS folds the `EXT-X-MEDIA:TYPE=AUDIO` group by language — one track per distinct language.**
The renditions it folds away never reach the app, so they cannot be selected client-side at any
price. The documented AudioTrack switch (`audioTracks[i].enabled = true`, webOS TV 3.0+) works
fine on the tracks that do surface: verified end to end on a fre+eng title, both by CDP and by
ear.

That is why the same-language case looked dead while fre+eng worked, and it is the part LG's docs
leave as "Multi-Audio: partially supported".

## Fix

New `dedupesAudioByLanguage` device-profile trait, shaped like the existing
`supportsHlsSubtitles`. Absent or `false` keeps today's behaviour for every other client; only
the webOS engine row sends `true`.

The master then publishes **one rendition per language**, with the track the user picked winning
its own language and every other language keeping its first. So:

- 3× `eng`: the group carries the picked English rendition, and the reload the streamInfo list
  already triggers comes back with different audio instead of the same one.
- `eng`/`eng`/`hin`: the picked English plus Hindi — Hindi stays switchable client-side.
- `fre`/`eng`: nothing is dropped, the instant client-side switch is untouched.

ffmpeg still runs the same `var_stream_map` layout, so the per-rendition audio plans, the uniform
group codec and the `/audio/<i>/` subdir numbering are unchanged — only the published subset moves.

Two client-side defects the same measurements exposed:

- `loadAudioTracks` adopted the engine list whenever it held more than one track. When the engine
  folds renditions the list is shorter than the source's, so its positional map to `streamInfo`
  slid every label by one and the folded-away tracks disappeared from the menu. It now keeps the
  streamInfo list in that case, whose picks route through a reload the backend can honour.
- webOS never emitted `audioTracksChanged` and `createWebOsEngine` was the only engine creator
  not calling `wireAudioTracks`, so the list was read exactly once, two seconds after load — and
  the native pipeline fills it after `loadedmetadata` and refills it on every reload-seek.
  `addtrack` / `removetrack` / `change` now feed the event. Track ids move from the demuxer
  stream id, which webOS numbers from 1 (`"1"`, `"2"` for positions 0 and 1), to the list
  position — `parseAudioIndex` reads that suffix back as a streamInfo index, so picking English
  was recording index 2 on a two-track file and any later reload fell back to track 0.

## Ordering

The backend validates device profiles with `forbidNonWhitelisted`, so it has to be deployed
before the webOS bundle that sends the new field — otherwise `/playback-info` answers 400.

## Tests

`generateMasterPlaylist` covers the picked-track-wins case, the other-language-preserved case,
the all-distinct no-op and the flag-off default. Full streaming suite green (544 tests), backend
and client typecheck clean.

## Not covered

Whether webOS honours `DEFAULT=YES` when choosing among renditions it folds cannot be read from
the web API — the fix does not depend on it, since the group now carries only one candidate per
language.
