### PR TITLE
fix(library): land the back morph on the restored row

### DIFF
--- a/client/src/app/features/library/library.spec.ts
+++ b/client/src/app/features/library/library.spec.ts
@@ -71,6 +71,9 @@ function stubTop(el: HTMLElement, top: number): void {
  *  dispatched on it) plus spies for the CDK methods the component calls. */
 function fakeViewport() {
   const el = document.createElement('div');
+  const wrapper = document.createElement('div');
+  wrapper.className = 'cdk-virtual-scroll-content-wrapper';
+  el.appendChild(wrapper);
   return {
     elementRef: { nativeElement: el },
     measureScrollOffset: vi.fn(() => 0),
@@ -247,7 +250,7 @@ describe('LibraryComponent — page scroll', () => {
     expect(viewport.setRenderedContentOffset).toHaveBeenCalledWith(offset);
   });
 
-  it('leaves a range that already covers the restored row alone', () => {
+  it('VERDICT: puts the restored row at the top of the range, offset painted now', () => {
     const offset = 520 * 50;
     const { component, attached$, detached$, navigatedBack } = createHarness(offset);
     navigatedBack.set(true);
@@ -258,10 +261,16 @@ describe('LibraryComponent — page scroll', () => {
     detached$.next(OWN_KEY);
     attached$.next(OWN_KEY);
 
-    // Row 50 is inside the 47-58 range the page kept, and re-rendering it would
-    // recycle the card DOM node the poster morph was stamped on.
-    expect(viewport.setRenderedRange).not.toHaveBeenCalled();
-    expect(viewport.setRenderedContentOffset).not.toHaveBeenCalled();
+    // A window-scrolling viewport re-ranges off whatever page scrolls while this
+    // one is detached, so the range it comes back with can hold the restored row
+    // and still be drawn at another page's offset.
+    expect(viewport.setRenderedRange).toHaveBeenCalledWith({ start: 50, end: 61 });
+    expect(viewport.setRenderedContentOffset).toHaveBeenCalledWith(offset);
+    expect(
+      viewport.elementRef.nativeElement.querySelector<HTMLElement>(
+        '.cdk-virtual-scroll-content-wrapper',
+      )!.style.transform,
+    ).toBe(`translateY(${offset}px)`);
   });
 
   it("keeps the active letter through the restore's own scroll event", async () => {

--- a/client/src/app/features/library/library.ts
+++ b/client/src/app/features/library/library.ts
@@ -327,11 +327,15 @@ export class LibraryComponent implements OnInit, OnDestroy {
       Math.floor(Math.max(0, offset - this.rowsOffset()) / this.rowHeight()),
       Math.max(0, rows - span),
     ));
-    // Only when it has moved: re-rendering a range recycles its views, and a
-    // poster morph pairs with the very DOM node the click stamped.
-    if (first >= range.start && first < range.end) return;
-    vp.setRenderedRange({ start: first, end: first + span });
-    vp.setRenderedContentOffset(first * this.rowHeight());
+    const top = first * this.rowHeight();
+    if (first !== range.start) vp.setRenderedRange({ start: first, end: first + span });
+    vp.setRenderedContentOffset(top);
+    // The rows only sit where that offset says once CDK's own pass writes their
+    // wrapper transform, and a poster morph is captured before it.
+    const wrapper = vp.elementRef.nativeElement.querySelector<HTMLElement>(
+      '.cdk-virtual-scroll-content-wrapper',
+    );
+    if (wrapper) wrapper.style.transform = `translateY(${top}px)`;
   }
   /** The offset lives in the shared memory, whose sticky restore lands after
    *  this: range from the value it is about to write. */


### PR DESCRIPTION
## Problem

Coming back from a media page to the library, the poster morph sometimes fails — the
picture flies off instead of landing on its card. Intermittent, and it only shows once the
library is scrolled past the first rendered window.

## Root cause

The grid's `cdk-virtual-scroll-viewport` is declared `scrollWindow`, so it re-ranges off
**any** page's scrolling while the library sits detached in the route cache. Coming back it
holds a range computed for the media page's offset (start 0), and two things then go wrong:

1. `renderRangeForOffset()` bailed out whenever the restored row happened to fall inside
   the range it came back with (`if (first >= range.start && first < range.end) return`) —
   which is exactly what a range reset to the top of a 47 000 px grid does.
2. CDK writes the rendered content offset as a wrapper `transform` in a change-detection
   pass of its own, which lands after the view transition has captured the destination.

Measured on the device over CDP, back from `/movies/48` to a library at y=2900:

```
                    scrollY   wrapper transform   rows  stamped card
READY (captured)    2900      translateY(0px)     7     top=-2073   ← 2.4k px off screen
finished            2900      translateY(1893px)  11    top=+387
```

So the transition paired the hero with a card the browser had placed 2.4 k px above the
viewport: the morph animates out of the screen, then the grid corrects itself once CDK
catches up.

## Fix

Range onto the restored row unconditionally, and paint the wrapper transform on the spot
instead of waiting for CDK's pass. Row views travel with their track key (the absolute row
index), so the `<img>` the click stamped keeps its `view-transition-name` across the
re-range — verified on the device: the stamped node comes back on the same card.

## Verification

Same probe, same build, four returns at increasing depth — the card's position at capture
now matches where it settles:

| restored offset | card top at capture | at finished | before the fix |
|---|---|---|---|
| 1500 | 273 | 274 | -1562 |
| 2200 | 330 | 331 | -1562 |
| 2900 | 387 | 387 | -2073 |
| 3600 | 255 | 255 | -2962 |

`library.spec.ts` gets the case that pinned the old early-return rewritten to pin the new
contract (range onto the row + offset painted now); 204 specs across `core/services`,
`library` and `layout` pass, `tsc -p tsconfig.app.json` clean.

## Follow-up, not done here

The detached viewport still re-ranges on every scroll of every other page — wasted work on
a long grid, and the reason this restore has to exist at all. Freezing it on detach needs
CDK internals (`_forOf`, `_scrollStrategy`), so it is left out.