### PR TITLE
fix(acquisition): floor release sizes so extras stop passing as the feature

### DIFF
--- a/backend/src/migrations/1785000000000-quality-definition-min-sizes.ts
+++ b/backend/src/migrations/1785000000000-quality-definition-min-sizes.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/** Every install seeded `minSize` at 0, which disabled the SIZE_TOO_LOW rule outright and let
+ *  extras indexed under a feature's name through. Only rows still at 0 move, so a tuned floor
+ *  survives. */
+const MIN_BY_QUALITY_ID: Record<number, number> = {
+  11: 150, // HDTV-720p
+  12: 150, // WEBDL-720p
+  13: 150, // WEBRip-720p
+  14: 250, // Bluray-720p
+  15: 250, // HDTV-1080p
+  16: 250, // WEBDL-1080p
+  17: 250, // WEBRip-1080p
+  18: 400, // Bluray-1080p
+  19: 8000, // Remux-1080p
+  20: 600, // HDTV-2160p
+  21: 600, // WEBDL-2160p
+  22: 600, // WEBRip-2160p
+  23: 1000, // Bluray-2160p
+  24: 15000, // Remux-2160p
+};
+
+export class QualityDefinitionMinSizes1785000000000
+  implements MigrationInterface
+{
+  name = 'QualityDefinitionMinSizes1785000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    for (const [qualityId, min] of Object.entries(MIN_BY_QUALITY_ID)) {
+      await queryRunner.query(
+        `UPDATE "quality_definitions" SET "minSize" = $1 WHERE "qualityId" = $2 AND "minSize" = 0`,
+        [min, Number(qualityId)],
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "quality_definitions" SET "minSize" = 0 WHERE "qualityId" = ANY($1)`,
+      [Object.keys(MIN_BY_QUALITY_ID).map(Number)],
+    );
+  }
+}

--- a/backend/src/modules/profiles/quality-definitions.service.ts
+++ b/backend/src/modules/profiles/quality-definitions.service.ts
@@ -12,6 +12,11 @@ import { QualityDefinitionItemDto } from './dto/update-quality-definitions.dto';
  *   720p: ~1000-3000 MB/h
  *   1080p: ~2000-8000 MB/h (WEB ~2-4 GB/h, Bluray ~4-8 GB/h, Remux ~15-25 GB/h)
  *   2160p: ~4000-20000 MB/h (WEB ~4-8 GB/h, Bluray ~10-20 GB/h, Remux ~30-60 GB/h)
+ *
+ * `min` is a floor against extras indexed under the feature's name (a making-of, a
+ * prologue, a trailer): those sit an order of magnitude below any real encode at the
+ * resolution they claim. Set well under the worst legitimate encode of each tier, and
+ * left at 0 below 720p where a real release genuinely is that small.
  */
 const DEFAULTS: Record<
   string,
@@ -22,22 +27,22 @@ const DEFAULTS: Record<
   // 480p
   '480': { min: 0, preferred: 800, max: 1500 },
   // 720p
-  '720-hdtv': { min: 0, preferred: 1200, max: 2500 },
-  '720-web': { min: 0, preferred: 1500, max: 3000 },
-  '720-bluray': { min: 0, preferred: 2500, max: 5000 },
-  '720': { min: 0, preferred: 1500, max: 3500 },
+  '720-hdtv': { min: 150, preferred: 1200, max: 2500 },
+  '720-web': { min: 150, preferred: 1500, max: 3000 },
+  '720-bluray': { min: 250, preferred: 2500, max: 5000 },
+  '720': { min: 150, preferred: 1500, max: 3500 },
   // 1080p
-  '1080-hdtv': { min: 0, preferred: 2000, max: 4000 },
-  '1080-web': { min: 0, preferred: 3000, max: 5000 },
-  '1080-bluray': { min: 0, preferred: 5000, max: 10000 },
-  '1080-remux': { min: 0, preferred: 18000, max: 30000 },
-  '1080': { min: 0, preferred: 3000, max: 6000 },
+  '1080-hdtv': { min: 250, preferred: 2000, max: 4000 },
+  '1080-web': { min: 250, preferred: 3000, max: 5000 },
+  '1080-bluray': { min: 400, preferred: 5000, max: 10000 },
+  '1080-remux': { min: 8000, preferred: 18000, max: 30000 },
+  '1080': { min: 250, preferred: 3000, max: 6000 },
   // 2160p
-  '2160-hdtv': { min: 0, preferred: 4000, max: 8000 },
-  '2160-web': { min: 0, preferred: 6000, max: 12000 },
-  '2160-bluray': { min: 0, preferred: 12000, max: 25000 },
-  '2160-remux': { min: 0, preferred: 35000, max: 60000 },
-  '2160': { min: 0, preferred: 8000, max: 20000 },
+  '2160-hdtv': { min: 600, preferred: 4000, max: 8000 },
+  '2160-web': { min: 600, preferred: 6000, max: 12000 },
+  '2160-bluray': { min: 1000, preferred: 12000, max: 25000 },
+  '2160-remux': { min: 15000, preferred: 35000, max: 60000 },
+  '2160': { min: 600, preferred: 8000, max: 20000 },
 };
 
 function getDefault(

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -1739,8 +1739,7 @@
       "specs": "Bedingungen",
       "add_spec": "Bedingung hinzufügen",
       "no_specs": "Noch keine Bedingung. Ein Format braucht mindestens eine.",
-      "negate": "Verneinen",
-      "required": "Erforderlich",
+      "required": "Immer erforderlich",
       "name_required": "Der Name ist erforderlich.",
       "save_error": "Speichern nicht möglich.",
       "save": "Speichern",
@@ -1756,7 +1755,7 @@
       "regex_placeholder": "regulärer Ausdruck",
       "value_placeholder": "Wert",
       "test_freeleech": "Als Freeleech behandeln",
-      "match_rule_hint": "Bedingungen desselben Typs sind Alternativen; verschiedene Typen müssen alle zutreffen. Eine erforderliche Bedingung muss immer zutreffen.",
+      "match_rule_hint": "Bedingungen desselben Typs sind Alternativen; verschiedene Typen müssen alle zutreffen.",
       "spec_type": {
         "title_regex": "Release-Name (Regex)",
         "source": "Quelle",
@@ -1776,7 +1775,15 @@
         "remastered": "Remastered",
         "criterion": "Criterion",
         "imax": "IMAX"
-      }
+      },
+      "required_hint": "Bei mehreren Bedingungen desselben Typs genügt eine Übereinstimmung. Aktivieren, damit auch diese zutreffen muss.",
+      "operator": {
+        "contains": "enthält",
+        "not_contains": "enthält nicht",
+        "is": "ist",
+        "not_is": "ist nicht"
+      },
+      "remove_spec": "Bedingung entfernen"
     },
     "naming": {
       "title": "Dateibenennung",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -1756,8 +1756,7 @@
       "specs": "Conditions",
       "add_spec": "Add a condition",
       "no_specs": "No condition yet. A format needs at least one.",
-      "negate": "Negate",
-      "required": "Required",
+      "required": "Always required",
       "name_required": "The name is required.",
       "save_error": "Unable to save.",
       "save": "Save",
@@ -1773,7 +1772,7 @@
       "regex_placeholder": "regular expression",
       "value_placeholder": "value",
       "test_freeleech": "Treat as freeleech",
-      "match_rule_hint": "Conditions of the same type are alternatives; different types must all hold. A required condition must always hold.",
+      "match_rule_hint": "Conditions of the same type are alternatives; different types must all hold.",
       "spec_type": {
         "title_regex": "Release name (regex)",
         "source": "Source",
@@ -1793,7 +1792,15 @@
         "remastered": "Remastered",
         "criterion": "Criterion",
         "imax": "IMAX"
-      }
+      },
+      "required_hint": "With several conditions of the same type, one match is enough. Tick this to require this one as well.",
+      "operator": {
+        "contains": "contains",
+        "not_contains": "does not contain",
+        "is": "is",
+        "not_is": "is not"
+      },
+      "remove_spec": "Remove the condition"
     },
     "naming": {
       "title": "File naming",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -1739,8 +1739,7 @@
       "specs": "Condiciones",
       "add_spec": "Añadir una condición",
       "no_specs": "Sin condiciones. Un formato necesita al menos una.",
-      "negate": "Negar",
-      "required": "Requerido",
+      "required": "Siempre requerida",
       "name_required": "El nombre es obligatorio.",
       "save_error": "No se puede guardar.",
       "save": "Guardar",
@@ -1756,7 +1755,7 @@
       "regex_placeholder": "expresión regular",
       "value_placeholder": "valor",
       "test_freeleech": "Tratar como freeleech",
-      "match_rule_hint": "Las condiciones del mismo tipo son alternativas; los tipos distintos deben cumplirse todos. Una condición requerida debe cumplirse siempre.",
+      "match_rule_hint": "Las condiciones del mismo tipo son alternativas; los tipos distintos deben cumplirse todos.",
       "spec_type": {
         "title_regex": "Nombre de la release (regex)",
         "source": "Fuente",
@@ -1776,7 +1775,15 @@
         "remastered": "Remasterizada",
         "criterion": "Criterion",
         "imax": "IMAX"
-      }
+      },
+      "required_hint": "Con varias condiciones del mismo tipo basta una coincidencia. Marca esta casilla para exigir también esta.",
+      "operator": {
+        "contains": "contiene",
+        "not_contains": "no contiene",
+        "is": "es",
+        "not_is": "no es"
+      },
+      "remove_spec": "Eliminar la condición"
     },
     "naming": {
       "title": "Nomenclatura de los archivos",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -1756,8 +1756,7 @@
       "specs": "Conditions",
       "add_spec": "Ajouter une condition",
       "no_specs": "Aucune condition. Un format en exige au moins une.",
-      "negate": "Nier",
-      "required": "Requis",
+      "required": "Toujours requise",
       "name_required": "Le nom est obligatoire.",
       "save_error": "Enregistrement impossible.",
       "save": "Enregistrer",
@@ -1773,7 +1772,7 @@
       "regex_placeholder": "expression régulière",
       "value_placeholder": "valeur",
       "test_freeleech": "Considérer comme freeleech",
-      "match_rule_hint": "Les conditions de même type sont des alternatives ; les types différents doivent tous être vérifiés. Une condition requise doit toujours être vérifiée.",
+      "match_rule_hint": "Les conditions de même type sont des alternatives ; les types différents doivent tous être vérifiés.",
       "spec_type": {
         "title_regex": "Nom de la release (regex)",
         "source": "Source",
@@ -1793,7 +1792,15 @@
         "remastered": "Remasterisée",
         "criterion": "Criterion",
         "imax": "IMAX"
-      }
+      },
+      "required_hint": "Avec plusieurs conditions du même type, une seule correspondance suffit. Cochez pour exiger aussi celle-ci.",
+      "operator": {
+        "contains": "contient",
+        "not_contains": "ne contient pas",
+        "is": "est",
+        "not_is": "n'est pas"
+      },
+      "remove_spec": "Supprimer la condition"
     },
     "naming": {
       "title": "Nommage des fichiers",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -1739,8 +1739,7 @@
       "specs": "Condizioni",
       "add_spec": "Aggiungi una condizione",
       "no_specs": "Nessuna condizione. Un formato ne richiede almeno una.",
-      "negate": "Nega",
-      "required": "Richiesto",
+      "required": "Sempre obbligatoria",
       "name_required": "Il nome è obbligatorio.",
       "save_error": "Salvataggio non riuscito.",
       "save": "Salva",
@@ -1756,7 +1755,7 @@
       "regex_placeholder": "espressione regolare",
       "value_placeholder": "valore",
       "test_freeleech": "Considera come freeleech",
-      "match_rule_hint": "Le condizioni dello stesso tipo sono alternative; tipi diversi devono valere tutti. Una condizione obbligatoria deve valere sempre.",
+      "match_rule_hint": "Le condizioni dello stesso tipo sono alternative; tipi diversi devono valere tutti.",
       "spec_type": {
         "title_regex": "Nome della release (regex)",
         "source": "Sorgente",
@@ -1776,7 +1775,15 @@
         "remastered": "Rimasterizzata",
         "criterion": "Criterion",
         "imax": "IMAX"
-      }
+      },
+      "required_hint": "Con più condizioni dello stesso tipo basta una corrispondenza. Seleziona per richiedere anche questa.",
+      "operator": {
+        "contains": "contiene",
+        "not_contains": "non contiene",
+        "is": "è",
+        "not_is": "non è"
+      },
+      "remove_spec": "Rimuovi la condizione"
     },
     "naming": {
       "title": "Denominazione dei file",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -1739,8 +1739,7 @@
       "specs": "Condições",
       "add_spec": "Adicionar uma condição",
       "no_specs": "Nenhuma condição. Um formato exige pelo menos uma.",
-      "negate": "Negar",
-      "required": "Obrigatório",
+      "required": "Sempre obrigatória",
       "name_required": "O nome é obrigatório.",
       "save_error": "Não foi possível guardar.",
       "save": "Guardar",
@@ -1756,7 +1755,7 @@
       "regex_placeholder": "expressão regular",
       "value_placeholder": "valor",
       "test_freeleech": "Tratar como freeleech",
-      "match_rule_hint": "Condições do mesmo tipo são alternativas; tipos diferentes têm de se verificar todos. Uma condição obrigatória tem de se verificar sempre.",
+      "match_rule_hint": "Condições do mesmo tipo são alternativas; tipos diferentes têm de se verificar todos.",
       "spec_type": {
         "title_regex": "Nome da release (regex)",
         "source": "Fonte",
@@ -1776,7 +1775,15 @@
         "remastered": "Remasterizada",
         "criterion": "Criterion",
         "imax": "IMAX"
-      }
+      },
+      "required_hint": "Com várias condições do mesmo tipo basta uma correspondência. Marque para exigir também esta.",
+      "operator": {
+        "contains": "contém",
+        "not_contains": "não contém",
+        "is": "é",
+        "not_is": "não é"
+      },
+      "remove_spec": "Remover a condição"
     },
     "naming": {
       "title": "Nomenclatura dos ficheiros",

--- a/client/src/app/features/settings/custom-formats/custom-formats.html
+++ b/client/src/app/features/settings/custom-formats/custom-formats.html
@@ -181,80 +181,88 @@
         </div>
 
         @for (spec of formSpecs(); track $index) {
-          <div class="flex flex-wrap gap-2 p-3 rounded-lg bg-base-200/40 border border-base-300">
-            <select
-    appTvSelect
-              class="select select-bordered select-xs"
-              [ngModel]="spec.type"
-              (ngModelChange)="changeSpecType($index, $event)"
-            >
-              @for (t of specTypes; track t) {
-                <option [value]="t">
-                  {{ 'settings.custom_formats.spec_type.' + t | translate }}
-                </option>
-              }
-            </select>
-            @if (valueOptions(spec.type); as options) {
+          <div class="flex flex-col gap-2 p-3 rounded-lg bg-base-200/40 border border-base-300">
+            <div class="flex items-center gap-2">
               <select
-    appTvSelect
-                class="select select-bordered select-xs flex-1 min-w-32"
-                [ngModel]="spec.value"
-                (ngModelChange)="updateSpec($index, { value: $event })"
+                appTvSelect
+                class="select select-bordered select-xs flex-1 min-w-0"
+                [ngModel]="spec.type"
+                (ngModelChange)="changeSpecType($index, $event)"
               >
-                @for (v of options; track v) {
-                  <option [value]="v">
-                    {{
-                      spec.type === 'edition'
-                        ? ('settings.custom_formats.edition.' + v | translate)
-                        : v
-                    }}
+                @for (t of specTypes; track t) {
+                  <option [value]="t">
+                    {{ 'settings.custom_formats.spec_type.' + t | translate }}
                   </option>
                 }
               </select>
-            } @else {
-              <input
-                type="text"
-                class="input input-bordered input-xs flex-1 min-w-32"
-                [class.input-error]="specInvalid(spec)"
-                [ngModel]="spec.value"
-                (ngModelChange)="updateSpec($index, { value: $event })"
-                [placeholder]="
-                  (spec.type === 'title_regex'
-                    ? 'settings.custom_formats.regex_placeholder'
-                    : 'settings.custom_formats.value_placeholder'
-                  ) | translate
-                "
-              />
-            }
-            <label class="label cursor-pointer gap-1.5 px-1">
-              <input
-                type="checkbox"
-                class="checkbox checkbox-xs"
-                [ngModel]="spec.negate"
-                (ngModelChange)="updateSpec($index, { negate: $event })"
-              />
-              <span class="label-text text-sm">{{
-                'settings.custom_formats.negate' | translate
-              }}</span>
-            </label>
-            <label class="label cursor-pointer gap-1.5 px-1">
-              <input
-                type="checkbox"
-                class="checkbox checkbox-xs"
-                [ngModel]="spec.required"
-                (ngModelChange)="updateSpec($index, { required: $event })"
-              />
-              <span class="label-text text-sm">{{
-                'settings.custom_formats.required' | translate
-              }}</span>
-            </label>
-            <button
-              type="button"
-              class="btn btn-ghost btn-xs text-error"
-              (click)="removeSpec($index)"
-            >
-              ✕
-            </button>
+              <select
+                appTvSelect
+                class="select select-bordered select-xs flex-1 min-w-0"
+                [ngModel]="spec.negate ? 'not' : 'is'"
+                (ngModelChange)="updateSpec($index, { negate: $event === 'not' })"
+              >
+                <option value="is">{{ operatorKey(spec.type, false) | translate }}</option>
+                <option value="not">{{ operatorKey(spec.type, true) | translate }}</option>
+              </select>
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs text-error shrink-0"
+                [attr.aria-label]="'settings.custom_formats.remove_spec' | translate"
+                (click)="removeSpec($index)"
+              >
+                ✕
+              </button>
+            </div>
+            <div class="flex items-center gap-3">
+              @if (valueOptions(spec.type); as options) {
+                <select
+                  appTvSelect
+                  class="select select-bordered select-xs flex-1 min-w-0"
+                  [ngModel]="spec.value"
+                  (ngModelChange)="updateSpec($index, { value: $event })"
+                >
+                  @for (v of options; track v) {
+                    <option [value]="v">
+                      {{
+                        spec.type === 'edition'
+                          ? ('settings.custom_formats.edition.' + v | translate)
+                          : v
+                      }}
+                    </option>
+                  }
+                </select>
+              } @else {
+                <input
+                  type="text"
+                  class="input input-bordered input-xs flex-1 min-w-0"
+                  [class.input-error]="specInvalid(spec)"
+                  [ngModel]="spec.value"
+                  (ngModelChange)="updateSpec($index, { value: $event })"
+                  [placeholder]="
+                    (spec.type === 'title_regex'
+                      ? 'settings.custom_formats.regex_placeholder'
+                      : 'settings.custom_formats.value_placeholder'
+                    ) | translate
+                  "
+                />
+              }
+              @if (showRequired(spec.type)) {
+                <label
+                  class="label cursor-pointer gap-1.5 shrink-0"
+                  [title]="'settings.custom_formats.required_hint' | translate"
+                >
+                  <input
+                    type="checkbox"
+                    class="checkbox checkbox-xs"
+                    [ngModel]="spec.required"
+                    (ngModelChange)="updateSpec($index, { required: $event })"
+                  />
+                  <span class="label-text text-sm">{{
+                    'settings.custom_formats.required' | translate
+                  }}</span>
+                </label>
+              }
+            </div>
           </div>
         }
 
@@ -271,12 +279,14 @@
     </div>
 
     <app-modal-footer flush>
+      @if (formError(); as error) {
+        <span class="text-sm text-error mr-auto self-center text-start">{{
+          error | translate
+        }}</span>
+      }
       <button type="button" class="btn btn-ghost" (click)="closeEditor()" [disabled]="saving()">
         {{ 'settings.custom_formats.cancel' | translate }}
       </button>
-      @if (formError(); as error) {
-        <span class="text-sm text-error mr-auto">{{ error | translate }}</span>
-      }
       <button
         type="button"
         class="btn btn-primary"

--- a/client/src/app/features/settings/custom-formats/custom-formats.ts
+++ b/client/src/app/features/settings/custom-formats/custom-formats.ts
@@ -153,9 +153,24 @@ export class CustomFormatsSettingsComponent implements OnInit {
     this.updateSpec(index, { type, value: this.valueOptions(type)?.[0] ?? '' });
   }
 
+  /** Only a pattern that cannot compile: an empty value is already named by `formError`,
+   *  and painting a freshly added condition red says nothing the user can act on. */
   specInvalid(spec: CustomFormatSpec): boolean {
-    if (!spec.value.trim()) return true;
-    return spec.type === 'title_regex' && !isValidRegex(spec.value);
+    return (
+      spec.type === 'title_regex' && spec.value.trim().length > 0 && !isValidRegex(spec.value)
+    );
+  }
+
+  /** `title_regex` is a substring search, so "contains" is literal; every other type
+   *  compares one parsed attribute for equality. */
+  operatorKey(type: CustomFormatSpecType, negate: boolean): string {
+    const verb = type === 'title_regex' ? 'contains' : 'is';
+    return `settings.custom_formats.operator.${negate ? 'not_' : ''}${verb}`;
+  }
+
+  /** Alone in its type group the flag changes nothing: the group has to match anyway. */
+  showRequired(type: CustomFormatSpecType): boolean {
+    return this.formSpecs().filter((s) => s.type === type).length > 1;
   }
 
   async save() {


### PR DESCRIPTION
## Why

Searching a freshly released film returned the extras indexed under its name as grabbable
candidates: the making-of documentary, an IMAX prologue, and 4K teaser trailers. They pass the
token-inclusion title check (their name contains every token of the film's) and the year check,
and nothing downstream could tell them apart from the feature.

The rule meant to catch this already existed. `SIZE_TOO_LOW` compares a release's MB/h against
the quality definition's `minSize`, with the media runtime as the divisor. But every install
seeded `minSize` at 0 on all 24 tiers, and the check is guarded by `min > 0`, so it never fired
on any install since the feature landed. Only `preferredSize` and `maxSize` ever had defaults.

## What changed

**Size floors.** `minSize` gets a real value per tier: 150 MB/h at 720p, 250 at 1080p, 600 at
2160p, 8000 and 15000 for the remux tiers. Set well under the worst legitimate encode of each
tier rather than near the preferred rate, and left at 0 below 720p where a real release genuinely
is that small. The existing codec factor already rebates the limits by 45% for HEVC and 55% for
AV1, so efficient encodes keep a wide margin.

A migration moves existing installs, but only rows still at 0, so a floor someone tuned by hand
survives. Tested on a fresh migration chain: `up`, `down`, and a hand-set 999 left untouched.

**Custom-format conditions.** `Negate` named the implementation rather than the effect, and there
was no readable way to express "does not contain". A regex condition is a substring search, so
the operator now says `contains` / `does not contain` literally; the other types compare one
parsed attribute, so they say `is` / `is not`.

`Required` only changes anything when two conditions share a type, since a lone condition has to
match either way. It now appears in that case only, with its rule as a tooltip instead of a
sentence in the shared hint. The footer error moves to the left edge (it sat after Cancel, so it
rendered wedged between the two actions), the condition row is laid out in two stable lines
instead of wrapping into three, and an empty value no longer paints the input red.

## Verification

Measured against the real indexer feed for a 173-minute film, through the plugin's own search
route so the whole chain is exercised:

| | before | after |
|---|---|---|
| grabbable releases | 81 | 69 |
| making-of / trailers grabbable | 17 | 4 |
| `SIZE_TOO_LOW` | 0 | 18 |

The best candidate is unchanged (a 1080p WEB-DL at 1546 MB/h) and no genuine release of the film
was lost. What drops: the making-of at 145 MB/h in 1080p and 71 at 720p, a 4K AV1 prologue at 176
MB/h, and two teaser trailers at 257 and 120 MB/h.

Backend `tsc` clean, `ng build` clean, the 72 tests over `release-scoring` and `profiles` pass.
Modal verified in a real browser at both one and two conditions.

## Known gap

4 rows still pass: the indexer reports no size for them, and no size rule can judge that. Catching
those needs runtime-based sample detection at import time, which is not in this PR.

## No plugin release needed

The download plugin never scores releases itself, it calls the host's `releases.score` and filters
on `rejections.length === 0` without knowing the codes. The new rejection reaches auto-grab, RSS
sync and the manual modal with the plugin untouched.
