### PR TITLE
fix(persons): ask the provider that issued a person id for their credits

### DIFF
--- a/backend/src/migrations/1785100000000-scope-person-ids-by-provider.ts
+++ b/backend/src/migrations/1785100000000-scope-person-ids-by-provider.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/** Person ids are provider-scoped: TVDB credits store a TVDB people id, so the
+ *  id alone is not unique and says nothing about who can resolve it. */
+export class ScopePersonIdsByProvider1785100000000
+  implements MigrationInterface
+{
+  name = 'ScopePersonIdsByProvider1785100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "persons" ADD COLUMN IF NOT EXISTS "provider" character varying(16) NOT NULL DEFAULT 'tmdb'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "persons" DROP CONSTRAINT IF EXISTS "UQ_4069db2315833af2a2bcdc59c42"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "persons" ADD CONSTRAINT "UQ_677a19ecc46b5da7b1a4314c82b" UNIQUE ("provider", "tmdbId")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "persons" DROP CONSTRAINT IF EXISTS "UQ_677a19ecc46b5da7b1a4314c82b"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "persons" ADD CONSTRAINT "UQ_4069db2315833af2a2bcdc59c42" UNIQUE ("tmdbId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "persons" DROP COLUMN IF EXISTS "provider"`,
+    );
+  }
+}

--- a/backend/src/modules/media/entities/person.entity.ts
+++ b/backend/src/modules/media/entities/person.entity.ts
@@ -1,9 +1,15 @@
-import { Entity, Column } from 'typeorm';
+import { Entity, Column, Unique } from 'typeorm';
 import { BaseEntity } from '../../../common/entities/base.entity';
 
 @Entity('persons')
