### PR TITLE
fix(client): repair the library's return from a media page on iOS

### DIFF
--- a/client/src/app/core/services/scroll-memory.service.spec.ts
+++ b/client/src/app/core/services/scroll-memory.service.spec.ts
@@ -4,6 +4,7 @@ import { NavigationStart, Router, Scroll } from '@angular/router';
 import { Subject } from 'rxjs';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ScrollMemoryService } from './scroll-memory.service';
+import { NavbarService } from './navbar.service';
 import { PageScrollerService } from './page-scroller.service';
 
 describe('ScrollMemoryService', () => {
@@ -11,16 +12,19 @@ describe('ScrollMemoryService', () => {
   let claimed: HTMLElement | null;
   let offset: number;
   let writes: number[];
+  let wentBack: boolean;
 
   beforeEach(() => {
     events = new Subject();
     claimed = null;
     offset = 0;
     writes = [];
+    wentBack = false;
     TestBed.configureTestingModule({
       providers: [
         provideZonelessChangeDetection(),
         { provide: Router, useValue: { events } },
+        { provide: NavbarService, useValue: { navigatedBack: () => wentBack } },
         {
           provide: PageScrollerService,
           useValue: {
@@ -43,6 +47,7 @@ describe('ScrollMemoryService', () => {
 
   it('saves and restores the claimed container, not the document', async () => {
     const s = service();
+    wentBack = true;
     claimed = document.createElement('div');
     s.activate('library-films');
     offset = 4160;
@@ -58,6 +63,7 @@ describe('ScrollMemoryService', () => {
 
   it('stops sticking once another page claims its own scroller', async () => {
     const s = service();
+    wentBack = true;
     claimed = document.createElement('div');
     s.activate('library-films');
     offset = 4160;
@@ -83,6 +89,7 @@ describe('ScrollMemoryService', () => {
 
   it('retries while a reattached container is not yet scrollable', async () => {
     const s = service();
+    wentBack = true;
     claimed = document.createElement('div');
     s.activate('library-films');
     offset = 4160;
@@ -107,5 +114,64 @@ describe('ScrollMemoryService', () => {
 
     expect(writes.length).toBeGreaterThan(1);
     expect(offset).toBe(4160);
+  });
+
+  it("holds a forward entry at the top when the router's own scroll is dropped", async () => {
+    service();
+    // WKWebView clamps the offset the previous, taller page had to this
+    // document's own maximum and ignores the router's single scrollTo.
+    offset = 1422;
+
+    events.next(new NavigationStart(1, '/movies/1'));
+    events.next(new Scroll({} as never, null, null));
+    await nextFrame();
+
+    expect(writes).toContain(0);
+    expect(offset).toBe(0);
+  });
+
+  it('takes the top back when the clamp lands a few frames later', async () => {
+    service();
+    events.next(new NavigationStart(1, '/movies/1'));
+    events.next(new Scroll({} as never, null, null));
+    await nextFrame();
+    writes.length = 0;
+
+    // WKWebView settles its contentSize off the main thread and reports the
+    // clamp as a scroll of its own, after the router's turn is over.
+    offset = 1422;
+    window.dispatchEvent(new Event('scroll'));
+
+    expect(writes).toEqual([0]);
+    expect(offset).toBe(0);
+  });
+
+  it('lets go of the top as soon as the user touches the page', async () => {
+    service();
+    events.next(new NavigationStart(1, '/movies/1'));
+    events.next(new Scroll({} as never, null, null));
+    await nextFrame();
+    writes.length = 0;
+
+    window.dispatchEvent(new Event('touchstart'));
+    offset = 900;
+    window.dispatchEvent(new Event('scroll'));
+
+    expect(writes).toEqual([]);
+    expect(offset).toBe(900);
+  });
+
+  it('leaves a return alone — its own restore owns the offset', async () => {
+    const s = service();
+    wentBack = true;
+    s.activate('library-films');
+    offset = 4160;
+    events.next(new NavigationStart(1, '/libraries/Films'));
+    offset = 1422;
+    events.next(new Scroll({} as never, null, null));
+    await nextFrame();
+    await nextFrame();
+
+    expect(writes).not.toContain(0);
   });
 });

--- a/client/src/app/core/services/scroll-memory.service.ts
+++ b/client/src/app/core/services/scroll-memory.service.ts
@@ -1,6 +1,13 @@
 import { Injectable, Injector, afterNextRender, inject } from '@angular/core';
 import { NavigationStart, Router, Scroll } from '@angular/router';
+import { NavbarService } from './navbar.service';
 import { PageScrollerService } from './page-scroller.service';
+
+/** How long a forward entry defends its own top. Long enough to outlast the
+ *  incoming document's growth, short enough to be over before a reader is. */
+const TOP_HOLD_MS = 600;
+/** Anything of these means the offset is the user's business now. */
+const USER_INPUT = ['touchstart', 'wheel', 'keydown'] as const;
 
 @Injectable({ providedIn: 'root' })
 export class ScrollMemoryService {
@@ -10,6 +17,9 @@ export class ScrollMemoryService {
   /** Whatever scrolls the active page — the document, or a container a page
    *  claimed. Both scroll models therefore share this one save/restore path. */
   private readonly pageScroller = inject(PageScrollerService);
+  /** Only a return asks for a remembered offset; everything else opens at the
+   *  top, and {@link enterAtTop} is what makes that stick. */
+  private readonly navbar = inject(NavbarService);
   /** False between NavigationStart and the router's own scroll. */
   private routerScrolled = true;
   private queued: (() => void)[] = [];
@@ -29,6 +39,7 @@ export class ScrollMemoryService {
         // scrolled whatever subscriber order puts first — same task either
         // way, so nothing in between is ever painted.
         if (due.length) queueMicrotask(() => due.forEach((fn) => fn()));
+        if (!this.navbar.navigatedBack()) queueMicrotask(() => this.enterAtTop());
       }
     });
   }
@@ -90,6 +101,36 @@ export class ScrollMemoryService {
     const owner = this.pageScroller.element();
     if (this.routerScrolled) this.stick(target, owner);
     else this.queued.push(() => this.stick(target, owner));
+  }
+
+  /**
+   * Hold a forward entry at the top. The router scrolls there once, and a
+   * WKWebView still sizing the incoming document drops that write — leaving
+   * the page at the offset the taller page before it had, which the new
+   * document's own maximum clamps to its footer.
+   *
+   * Two passes, because that clamp is not bound to this task: the sticky one
+   * for an offset that is already wrong, and a listener for the one that
+   * arrives a few frames later off the scrolling thread. Both end early —
+   * the first on the frame it reads zero, the second on the first thing the
+   * user does, so neither ever pulls against a real gesture.
+   */
+  private enterAtTop(): void {
+    const owner = this.pageScroller.element();
+    this.stick(0, owner);
+
+    const deadline = performance.now() + TOP_HOLD_MS;
+    const target: EventTarget = owner ?? window;
+    const done = () => {
+      target.removeEventListener('scroll', onScroll);
+      for (const ev of USER_INPUT) target.removeEventListener(ev, done);
+    };
+    const onScroll = () => {
+      if (performance.now() > deadline || this.pageScroller.element() !== owner) return done();
+      if (this.pageScroller.offset() > 1) this.pageScroller.scrollTo(0);
+    };
+    target.addEventListener('scroll', onScroll, { passive: true });
+    for (const ev of USER_INPUT) target.addEventListener(ev, done, { passive: true, once: true });
   }
 
   private stick(target: number, owner: HTMLElement | null): void {

--- a/client/src/app/features/library/library.spec.ts
+++ b/client/src/app/features/library/library.spec.ts
@@ -454,6 +454,42 @@ describe('LibraryComponent — window scroller (TV / desktop)', () => {
     }
   });
 
+  it('stops reading the window once detached, so the letter survives the trip', async () => {
+    const { component, detached$ } = createHarness('window');
+    component.list.setItems(twoSections(), (m) => m.title);
+    const viewport = attachViewport(component);
+    viewport.measureScrollOffset.mockReturnValue(component.rowHeight());
+    window.dispatchEvent(new Event('scroll'));
+    await nextFrame();
+    expect(component.list.activeLetter()).toBe('B');
+
+    detached$.next(OWN_KEY);
+    // The page the user moved on to scrolls the same window back to the top.
+    viewport.measureScrollOffset.mockReturnValue(0);
+    window.dispatchEvent(new Event('scroll'));
+    await nextFrame();
+
+    expect(component.list.activeLetter()).toBe('B');
+  });
+
+  it('reads the window again once reattached', async () => {
+    const { component, attached$, detached$, navigatedBack } = createHarness('window');
+    component.list.setItems(twoSections(), (m) => m.title);
+    const viewport = attachViewport(component);
+    navigatedBack.set(true);
+
+    detached$.next(OWN_KEY);
+    attached$.next(OWN_KEY);
+    // Past the hold that protects the restore's own scroll event.
+    vi.spyOn(performance, 'now').mockReturnValue(performance.now() + 1000);
+    viewport.measureScrollOffset.mockReturnValue(component.rowHeight());
+    window.dispatchEvent(new Event('scroll'));
+    await nextFrame();
+
+    expect(component.list.activeLetter()).toBe('B');
+    vi.restoreAllMocks();
+  });
+
   it('does not touch the page scroller across a detach/attach cycle', () => {
     const { pageScroller, attached$, detached$ } = createHarness('window');
 

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -142,6 +142,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
       // Synchronously, so the shared restore that follows writes this shell
       // and not the document.
       if (!this.windowScroll()) this.pageScroller.claim(this.shellRef.nativeElement);
+      this.bindLetterScroll();
       if (!this.navbar.navigatedBack()) this.enterAtTop();
       else {
         // The letter survives the trip in this component; the restore's own
@@ -152,6 +153,9 @@ export class LibraryComponent implements OnInit, OnDestroy {
     },
     onDetach: () => {
       if (!this.windowScroll()) this.pageScroller.release(this.shellRef.nativeElement);
+      // The window keeps scrolling for the pages that follow, and a detached
+      // page listening to it recomputes its letter off their offset.
+      this.unbindLetterScroll();
     },
   });
 
@@ -371,6 +375,23 @@ export class LibraryComponent implements OnInit, OnDestroy {
     }
     this.shellRef.nativeElement.scrollTo({ top, left: 0, behavior: 'instant' });
   }
+  /** Bound only while the page is on screen: whichever scroller it reads,
+   *  the offset it would see once detached is another page's. */
+  private letterScrollTarget?: HTMLElement | Window;
+  private bindLetterScroll(): void {
+    if (this.letterScrollTarget) return;
+    const target = this.windowScroll() ? window : this.shellRef.nativeElement;
+    target.addEventListener('scroll', this.onLetterScroll, { passive: true });
+    this.letterScrollTarget = target;
+  }
+  private unbindLetterScroll(): void {
+    this.letterScrollTarget?.removeEventListener('scroll', this.onLetterScroll);
+    this.letterScrollTarget = undefined;
+    if (this.letterRaf !== null) {
+      cancelAnimationFrame(this.letterRaf);
+      this.letterRaf = null;
+    }
+  }
   private holdLetter(): void {
     this.letterHeldUntil = performance.now() + LibraryComponent.LETTER_HOLD_MS;
   }
@@ -414,13 +435,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
   private loadGen = 0;
 
   ngOnInit() {
-    const shell = this.shellRef.nativeElement;
-    if (this.windowScroll()) {
-      window.addEventListener('scroll', this.onLetterScroll, { passive: true });
-    } else {
-      this.pageScroller.claim(shell);
-      shell.addEventListener('scroll', this.onLetterScroll, { passive: true });
-    }
+    if (!this.windowScroll()) this.pageScroller.claim(this.shellRef.nativeElement);
+    this.bindLetterScroll();
     // A resize can change the column count, which re-chunks the rows.
     this.onResize = () => {
       this.rowMeasured = false;
@@ -553,13 +569,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
     this.list.destroy();
     if (this.onResize) window.removeEventListener('resize', this.onResize);
     this.scrollMemory.deactivate();
-    if (this.windowScroll()) {
-      window.removeEventListener('scroll', this.onLetterScroll);
-    } else {
-      this.shellRef.nativeElement.removeEventListener('scroll', this.onLetterScroll);
-      this.pageScroller.release(this.shellRef.nativeElement);
-    }
-    if (this.letterRaf !== null) cancelAnimationFrame(this.letterRaf);
+    this.unbindLetterScroll();
+    if (!this.windowScroll()) this.pageScroller.release(this.shellRef.nativeElement);
     this.navbar.clearPageTitle();
     this.paramSub?.unsubscribe();
 

--- a/client/src/app/shared/components/media-card/media-card.spec.ts
+++ b/client/src/app/shared/components/media-card/media-card.spec.ts
@@ -15,6 +15,7 @@ import { PlayableMediaService } from '../../../core/services/playable-media.serv
 import { NavbarService } from '../../../core/services/navbar.service';
 import { PluginUiRegistryService } from '../../../core/plugin-ui/plugin-ui-registry.service';
 import type { SlotId, UiContribution } from '@fliks/plugin-contract/ui';
+import { stampPoster } from '../../utils/view-transition';
 
 /**
  * Characterisation test for the card's contextual actions menu. Captures the
@@ -656,9 +657,11 @@ describe('media-card poster morph opt-out', () => {
     (document as unknown as { startViewTransition: unknown }).startViewTransition = () => ({
       finished: Promise.resolve(),
     });
+    // Stamped the way a click does it, since only those are this module's to
+    // clear — a name a page declares for its own hero is left alone.
     const stale = document.createElement('img');
-    stale.style.viewTransitionName = 'media-poster-3';
     document.body.appendChild(stale);
+    stampPoster(stale, 3);
 
     const h = await createFixture(FULL_MEMBER, {
       media: makeMedia({ posterUrl: '/api/images/poster.jpg' }),

--- a/client/src/app/shared/layout/layout.spec.ts
+++ b/client/src/app/shared/layout/layout.spec.ts
@@ -69,6 +69,8 @@ interface Fixture {
   /** Overrides the SSE `lastEvent` signal — a real writable signal, needed so
    *  the component's `sseEffect` reacts to `.set()` calls made mid-test. */
   sseLastEvent?: ReturnType<typeof signal<SseEvent | null>>;
+  /** Marks the active page as a hero (fanart) page. */
+  isHeroPage?: boolean;
   /** Overrides `CountsApiService.get` — a spy, so tests can assert call counts. */
   countsGet?: () => Promise<{ mediaByLibrary: Record<number, number>; badgeCounts: Record<string, number>; pendingRequests: number }>;
 }
@@ -138,7 +140,7 @@ async function createFixture(f: Fixture, routes: Routes = []): Promise<Component
           navbarTransparent: () => false,
           heroLogoUrl: () => null,
           heroTitle: () => '',
-          isHeroPage: () => false,
+          isHeroPage: () => !!f.isHeroPage,
           showBackButton: () => false,
           mobileNavTitle: () => '',
           mobileNavbarVisible: () => true,
@@ -509,6 +511,24 @@ describe('LayoutComponent sidebar counts — SSE debounce', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('LayoutComponent — chrome clearance', () => {
+  afterEach(() => {
+    nativeState.value = false;
+  });
+
+  it('reserves the same space on a hero page as anywhere else', async () => {
+    const plain = (await createFixture(NATIVE_PHONE)).componentInstance.chromeTop();
+    TestBed.resetTestingModule();
+    const hero = (await createFixture({ ...NATIVE_PHONE, isHeroPage: true })).componentInstance.chromeTop();
+
+    // A hero page takes the bar's height back in CSS (`body.hero-page`), which
+    // NavbarService toggles synchronously. Folding it into this value instead
+    // lands it a change detection late — after WebKit has laid out the cached
+    // page the router just reattached, which iOS 18.7 never redoes.
+    expect(hero).toBe(plain);
   });
 });
 

--- a/client/src/app/shared/layout/layout.ts
+++ b/client/src/app/shared/layout/layout.ts
@@ -189,18 +189,23 @@ export class LayoutComponent implements OnInit, OnDestroy {
     return this.deepestRouteOwnsScroll() && this.scrollMode.mode() === 'container';
   }
 
-  /** Fixed navbar's own clearance: its height (0 on hero pages / TV, where it
-   *  doesn't reserve space) plus safe area — 0 wherever the mobile-style
-   *  navbar itself is hidden (desktop, or a pinned tablet sidebar). TV and
-   *  desktop never own the scroll (see `PageScrollModeService`), so their
-   *  in-flow bar always reserves its own space here rather than being fixed. */
+  /** Fixed navbar's own clearance: its height (0 on TV, where it doesn't
+   *  reserve space) plus safe area — 0 wherever the mobile-style navbar
+   *  itself is hidden (desktop, or a pinned tablet sidebar). TV and desktop
+   *  never own the scroll (see `PageScrollModeService`), so their in-flow bar
+   *  always reserves its own space here rather than being fixed.
+   *  Deliberately hero-blind: a hero page takes the space back through
+   *  `body.hero-page` in CSS (styles.css), which NavbarService toggles
+   *  synchronously — a value that only lands at the next change detection
+   *  reaches a reattached cached page after WebKit has already laid it out,
+   *  and iOS 18.7 never re-lays it out for a parent's padding change. */
   private readonly navbarSpacerHeight = computed(() => {
     if (!this.navbar.mobileNavbarVisible()) return '0px';
-    if (this.navbar.isHeroPage() || this.tv.isTv()) return '0px';
+    if (this.tv.isTv()) return '0px';
     return 'calc(3rem + env(safe-area-inset-top, 0px))';
   });
   private readonly contentGapTop = computed(() =>
-    !this.navbar.isHeroPage() && !this.isNative && this.navbar.mobileNavbarVisible() ? '2rem' : '1rem',
+    !this.isNative && this.navbar.mobileNavbarVisible() ? '2rem' : '1rem',
   );
   /** Published as a CSS var so a page that owns its scroller reserves the same
    *  space inside itself, and content still scrolls under the fixed navbar. */

--- a/client/src/app/shared/utils/view-transition.spec.ts
+++ b/client/src/app/shared/utils/view-transition.spec.ts
@@ -61,6 +61,25 @@ describe('view-transition poster stamps', () => {
     expect(card.style.viewTransitionName).toBe('media-poster-ep-42');
   });
 
+  it("leaves a page's own declared name alone", () => {
+    const hero = img();
+    // A media page declares this through a style binding, which Angular only
+    // rewrites when its value changes — so taking it away here took it away
+    // for the rest of a cached page's life, and the trip back from it found
+    // no partner for the card, morphing the badge overlay instead.
+    hero.style.viewTransitionName = 'media-poster-7';
+    const card = img();
+
+    stampPoster(card, 9);
+
+    expect(hero.style.viewTransitionName).toBe('media-poster-7');
+    expect(card.style.viewTransitionName).toBe('media-poster-9');
+
+    clearPosterStamps();
+    expect(hero.style.viewTransitionName).toBe('media-poster-7');
+    expect(card.style.viewTransitionName).toBe('');
+  });
+
   it('clears every stamp for a navigation that owns no poster', () => {
     const card = img();
     stampPoster(card, 7);

--- a/client/src/app/shared/utils/view-transition.ts
+++ b/client/src/app/shared/utils/view-transition.ts
@@ -8,15 +8,20 @@
  */
 /** The clicked card's badges and progress bar, captured as one layer. */
 export const CARD_OVERLAY_NAME = 'media-card-overlay';
+/**
+ * Marks what this module put there. A media page names its own hero the same
+ * way — a style binding is an inline style too — and Angular does not rewrite
+ * a binding whose value has not changed, so clearing by inline style took that
+ * name away for good on a page kept in the route cache: the trip back then
+ * found nothing to pair the card with.
+ */
+const STAMPED = 'data-poster-stamped';
 
 export function clearPosterStamps(): void {
-  document
-    .querySelectorAll<HTMLElement>(
-      'img[style*="view-transition-name"], [data-card-overlay][style*="view-transition-name"]',
-    )
-    .forEach((el) => {
-      el.style.viewTransitionName = '';
-    });
+  document.querySelectorAll<HTMLElement>(`[${STAMPED}]`).forEach((el) => {
+    el.style.viewTransitionName = '';
+    el.removeAttribute(STAMPED);
+  });
 }
 
 export function stampPoster(
@@ -31,9 +36,13 @@ export function stampPoster(
   img.style.viewTransitionName = episodeId
     ? `media-poster-ep-${episodeId}`
     : `media-poster-${mediaId}`;
+  img.setAttribute(STAMPED, '');
   // The morphing poster is painted above the page snapshot, so the card's own
   // badges only reappear when the animation ends unless they are lifted too.
-  if (overlay) overlay.style.viewTransitionName = CARD_OVERLAY_NAME;
+  if (overlay) {
+    overlay.style.viewTransitionName = CARD_OVERLAY_NAME;
+    overlay.setAttribute(STAMPED, '');
+  }
 }
 
 interface RouteNode {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -751,6 +751,16 @@ html.vt-player-close body.tv main.page-enter {
 app-layout main {
   padding-block: var(--chrome-top, 0px) var(--chrome-bottom, 0px);
 }
+/* A hero page runs its fanart under the transparent navbar, so it keeps the
+   gap and drops the bar's height. A class rather than a term in
+   `--chrome-top`: NavbarService toggles it synchronously while the outgoing
+   page is deactivated, which is early enough for the cached page the router
+   is about to reattach to be laid out with its final padding. A value that
+   only lands at the next change detection arrives after that layout, and
+   iOS 18.7 WebKit never re-lays a subtree out for a parent's padding change. */
+body.hero-page app-layout main {
+  padding-top: 1rem;
+}
 
 /* Bounds a page whose route sets `ownsScroll` (layout.ts) to the viewport;
    gated so every other route keeps scrolling the document unbounded. */
@@ -815,6 +825,10 @@ body.tv .drawer.owns-scroll nav.navbar,
   overflow: hidden auto;
   padding-block: var(--chrome-top, 0px) var(--chrome-bottom, 0px);
   padding-inline: var(--page-p);
+}
+/* Same hero rule as `main` above, for a hero page that owns its scroller. */
+body.hero-page .page-scroller {
+  padding-top: 1rem;
 }
 /* A scroll container's automatic minimum size is zero, so the tabs row would
    absorb the whole column's shrink pressure and collapse to its scrollbar. */

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1576,6 +1576,11 @@ html.vt-poster-out::view-transition-old(vt-fab) {
    with the card it belongs to rather than hanging over the page. */
 ::view-transition-group(media-card-overlay) {
   z-index: 2;
+  /* Never travels, even when it does find a partner: a stamp kept alive in a
+     cached page can leave one of these on the side being left, and the two
+     then pair into a badge layer flying across the screen — the one thing on
+     the trip that must not read as the subject of the animation. */
+  animation: none;
   /* Captured out of the figure that rounds it, so the progress bar arrives with
      square ends unless the snapshot carries the card's own radius. */
   clip-path: inset(0 round 0.5rem);


### PR DESCRIPTION
Two bugs on the way back from a media page into a library, both reproduced and
then verified fixed on a physical iPhone XS (iOS 18.7) and in the iOS 18.3
simulator, with the measurements below taken from an instrumented build.

## The alphabet letter (all of iOS in window mode)

Scroll to the Cs, open a title, come back: the index reads `#`.

The letter is not lost on the way back — it is destroyed on the way out.
In window mode the page listens to `window` for the offset the letter is
derived from, and a cached route is *detached*, not destroyed, so that
listener outlives the page. The router's scroll-to-top for the media page
therefore recomputed the letter off offset 0:

```
02 scrolled  sy=6000 letter=C
LIB sync mso=0 → sync-set row=0 letter=#     ← still on the way out
03 detail
LIB attach back=true letter=#  → LIB hold    ← the hold now protects a wrong value
LIB sync held=true mso=5717 (suppressed)     ← and suppresses the correction
```

The 600ms hold that exists to keep the restore's own scroll event from
recomputing the letter is what then makes it stick.

Container mode (Android, and phones/tablets by default) never showed it: a
detached element's `scrollTop` cannot move, so the same listener stays silent.
The fix binds the listener on attach and unbinds it on detach, in both modes.

## The unreachable top of the page (iPhone XS only)

Same trip, then scroll back to the top: the first 92px of the page sit under
the fixed topbar and cannot be reached.

`main`'s computed `padding-top` reads the full 108px throughout — the box is
simply never re-laid out. On the device, with the page in that state:

| probe | computed padding-top | child's rect top |
| --- | --- | --- |
| as-is | 108px | 16 |
| write 200px | 200px | 16 |
| touch the child's own margin | 200px | 292 (= 200 + 92) |
| back to 108px | 108px | 200 |
| force a reflow on `main` | 108px | 108 |

WebKit there does not dirty a subtree for its parent's padding change, once
that subtree has been re-inserted — which is exactly what the route-reuse
cache does on every return. The subtree is reattached while `--chrome-top`
still holds the hero page's value (16px), and the change back to 108px never
lands. iOS 18.3 and Android re-lay out correctly, which is why only the XS
showed it.

So the fix removes the change rather than the symptom: `--chrome-top` no
longer carries the hero term, and a hero page drops the bar's height through
`body.hero-page` — a class `NavbarService` toggles synchronously while the
outgoing page is deactivated, i.e. before the router reattaches the cached
page, which is therefore laid out with its final padding. The hero page's own
clearance is unchanged (1rem, as before).

## Verified

Automated replay (library → scroll → open a title → back → scroll to top) on
the XS, before → after:

- letter through the return: `#` → `C`
- shell top at scroll 0: `16` → `108` (topbar ends at 97)
- shell top at the restored offset: `-5984` → `-5892`

Same replay green in the simulator in **both** scroll modes, so the shipped
container default is covered too. `894` unit tests pass, including three new
ones: the letter surviving a detach, the listener coming back on reattach,
and the chrome clearance being identical on a hero page and off it.

## Landing on the detail page's footer (rare, iOS)

Reported after the two above: opening a card from a library occasionally
arrives at the bottom of the detail page.

A forward entry is scrolled to the top by the router, once. On WKWebView that
single write is dropped while the incoming document is still sizing itself —
the same drop the restore path already carries a sticky pass for — so the page
keeps the offset the much taller library had, and the new document's own
maximum clamps it to its footer. `plan/library-grid-owns-its-scroll.md` records
the same signature from an earlier session: `y=1422 max=1422`, the page never
moved.

Not reproduced programmatically: 20 scripted opens from offsets up to 40000,
across five settle delays, all landed at 0 — the real thing depends on where
the scrolling thread is when the swap happens, which a synthetic scroll does
not recreate. The fix is therefore written as a net around the measured
mechanism rather than around a captured failure, and its two halves are
verified separately on the device:

- an offset already wrong when the router takes its turn → the sticky pass,
  same 600ms rAF loop as `restoreSticky`;
- an offset clamped a few frames later, off the scrolling thread → a scroll
  listener that takes the top back.

Both stop early: the first on the frame it reads zero, the second on the
user's first touch, wheel or key. A return is excluded outright, so the
restore path is untouched.

Verified on the XS: nine forward opens from 6000 / 20000 / 40000 all land at
0; a clamp injected 80, 200 and 400ms after arrival is taken back (at 900ms it
is not — past the window, by design); and the same run re-checks the two
earlier fixes (letter `C → C`, page top at 108 with the topbar ending at 97).


## The badge overlay morphing instead of the poster (rare)

Reported next: coming back from a media page, sometimes the card's badge
overlay is what animates and the poster only fades.

Captured on the device, on the failing trip:

```
BACK from=/movies/162 id=162
groups=[old:media-poster-345, group:media-card-overlay, new:media-poster-162]
```

The poster has an old and a new, but under different names — no pair, so
nothing morphs. The only paired thing, and therefore the only thing with a
group animation, is the overlay.

Two faults, both needed:

1. `stampPoster` cleared **every** inline `view-transition-name` in the
   document, and a media page declares its own hero's name through a style
   binding — an inline style too. Angular does not rewrite a binding whose
   value has not changed, so clicking a title inside a media page took that
   page's hero name away for the rest of its life in the route cache. Hence
   `old:media-poster-345`, the stamp of the card that was clicked *inside*
   the page, instead of the page's own `media-poster-162`. Clearing now only
   touches what the stamp itself marked.
2. That left `media-card-overlay` as the only name on both sides — the card
   clicked inside the page being left keeps its stamp, and the card being
   landed on has one too. Its group carried no animation rule, so it
   travelled across the screen. The overlay exists to sit above the morph,
   never to be its subject, so it now holds still whether or not it pairs.

Reproduced deterministically once the driver clicked the card's figure
rather than its title anchor (only the figure's path stamps): three trips
out of three showed `group(media-card-overlay)` with the poster unpaired,
and after the fix all three show `group + old + new` on the poster and no
group at all for the overlay.
