### PR TITLE
fix(subtitles): scope the sync reference list to the current episode

### DIFF
--- a/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
+++ b/client/src/app/shared/components/subtitles-modal/subtitles-modal.ts
@@ -510,7 +510,7 @@ export class SubtitlesModalComponent {
   readonly subtitleStreams = computed(() => this.streams().filter((s) => s.type === 'subtitle'));
   /** External subtitle files usable as sync reference (excluding the one being synced) */
   readonly externalSubtitleRefs = computed(() =>
-    this.subtitles().filter((s) => s.relativePath && s.id !== this.syncSubtitleId()),
+    this.filteredSubtitles().filter((s) => s.relativePath && s.id !== this.syncSubtitleId()),
   );
 
   // Sync modal state


### PR DESCRIPTION
## Problem

In the subtitles modal, `Actions > Décalage > Synchroniser`, the **Reference** picker listed every external subtitle of the whole media. On a series that means all episodes' files, so the dropdown showed dozens of entries all labelled the same way (`English — disk (Downloaded)`), and picking one would sync against another episode's timings.

## Fix

`externalSubtitleRefs` now reads `filteredSubtitles()` instead of `subtitles()` — the same episode + selected-file filter every other list in the modal already uses.

## Notes

The option labels are unchanged, so the few remaining candidates still render identically when they share a language and provider. Adding the filename would disambiguate them; left out as it wasn't part of this fix.