### PR TITLE
fix(media): reset the page and purge caches when a file is deleted

### DIFF
--- a/backend/src/modules/media/media-service/media-mutation.service.spec.ts
+++ b/backend/src/modules/media/media-service/media-mutation.service.spec.ts
@@ -254,3 +254,40 @@ describe('MediaMutationService remove disk cleanup', () => {
     });
   });
 });
+
+describe('MediaMutationService deleteMediaFile cache cleanup', () => {
+  it('purges the sprite and subtitle caches with the id the row had', async () => {
+    const file = { id: 77, episodeId: null, relativePath: 'a.mkv' };
+    const thumbnails = { deleteForFile: jest.fn() };
+    const subtitleStream = { clearMediaFileSubtitleCache: jest.fn() };
+    const mediaFileRepo = {
+      findOne: jest.fn().mockResolvedValue(file),
+      // TypeORM blanks the primary key of a removed entity.
+      remove: jest.fn(() => {
+        (file as { id?: number }).id = undefined;
+      }),
+      count: jest.fn(),
+    };
+
+    const service = new MediaMutationService(
+      { findOne: jest.fn().mockResolvedValue({ id: 1, title: 'placeholder', path: null }) } as never,
+      {} as never,
+      {} as never,
+      mediaFileRepo as never,
+      {} as never,
+      {} as never,
+      { dispatch: jest.fn() } as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      { emitDomain: jest.fn() } as never,
+      thumbnails as never,
+      subtitleStream as never,
+    );
+
+    await service.deleteMediaFile(1, 77, false);
+
+    expect(thumbnails.deleteForFile).toHaveBeenCalledWith(77);
+    expect(subtitleStream.clearMediaFileSubtitleCache).toHaveBeenCalledWith(77);
+  });
+});

--- a/backend/src/modules/media/media-service/media-mutation.service.ts
+++ b/backend/src/modules/media/media-service/media-mutation.service.ts
@@ -358,9 +358,11 @@ export class MediaMutationService {
     }
 
     const episodeId = file.episodeId;
+    // `remove()` blanks the entity's primary key, so read it first.
+    const removedFileId = file.id;
     await this.mediaFileRepo.remove(file);
