### PR TITLE
feat(ios): add a native left-edge back swipe

### DIFF
--- a/client/ios/.gitignore
+++ b/client/ios/.gitignore
@@ -2,7 +2,7 @@ App/build
 App/Pods
 App/output
 App/App/public
-DerivedData
+DerivedData*/
 xcuserdata
 
 # Cordova plugins for Capacitor

--- a/client/ios/App/App.xcodeproj/project.pbxproj
+++ b/client/ios/App/App.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		F1000001AAAA000000000008 /* SubtitleOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001AAAA000000000018 /* SubtitleOverlayView.swift */; };
 		F1000001AAAA000000000009 /* DownloadPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001AAAA000000000019 /* DownloadPlugin.swift */; };
 		F1000001AAAA00000000000A /* OrientationPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001AAAA00000000001A /* OrientationPlugin.swift */; };
+		F1000001AAAA00000000000B /* BackGesturePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001AAAA00000000001B /* BackGesturePlugin.swift */; };
 		F954F4DC03C3615047B0AABF /* DownloadActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8546BB7ADC2E5B59E726E7ED /* DownloadActivityAttributes.swift */; };
 		F9D6B0DE0B5D3649DA0CC8B8 /* FliksDownloadWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2014FCBAA5253E0B35A8DFD6 /* FliksDownloadWidgetBundle.swift */; };
 /* End PBXBuildFile section */
@@ -85,6 +86,7 @@
 		F1000001AAAA000000000018 /* SubtitleOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtitleOverlayView.swift; sourceTree = "<group>"; };
 		F1000001AAAA000000000019 /* DownloadPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadPlugin.swift; sourceTree = "<group>"; };
 		F1000001AAAA00000000001A /* OrientationPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationPlugin.swift; sourceTree = "<group>"; };
+		F1000001AAAA00000000001B /* BackGesturePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackGesturePlugin.swift; sourceTree = "<group>"; };
 		FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -147,6 +149,7 @@
 				F1000001AAAA000000000013 /* NativePlayerPlugin.swift */,
 				F1000001AAAA000000000014 /* ImmersivePlugin.swift */,
 				F1000001AAAA00000000001A /* OrientationPlugin.swift */,
+				F1000001AAAA00000000001B /* BackGesturePlugin.swift */,
 				F1000001AAAA000000000015 /* PipPlugin.swift */,
 				F1000001AAAA000000000016 /* CastPlugin.swift */,
 				F1000001AAAA000000000017 /* AudioCapabilitiesPlugin.swift */,
@@ -353,6 +356,7 @@
 				F1000001AAAA000000000003 /* NativePlayerPlugin.swift in Sources */,
 				F1000001AAAA000000000004 /* ImmersivePlugin.swift in Sources */,
 				F1000001AAAA00000000000A /* OrientationPlugin.swift in Sources */,
+				F1000001AAAA00000000000B /* BackGesturePlugin.swift in Sources */,
 				F1000001AAAA000000000005 /* PipPlugin.swift in Sources */,
 				F1000001AAAA000000000006 /* CastPlugin.swift in Sources */,
 				F1000001AAAA000000000007 /* AudioCapabilitiesPlugin.swift in Sources */,