+@Unique(['provider', 'tmdbId'])
 export class Person extends BaseEntity {
-  @Column({ unique: true })
+  /** Provider that issued {@link tmdbId}: TVDB credits store a TVDB people id
+   *  in that column, so it is only a TMDB id when this says `tmdb`. */
+  @Column({ length: 16, default: 'tmdb' })
+  provider: string;
+
+  @Column()
   tmdbId: number;
 
   @Column()

--- a/backend/src/modules/media/media-service/media-metadata.service.ts
+++ b/backend/src/modules/media/media-service/media-metadata.service.ts
@@ -1078,7 +1078,8 @@ export class MediaMetadataService {
     if (uniqueIds.length > 0) {
       const existingPersons = await this.personRepo
         .createQueryBuilder('p')
-        .where('p.tmdbId IN (:...ids)', { ids: uniqueIds })
+        .where('p.provider = :provider', { provider: details.provider })
+        .andWhere('p.tmdbId IN (:...ids)', { ids: uniqueIds })
         .getMany();
       for (const p of existingPersons) personMap.set(p.tmdbId, p);
 
@@ -1091,7 +1092,11 @@ export class MediaMetadataService {
         .map((id) => allCredits.find((c) => c.externalId === id))
         .filter((c): c is (typeof allCredits)[number] => !!c)
         .map((c) =>
-          this.personRepo.create({ tmdbId: c.externalId, name: c.name }),
+          this.personRepo.create({
+            provider: details.provider,
+            tmdbId: c.externalId,
+            name: c.name,
+          }),
         );
       const inserted = newRows.length
         ? await this.personRepo.save(newRows)
@@ -1207,7 +1212,9 @@ export class MediaMetadataService {
         person.metadataRefreshedAt.getTime() < refreshThreshold;
       if (!needsRefresh) continue;
       try {
-        const pd = await this.tmdb.getPersonDetails(String(person.tmdbId));
+        const pd = await this.providerRegistry
+          .resolve(details.provider)
+          .getPersonDetails(String(person.tmdbId));
         let localAvatar: string | undefined;
         if (pd.avatarUrl) {
           const dl = await this.downloadPersonAvatar(person.id, pd.avatarUrl);

--- a/backend/src/modules/metadata-providers/providers/tvdb-api.types.ts
+++ b/backend/src/modules/metadata-providers/providers/tvdb-api.types.ts
@@ -189,9 +189,18 @@ export interface TvdbArtwork {
   includesText: boolean;
 }
 
+export interface TvdbCharacterWork {
+  name: string;
+  image: string | null;
+  year?: string | null;
+}
+
 export interface TvdbCharacter {
   id: number;
   name: string;
+  /** The work the character belongs to — only the people endpoints expand it. */
+  series?: TvdbCharacterWork | null;
+  movie?: TvdbCharacterWork | null;
   seriesId: number | null;
   episodeId: number | null;
   movieId: number | null;

--- a/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
+++ b/backend/src/modules/metadata-providers/providers/tvdb.provider.ts
@@ -458,29 +458,28 @@ export class TvdbProvider implements IMetadataProvider {
     );
     const chars = data.data?.characters ?? [];
 
+    const credit = (c: TvdbCharacter) => {
+      const work = c.series ?? c.movie;
+      return {
+        externalId: c.seriesId ?? c.movieId ?? 0,
+        title: work?.name ?? '',
+        mediaType: (c.movieId ? 'movie' : 'series') as 'movie' | 'series',
+        posterUrl: work?.image ?? c.image ?? null,
+        releaseDate: work?.year ? `${work.year}-01-01` : null,
+        rating: 0,
+      };
+    };
+
     const cast: PersonCreditItem[] = chars
       .filter((c) => c.peopleType === 'Actor' || c.peopleType === 'Guest Star')
-      .map((c) => ({
-        externalId: c.seriesId ?? c.movieId ?? 0,
-        title: '',
-        mediaType: c.movieId ? 'movie' : 'series',
-        character: c.name,
-        posterUrl: c.image ?? null,
-        releaseDate: null,
-        rating: 0,
-      }));
+      .map((c) => ({ ...credit(c), character: c.name }));
 
     const crew: PersonCreditItem[] = chars
       .filter((c) => c.peopleType !== 'Actor' && c.peopleType !== 'Guest Star')
       .map((c) => ({
-        externalId: c.seriesId ?? c.movieId ?? 0,
-        title: '',
-        mediaType: c.movieId ? 'movie' : 'series',
+        ...credit(c),
         job: c.peopleType,
         department: c.peopleType,
-        posterUrl: c.image ?? null,
-        releaseDate: null,
-        rating: 0,
       }));
 
     return { cast, crew };

--- a/backend/src/modules/persons/persons.module.ts
+++ b/backend/src/modules/persons/persons.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { Media } from '../media/entities/media.entity';
 import { Person } from '../media/entities/person.entity';
 import { MediaCast } from '../media/entities/media-cast.entity';
 import { MediaCrew } from '../media/entities/media-crew.entity';
@@ -10,7 +11,7 @@ import { PersonsController } from './persons.controller';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Person, MediaCast, MediaCrew]),
+    TypeOrmModule.forFeature([Person, MediaCast, MediaCrew, Media]),
     MetadataProvidersModule,
     ImageModule,
   ],

--- a/backend/src/modules/persons/persons.provider-credits.spec.ts
+++ b/backend/src/modules/persons/persons.provider-credits.spec.ts
@@ -1,0 +1,71 @@
+import { AxiosError } from 'axios';
+import { PersonsService } from './persons.service';
+
+/** A person id only means something to the provider that issued it: a TVDB
+ *  people id sent to TMDB 404s. */
+describe('PersonsService.getProviderCredits, provider mismatch', () => {
+  const credits = {
+    cast: [{ externalId: 393187, title: 'Sample Series' }],
+    crew: [],
+  };
+
+  function harness(tmdbError: unknown) {
+    const personRepo = {
+      findOne: jest.fn(() =>
+        Promise.resolve({ id: 2752, provider: 'tmdb', tmdbId: 310628 }),
+      ),
+      update: jest.fn(() => Promise.resolve({})),
+    };
+    const tmdb = {
+      name: 'tmdb',
+      getPersonCredits: jest.fn(() => Promise.reject(tmdbError)),
+    };
+    const tvdb = {
+      name: 'tvdb',
+      getPersonCredits: jest.fn(() => Promise.resolve(credits)),
+    };
+    const providers = {
+      resolve: jest.fn(() => tmdb),
+      getFallback: jest.fn(() => tvdb),
+    };
+    const mediaRepo = {
+      find: jest.fn(() => Promise.resolve([{ id: 38, tvdbId: 393187 }])),
+    };
+
+    const service = Object.create(PersonsService.prototype) as PersonsService;
+    Object.assign(service, {
+      personRepo,
+      mediaRepo,
+      providers,
+      log: { log: jest.fn() },
+    });
+    return { service, personRepo, tvdb };
+  }
+
+  const notFound = () => {
+    const err = new AxiosError('Request failed with status code 404');
+    err.response = { status: 404 } as AxiosError['response'];
+    return err;
+  };
+
+  it('retries on the other provider, pins the row and links owned media', async () => {
+    const { service, personRepo, tvdb } = harness(notFound());
+
+    await expect(service.getProviderCredits(2752)).resolves.toEqual({
+      provider: 'tvdb',
+      cast: [{ externalId: 393187, title: 'Sample Series', mediaId: 38 }],
+      crew: [],
+    });
+    expect(tvdb.getPersonCredits).toHaveBeenCalledWith('310628');
+    expect(personRepo.update).toHaveBeenCalledWith(2752, { provider: 'tvdb' });
+  });
+
+  it('propagates anything that is not a 404', async () => {
+    const err = new AxiosError('timeout of 10000ms exceeded');
+    const { service, personRepo, tvdb } = harness(err);
+
+    await expect(service.getProviderCredits(2752)).rejects.toBe(err);
+    expect(tvdb.getPersonCredits).not.toHaveBeenCalled();
+    expect(personRepo.update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/persons/persons.service.ts
+++ b/backend/src/modules/persons/persons.service.ts
@@ -1,18 +1,35 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import axios from 'axios';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, DataSource } from 'typeorm';
+import { Repository, DataSource, In } from 'typeorm';
+import { Media } from '../media/entities/media.entity';
 import { Person } from '../media/entities/person.entity';
 import { MediaCast } from '../media/entities/media-cast.entity';
 import { MediaCrew } from '../media/entities/media-crew.entity';
-import { TmdbProvider } from '../metadata-providers/providers/tmdb.provider';
-import { PersonCombinedCredits } from '../metadata-providers/interfaces/metadata-provider.interface';
+import { MetadataProviderRegistry } from '../metadata-providers/metadata-provider.registry';
+import {
+  IMetadataProvider,
+  PersonCreditItem,
+} from '../metadata-providers/interfaces/metadata-provider.interface';
 import { ImageService } from '../images/image.service';
+
+/** A provider credit plus the id of the library media holding that work, so
+ *  the card can open it instead of the "add" page. */
+export type PersonCredit = PersonCreditItem & { mediaId: number | null };
+
+export interface PersonCredits {
+  provider: string;
+  cast: PersonCredit[];
+  crew: PersonCredit[];
+}
 
 /** Refresh person details if older than 7 days. */
 const REFRESH_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
 
 @Injectable()
 export class PersonsService {
+  private readonly log = new Logger(PersonsService.name);
+
   constructor(
     @InjectRepository(Person)
     private readonly personRepo: Repository<Person>,
@@ -20,8 +37,10 @@ export class PersonsService {
     private readonly castRepo: Repository<MediaCast>,
     @InjectRepository(MediaCrew)
     private readonly crewRepo: Repository<MediaCrew>,
+    @InjectRepository(Media)
+    private readonly mediaRepo: Repository<Media>,
     private readonly dataSource: DataSource,
-    private readonly tmdb: TmdbProvider,
+    private readonly providers: MetadataProviderRegistry,
     private readonly imageService: ImageService,
   ) {}
 
@@ -68,10 +87,35 @@ export class PersonsService {
     return { person, cast, crew };
   }
 
-  async getProviderCredits(id: number): Promise<PersonCombinedCredits> {
+  async getProviderCredits(id: number): Promise<PersonCredits> {
     const person = await this.personRepo.findOne({ where: { id } });
     if (!person) throw new NotFoundException(`Person #${id} not found`);
-    return this.tmdb.getPersonCredits(String(person.tmdbId));
+    const credits = await this.callProvider(person, (p) =>
+      p.getPersonCredits(String(person.tmdbId)),
+    );
+    const cast = credits.cast.map((c) => ({ ...c, mediaId: null }));
+    const crew = credits.crew.map((c) => ({ ...c, mediaId: null }));
+    await this.linkOwnedMedia([...cast, ...crew], person.provider);
+    return { provider: person.provider, cast, crew };
+  }
+
+  /** Credit ids are the provider's work ids, which is exactly what the media
+   *  rows store as `tmdbId`/`tvdbId`. */
+  private async linkOwnedMedia(
+    credits: PersonCredit[],
+    provider: string,
+  ): Promise<void> {
+    const ids = [...new Set(credits.map((c) => c.externalId))].filter(Boolean);
+    if (!ids.length) return;
+    const column = provider === 'tvdb' ? 'tvdbId' : 'tmdbId';
+    const owned = await this.mediaRepo.find({
+      where: { [column]: In(ids) },
+      select: ['id', column],
+    });
+    const byExternalId = new Map(owned.map((m) => [m[column], m.id]));
+    for (const c of credits) {
+      c.mediaId = byExternalId.get(c.externalId) ?? null;
+    }
   }
 
   private async ensureDetailsLoaded(person: Person): Promise<void> {
@@ -82,7 +126,9 @@ export class PersonsService {
     if (!needsRefresh) return;
 
     try {
-      const details = await this.tmdb.getPersonDetails(String(person.tmdbId));
+      const details = await this.callProvider(person, (p) =>
+        p.getPersonDetails(String(person.tmdbId)),
+      );
       let localAvatar: string | undefined;
       if (details.avatarUrl) {
         const dl = await this.imageService.downloadAndStore(
@@ -105,7 +151,30 @@ export class PersonsService {
       await this.personRepo.update(person.id, updates);
       Object.assign(person, updates);
     } catch {
-      // If TMDB call fails, serve stale data
+      // If the provider call fails, serve stale data
+    }
+  }
+
+  /** `tmdbId` is provider-scoped: a 404 means the id belongs to the other
+   *  provider, so retry there and pin the row to it. */
+  private async callProvider<T>(
+    person: Person,
+    call: (provider: IMetadataProvider) => Promise<T>,
+  ): Promise<T> {
+    const provider = this.providers.resolve(person.provider);
+    try {
+      return await call(provider);
+    } catch (err) {
+      const fallback = this.providers.getFallback(provider.name);
+      if (!fallback || !axios.isAxiosError(err) || err.response?.status !== 404)
+        throw err;
+      const result = await call(fallback);
+      await this.personRepo.update(person.id, { provider: fallback.name });
+      person.provider = fallback.name;
+      this.log.log(
+        `person#${person.id} id ${person.tmdbId} is a ${fallback.name} id, not ${provider.name}`,
+      );
+      return result;
     }
   }
 }

--- a/client/src/app/core/services/api/persons-api.service.ts
+++ b/client/src/app/core/services/api/persons-api.service.ts
@@ -42,9 +42,12 @@ export interface PersonProviderCreditItem {
   posterUrl: string | null;
   releaseDate: string | null;
   rating: number;
+  /** Id of the library media holding this work, null when it is not owned. */
+  mediaId: number | null;
 }
 
 export interface PersonProviderCredits {
+  provider: string;
   cast: PersonProviderCreditItem[];
   crew: PersonProviderCreditItem[];
 }

--- a/client/src/app/features/person-detail/person-filmography.html
+++ b/client/src/app/features/person-detail/person-filmography.html
@@ -8,30 +8,14 @@
       <h2 class="text-lg font-semibold mb-3">{{ 'person_detail.as_actor' | translate }}</h2>
       <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-1.5 sm:gap-4">
         @for (c of pc.cast; track c.externalId + (c.character || '')) {
-          <div class="card bg-base-100 shadow-md relative overflow-hidden">
-            <figure class="relative aspect-2/3 bg-base-300">
-              @if (c.posterUrl) {
-                <img [cachedSrc]="c.posterUrl | resolveUrl:'thumb'" [alt]="c.title" class="w-full h-full object-cover" loading="lazy" />
-              } @else {
-                <div class="flex items-center justify-center w-full h-full text-base-content/30">
-                  <svg lucideFilm class="h-16 w-16" [strokeWidth]="1.5"></svg>
-                </div>
-              }
-            </figure>
-            <div class="block px-3 py-2 text-center h-14">
-              <h3 class="text-sm font-medium line-clamp-1">{{ c.title }}</h3>
-              <p class="text-xs text-base-content/50 line-clamp-1">
-                @if (c.character) {
-                  {{ c.character }}
-                } @else if (c.releaseDate) {
-                  {{ c.releaseDate | slice:0:4 }}
-                }
-              </p>
-            </div>
-            <div class="absolute bottom-0 left-0 right-0 h-1 bg-base-100 pointer-events-none">
-              <div class="h-full bg-base-300 w-full"></div>
-            </div>
-          </div>
+          <app-media-card
+            [imageUrl]="c.posterUrl"
+            [title]="c.title"
+            [subtitle]="subtitleFor(c)"
+            [rating]="c.rating"
+            [badge]="c.mediaId ? 'library' : null"
+            [link]="linkFor(c)"
+          />
         }
       </div>
     </div>
@@ -41,24 +25,14 @@
       <h2 class="text-lg font-semibold mb-3">{{ 'person_detail.as_crew' | translate }}</h2>
       <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-1.5 sm:gap-4">
         @for (c of pc.crew; track c.externalId + (c.job || '')) {
-          <div class="card bg-base-100 shadow-md relative overflow-hidden">
-            <figure class="relative aspect-2/3 bg-base-300">
-              @if (c.posterUrl) {
-                <img [cachedSrc]="c.posterUrl | resolveUrl:'thumb'" [alt]="c.title" class="w-full h-full object-cover" loading="lazy" />
-              } @else {
-                <div class="flex items-center justify-center w-full h-full text-base-content/30">
-                  <svg lucideFilm class="h-16 w-16" [strokeWidth]="1.5"></svg>
-                </div>
-              }
-            </figure>
-            <div class="block px-3 py-2 text-center h-14">
-              <h3 class="text-sm font-medium line-clamp-1">{{ c.title }}</h3>
-              <p class="text-xs text-base-content/50 line-clamp-1">{{ c.job }}</p>
-            </div>
-            <div class="absolute bottom-0 left-0 right-0 h-1 bg-base-100 pointer-events-none">
-              <div class="h-full bg-base-300 w-full"></div>
-            </div>
-          </div>
+          <app-media-card
+            [imageUrl]="c.posterUrl"
+            [title]="c.title"
+            [subtitle]="subtitleFor(c)"
+            [rating]="c.rating"
+            [badge]="c.mediaId ? 'library' : null"
+            [link]="linkFor(c)"
+          />
         }
       </div>
     </div>

--- a/client/src/app/features/person-detail/person-filmography.ts
+++ b/client/src/app/features/person-detail/person-filmography.ts
@@ -1,19 +1,16 @@
 import { Component, signal, inject, OnInit } from '@angular/core';
-import { SlicePipe } from '@angular/common';
 import { TranslatePipe } from '@ngx-translate/core';
-import { LucideFilm } from '@lucide/angular';
-import { ResolveUrlPipe } from '../../core/pipes/resolve-url.pipe';
 import {
   PersonsApiService,
   PersonProviderCredits,
+  PersonProviderCreditItem,
 } from '../../core/services/api/persons-api.service';
 import { PersonDetailComponent } from './person-detail';
-import { CachedSrcDirective } from '../../shared/directives/cached-src.directive';
+import { MediaCardComponent } from '../../shared/components/media-card/media-card';
 
 @Component({
   selector: 'app-person-filmography',
-  imports: [
-    CachedSrcDirective,TranslatePipe, SlicePipe, ResolveUrlPipe, LucideFilm],
+  imports: [TranslatePipe, MediaCardComponent],
   templateUrl: './person-filmography.html',
 })
 export class PersonFilmographyComponent implements OnInit {
@@ -25,6 +22,27 @@ export class PersonFilmographyComponent implements OnInit {
 
   ngOnInit() {
     this.load();
+  }
+
+  /** Role first, release year when the provider gives none. */
+  subtitleFor(credit: PersonProviderCreditItem): string | undefined {
+    return (
+      credit.character || credit.job || credit.releaseDate?.slice(0, 4) || undefined
+    );
+  }
+
+  /** Owned works open in the library; the rest land on the provider preview
+   *  page, where they can be requested. */
+  linkFor(credit: PersonProviderCreditItem): string[] {
+    const series = credit.mediaType === 'series';
+    if (credit.mediaId) {
+      return [series ? '/series' : '/movies', String(credit.mediaId)];
+    }
+    return [
+      series ? '/add/tv' : '/add/movie',
+      this.credits()?.provider ?? 'tmdb',
+      String(credit.externalId),
+    ];
   }
 
   private async load() {


### PR DESCRIPTION
## Problem

`/persons/2752/filmography` returned an internal server error:

```
ERROR [ExceptionsHandler] AxiosError: Request failed with status code 404
url: '/person/310628/combined_credits'
```

`persons.tmdbId` stores whatever id the importing provider returned. Person 2752 (credited on a
TVDB-scraped series) holds the TVDB people id `310628`, but `getProviderCredits` always called
TMDB. The same conflation:

- silently stopped `ensureDetailsLoaded` refreshing the biography/avatar of every TVDB person,
- let a TVDB people id collide with an unrelated TMDB person on the `UNIQUE (tmdbId)` index.

## Fix

- `persons.provider` records who issued the id; the unique key is now `(provider, tmdbId)`, and the
  import scopes its person lookup and insert to `details.provider`.
- `PersonsService` resolves the provider through the existing `MetadataProviderRegistry`. Rows
  written before the column all claim TMDB, so a 404 retries the other provider and pins the row to
  it (person 2752 is `provider=tvdb` after one visit). Anything that is not a 404 propagates.
- TVDB credits were mapped with an empty title, no poster and no year, so the tab would have
  rendered blank cards; `characters[].series/movie` carries all three.
- The response now also carries `provider` and, per credit, the `mediaId` of the library media
  holding that work.

## Filmography cards

The tab drew its own card markup. It now uses the shared `app-media-card`, identical to the
"In my library" tab: works already in the library get the green check and open their media page,
the rest link to the provider preview page.

## Verification

- Migration up/down/up on a throwaway DB; the CI drift check reports `No changes in database schema
  were found`.
- Live on the dev stack: `/api/persons/2752/provider-credits` → 200, 149 cast credits, `Ahsoka`
  linked to media 38.
- Real browser on `/persons/2752/filmography`: 151 cards, `Ahsoka` badged and linking to
  `/series/38`, `Unstoppable` linking to `/add/movie/tvdb/233`.
- Backend `tsc` clean, 186 suites / 1986 tests pass, client `ng build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)