-    void this.thumbnails.deleteForFile(file.id);
-    void this.subtitleStream.clearMediaFileSubtitleCache(file.id);
+    void this.thumbnails.deleteForFile(removedFileId);
+    void this.subtitleStream.clearMediaFileSubtitleCache(removedFileId);
     if (episodeId != null) {
       const remaining = await this.mediaFileRepo.count({
         where: { episode: { id: episodeId } },

--- a/backend/src/modules/media/media-service/media-rescan.service.ts
+++ b/backend/src/modules/media/media-service/media-rescan.service.ts
@@ -526,10 +526,12 @@ export class MediaRescanService {
           );
         }
         const episodeId = dbFile.episodeId;
+        // `remove()` blanks the entity's primary key, so read it first.
+        const removedFileId = dbFile.id;
         try {
           await this.mediaFileRepo.remove(dbFile);
-          void this.thumbnailService.deleteForFile(dbFile.id);
-          void this.subtitleStream.clearMediaFileSubtitleCache(dbFile.id);
+          void this.thumbnailService.deleteForFile(removedFileId);
+          void this.subtitleStream.clearMediaFileSubtitleCache(removedFileId);
           removed++;
           this.log.log(
             `Rescan: removed missing file "${normPath}" for media #${mediaId}`,

--- a/client/src/app/features/media-detail/media-detail.file-selection.spec.ts
+++ b/client/src/app/features/media-detail/media-detail.file-selection.spec.ts
@@ -1,0 +1,132 @@
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { provideTranslateService, TranslateLoader } from '@ngx-translate/core';
+import { EMPTY, of } from 'rxjs';
+import { vi, afterEach, describe, it, expect } from 'vitest';
+import { MediaDetailComponent } from './media-detail';
+import { MediaService, Media } from '../../core/services/api/media.service';
+import { MediaDetailReleasePickerService } from './media-detail-release-picker.service';
+import { AuthService } from '../../core/services/auth.service';
+import { ProfilesService } from '../../core/services/api/profiles.service';
+import { LibrariesApiService } from '../../core/services/api/libraries-api.service';
+import { NavbarService } from '../../core/services/navbar.service';
+import { BackgroundService } from '../../core/services/background.service';
+import { StreamingApiService } from '../../core/services/api/streaming-api.service';
+import { MarkersApiService } from '../../core/services/api/markers-api.service';
+import { RequestsService } from '../../core/services/api/requests.service';
+import { ConfirmationService } from '../../core/services/confirmation.service';
+import { ToastService } from '../../core/services/toast.service';
+import { SseService } from '../../core/services/sse.service';
+import { DownloadManagerService } from '../../core/services/download-manager.service';
+import { DownloadProgressService } from '../../core/services/download-progress.service';
+import { TvService } from '../../core/services/tv.service';
+import { ScrollMemoryService } from '../../core/services/scroll-memory.service';
+import { AddToPlaylistService } from '../../core/services/add-to-playlist.service';
+import { RecommendService } from '../../core/services/recommend.service';
+import { LikesApiService } from '../../core/services/api/likes-api.service';
+
+const MEDIA_ID = 42;
+
+const baseMovie: Media = {
+  id: MEDIA_ID,
+  title: 'Test Movie',
+  originalTitle: 'Test Movie',
+  year: 2024,
+  type: 'movie',
+  tmdbId: 1,
+  overview: '',
+  status: 'released',
+  monitored: true,
+  posterUrl: null,
+  fanartUrl: null,
+  logoUrl: null,
+  additionalFanartUrls: [],
+  rating: 0,
+  runtime: 100,
+  files: [],
+};
+
+function createHarness() {
+  const confirm = vi.fn().mockResolvedValue(false);
+
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      provideTranslateService({
+        lang: 'en',
+        loader: { provide: TranslateLoader, useValue: { getTranslation: () => of({}) } },
+      }),
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          paramMap: EMPTY,
+          snapshot: { data: { kind: 'movie' }, paramMap: { get: () => null } },
+        },
+      },
+      { provide: Router, useValue: { navigate: vi.fn(), getCurrentNavigation: () => null } },
+      { provide: MediaService, useValue: { getOne: vi.fn(async () => baseMovie), delete: vi.fn() } },
+      { provide: MediaDetailReleasePickerService, useValue: {} },
+      { provide: AuthService, useValue: { hasPermission: () => false } },
+      { provide: ProfilesService, useValue: {} },
+      { provide: LibrariesApiService, useValue: {} },
+      { provide: NavbarService, useValue: { enterHeroPage: vi.fn(), leaveHeroPage: vi.fn() } },
+      { provide: BackgroundService, useValue: { set: vi.fn(), release: vi.fn(), suspend: vi.fn(), url: signal(null) } },
+      { provide: ConfirmationService, useValue: { confirm } },
+      { provide: ToastService, useValue: { success: vi.fn(), error: vi.fn() } },
+      { provide: SseService, useValue: { lastEvent: signal(null) } },
+      { provide: StreamingApiService, useValue: {} },
+      { provide: MarkersApiService, useValue: {} },
+      { provide: RequestsService, useValue: {} },
+      { provide: DownloadManagerService, useValue: {} },
+      { provide: DownloadProgressService, useValue: { progress: signal(new Map()) } },
+      { provide: TvService, useValue: { isTv: () => false } },
+      { provide: ScrollMemoryService, useValue: { activate: vi.fn(), deactivate: vi.fn(), restoreSticky: vi.fn() } },
+      { provide: AddToPlaylistService, useValue: {} },
+      { provide: RecommendService, useValue: {} },
+      { provide: LikesApiService, useValue: { state: vi.fn(async () => ({ media: false, seasonIds: [], episodeIds: [] })) } },
+    ],
+  });
+
+  TestBed.overrideComponent(MediaDetailComponent, { set: { template: '', imports: [] } });
+
+  const fixture = TestBed.createComponent(MediaDetailComponent);
+  fixture.detectChanges();
+
+  return { fixture, confirm };
+}
+
+describe('MediaDetailComponent - file selection', () => {
+  afterEach(() => TestBed.resetTestingModule());
+
+  const file = { id: 7, quality: '1080p', relativePath: 'a.mkv', size: 1 };
+
+  it('clears the selection when the selected file is gone', () => {
+    const { fixture } = createHarness();
+    const c = fixture.componentInstance;
+
+    c.media.set({ ...baseMovie, files: [file] });
+    fixture.detectChanges();
+    expect(c.selectedFileId()).toBe(file.id);
+
+    c.media.set({ ...baseMovie, files: [] });
+    fixture.detectChanges();
+    expect(c.selectedFileId()).toBeNull();
+    expect(c.activeFileId()).toBeNull();
+  });
+
+  it('keeps a series selection that points at an episode file', () => {
+    const { fixture } = createHarness();
+    const c = fixture.componentInstance;
+    const series = { ...baseMovie, type: 'series' as const, files: [{ ...file, episodeId: 3 }] };
+
+    c.media.set(series);
+    c.selectedFileId.set(file.id);
+    fixture.detectChanges();
+    expect(c.selectedFileId()).toBe(file.id);
+
+    c.media.set({ ...series, files: [] });
+    fixture.detectChanges();
+    expect(c.selectedFileId()).toBeNull();
+  });
+});