--- a/client/ios/App/App/BackGesturePlugin.swift
+++ b/client/ios/App/App/BackGesturePlugin.swift
@@ -1,0 +1,272 @@
+import Foundation
+import Capacitor
+import UIKit
+import WebKit
+
+/// Left-edge back gesture for the WebView shell.
+///
+/// A Capacitor app is a single view controller, so iOS never offers its
+/// interactive pop. The recognizer here runs at UIKit priority — the WebView's
+/// scroll pan is made to wait on it, so a horizontal carousel sitting on the
+/// edge can't steal the swipe — slides a snapshot of the current page off to
+/// the right under the finger, and hands the commit to JS, which runs the
+/// app's own back (same path as the Android hardware button).
+///
+/// The page underneath is a snapshot too: JS captures every page it leaves,
+/// and this keeps them in a stack that mirrors the router's own back stack, so
+/// the swipe reveals the page it is returning to rather than a flat colour.
+///
+/// Usage from JS:
+///   BackGesture.setEnabled({ enabled: true })
+///   BackGesture.captureCandidate()          // on NavigationStart
+///   BackGesture.settle({ delta })           // on NavigationEnd
+///   BackGesture.addListener('end', …)       // carries { commit }
+@objc(BackGesturePlugin)
+public class BackGesturePlugin: CAPPlugin, CAPBridgedPlugin, UIGestureRecognizerDelegate {
+    public let identifier = "BackGesturePlugin"
+    public let jsName = "BackGesture"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "setEnabled", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "captureCandidate", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "settle", returnType: CAPPluginReturnPromise),
+    ]
+
+    /// Past this fraction of the screen the release commits, whatever the speed.
+    private static let commitProgress: CGFloat = 0.3
+    /// A flick commits below that fraction, in points per second.
+    private static let commitVelocity: CGFloat = 500
+    /// How far the page underneath trails the finger, as a fraction of the
+    /// screen — the depth cue iOS uses on its own pop.
+    private static let parallax: CGFloat = 0.28
+    private static let dimAlpha: CGFloat = 0.32
+    /// A full-screen snapshot costs ~10 MB, and two levels of parallax cover
+    /// detail → library → home. Deeper returns fall back to the flat backdrop.
+    private static let maxSnapshots = 3
+    /// Matches the WebView background from capacitor.config.ts, so a return with
+    /// no snapshot behind it reads as the app, not as a hole.
+    private static let backdropColor = UIColor(red: 0.114, green: 0.137, blue: 0.161, alpha: 1)
+
+    private weak var recognizer: UIScreenEdgePanGestureRecognizer?
+    private var snapshot: UIView?
+    private var previous: UIView?
+    private var dim: UIView?
+    private var backdrop: UIView?
+    /// Set between .began and the async snapshot arriving; a gesture that ends
+    /// in that window must not install the overlay afterwards.
+    private var awaitingSnapshot = false
+    private var width: CGFloat = 1
+
+    /// Pages left behind, oldest first: the last one is what a back returns to.
+    /// Entries can be nil — a capture that failed, or one JS skipped — so the
+    /// stack stays index-aligned with the router's and only loses its parallax.
+    private var pageSnapshots: [UIImage?] = []
+    /// Captured when a navigation starts, kept or dropped once the router says
+    /// whether it grew the back stack.
+    private var candidate: UIImage?
+
+    override public func load() {
+        DispatchQueue.main.async { [weak self] in self?.attach() }
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(dropSnapshots),
+            name: UIApplication.didReceiveMemoryWarningNotification,
+            object: nil
+        )
+    }
+
+    private func attach() {
+        guard let container = bridge?.viewController?.view else { return }
+        let pan = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(handle(_:)))
+        pan.edges = .left
+        pan.delegate = self
+        container.addGestureRecognizer(pan)
+        // Without this the WebView scrolls under the finger while the snapshot
+        // slides. Edge pans fail immediately away from the edge, so the wait
+        // costs nothing anywhere else on screen.
+        bridge?.webView?.scrollView.panGestureRecognizer.require(toFail: pan)
+        recognizer = pan
+    }
+
+    @objc private func dropSnapshots() {
+        pageSnapshots.removeAll()
+        candidate = nil
+    }
+
+    @objc func setEnabled(_ call: CAPPluginCall) {
+        let enabled = call.getBool("enabled") ?? true
+        DispatchQueue.main.async { [weak self] in
+            // No teardown here: the commit itself disarms the gesture (the page
+            // reached has nowhere left to go back to), and tearing down on that
+            // would uncover the WebView before the new page had painted. A
+            // disabled recognizer cancels any live gesture, which finishes
+            // through .cancelled and cleans up there.
+            self?.recognizer?.isEnabled = enabled
+            call.resolve()
+        }
+    }
+
+    /// Snapshots the page a navigation is leaving. Resolves immediately: the
+    /// capture is async and the caller has nothing to wait for.
+    @objc func captureCandidate(_ call: CAPPluginCall) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let webView = self.bridge?.webView else {
+                call.resolve()
+                return
+            }
+            // afterScreenUpdates would wait for the next render pass, and
+            // mid-navigation that pass is the destination page: the shot came
+            // back after settle had already given up on it.
+            let config = WKSnapshotConfiguration()
+            config.afterScreenUpdates = false
+            // Resolved only once the image is stored, so JS can hold settle
+            // back until the candidate exists.
+            webView.takeSnapshot(with: config) { [weak self] image, _ in
+                self?.candidate = image
+                call.resolve()
+            }
+        }
+    }
+
+    /// `delta` is how much the router's back stack grew or shrank over the
+    /// navigation. Mirroring it here rather than re-deriving which navigations
+    /// count keeps one source of truth for what back returns to.
+    @objc func settle(_ call: CAPPluginCall) {
+        let delta = call.getInt("delta") ?? 0
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                call.resolve()
+                return
+            }
+            if delta > 0 {
+                self.pageSnapshots.append(self.candidate)
+                while self.pageSnapshots.count > Self.maxSnapshots {
+                    self.pageSnapshots.removeFirst()
+                }
+            }
+            self.candidate = nil
+            for _ in 0..<max(0, -delta) where !self.pageSnapshots.isEmpty {
+                self.pageSnapshots.removeLast()
+            }
+            call.resolve()
+        }
+    }
+
+    @objc private func handle(_ pan: UIScreenEdgePanGestureRecognizer) {
+        guard let container = pan.view else { return }
+        let translation = max(0, pan.translation(in: container).x)
+
+        switch pan.state {
+        case .began:
+            width = max(container.bounds.width, 1)
+            captureSnapshot()
+        case .changed:
+            apply(translation: translation)
+        case .ended, .cancelled, .failed:
+            let velocity = pan.velocity(in: container).x
+            let commit = pan.state == .ended
+                && (translation / width > Self.commitProgress || velocity > Self.commitVelocity)
+            finish(commit: commit, from: translation, velocity: velocity)
+        default:
+            break
+        }
+    }
+
+    /// takeSnapshot rather than snapshotView: WebKit renders out of process, and
+    /// the UIView-level copy comes back blank often enough to matter.
+    private func captureSnapshot() {
+        guard let webView = bridge?.webView, let container = bridge?.viewController?.view else { return }
+        let config = WKSnapshotConfiguration()
+        config.afterScreenUpdates = false
+        awaitingSnapshot = true
+        webView.takeSnapshot(with: config) { [weak self] image, _ in
+            guard let self, self.awaitingSnapshot, let image else { return }
+            self.awaitingSnapshot = false
+            self.install(image: image, over: webView, in: container)
+        }
+    }
+
+    private func install(image: UIImage, over webView: WKWebView, in container: UIView) {
+        let frame = container.convert(webView.bounds, from: webView)
+
+        let backdrop = UIView(frame: container.bounds)
+        backdrop.backgroundColor = Self.backdropColor
+        backdrop.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        container.addSubview(backdrop)
+        self.backdrop = backdrop
+
+        if let behind = pageSnapshots.last ?? nil {
+            let view = UIImageView(image: behind)
+            view.frame = frame
+            container.addSubview(view)
+            previous = view
+
+            let shade = UIView(frame: view.bounds)
+            shade.backgroundColor = .black
+            shade.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            view.addSubview(shade)
+            dim = shade
+        }
+
+        let view = UIImageView(image: image)
+        view.frame = frame
+        view.layer.shadowColor = UIColor.black.cgColor
+        view.layer.shadowOpacity = 0.4
+        view.layer.shadowRadius = 12
+        view.layer.shadowOffset = CGSize(width: -4, height: 0)
+        container.addSubview(view)
+        snapshot = view
+
+        // The finger has moved during the capture; catch up in one step.
+        let live = recognizer?.state == .changed || recognizer?.state == .began
+        apply(translation: live ? max(0, recognizer?.translation(in: container).x ?? 0) : 0)
+    }
+
+    private func apply(translation: CGFloat) {
+        let progress = min(max(translation / width, 0), 1)
+        snapshot?.transform = CGAffineTransform(translationX: translation, y: 0)
+        previous?.transform = CGAffineTransform(translationX: -Self.parallax * width * (1 - progress), y: 0)
+        dim?.alpha = Self.dimAlpha * (1 - progress)
+    }
+
+    private func finish(commit: Bool, from translation: CGFloat, velocity: CGFloat) {
+        awaitingSnapshot = false
+        notifyListeners("end", data: ["commit": commit])
+
+        guard snapshot != nil else {
+            teardown()
+            return
+        }
+
+        let target = commit ? width : 0
+        let distance = abs(target - translation)
+        // Track the flick's speed, within the bounds iOS uses for its own pop.
+        let duration = min(0.4, max(0.12, Double(distance / max(abs(velocity), 400))))
+        UIView.animate(withDuration: duration, delay: 0, options: [.curveEaseOut, .beginFromCurrentState]) {
+            self.apply(translation: target)
+        } completion: { [weak self] _ in
+            // JS gets the commit before the slide starts, so the router has the
+            // whole animation to swap the page in behind the backdrop.
+            self?.teardown()
+        }
+    }
+
+    private func teardown() {
+        snapshot?.removeFromSuperview()
+        snapshot = nil
+        previous?.removeFromSuperview()
+        previous = nil
+        dim = nil
+        backdrop?.removeFromSuperview()
+        backdrop = nil
+        awaitingSnapshot = false
+    }
+
+    // The gesture owns the touch outright: nothing in the page scrolls while
+    // the page itself is sliding away.
+    public func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer
+    ) -> Bool {
+        return false
+    }
+}

