### PR TITLE
fix(client): stop the outgoing page jumping into a view transition

### DIFF
--- a/client/src/app/core/services/route-reuse.strategy.spec.ts
+++ b/client/src/app/core/services/route-reuse.strategy.spec.ts
@@ -1,6 +1,14 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRouteSnapshot, DetachedRouteHandle, Route } from '@angular/router';
+import {
+  ActivatedRouteSnapshot,
+  DetachedRouteHandle,
+  NavigationCancel,
+  NavigationEnd,
+  Route,
+  Router,
+} from '@angular/router';
+import { Subject } from 'rxjs';
 import { vi } from 'vitest';
 import { CachingReuseStrategy } from './route-reuse.strategy';
 
@@ -20,8 +28,13 @@ function handleWithDestroy(): DetachedRouteHandle & FakeHandle {
 }
 
 describe('CachingReuseStrategy', () => {
+  let events: Subject<unknown>;
+
   function setup() {
-    TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
+    events = new Subject<unknown>();
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection(), { provide: Router, useValue: { events } }],
+    });
     return TestBed.inject(CachingReuseStrategy);
   }
 
@@ -77,6 +90,26 @@ describe('CachingReuseStrategy', () => {
     expect(handles[1].destroy).toHaveBeenCalledTimes(1);
     expect(strategy.shouldAttach(snapshotFor(route, { libraryName: 'lib0' }))).toBe(true);
     expect(strategy.shouldAttach(snapshotFor(route, { libraryName: 'lib1' }))).toBe(false);
+  });
+
+  it('VERDICT: attach fires at NavigationEnd, never while retrieve builds the router state', () => {
+    const strategy = setup();
+    const route: Route = { path: 'movies/:id', data: { reuse: true } };
+    const snapshot = snapshotFor(route, { id: '7' });
+    const attached: string[] = [];
+    strategy.store(snapshot, handleWithDestroy());
+    strategy.attached$.subscribe((key) => attached.push(key));
+
+    strategy.retrieve(snapshot);
+    expect(attached).toEqual([]);
+
+    // A navigation that never activates attaches nothing.
+    events.next(new NavigationCancel(1, '/movies/7', ''));
+    expect(attached).toEqual([]);
+
+    strategy.retrieve(snapshot);
+    events.next(new NavigationEnd(2, '/movies/7', '/movies/7'));
+    expect(attached).toEqual([strategy.keyFor(snapshot)]);
   });
 
   it('VERDICT: re-storing the same handle under an existing key does not destroy it', () => {

--- a/client/src/app/core/services/route-reuse.strategy.ts
+++ b/client/src/app/core/services/route-reuse.strategy.ts
@@ -1,6 +1,15 @@
-import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, DetachedRouteHandle, Route, RouteReuseStrategy } from '@angular/router';
-import { Observable, Subject } from 'rxjs';
+import { Injectable, Injector, inject } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  DetachedRouteHandle,
+  NavigationCancel,
+  NavigationEnd,
+  NavigationError,
+  Route,
+  Router,
+  RouteReuseStrategy,
+} from '@angular/router';
+import { filter, Observable, Subject, take } from 'rxjs';
 
 /** Cap on live detached trees; a handful of libraries visited in one tab, bounding the pathological per-param leak. */
 const MAX_CACHE_SIZE = 10;
@@ -32,6 +41,8 @@ export class CachingReuseStrategy implements RouteReuseStrategy {
 
   private readonly routeIds = new WeakMap<Route, string>();
   private nextRouteId = 0;
+
+  private readonly injector = inject(Injector);
 
   private readonly attachedSubject = new Subject<string>();
   private readonly detachedSubject = new Subject<string>();
@@ -112,11 +123,29 @@ export class CachingReuseStrategy implements RouteReuseStrategy {
       // Re-insert to mark most-recently-used for the LRU eviction in store().
       this.cache.delete(key);
       this.cache.set(key, handle);
-      // Microtask so the outlet has finished attaching before subscribers run
-      // their refresh / focus-restore work.
-      queueMicrotask(() => this.attachedSubject.next(key));
+      this.notifyWhenActivated(key);
     }
     return handle;
+  }
+
+  /** Attached means attached: `retrieve` runs a frame before the outlet swaps,
+   *  so reclaiming global chrome there moves the page still on screen. */
+  private notifyWhenActivated(key: string): void {
+    // Lazily resolved: the Router itself depends on this strategy.
+    this.injector
+      .get(Router)
+      .events.pipe(
+        filter(
+          (e) =>
+            e instanceof NavigationEnd ||
+            e instanceof NavigationCancel ||
+            e instanceof NavigationError,
+        ),
+        take(1),
+      )
+      .subscribe((e) => {
+        if (e instanceof NavigationEnd) this.attachedSubject.next(key);
+      });
   }
 
   shouldReuseRoute(future: ActivatedRouteSnapshot, current: ActivatedRouteSnapshot): boolean {


### PR DESCRIPTION
## Problem

On Android, tapping a media card in the library makes the library jump upward just as the
view transition opens.

## Root cause

`CachingReuseStrategy.retrieve()` is called from the router's `createRouterState`, i.e.
while the navigation is still being planned — a whole frame before the outlet swaps. It
notified `attached$` from a microtask, so every `keepRouteFresh({ onAttach })` subscriber
ran while the page being left was still the live document.

A cached media page's `onAttach` reclaims the global chrome, and `NavbarService
.enterHeroPage()` adds `body.hero-page`, which drops `<main>`'s top padding. Traced on the
device over CDP (`padTop`, `cardTop`, `startViewTransition` hooks, one sample per frame):

```
VT.start     path=/libraries/Films  padTop=99px  cardTop=-641  hero=false
raf          path=/libraries/Films  padTop=16px  cardTop=-724  hero=true   <- 83 px up
VT.updateCb  path=/libraries/Films  padTop=16px  cardTop=-724  hero=true
VT.ready     path=/movies/24        padTop=16px
```

That `raf` frame is the one the transition captures as its old state, so the shift is both
painted live and baked into the snapshot. It needs the media page to be in the reuse cache,
so it shows from the second visit onward (any of the last 10 pages visited).

## Fix

Fire `attached$` on the `NavigationEnd` of the navigation that retrieved the handle, and
never for one that is cancelled or errors. That is the swap itself: the same task as the
outlet's attach, still ahead of the first layout of the attached page, so the hero padding
keeps landing before WebKit lays the cached page out (the constraint from #1351).

The same early window also had the library's own `onAttach` scrolling the document and
re-declaring the ambient backdrop while the outgoing page was still on screen; both now
land at the swap.

## Verification

- A/B in Chromium against the dev stack, same probe: with the old timing `padTop` drops to
  `16px` while `location.pathname` is still `/libraries/Films` (card top 240 → 176); with
  the fix it stays `80px` until the path is `/movies/21`.
- Return trip re-checked: back from the media page restores the library offset (y=500),
  padding and hero state.
- `route-reuse.strategy.spec.ts` gets a case pinning the timing; `src/app/core/services`,
  `library` and `layout` specs pass (204 tests), `tsc -p tsconfig.app.json` clean.