--- a/client/src/app/features/media-detail/media-detail.ts
+++ b/client/src/app/features/media-detail/media-detail.ts
@@ -414,13 +414,13 @@ export class MediaDetailComponent implements OnInit, OnDestroy {
     return this.mediaFiles().find((f) => f.id === id) ?? null;
   });
 
-  /** Auto-select first file when mediaFiles change and no selection exists */
+  /** Keep the selection pointing at a file that still exists — validated against
+   *  every file (a series' selection is an episode file, absent from `mediaFiles`). */
   private readonly autoSelectFileEffect = effect(() => {
-    const files = this.mediaFiles();
+    const all = this.media()?.files ?? [];
     const current = this.selectedFileId();
-    if (files.length && (!current || !files.some((f) => f.id === current))) {
-      this.selectedFileId.set(files[0].id);
-    }
+    if (current != null && all.some((f) => f.id === current)) return;
+    this.selectedFileId.set(this.mediaFiles()[0]?.id ?? null);
   });
 
   // ── Episode full-page mode (when navigating to series/:id/episode/:episodeId) ──


### PR DESCRIPTION
Two independent bugs, one per symptom reported when deleting a file from a media.

## 1. The detail page never resets

`autoSelectFileEffect` only corrected a stale `selectedFileId` while the file list was
non-empty. Deleting the last file left the signal pointing at a dead id, and the whole header
gates on it (`@if (selectedFileId() ...)`): the play button stayed, `selectedFile()` resolved
to `null`, so the audio row rendered with no tracks.

It survived a page reload for the same reason. The SWR cache serves the pre-delete body on
first paint, the effect latches the id it carries, then the forced refetch lands with
`files: []` — and the old condition no longer applied, so the dead id stuck.

The effect now validates against every file on the media rather than `mediaFiles()`, which is
empty by design for a series. That covers a series too, whose selection is an episode file.

## 2. Sprite and subtitle caches were never purged

TypeORM blanks an entity's primary key inside `remove()`
(`SubjectExecutor.updateSpecialColumnsInPersistedEntities`), so both single-file paths —
`deleteMediaFile` and the rescan's missing-file cleanup — passed `undefined` to
`deleteForFile` / `clearMediaFileSubtitleCache` and recursively wiped a directory literally
named `undefined`. The real sprite sheets and cached VTTs stayed on disk forever.

`MediaMutationService.remove(id)` (deleting a whole media) already captured the ids before the
`remove()` call; the two single-file paths now do the same.

## Verification

Three tests, each confirmed to fail on the previous code and pass on this branch:

- `media-detail.file-selection.spec.ts` — selection cleared when the file is gone (movie and
  series).
- `media-mutation.service.spec.ts` — the cache purge receives the id the row had, with a fake
  repo that reproduces TypeORM's key blanking.

`tsc --noEmit` clean on both `backend` and `client`.

## Not included

Purging the transcode cache for a deleted file — no evidence of orphaned segments yet.