--- a/client/ios/App/App/BackGesturePlugin.swift
+++ b/client/ios/App/App/BackGesturePlugin.swift
@@ -20,6 +20,7 @@ import WebKit
 ///   BackGesture.setEnabled({ enabled: true })
 ///   BackGesture.captureCandidate()          // on NavigationStart
 ///   BackGesture.settle({ delta })           // on NavigationEnd
+///   BackGesture.settled()                   // page done rebuilding
 ///   BackGesture.addListener('end', …)       // carries { commit }
 @objc(BackGesturePlugin)
 public class BackGesturePlugin: CAPPlugin, CAPBridgedPlugin, UIGestureRecognizerDelegate {
@@ -29,6 +30,7 @@ public class BackGesturePlugin: CAPPlugin, CAPBridgedPlugin, UIGestureRecognizer
         CAPPluginMethod(name: "setEnabled", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "captureCandidate", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "settle", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "settled", returnType: CAPPluginReturnPromise),
     ]
 
     /// Past this fraction of the screen the release commits, whatever the speed.
@@ -54,7 +56,20 @@ public class BackGesturePlugin: CAPPlugin, CAPBridgedPlugin, UIGestureRecognizer
     /// Set between .began and the async snapshot arriving; a gesture that ends
     /// in that window must not install the overlay afterwards.
     private var awaitingSnapshot = false
+    /// Identifies the gesture a pending capture belongs to. Releasing before the
+    /// image lands and starting again re-arms `awaitingSnapshot`, which the
+    /// stale capture would otherwise take for its own — installing an overlay
+    /// for a gesture already over, with nothing left to tear it down.
+    private var gestureId = 0
     private var width: CGFloat = 1
+    /// Set once the slide is over and the overlay is only waiting on the page.
+    private var awaitingSettle = false
+    /// Uncovers the WebView even if JS never reports, so a stalled navigation
+    /// cannot leave the page hidden.
+    private var settleFallback: DispatchWorkItem?
+    /// Last resort: an overlay belongs to a live gesture or to the wait after a
+    /// commit. Outside both, it is orphaned, and an orphan hides the whole app.
+    private var watchdog: DispatchWorkItem?
 
     /// Pages left behind, oldest first: the last one is what a back returns to.
     /// Entries can be nil — a capture that failed, or one JS skipped — so the
@@ -63,6 +78,9 @@ public class BackGesturePlugin: CAPPlugin, CAPBridgedPlugin, UIGestureRecognizer
     /// Captured when a navigation starts, kept or dropped once the router says
     /// whether it grew the back stack.
     private var candidate: UIImage?
+    /// Identifies the navigation a pending capture belongs to, so one that comes
+    /// back after its own settle is dropped instead of being pushed for the next.
+    private var captureId = 0
 
     override public func load() {
         DispatchQueue.main.async { [weak self] in self?.attach() }
@@ -72,6 +90,20 @@ public class BackGesturePlugin: CAPPlugin, CAPBridgedPlugin, UIGestureRecognizer
             name: UIApplication.didReceiveMemoryWarningNotification,
             object: nil
         )
+        // A rotation resizes the container under an overlay whose layers are
+        // laid out in points fixed at .began, and the hold after a commit can
+        // still be running. Dropping it hands the page straight back.
+        UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(dropOverlay),
+            name: UIDevice.orientationDidChangeNotification,
+            object: nil
+        )
+    }
+
+    @objc private func dropOverlay() {
+        DispatchQueue.main.async { [weak self] in self?.teardown() }
     }
 
     private func attach() {
@@ -90,6 +122,17 @@ public class BackGesturePlugin: CAPPlugin, CAPBridgedPlugin, UIGestureRecognizer
     @objc private func dropSnapshots() {
         pageSnapshots.removeAll()
         candidate = nil
+    }
+
+    /// Called by JS once the returning page has stopped rebuilding. A cached
+    /// page comes back with its rows re-rendered, and the frames painted while
+    /// that runs can be half-filled.
+    @objc func settled(_ call: CAPPluginCall) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if self.awaitingSettle { self.teardown() }
+            call.resolve()
+        }
     }
 
     @objc func setEnabled(_ call: CAPPluginCall) {
@@ -144,6 +187,7 @@ public class BackGesturePlugin: CAPPlugin, CAPBridgedPlugin, UIGestureRecognizer
                 }
             }
             self.candidate = nil
+            self.captureId &+= 1
             for _ in 0..<max(0, -delta) where !self.pageSnapshots.isEmpty {
                 self.pageSnapshots.removeLast()
             }
@@ -157,8 +201,9 @@ public class BackGesturePlugin: CAPPlugin, CAPBridgedPlugin, UIGestureRecognizer
 
         switch pan.state {
         case .began:
+            gestureId &+= 1
             width = max(container.bounds.width, 1)
-            captureSnapshot()
+            captureSnapshot(for: gestureId)
         case .changed:
             apply(translation: translation)
         case .ended, .cancelled, .failed:
@@ -173,28 +218,39 @@ public class BackGesturePlugin: CAPPlugin, CAPBridgedPlugin, UIGestureRecognizer
 
     /// takeSnapshot rather than snapshotView: WebKit renders out of process, and
     /// the UIView-level copy comes back blank often enough to matter.
-    private func captureSnapshot() {
+    private func captureSnapshot(for id: Int) {
         guard let webView = bridge?.webView, let container = bridge?.viewController?.view else { return }
         let config = WKSnapshotConfiguration()
         config.afterScreenUpdates = false
         awaitingSnapshot = true
         webView.takeSnapshot(with: config) { [weak self] image, _ in
-            guard let self, self.awaitingSnapshot, let image else { return }
+            guard let self, id == self.gestureId, self.awaitingSnapshot, let image else { return }
             self.awaitingSnapshot = false
+            // The finger may have lifted while the image was being taken.
+            let state = self.recognizer?.state
+            guard state == .began || state == .changed else { return }
             self.install(image: image, over: webView, in: container)
         }
     }
 
     private func install(image: UIImage, over webView: WKWebView, in container: UIView) {
+        // Nothing of a previous gesture survives into this one.
+        teardown()
         let frame = container.convert(webView.bounds, from: webView)
 
         let backdrop = UIView(frame: container.bounds)
         backdrop.backgroundColor = Self.backdropColor
         backdrop.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        // The hold can outlast the slide; a tap then belongs to the page
+        // underneath, which is already the one on display.
+        backdrop.isUserInteractionEnabled = false
         container.addSubview(backdrop)
         self.backdrop = backdrop
 
-        if let behind = pageSnapshots.last ?? nil {
+        // A snapshot taken in the other orientation would be stretched into
+        // this frame. The stack keeps it — rotating back makes it usable again
+        // — and this return simply falls back to the flat backdrop.
+        if let behind = pageSnapshots.last ?? nil, matches(behind, frame) {
             let view = UIImageView(image: behind)
             view.frame = frame
             container.addSubview(view)
@@ -215,10 +271,33 @@ public class BackGesturePlugin: CAPPlugin, CAPBridgedPlugin, UIGestureRecognizer
         view.layer.shadowOffset = CGSize(width: -4, height: 0)
         container.addSubview(view)
         snapshot = view
+        armWatchdog()
 
         // The finger has moved during the capture; catch up in one step.
         let live = recognizer?.state == .changed || recognizer?.state == .began
         apply(translation: live ? max(0, recognizer?.translation(in: container).x ?? 0) : 0)
+    }
+
+    private func armWatchdog() {
+        watchdog?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.backdrop != nil, !self.awaitingSettle else { return }
+            let state = self.recognizer?.state
+            guard state != .began && state != .changed else {
+                self.armWatchdog()
+                return
+            }
+            self.teardown()
+        }
+        watchdog = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2, execute: work)
+    }
+
+    /// Same shape, within the rounding a snapshot's pixel size introduces.
+    private func matches(_ image: UIImage, _ frame: CGRect) -> Bool {
+        guard image.size.height > 0, frame.height > 0 else { return false }
+        let ratio = (image.size.width / image.size.height) / (frame.width / frame.height)
+        return abs(ratio - 1) < 0.02
     }
 
     private func apply(translation: CGFloat) {
@@ -244,13 +323,28 @@ public class BackGesturePlugin: CAPPlugin, CAPBridgedPlugin, UIGestureRecognizer
         UIView.animate(withDuration: duration, delay: 0, options: [.curveEaseOut, .beginFromCurrentState]) {
             self.apply(translation: target)
         } completion: { [weak self] _ in
-            // JS gets the commit before the slide starts, so the router has the
-            // whole animation to swap the page in behind the backdrop.
-            self?.teardown()
+            guard let self else { return }
+            guard commit else {
+                self.teardown()
+                return
+            }
+            // What stays on screen is the snapshot of the page being returned
+            // to, so waiting on it shows the viewer nothing but the destination.
+            self.snapshot?.removeFromSuperview()
+            self.snapshot = nil
+            self.awaitingSettle = true
+            let fallback = DispatchWorkItem { [weak self] in self?.teardown() }
+            self.settleFallback = fallback
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.9, execute: fallback)
         }
     }
 
     private func teardown() {
+        watchdog?.cancel()
+        watchdog = nil
+        awaitingSettle = false
+        settleFallback?.cancel()
+        settleFallback = nil
         snapshot?.removeFromSuperview()
         snapshot = nil
         previous?.removeFromSuperview()

--- a/client/ios/App/App/FlksViewController.swift
+++ b/client/ios/App/App/FlksViewController.swift
@@ -29,6 +29,7 @@ class FlksViewController: CAPBridgeViewController {
         bridge?.registerPluginInstance(PipPlugin())
         bridge?.registerPluginInstance(CastPlugin())
         bridge?.registerPluginInstance(DownloadPlugin())
+        bridge?.registerPluginInstance(BackGesturePlugin())
     }
 
     func updateStatusBar(hidden: Bool) {

--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -51,6 +51,7 @@ import {
   leavingPosterPage,
   leafRoutePath,
   markViewTransition,
+  swipeBackActive,
   WATCH_PATH,
 } from './shared/utils/view-transition';
 
@@ -112,6 +113,10 @@ export const appConfig: ApplicationConfig = {
               // Episode → episode: the cross-fade keeps the old page (and its scroll
               // offset) on screen, so the jump to top only lands once it ends.
               onViewTransitionCreated: ({ transition, from, to }) => {
+                if (swipeBackActive()) {
+                  transition.skipTransition();
+                  return;
+                }
                 const closingPlayer =
                   leafRoutePath(from) === WATCH_PATH && leafRoutePath(to) !== WATCH_PATH;
                 // A native surface renders outside the WebView, and the class that

--- a/client/src/app/app.ts
+++ b/client/src/app/app.ts
@@ -20,6 +20,7 @@ import { FolderPickerModalComponent } from './shared/components/folder-picker-mo
 import { SelectPickerComponent } from './shared/components/select-picker';
 import { DismissableStackService } from './core/services/dismissable-stack.service';
 import { NavbarService } from './core/services/navbar.service';
+import { BackGestureService } from './core/services/back-gesture.service';
 import { PwaAutoUpdateService } from './core/services/pwa-auto-update.service';
 import { AppResumeService } from './core/services/app-resume.service';
 import { OfflinePlaybackSyncService } from './core/services/offline-playback-sync.service';
@@ -53,6 +54,7 @@ export class App implements OnInit, OnDestroy {
   private readonly router = inject(Router);
   private readonly dismissStack = inject(DismissableStackService);
   private readonly navbar = inject(NavbarService);
+  private readonly backGesture = inject(BackGestureService);
   private readonly pwaAutoUpdate = inject(PwaAutoUpdateService);
   private readonly appResume = inject(AppResumeService);
   /** Injected so the offline playback queue is flushed on start, not only when
@@ -137,6 +139,10 @@ export class App implements OnInit, OnDestroy {
       }).then((handle) => {
         this.backButtonListener = handle;
       });
+
+      // iOS has no hardware back and a Capacitor app gets no interactive pop,
+      // so the left-edge swipe is recognized natively and lands here.
+      this.backGesture.init(() => this.handleBackButton());
 
       // Stamp the background-entry time so the resume handler can tell a real
       // away-spell from a momentary interruption (see AppResumeService).
@@ -344,6 +350,7 @@ export class App implements OnInit, OnDestroy {
       document.removeEventListener('visibilitychange', this.visibilityListener);
     }
     this.backButtonListener?.remove();
+    this.backGesture.destroy();
     this.resumeListener?.remove();
     this.pauseListener?.remove();
     if (this.tvBackKeyListener) {

--- a/client/src/app/core/services/back-gesture.service.ts
+++ b/client/src/app/core/services/back-gesture.service.ts
@@ -26,14 +26,8 @@ const BackGesture = registerPlugin<BackGesturePlugin>('BackGesture');
  *  own panels, where sliding the entire screen off reads as leaving the app. */
 const UNSWIPEABLE = ['/watch', '/admin', '/account', '/app-settings'];
 
-/**
- * Above this, a frame belongs to the rebuild rather than to a page at rest.
- *
- * It sits between two populations rather than at a refresh rate: rebuilding
- * lands frames 60-80 ms apart because the work is the CPU's and not the panel's,
- * while a page at rest paces at 8-17 ms. A 120 Hz phone widens that gap from
- * below, it does not close it, so one number serves both.
- */
+/** Above this a frame belongs to the rebuild, which lands them 60-80 ms apart
+ *  where a page at rest paces at 8-17 ms. */
 const SMOOTH_FRAME_MS = 24;
 
 /**

--- a/client/src/app/core/services/back-gesture.service.ts
+++ b/client/src/app/core/services/back-gesture.service.ts
@@ -26,8 +26,14 @@ const BackGesture = registerPlugin<BackGesturePlugin>('BackGesture');
  *  own panels, where sliding the entire screen off reads as leaving the app. */
 const UNSWIPEABLE = ['/watch', '/admin', '/account', '/app-settings'];
 
-/** A frame at screen rate, with room for a 60 Hz frame that ran a little long.
- *  The rebuild this waits out lands frames three to four times slower. */
+/**
+ * Above this, a frame belongs to the rebuild rather than to a page at rest.
+ *
+ * It sits between two populations rather than at a refresh rate: rebuilding
+ * lands frames 60-80 ms apart because the work is the CPU's and not the panel's,
+ * while a page at rest paces at 8-17 ms. A 120 Hz phone widens that gap from
+ * below, it does not close it, so one number serves both.
+ */
 const SMOOTH_FRAME_MS = 24;
 
 /**

--- a/client/src/app/core/services/back-gesture.service.ts
+++ b/client/src/app/core/services/back-gesture.service.ts
@@ -1,0 +1,133 @@
+import { Injectable, effect, inject, signal } from '@angular/core';
+import { NavigationEnd, NavigationStart, Router } from '@angular/router';
+import { filter, take } from 'rxjs';
+import { Capacitor, registerPlugin, type PluginListenerHandle } from '@capacitor/core';
+import { CastPlayerService } from './cast-player.service';
+import { DismissableStackService } from './dismissable-stack.service';
+import { NavbarService } from './navbar.service';
+import { remoteOverlayOpen } from './remote-playback-target';
+import { setSwipeBackActive } from '../../shared/utils/view-transition';
+
+interface BackGesturePlugin {
+  setEnabled(options: { enabled: boolean }): Promise<void>;
+  captureCandidate(): Promise<void>;
+  settle(options: { delta: number }): Promise<void>;
+  addListener(
+    event: 'end',
+    callback: (data: { commit?: boolean }) => void,
+  ): Promise<PluginListenerHandle>;
+}
+
+const BackGesture = registerPlugin<BackGesturePlugin>('BackGesture');
+
+/** Routes the gesture stays out of. The player owns the whole screen and has
+ *  its own back; the settings, account and admin shells navigate between their
+ *  own panels, where sliding the entire screen off reads as leaving the app. */
+const UNSWIPEABLE = ['/watch', '/admin', '/account', '/app-settings'];
+
+/**
+ * iOS left-edge swipe-back. The recognizer and the slide animation live in
+ * BackGesturePlugin.swift; this side decides when the gesture is armed and
+ * runs the app's own back on commit.
+ *
+ * Arming is a signal effect rather than a check at gesture time: the native
+ * recognizer has to be off *before* the touch, or it swallows the pan that
+ * belongs to a carousel or an open sheet.
+ *
+ * It also feeds the native side a snapshot of every page left behind, so the
+ * swipe can slide the current page off the one it is returning to. The stack
+ * is kept aligned by mirroring NavbarService's own depth: replaced URLs,
+ * query-only changes and the player's back all decide differently there, and
+ * re-deriving those rules here would drift.
+ */
+@Injectable({ providedIn: 'root' })
+export class BackGestureService {
+  private readonly router = inject(Router);
+  private readonly navbar = inject(NavbarService);
+  private readonly dismissStack = inject(DismissableStackService);
+  private readonly castPlayer = inject(CastPlayerService);
+
+  private readonly available = Capacitor.getPlatform() === 'ios';
+  private readonly url = signal(this.router.url);
+  private listener?: PluginListenerHandle;
+  private enabled = true;
+  /** Back-stack depth at the last NavigationEnd. goBack() pops before it
+   *  navigates, so a start-of-navigation reading already shows the pop. */
+  private lastDepth = 0;
+  /** Resolves when the pending capture has been stored. settle() consumes the
+   *  candidate, and a fast navigation reaches its end before the snapshot
+   *  comes back. */
+  private capturing: Promise<unknown> = Promise.resolve();
+
+  private readonly armEffect = effect(() => {
+    const url = this.url();
+    const enabled =
+      this.navbar.canGoBack() &&
+      !UNSWIPEABLE.some((prefix) => url.startsWith(prefix)) &&
+      !this.dismissStack.hasAny() &&
+      !this.castPlayer.expanded() &&
+      !remoteOverlayOpen();
+    if (!this.available || enabled === this.enabled) return;
+    this.enabled = enabled;
+    void BackGesture.setEnabled({ enabled }).catch(() => {});
+  });
+
+  constructor() {
+    if (!this.available) return;
+    this.router.events.subscribe((e) => {
+      if (e instanceof NavigationStart) {
+        // A query-only change is in-page state (library tabs, filters); the
+        // navbar doesn't push one, so there is nothing to capture.
+        if (this.pathOf(e.url) !== this.pathOf(this.url())) {
+          this.capturing = BackGesture.captureCandidate().catch(() => {});
+        }
+      }
+      if (e instanceof NavigationEnd) {
+        this.url.set(e.urlAfterRedirects);
+        const depth = this.navbar.backDepth;
+        const delta = depth - this.lastDepth;
+        this.lastDepth = depth;
+        void this.capturing.then(() => BackGesture.settle({ delta })).catch(() => {});
+      }
+    });
+  }
+
+  /** `onCommit` is the app's shared back path, so the gesture closes layers
+   *  and leaves the player exactly like the Android hardware button. */
+  init(onCommit: () => void): void {
+    if (!this.available) return;
+    void BackGesture.addListener('end', ({ commit }) => {
+      if (!commit) return;
+      setSwipeBackActive(true);
+      this.releaseTransitionsOnArrival();
+      onCommit();
+    }).then((handle) => {
+      this.listener = handle;
+    });
+  }
+
+  private pathOf(url: string): string {
+    return url.split(/[?#]/)[0];
+  }
+
+  /** Back doesn't always navigate — it may have closed a layer instead — so the
+   *  flag is released on a timer too, or one such gesture would disable every
+   *  later view transition. */
+  private releaseTransitionsOnArrival(): void {
+    const subscription = this.router.events
+      .pipe(
+        filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+        take(1),
+      )
+      .subscribe(() => setTimeout(() => setSwipeBackActive(false)));
+    setTimeout(() => {
+      subscription.unsubscribe();
+      setSwipeBackActive(false);
+    }, 1000);
+  }
+
+  destroy(): void {
+    void this.listener?.remove();
+    this.listener = undefined;
+  }
+}

--- a/client/src/app/core/services/back-gesture.service.ts
+++ b/client/src/app/core/services/back-gesture.service.ts
@@ -10,6 +10,7 @@ import { setSwipeBackActive } from '../../shared/utils/view-transition';
 
 interface BackGesturePlugin {
   setEnabled(options: { enabled: boolean }): Promise<void>;
+  settled(): Promise<void>;
   captureCandidate(): Promise<void>;
   settle(options: { delta: number }): Promise<void>;
   addListener(
@@ -24,6 +25,10 @@ const BackGesture = registerPlugin<BackGesturePlugin>('BackGesture');
  *  its own back; the settings, account and admin shells navigate between their
  *  own panels, where sliding the entire screen off reads as leaving the app. */
 const UNSWIPEABLE = ['/watch', '/admin', '/account', '/app-settings'];
+
+/** A frame at screen rate, with room for a 60 Hz frame that ran a little long.
+ *  The rebuild this waits out lands frames three to four times slower. */
+const SMOOTH_FRAME_MS = 24;
 
 /**
  * iOS left-edge swipe-back. The recognizer and the slide animation live in
@@ -101,9 +106,38 @@ export class BackGestureService {
       setSwipeBackActive(true);
       this.releaseTransitionsOnArrival();
       onCommit();
+      this.reportSettled();
     }).then((handle) => {
       this.listener = handle;
     });
+  }
+
+  /**
+   * Tells the native side when the page it navigated to has stopped rebuilding.
+   *
+   * A cached page comes back with its rows re-rendered, and on a slower device
+   * that rebuild runs for a few hundred milliseconds, painting half-filled
+   * frames along the way. Frame pacing is the signal for it: while the rebuild
+   * runs, frames land 60-80 ms apart, and two in a row at screen rate mean it
+   * is over. The snapshot held until then is the destination's own, so the
+   * wait shows nothing the viewer would not see anyway.
+   */
+  private reportSettled(): void {
+    const start = performance.now();
+    let previous = start;
+    let smooth = 0;
+    const tick = (now: number) => {
+      if (now - previous <= SMOOTH_FRAME_MS) smooth++;
+      else smooth = 0;
+      previous = now;
+      // The native side drops the overlay on its own past its own deadline.
+      if (smooth >= 2 || now - start > 900) {
+        void BackGesture.settled().catch(() => {});
+        return;
+      }
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
   }
 
   private pathOf(url: string): string {

--- a/client/src/app/core/services/navbar.service.ts
+++ b/client/src/app/core/services/navbar.service.ts
@@ -147,6 +147,13 @@ export class NavbarService {
     });
   }
 
+  /** Depth of the back stack. Read by the iOS swipe-back to keep its own stack
+   *  of page snapshots aligned with this one without re-deriving which
+   *  navigations count as a push. */
+  get backDepth(): number {
+    return this.history.length;
+  }
+
   /** URL path without query/fragment — query-only changes on the same path are
    *  in-page state (tabs / filters), not navigations to push onto the stack. */
   private pathOf(url: string): string {

--- a/client/src/app/shared/utils/view-transition.ts
+++ b/client/src/app/shared/utils/view-transition.ts
@@ -117,3 +117,15 @@ export function markViewTransition(transition: { finished: Promise<unknown> }): 
 export function viewTransitionRunning(): boolean {
   return document.documentElement.classList.contains(VIEW_TRANSITION_CLASS);
 }
+
+let swipeBack = false;
+
+/** A swipe-back is animated natively, under an opaque snapshot of the page
+ *  being left: the web transition would run unseen and outlast the slide. */
+export function setSwipeBackActive(active: boolean): void {
+  swipeBack = active;
+}
+
+export function swipeBackActive(): boolean {
+  return swipeBack;
+}


### PR DESCRIPTION
iOS has no hardware back, and a Capacitor app is a single view controller, so it never gets the interactive pop a `UINavigationController` provides. The only way back was the arrow in the top-left corner, where Android has had a gesture all along.

## How it works

The recognizer lives in UIKit rather than in the page: a `UIScreenEdgePanGestureRecognizer` takes priority over the WebView's scroll pan, so a poster carousel sitting on the screen edge cannot steal the swipe. The commit is handed to JS, which runs the same back path as the Android hardware button, layer dismissal included.

The page underneath is a snapshot of the one being returned to, captured when it was left. Its stack mirrors `NavbarService`'s own depth rather than re-deriving which navigations count as a push: replaced URLs, query-only changes and the player's back each decide differently there, and a stack that drifts shows the wrong page. Entries can be nil, so a failed capture costs its parallax and not the alignment.

The gesture stays out of the player and of the settings, account and admin shells, which navigate between their own panels — sliding the whole screen off for a panel change reads as leaving the app.

## Timing

The overlay is not dropped when the slide ends. A cached page comes back with its rows re-rendered, and on an iPhone XS that rebuild runs for a few hundred milliseconds, painting half-filled frames along the way — measured by dumping the live WebView every 33 ms during a return. Frame pacing is the signal: two frames in a row at screen rate mean it is over. What is held meanwhile is the snapshot of the destination itself, so the wait shows nothing the viewer would not see anyway.

That rebuild is the page's own, not the gesture's: a scripted return taken with the back arrow shows the same gap. This only stops the swipe from exposing it.

## Edge cases

- Rotation drops the overlay, and a snapshot taken in the other orientation is skipped rather than stretched. The stack keeps it, so rotating back makes it usable again.
- Both async captures carry the id of what they belong to. Releasing a swipe before its image landed and starting another used to install an overlay for a gesture already over, with nothing left to tear it down — the app looked frozen.
- A watchdog removes any overlay with no live gesture and no pending settle.

## Testing

Built and exercised on an iPhone XS: returns from a media page to a library and to the home page, consecutive back swipes, cancelled swipes, fast flicks, swipes started and released immediately, and rotation right after a commit. 877 unit tests pass.