### PR TITLE
fix(plugins): close the gap between a plugin menu entry and the policy behind it

### DIFF
--- a/backend/src/common/constants/permissions.ts
+++ b/backend/src/common/constants/permissions.ts
@@ -13,6 +13,7 @@ export const PERMISSIONS = [
   'subtitles.manage',
   'settings.access',
   'users.manage',
+  'roles.manage',
 ] as const;
 
 export type Permission = (typeof PERMISSIONS)[number];

--- a/backend/src/common/constants/plugin-permissions.ts
+++ b/backend/src/common/constants/plugin-permissions.ts
@@ -22,3 +22,13 @@ export function pluginPermissionSubject(pluginId: string, name: string): string 
 export function isPluginPermissionSubject(value: string): boolean {
   return value.startsWith(PLUGIN_SUBJECT_PREFIX) && value.length > PLUGIN_SUBJECT_PREFIX.length;
 }
+
+/** Splits a grant: a bare subject allows every action, `read:plugin:<id>:<name>` only that one.
+ *  The action comes back as written; judging it against a vocabulary is the caller's job. */
+export function parsePluginPermissionGrant(value: string): { action?: string; subject: string } | null {
+  if (isPluginPermissionSubject(value)) return { subject: value };
+  const sep = value.indexOf(':');
+  if (sep === -1) return null;
+  const subject = value.slice(sep + 1);
+  return isPluginPermissionSubject(subject) ? { action: value.slice(0, sep), subject } : null;
+}

--- a/backend/src/common/plugin-contract/ui-contribution.ts
+++ b/backend/src/common/plugin-contract/ui-contribution.ts
@@ -439,11 +439,13 @@ export interface TableConfigPage extends ConfigPageBase {
   /** Core SSE event types that re-fetch the list as they arrive, coalesced to at most one
    *  fetch per {@link TABLE_REFRESH_MIN_MS}. */
   refreshOn?: string[];
-  /** List-scope actions (clear-all and the like), distinct from `rowActions`. */
+  /** List-scope actions (clear-all and the like), distinct from `rowActions`. `when` gates on the
+   *  viewer exactly as a row action's does; an older client ignores it and renders the button. */
   listActions?: {
     labelKey: string;
     method: 'POST' | 'DELETE';
     path: string;
     confirmKey?: string;
+    when?: WhenPredicate[];
   }[];
 }

--- a/backend/src/migrations/1785200000000-split-roles-manage-permission.ts
+++ b/backend/src/migrations/1785200000000-split-roles-manage-permission.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/** Managing roles is its own permission now. Whoever could do it through `users.manage`
+ *  keeps it, so an upgrade never silently locks an operator out of the roles editor. */
+export class SplitRolesManagePermission1785200000000 implements MigrationInterface {
+  name = 'SplitRolesManagePermission1785200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "roles"
+       SET "permissions" = ("permissions"::jsonb || '["roles.manage"]'::jsonb)::text
+       WHERE "permissions"::jsonb ? 'users.manage'
+         AND NOT ("permissions"::jsonb ? 'roles.manage')`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "roles"
+       SET "permissions" = COALESCE(
+             (SELECT jsonb_agg(p) FROM jsonb_array_elements("permissions"::jsonb) AS t(p) WHERE p <> '"roles.manage"'::jsonb),
+             '[]'::jsonb
+           )::text
+       WHERE "permissions"::jsonb ? 'roles.manage'`,
+    );
+  }
+}

--- a/backend/src/modules/auth/casl/casl-ability.factory.spec.ts
+++ b/backend/src/modules/auth/casl/casl-ability.factory.spec.ts
@@ -32,6 +32,19 @@ describe('CaslAbilityFactory — plugin-declared subjects', () => {
     expect(ability.can(Action.Read, 'plugin:fliks.myplugin:download')).toBe(true);
   });
 
+  it('narrows an action-prefixed grant to that action alone', () => {
+    const ability = factory.createForUser(fakeUser(['read:plugin:fliks.myplugin:download']));
+    expect(ability.can(Action.Read, 'plugin:fliks.myplugin:download')).toBe(true);
+    expect(ability.can(Action.Manage, 'plugin:fliks.myplugin:download')).toBe(false);
+    expect(ability.can(Action.Delete, 'plugin:fliks.myplugin:download')).toBe(false);
+  });
+
+  it('denies a grant prefixed with an action the enum does not know', () => {
+    const ability = factory.createForUser(fakeUser(['sudo:plugin:fliks.myplugin:download']));
+    expect(ability.can(Action.Read, 'plugin:fliks.myplugin:download')).toBe(false);
+    expect(ability.can(Action.Manage, 'plugin:fliks.myplugin:download')).toBe(false);
+  });
+
   it('ignores a permission string that is not shaped like a plugin subject', () => {
     const ability = factory.createForUser(fakeUser(['media.read']));
     expect(ability.can(Action.Read, 'plugin:fliks.myplugin:download')).toBe(false);

--- a/backend/src/modules/auth/casl/casl-ability.factory.spec.ts
+++ b/backend/src/modules/auth/casl/casl-ability.factory.spec.ts
@@ -1,6 +1,8 @@
 import { CaslAbilityFactory } from './casl-ability.factory';
 import { Action } from './actions.enum';
 import type { User } from '../../users/entities/user.entity';
+import { User as UserEntity } from '../../users/entities/user.entity';
+import { Role } from '../../roles/entities/role.entity';
 
 function fakeUser(permissions: string[], isAdmin = false): User {
   // `User.permissions` is a getter that overrides to `['manage:all']` when `isAdmin` — mirror
@@ -48,5 +50,28 @@ describe('CaslAbilityFactory — plugin-declared subjects', () => {
   it('ignores a permission string that is not shaped like a plugin subject', () => {
     const ability = factory.createForUser(fakeUser(['media.read']));
     expect(ability.can(Action.Read, 'plugin:fliks.myplugin:download')).toBe(false);
+  });
+});
+
+describe('CaslAbilityFactory: users and roles are separate permissions', () => {
+  const factory = new CaslAbilityFactory();
+
+  it('lets users.manage list roles without editing them', () => {
+    const ability = factory.createForUser(fakeUser(['users.manage']));
+    expect(ability.can(Action.Manage, UserEntity)).toBe(true);
+    expect(ability.can(Action.Read, Role)).toBe(true);
+    expect(ability.can(Action.Manage, Role)).toBe(false);
+  });
+
+  it('lets roles.manage edit roles without touching users', () => {
+    const ability = factory.createForUser(fakeUser(['roles.manage']));
+    expect(ability.can(Action.Manage, Role)).toBe(true);
+    expect(ability.can(Action.Manage, UserEntity)).toBe(false);
+  });
+
+  it('denies both to a role holding neither', () => {
+    const ability = factory.createForUser(fakeUser(['media.read']));
+    expect(ability.can(Action.Read, Role)).toBe(false);
+    expect(ability.can(Action.Manage, UserEntity)).toBe(false);
   });
 });

--- a/backend/src/modules/auth/casl/casl-ability.factory.ts
+++ b/backend/src/modules/auth/casl/casl-ability.factory.ts
@@ -16,7 +16,7 @@ import { TranslationProvider } from '../../subtitles/entities/translation-provid
 import { Library } from '../../libraries/entities/library.entity';
 import { Playlist } from '../../playlists/entities/playlist.entity';
 import { Action } from './actions.enum';
-import { isPluginPermissionSubject } from '../../../common/constants/plugin-permissions';
+import { parsePluginPermissionGrant } from '../../../common/constants/plugin-permissions';
 
 type Subjects =
   | InferSubjects<
@@ -38,6 +38,8 @@ type Subjects =
 
 export type AppAbility = MongoAbility<[Action, Subjects]>;
 
+const ACTIONS: ReadonlySet<string> = new Set(Object.values(Action));
+
 @Injectable()
 export class CaslAbilityFactory {
   createForUser(user: User): AppAbility {
@@ -54,7 +56,12 @@ export class CaslAbilityFactory {
     // Self-contained: `PluginRouteGuard` re-checks the subject against that same plugin's
     // declared set, so granting it here needs no live plugin registry at all.
     for (const perm of perms) {
-      if (isPluginPermissionSubject(perm)) can(Action.Manage, perm as `plugin:${string}`);
+      const grant = parsePluginPermissionGrant(perm);
+      if (!grant) continue;
+      // An action the enum doesn't know is denied outright rather than widened to `manage`.
+      const action = grant.action ?? Action.Manage;
+      if (!ACTIONS.has(action)) continue;
+      can(action as Action, grant.subject as `plugin:${string}`);
     }
 
     // Every authenticated user can read/update themselves

--- a/backend/src/modules/auth/casl/casl-ability.factory.ts
+++ b/backend/src/modules/auth/casl/casl-ability.factory.ts
@@ -15,6 +15,7 @@ import { SubtitleFile } from '../../subtitles/entities/subtitle-file.entity';
 import { TranslationProvider } from '../../subtitles/entities/translation-provider.entity';
 import { Library } from '../../libraries/entities/library.entity';
 import { Playlist } from '../../playlists/entities/playlist.entity';
+import { Role } from '../../roles/entities/role.entity';
 import { Action } from './actions.enum';
 import { parsePluginPermissionGrant } from '../../../common/constants/plugin-permissions';
 
@@ -30,6 +31,7 @@ type Subjects =
       | typeof TranslationProvider
       | typeof Library
       | typeof Playlist
+      | typeof Role
     >
   | 'Settings'
   | 'all'
@@ -133,7 +135,10 @@ export class CaslAbilityFactory {
     // --- users ---
     if (perms.has('users.manage')) {
       can(Action.Manage, User);
+      // Assigning a role to a user means listing them; editing one does not follow.
+      can(Action.Read, Role);
     }
+    if (perms.has('roles.manage')) can(Action.Manage, Role);
 
     return build();
   }

--- a/backend/src/modules/plugins/plugin-install.service.spec.ts
+++ b/backend/src/modules/plugins/plugin-install.service.spec.ts
@@ -8,6 +8,8 @@ import { PluginInstallException } from './plugin-install.exception';
 import { PluginStagingService } from './plugin-staging.service';
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginUiController } from './plugin-ui.controller';
+import { CaslAbilityFactory } from '../auth/casl/casl-ability.factory';
+import type { User } from '../users/entities/user.entity';
 import { PluginDatabaseService } from './plugin-database.service';
 import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry, fakeCountsCache } from './plugin-registry.test-helpers';
 import { PluginPackage } from './entities/plugin-package.entity';
@@ -849,12 +851,13 @@ describe('PluginInstallService', () => {
 
     it('excludes a disabled plugin from GET /plugins/ui — the controller reads the same registry membership', async () => {
       const manifest = await installData({ id: 'fliks.disableui' });
-      const ui = new PluginUiController(registry);
-      expect(ui.list().map((r) => r.pluginId)).toContain(manifest.id);
+      const ui = new PluginUiController(registry, new CaslAbilityFactory());
+      const admin = { isAdmin: true, permissions: ['manage:all'] } as User;
+      expect(ui.list(admin).map((r) => r.pluginId)).toContain(manifest.id);
 
       await service.disable(manifest.id);
 
-      expect(ui.list().map((r) => r.pluginId)).not.toContain(manifest.id);
+      expect(ui.list(admin).map((r) => r.pluginId)).not.toContain(manifest.id);
     });
   });
 

--- a/backend/src/modules/plugins/plugin-registry.service.permissions.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.permissions.spec.ts
@@ -153,3 +153,36 @@ describe('PluginRegistryService — a route may only authorize against its own p
     expect(service.declaredPermissionsFor('fliks.a').size).toBe(0);
   });
 });
+
+describe('PluginRegistryService.listGrantablePermissions', () => {
+  it('lists each policy the routes declare, so read and manage on one subject stay separate', async () => {
+    const manifest = processManifest('fliks.a', ['queue', 'indexers'], [
+      { method: 'GET', path: '/queue', policy: 'read:plugin:fliks.a:queue' },
+      { method: 'GET', path: '/indexers', policy: 'read:plugin:fliks.a:indexers' },
+      { method: 'POST', path: '/indexers', policy: 'manage:plugin:fliks.a:indexers' },
+    ]);
+    const service = makeService();
+    await service.register(makePackage(manifest));
+
+    expect(service.listGrantablePermissions()).toEqual([
+      'manage:plugin:fliks.a:indexers',
+      'read:plugin:fliks.a:indexers',
+      'read:plugin:fliks.a:queue',
+    ]);
+  });
+
+  it('falls back to the bare subject for a declared permission no route names', async () => {
+    const manifest = processManifest('fliks.a', ['reports']);
+    const service = makeService();
+    await service.register(makePackage(manifest));
+
+    expect(service.listGrantablePermissions()).toEqual(['plugin:fliks.a:reports']);
+  });
+
+  it('is empty for a plugin declaring no permission at all', async () => {
+    const service = makeService();
+    await service.register(makePackage(processManifest('fliks.a', [])));
+
+    expect(service.listGrantablePermissions()).toEqual([]);
+  });
+});

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -35,6 +35,7 @@ import {
   type ReleasePickerRoutes,
   type PlayerDeclaration,
   type ConfigPage,
+  type UiContribution,
 } from '../../common/plugin-contract';
 import { OFFICIAL_KEYS, resolveTrust, readArchiveEntries, type TrustOutcome } from './archive';
 import { extractCachedDenyList, findDenial } from './catalog/catalog';
@@ -72,6 +73,9 @@ const EMPTY_SUBJECT_SET: ReadonlySet<string> = new Set();
 
 const CORE_JOB_NAME_SET: ReadonlySet<string> = new Set(RESERVED_CORE_JOB_NAMES);
 
+/** The two prefixes core mounts `plugin-view` under; any other path is a core page. */
+const PLUGIN_VIEW_PREFIXES: readonly string[] = ['/admin/settings/plugins/', '/plugins/'];
+
 const RELEASE_PICKER_CONTEXTS: readonly (keyof ReleasePickerRoutes)[] = ['movie', 'season', 'episode'];
 /** The method each `releasePicker` action's declared route must carry. */
 const RELEASE_PICKER_ACTIONS: readonly { key: keyof ReleasePickerPair; method: string }[] = [
@@ -108,6 +112,7 @@ export type PluginRegistrationFailureReason =
   | 'duplicate-route'
   | 'invalid-release-picker'
   | 'invalid-player'
+  | 'invalid-ui-contribution'
   | 'invalid-permission'
   | 'invalid-job-name'
   | 'invalid-job-cron'
@@ -306,6 +311,13 @@ export class PluginRegistryService implements OnModuleInit {
 
     const playerCheck = this.validatePlayer(manifest.ui?.player, manifest.kind === 'process' ? manifest.routes : []);
     if (!playerCheck.ok) return this.fail(pkg.pluginId, playerCheck.reason, playerCheck.detail);
+
+    const viewTargetsCheck = this.validateUiViewTargets(
+      pkg.pluginId,
+      manifest.ui?.contributions ?? [],
+      manifest.ui?.configPages ?? [],
+    );
+    if (!viewTargetsCheck.ok) return this.fail(pkg.pluginId, viewTargetsCheck.reason, viewTargetsCheck.detail);
 
     const i18nCheck = this.validateI18nNamespace(pkg.pluginId, manifest);
     if (!i18nCheck.ok) return this.fail(pkg.pluginId, i18nCheck.reason, i18nCheck.detail);
@@ -807,6 +819,34 @@ export class PluginRegistryService implements OnModuleInit {
         reason: 'invalid-player',
         detail: `ui.player.preRollRoute "${player.preRollRoute}" is not declared as a POST route in routes[]`,
       };
+    }
+    return { ok: true };
+  }
+
+  /** A contribution routing into a plugin view must name one of this manifest's own `configPages`:
+   *  core renders "unavailable" for an id nobody declares, which reads as a broken plugin. */
+  private validateUiViewTargets(
+    pluginId: string,
+    contributions: UiContribution[],
+    configPages: ConfigPage[],
+  ): { ok: true } | { ok: false; reason: PluginRegistrationFailureReason; detail: string } {
+    const pageIds = new Set(configPages.map((page) => page.id));
+    const pending = [...contributions];
+    while (pending.length > 0) {
+      const contribution = pending.pop()!;
+      pending.push(...(contribution.children ?? []));
+      if (contribution.action?.kind !== 'route' || typeof contribution.action.path !== 'string') continue;
+      const path = contribution.action.path;
+      const prefix = PLUGIN_VIEW_PREFIXES.find((candidate) => path.startsWith(candidate));
+      if (!prefix) continue;
+      const segments = path.slice(prefix.length).split('/');
+      if (segments.length !== 2 || segments[0] !== pluginId || !pageIds.has(segments[1])) {
+        return {
+          ok: false,
+          reason: 'invalid-ui-contribution',
+          detail: `contribution "${contribution.id}" routes to "${path}", which is not one of this plugin's ui.configPages`,
+        };
+      }
     }
     return { ok: true };
   }

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -502,6 +502,26 @@ export class PluginRegistryService implements OnModuleInit {
     return this.declaredPermissions.get(pluginId) ?? EMPTY_SUBJECT_SET;
   }
 
+  /** Every grant an admin can tick on a role: each policy the plugins' routes declare, plus any
+   *  declared subject no route names. Authorizes nothing; `PluginRouteGuard` re-checks the grant. */
+  listGrantablePermissions(): string[] {
+    const grants = new Set<string>();
+    for (const plugin of this.registry.values()) {
+      const subjects = this.declaredPermissionsFor(plugin.pluginId);
+      if (subjects.size === 0) continue;
+      const covered = new Set<string>();
+      const routes = plugin.manifest.kind === 'process' ? plugin.manifest.routes : [];
+      for (const route of routes) {
+        const subject = route.policy.slice(route.policy.indexOf(':') + 1);
+        if (!subjects.has(subject)) continue;
+        grants.add(route.policy);
+        covered.add(subject);
+      }
+      for (const subject of subjects) if (!covered.has(subject)) grants.add(subject);
+    }
+    return [...grants].sort();
+  }
+
   /** Every registered webhook subscribed to `eventType` — the dispatcher's fan-out list. */
   listWebhooksForEvent(eventType: string): { pluginId: string; webhook: string }[] {
     const out: { pluginId: string; webhook: string }[] = [];

--- a/backend/src/modules/plugins/plugin-registry.service.ui-views.spec.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ui-views.spec.ts
@@ -1,0 +1,91 @@
+import { PluginRegistryService } from './plugin-registry.service';
+import { PluginPackage } from './entities/plugin-package.entity';
+import { minimalProcessManifest } from './archive/test-manifests';
+import { fakeRegistrationRepo, fakeProcessService, fakePluginJobsService, fakeScheduledJobRegistry, fakeCountsCache } from './plugin-registry.test-helpers';
+import type { ConfigPage, PluginManifest, UiContribution } from '../../common/plugin-contract';
+
+const COMPATIBLE_RANGE = '>=1.0.0';
+
+const QUEUE_PAGE: ConfigPage = { id: 'queue', kind: 'table', labelKey: 'q', list: '/queue', columns: [] };
+
+function makePackage(manifest: PluginManifest): PluginPackage {
+  return {
+    id: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    pluginId: manifest.id,
+    version: manifest.version,
+    archive: Buffer.alloc(0),
+    origin: 'manual',
+    signature: 'unsigned',
+    verifiedByKeyId: null,
+    manifest,
+    status: 'active',
+  } as PluginPackage;
+}
+
+function makeService(): PluginRegistryService {
+  return new PluginRegistryService(
+    { find: jest.fn().mockResolvedValue([]) } as never,
+    { find: jest.fn().mockResolvedValue([]) } as never,
+    fakeRegistrationRepo() as never,
+    fakeProcessService() as never,
+    fakePluginJobsService() as never,
+    fakeScheduledJobRegistry() as never,
+    fakeCountsCache() as never,
+    { get: async () => null } as never,
+  );
+}
+
+function navTo(path: string): UiContribution {
+  return { id: 'nav.queue', slot: 'nav.acquisition', weight: 100, labelKey: 'q', action: { kind: 'route', path } };
+}
+
+function manifestWith(contributions: UiContribution[], configPages: ConfigPage[] = [QUEUE_PAGE]): PluginManifest {
+  return minimalProcessManifest(
+    { 'plugin.js': 'a'.repeat(64), 'logo.png': 'b'.repeat(64) },
+    {
+      id: 'fliks.a',
+      fliks: COMPATIBLE_RANGE,
+      routes: [{ method: 'GET', path: '/queue', policy: 'read:Media' }],
+      ui: { contributions, configPages },
+    },
+  ) as unknown as PluginManifest;
+}
+
+describe('PluginRegistryService — a contribution may only open a view this manifest declares', () => {
+  it.each([
+    ['the sidebar prefix', '/plugins/fliks.a/queue'],
+    ['the admin settings prefix', '/admin/settings/plugins/fliks.a/queue'],
+  ])('accepts a contribution routing to a declared page under %s', async (_label, path) => {
+    const result = await makeService().register(makePackage(manifestWith([navTo(path)])));
+    expect(result).toEqual({ ok: true, pluginId: 'fliks.a' });
+  });
+
+  it('leaves a core route alone — it is not a plugin view', async () => {
+    const result = await makeService().register(makePackage(manifestWith([navTo('/requests')])));
+    expect(result).toEqual({ ok: true, pluginId: 'fliks.a' });
+  });
+
+  it.each([
+    ['a page id nothing declares', '/plugins/fliks.a/history'],
+    ['another plugin id', '/plugins/fliks.b/queue'],
+    ['a deeper path than <pluginId>/<pageId>', '/plugins/fliks.a/queue/1'],
+  ])('refuses %s ("%s")', async (_label, path) => {
+    const result = await makeService().register(makePackage(manifestWith([navTo(path)])));
+    expect(result).toMatchObject({ ok: false, pluginId: 'fliks.a', reason: 'invalid-ui-contribution' });
+  });
+
+  it('walks a submenu\'s children, which carry routes of their own', async () => {
+    const parent: UiContribution = {
+      id: 'group',
+      slot: 'media.actions',
+      weight: 10,
+      labelKey: 'g',
+      action: { kind: 'submenu' },
+      children: [navTo('/plugins/fliks.a/nosuchpage')],
+    };
+    const result = await makeService().register(makePackage(manifestWith([parent])));
+    expect(result).toMatchObject({ ok: false, reason: 'invalid-ui-contribution' });
+  });
+});

--- a/backend/src/modules/plugins/plugin-ui.controller.spec.ts
+++ b/backend/src/modules/plugins/plugin-ui.controller.spec.ts
@@ -1,5 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { PluginUiController } from './plugin-ui.controller';
+import { CaslAbilityFactory } from '../auth/casl/casl-ability.factory';
+import type { User } from '../users/entities/user.entity';
 import type { RegisteredPlugin } from './plugin-registry.service';
 import type { TrustOutcome } from './archive';
 import { PLUGIN_API_VERSION } from '../../common/plugin-contract';
@@ -95,28 +97,44 @@ function processPlugin(pluginId: string): RegisteredPlugin {
   };
 }
 
-function makeController(plugins: RegisteredPlugin[], stateByPluginId: Record<string, string | null> = {}) {
+const ADMIN = { isAdmin: true, permissions: ['manage:all'] } as User;
+/** A role holding exactly these grants; `permissions` is a getter on the real entity. */
+function userWith(permissions: string[]): User {
+  return { isAdmin: false, permissions } as User;
+}
+
+function makeController(
+  plugins: RegisteredPlugin[],
+  stateByPluginId: Record<string, string | null> = {},
+  routes: Record<string, string> = {},
+) {
   const registry = {
     list: jest.fn().mockReturnValue(plugins),
     processStateOf: jest.fn((pluginId: string) => stateByPluginId[pluginId] ?? null),
     releasePickerFor: jest.fn().mockReturnValue(undefined),
+    resolveRoute: jest.fn((_pluginId: string, _method: string, path: string) =>
+      routes[path] ? { route: { method: 'GET', path, policy: routes[path] }, params: {} } : null,
+    ),
+    declaredPermissionsFor: jest.fn((pluginId: string) =>
+      new Set(Object.values(routes).map((policy) => policy.slice(policy.indexOf(':') + 1)).filter((s) => s.includes(pluginId))),
+    ),
   };
-  return { controller: new PluginUiController(registry as never), registry };
+  return { controller: new PluginUiController(registry as never, new CaslAbilityFactory()), registry };
 }
 
 describe('PluginUiController', () => {
   it('never calls a plugin — only reads the registry\'s cached manifest', () => {
     const { controller, registry } = makeController([dataPlugin('fliks.a')]);
 
-    controller.list();
+    controller.list(ADMIN);
 
-    expect(Object.keys(registry)).toEqual(['list', 'processStateOf', 'releasePickerFor']);
+    expect(Object.keys(registry)).toEqual(['list', 'processStateOf', 'releasePickerFor', 'resolveRoute', 'declaredPermissionsFor']);
     expect(registry.list).toHaveBeenCalledTimes(1);
   });
 
   it('includes a data plugin unconditionally — it has no process to be unhealthy', () => {
     const { controller } = makeController([dataPlugin('fliks.a')]);
-    const result = controller.list();
+    const result = controller.list(ADMIN);
     expect(result).toEqual([{ pluginId: 'fliks.a', name: expect.any(String), contributions: [], configPages: [], i18n: {} }]);
   });
 
@@ -125,7 +143,7 @@ describe('PluginUiController', () => {
     plugin.manifest.i18n = { en: { 'fliks.a.label': 'Label' }, fr: { 'fliks.a.label': 'Libellé' } };
     const { controller } = makeController([plugin]);
 
-    expect(controller.list()[0].i18n).toEqual({
+    expect(controller.list(ADMIN)[0].i18n).toEqual({
       en: { 'fliks.a.label': 'Label' },
       fr: { 'fliks.a.label': 'Libellé' },
     });
@@ -133,7 +151,7 @@ describe('PluginUiController', () => {
 
   it('includes a process plugin whose process is ready, with its contributions', () => {
     const { controller } = makeController([processPlugin('fliks.b')], { 'fliks.b': 'ready' });
-    const result = controller.list();
+    const result = controller.list(ADMIN);
     expect(result).toHaveLength(1);
     expect(result[0].pluginId).toBe('fliks.b');
     expect(result[0].contributions).toHaveLength(1);
@@ -148,13 +166,13 @@ describe('PluginUiController', () => {
     const { controller, registry } = makeController([processPlugin('fliks.b')], { 'fliks.b': 'ready' });
     registry.releasePickerFor.mockReturnValue(picker);
 
-    expect(controller.list()[0].releasePicker).toEqual(picker);
+    expect(controller.list(ADMIN)[0].releasePicker).toEqual(picker);
     expect(registry.releasePickerFor).toHaveBeenCalledWith('fliks.b');
   });
 
   it.each(['crashed', 'degraded', null])('filters out a process plugin whose state is "%s"', (state) => {
     const { controller } = makeController([processPlugin('fliks.b')], { 'fliks.b': state });
-    expect(controller.list()).toEqual([]);
+    expect(controller.list(ADMIN)).toEqual([]);
   });
 
   it('mixes a healthy process plugin and a data plugin, filtering only the unhealthy one', () => {
@@ -162,8 +180,53 @@ describe('PluginUiController', () => {
       [dataPlugin('fliks.a'), processPlugin('fliks.b'), processPlugin('fliks.c')],
       { 'fliks.b': 'ready', 'fliks.c': 'crashed' },
     );
-    const result = controller.list();
+    const result = controller.list(ADMIN);
     expect(result.map((r) => r.pluginId)).toEqual(['fliks.a', 'fliks.b']);
+  });
+
+  describe('per-viewer filtering', () => {
+    const ROUTES = { '/queue': 'read:plugin:fliks.download:queue' };
+
+    function queuePlugin(): RegisteredPlugin {
+      const plugin = processPlugin('fliks.download');
+      plugin.manifest.ui = {
+        contributions: [
+          { id: 'nav.queue', slot: 'nav.acquisition', weight: 100, labelKey: 'q', action: { kind: 'route', path: '/plugins/fliks.download/queue' } },
+          { id: 'media.grab', slot: 'media.actions', weight: 10, labelKey: 'g', action: { kind: 'action', actionId: 'media.grab-best' } },
+        ],
+        configPages: [
+          { id: 'queue', kind: 'table', labelKey: 'q', list: '/queue', columns: [] },
+          { id: 'general', labelKey: 'g', fields: [] },
+        ],
+      };
+      return plugin;
+    }
+
+    it('hides a table page, and the contribution opening it, from a viewer its route refuses', () => {
+      const { controller } = makeController([queuePlugin()], { 'fliks.download': 'ready' }, ROUTES);
+
+      const entry = controller.list(userWith(['media.read']))[0];
+
+      expect(entry.configPages.map((p) => p.id)).toEqual(['general']);
+      expect(entry.contributions.map((c) => c.id)).toEqual(['media.grab']);
+    });
+
+    it('keeps both for a viewer holding the grant the route was declared under', () => {
+      const { controller } = makeController([queuePlugin()], { 'fliks.download': 'ready' }, ROUTES);
+
+      const entry = controller.list(userWith(['plugin:fliks.download:queue']))[0];
+
+      expect(entry.configPages.map((p) => p.id)).toEqual(['queue', 'general']);
+      expect(entry.contributions.map((c) => c.id)).toEqual(['nav.queue', 'media.grab']);
+    });
+
+    it('hides a table page whose list route no longer resolves, rather than leaving it to 403', () => {
+      const { controller } = makeController([queuePlugin()], { 'fliks.download': 'ready' }, {});
+
+      const entry = controller.list(userWith(['plugin:fliks.download:queue']))[0];
+
+      expect(entry.configPages.map((p) => p.id)).toEqual(['general']);
+    });
   });
 
   describe('i18n collisions', () => {
@@ -182,7 +245,7 @@ describe('PluginUiController', () => {
       const b = dataPlugin('fliks.b', { i18n: { en: { 'b.label': 'B' } } });
       const { controller } = makeController([a, b]);
 
-      expect(controller.list().map((r) => r.pluginId)).toEqual(['fliks.a', 'fliks.b']);
+      expect(controller.list(ADMIN).map((r) => r.pluginId)).toEqual(['fliks.a', 'fliks.b']);
     });
 
     it('drops the plugin that sorts later by id when two plugins declare the exact same key', () => {
@@ -190,7 +253,7 @@ describe('PluginUiController', () => {
       const b = dataPlugin('fliks.b', { i18n: { en: { 'shared.label': 'B' } } });
       const { controller } = makeController([b, a]);
 
-      const result = controller.list();
+      const result = controller.list(ADMIN);
       expect(result.map((r) => r.pluginId)).toEqual(['fliks.a']);
     });
 
@@ -199,7 +262,7 @@ describe('PluginUiController', () => {
       const leaf = dataPlugin('fliks.b', { i18n: { en: { 'config.title': 'B leaf' } } });
       const { controller } = makeController([branch, leaf]);
 
-      expect(controller.list().map((r) => r.pluginId)).toEqual(['fliks.a']);
+      expect(controller.list(ADMIN).map((r) => r.pluginId)).toEqual(['fliks.a']);
     });
 
     it('keeps the official-signed plugin over a colliding non-official one, even when the official id sorts later', () => {
@@ -207,7 +270,7 @@ describe('PluginUiController', () => {
       const official = dataPlugin('fliks.official', { i18n: { en: { 'shared.label': 'real' } }, signature: 'official' });
       const { controller } = makeController([attacker, official]);
 
-      const result = controller.list();
+      const result = controller.list(ADMIN);
       expect(result.map((r) => r.pluginId)).toEqual(['fliks.official']);
     });
 
@@ -216,7 +279,7 @@ describe('PluginUiController', () => {
       const b = dataPlugin('fliks.b', { i18n: { en: { 'shared.label': 'B' } } });
       const { controller } = makeController([a, b]);
 
-      controller.list();
+      controller.list(ADMIN);
 
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('fliks.b'));
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('shared.label'));
@@ -227,7 +290,7 @@ describe('PluginUiController', () => {
       const a = dataPlugin('fliks.a', { i18n: { en: { 'a.deep.nested.key': 'value' } } });
       const { controller } = makeController([a]);
 
-      expect(controller.list()).toHaveLength(1);
+      expect(controller.list(ADMIN)).toHaveLength(1);
       expect(warnSpy).not.toHaveBeenCalled();
     });
 
@@ -236,7 +299,7 @@ describe('PluginUiController', () => {
       const download = dataPlugin('fliks.download', { i18n: { en: realKeyDict(REAL_DOWNLOAD_KEYS) } });
       const { controller } = makeController([webhooks, download]);
 
-      const result = controller.list();
+      const result = controller.list(ADMIN);
       expect(result.map((r) => r.pluginId).sort()).toEqual(['fliks.download', 'fliks.webhooks']);
       expect(warnSpy).not.toHaveBeenCalled();
     });

--- a/backend/src/modules/plugins/plugin-ui.controller.ts
+++ b/backend/src/modules/plugins/plugin-ui.controller.ts
@@ -1,6 +1,10 @@
 import { Controller, Get, Logger, UseGuards } from '@nestjs/common';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { CaslAbilityFactory, type AppAbility } from '../auth/casl/casl-ability.factory';
+import { checkDeclaredPolicy } from './proxy/policy-vocabulary';
 import { PluginRegistryService, type RegisteredPlugin } from './plugin-registry.service';
+import type { User } from '../users/entities/user.entity';
 import type { ConfigPage, ReleasePickerRoutes, UiContribution } from '../../common/plugin-contract';
 
 export interface PluginUiEntry {
@@ -13,6 +17,11 @@ export interface PluginUiEntry {
   i18n: Record<string, Record<string, string>>;
   /** At most one plugin across the whole listing ever carries this. */
   releasePicker?: ReleasePickerRoutes;
+}
+
+/** Both paths core mounts a plugin's `<pageId>` view under: the sidebar one and the admin one. */
+function viewPathsFor(pluginId: string, pageId: string): string[] {
+  return [`/plugins/${pluginId}/${pageId}`, `/admin/settings/plugins/${pluginId}/${pageId}`];
 }
 
 /** Every key (any locale) a plugin's manifest declares, flattened into one set. */
@@ -73,30 +82,63 @@ function withoutI18nCollisions(plugins: readonly RegisteredPlugin[], logger: Log
 }
 
 /**
- * Feeds the app-initializer chain that gates the splash screen, so every logged-in user needs
- * it — auth-only, no permission gate, mirroring `CountsController`. Reads the in-memory manifest
- * cache `PluginRegistryService` already keeps (never a live call to a plugin): a dead plugin's
- * socket timeout must never hold up app boot.
+ * Feeds the app-initializer chain that gates the splash screen, so every logged-in user needs it:
+ * open to any session, but its payload is cut to what the caller's own ability allows. Reads the
+ * in-memory manifest cache `PluginRegistryService` already keeps (never a live call to a plugin):
+ * a dead plugin's socket timeout must never hold up app boot.
  */
 @Controller('plugins')
 @UseGuards(JwtOrApiKeyGuard)
 export class PluginUiController {
   private readonly logger = new Logger(PluginUiController.name);
 
-  constructor(private readonly registry: PluginRegistryService) {}
+  constructor(
+    private readonly registry: PluginRegistryService,
+    private readonly abilityFactory: CaslAbilityFactory,
+  ) {}
 
   @Get('ui')
-  list(): PluginUiEntry[] {
+  list(@CurrentUser() user: User): PluginUiEntry[] {
+    const ability = this.abilityFactory.createForUser(user);
     const active = this.registry
       .list()
       .filter((plugin) => plugin.kind === 'data' || this.registry.processStateOf(plugin.pluginId) === 'ready');
-    return withoutI18nCollisions(active, this.logger).map((plugin) => ({
-      pluginId: plugin.pluginId,
-      name: plugin.manifest.name,
-      contributions: plugin.manifest.ui?.contributions ?? [],
-      configPages: plugin.manifest.ui?.configPages ?? [],
-      i18n: plugin.manifest.i18n ?? {},
-      releasePicker: this.registry.releasePickerFor(plugin.pluginId),
-    }));
+    return withoutI18nCollisions(active, this.logger).map((plugin) => {
+      const { contributions, configPages } = this.visibleTo(plugin, ability);
+      return {
+        pluginId: plugin.pluginId,
+        name: plugin.manifest.name,
+        contributions,
+        configPages,
+        i18n: plugin.manifest.i18n ?? {},
+        releasePicker: this.registry.releasePickerFor(plugin.pluginId),
+      };
+    });
+  }
+
+  /** Drops the pages this viewer may not read and the contributions opening them. A manifest's
+   *  own `when` cannot make this join: only core knows the policy behind a page's route. */
+  private visibleTo(plugin: RegisteredPlugin, ability: AppAbility): { contributions: UiContribution[]; configPages: ConfigPage[] } {
+    const pages = plugin.manifest.ui?.configPages ?? [];
+    const contributions = plugin.manifest.ui?.contributions ?? [];
+    const subjects = this.registry.declaredPermissionsFor(plugin.pluginId);
+    const hiddenPaths = new Set<string>();
+    const visiblePages = pages.filter((page) => {
+      if (this.mayReadPage(plugin.pluginId, page, ability, subjects)) return true;
+      for (const path of viewPathsFor(plugin.pluginId, page.id)) hiddenPaths.add(path);
+      return false;
+    });
+    return {
+      configPages: visiblePages,
+      contributions: contributions.filter((c) => c.action.kind !== 'route' || !hiddenPaths.has(c.action.path)),
+    };
+  }
+
+  /** A `form` page reads no plugin route and rides the admin gate. Every other kind needs the
+   *  policy of the route it lists from, and an unresolvable route hides the page. */
+  private mayReadPage(pluginId: string, page: ConfigPage, ability: AppAbility, subjects: ReadonlySet<string>): boolean {
+    if (page.kind !== 'table' && page.kind !== 'providers') return true;
+    const resolved = this.registry.resolveRoute(pluginId, 'GET', page.list);
+    return !!resolved && checkDeclaredPolicy(resolved.route.policy, ability, subjects);
   }
 }

--- a/backend/src/modules/roles/roles.controller.ts
+++ b/backend/src/modules/roles/roles.controller.ts
@@ -16,7 +16,7 @@ import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
 import { PoliciesGuard } from '../auth/casl/policies.guard';
 import { CheckPolicies } from '../auth/casl/check-policies.decorator';
 import { Action } from '../auth/casl/actions.enum';
-import { User } from '../users/entities/user.entity';
+import { Role } from './entities/role.entity';
 
 @Controller('roles')
 @UseGuards(JwtOrApiKeyGuard, PoliciesGuard)
@@ -24,37 +24,37 @@ export class RolesController {
   constructor(private readonly rolesService: RolesService) {}
 
   @Get()
-  @CheckPolicies((ability) => ability.can(Action.Manage, User))
+  @CheckPolicies((ability) => ability.can(Action.Read, Role))
   findAll() {
     return this.rolesService.findAll();
   }
 
   @Get('permissions')
-  @CheckPolicies((ability) => ability.can(Action.Manage, User))
+  @CheckPolicies((ability) => ability.can(Action.Manage, Role))
   getPermissions() {
     return this.rolesService.getAvailablePermissions();
   }
 
   @Get(':id')
-  @CheckPolicies((ability) => ability.can(Action.Manage, User))
+  @CheckPolicies((ability) => ability.can(Action.Read, Role))
   findOne(@Param('id', ParseIntPipe) id: number) {
     return this.rolesService.findOne(id);
   }
 
   @Post()
-  @CheckPolicies((ability) => ability.can(Action.Manage, User))
+  @CheckPolicies((ability) => ability.can(Action.Manage, Role))
   create(@Body() dto: CreateRoleDto) {
     return this.rolesService.create(dto);
   }
 
   @Put(':id')
-  @CheckPolicies((ability) => ability.can(Action.Manage, User))
+  @CheckPolicies((ability) => ability.can(Action.Manage, Role))
   update(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateRoleDto) {
     return this.rolesService.update(id, dto);
   }
 
   @Delete(':id')
-  @CheckPolicies((ability) => ability.can(Action.Manage, User))
+  @CheckPolicies((ability) => ability.can(Action.Manage, Role))
   remove(@Param('id', ParseIntPipe) id: number) {
     return this.rolesService.remove(id);
   }

--- a/backend/src/modules/roles/roles.module.ts
+++ b/backend/src/modules/roles/roles.module.ts
@@ -6,9 +6,10 @@ import { RolesController } from './roles.controller';
 import { AuthModule } from '../auth/auth.module';
 import { User } from '../users/entities/user.entity';
 import { Library } from '../libraries/entities/library.entity';
+import { PluginsModule } from '../plugins/plugins.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Role, User, Library]), AuthModule],
+  imports: [TypeOrmModule.forFeature([Role, User, Library]), AuthModule, PluginsModule],
   controllers: [RolesController],
   providers: [RolesService],
   exports: [TypeOrmModule, RolesService],

--- a/backend/src/modules/roles/roles.service.ts
+++ b/backend/src/modules/roles/roles.service.ts
@@ -13,6 +13,7 @@ import { UpdateRoleDto } from './dto/update-role.dto';
 import { DEFAULT_ROLES, PERMISSIONS } from '../../common/constants/permissions';
 import { User } from '../users/entities/user.entity';
 import { Library } from '../libraries/entities/library.entity';
+import { PluginRegistryService } from '../plugins/plugin-registry.service';
 
 @Injectable()
 export class RolesService implements OnModuleInit {
@@ -25,6 +26,7 @@ export class RolesService implements OnModuleInit {
     private readonly userRepo: Repository<User>,
     @InjectRepository(Library)
     private readonly libraryRepo: Repository<Library>,
+    private readonly plugins: PluginRegistryService,
   ) {}
 
   private async loadLibraries(ids?: number[]): Promise<Library[]> {
@@ -128,9 +130,10 @@ export class RolesService implements OnModuleInit {
     await this.roleRepo.remove(role);
   }
 
-  /** Return the list of all available permission keys. */
+  /** Core's keys plus every grant the installed plugins declare: without the second half a
+   *  plugin route is reachable by admins only, whatever policy it declares. */
   getAvailablePermissions(): string[] {
-    return [...PERMISSIONS];
+    return [...PERMISSIONS, ...this.plugins.listGrantablePermissions()];
   }
 
   async getDefaultRole(): Promise<Role | null> {

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -44,8 +44,8 @@ export class UsersController {
   /** Admin: create a new user */
   @Post()
   @CheckPolicies((ability) => ability.can(Action.Manage, User))
-  create(@Body() dto: CreateUserDto) {
-    return this.usersService.create(dto);
+  create(@Body() dto: CreateUserDto, @CurrentUser() requester: User) {
+    return this.usersService.create(dto, requester);
   }
 
   /** Self: upload a new avatar (cropped square JPEG). The target is always the

--- a/backend/src/modules/users/users.service.role-assignment.spec.ts
+++ b/backend/src/modules/users/users.service.role-assignment.spec.ts
@@ -1,0 +1,75 @@
+import { ForbiddenException } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { CaslAbilityFactory } from '../auth/casl/casl-ability.factory';
+import type { User } from './entities/user.entity';
+
+/** `permissions` is a getter on the real entity; mirror it rather than set a plain property. */
+function actor(permissions: string[]): User {
+  return { id: 1, isAdmin: false, permissions } as User;
+}
+
+function makeService(target: Partial<User>) {
+  const userRepo = {
+    findOne: jest.fn().mockResolvedValue({ id: 2, roleId: 1, userRole: { id: 1 }, ...target }),
+    save: jest.fn().mockImplementation((u) => Promise.resolve(u)),
+    createQueryBuilder: jest.fn(),
+  };
+  const libraryAccessRepo = {
+    createQueryBuilder: jest.fn().mockReturnValue({
+      select: () => ({ where: () => ({ getRawMany: async () => [] }) }),
+    }),
+  };
+  const service = new UsersService(
+    userRepo as never,
+    { findOne: jest.fn() } as never,
+    libraryAccessRepo as never,
+    new CaslAbilityFactory(),
+    {} as never,
+    { dropConnectionsForUser: jest.fn() } as never,
+  );
+  return { service, userRepo };
+}
+
+describe('UsersService: assigning a role needs roles.manage', () => {
+  it('refuses a role change from a user manager who cannot manage roles', async () => {
+    const { service, userRepo } = makeService({});
+
+    await expect(service.update(2, { roleId: 3 }, actor(['users.manage']))).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(userRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('allows every other field for that same manager', async () => {
+    const { service, userRepo } = makeService({ enabled: true });
+
+    await service.update(2, { enabled: false }, actor(['users.manage']));
+
+    expect(userRepo.save).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+
+  it('allows the role change once roles.manage is held too', async () => {
+    const { service, userRepo } = makeService({});
+
+    await service.update(2, { roleId: 3 }, actor(['users.manage', 'roles.manage']));
+
+    expect(userRepo.save).toHaveBeenCalledWith(expect.objectContaining({ roleId: 3 }));
+  });
+
+  it('ignores a resend of the role the user already has', async () => {
+    const { service, userRepo } = makeService({});
+
+    await service.update(2, { roleId: 1 }, actor(['users.manage']));
+
+    expect(userRepo.save).toHaveBeenCalled();
+  });
+
+  it('refuses to pick a role when creating a user without roles.manage', async () => {
+    const { service, userRepo } = makeService({});
+    userRepo.findOne.mockResolvedValueOnce(null); // username is free
+
+    await expect(
+      service.create({ username: 'x', password: 'password1', roleId: 3 }, actor(['users.manage'])),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -148,11 +148,18 @@ export class UsersService implements OnModuleInit {
     };
   }
 
-  async create(dto: CreateUserDto): Promise<PublicUser> {
+  async create(dto: CreateUserDto, requester: User): Promise<PublicUser> {
     const existing = await this.userRepo.findOne({
       where: { username: dto.username },
     });
     if (existing) throw new ConflictException('Username already taken');
+
+    // Picking a role is granting permissions, so it belongs to whoever manages roles.
+    if (dto.roleId !== undefined && !this.caslAbilityFactory.createForUser(requester).can(Action.Manage, Role)) {
+      throw new ForbiddenException(
+        'Only users with roles.manage permission can assign a role',
+      );
+    }
 
     let roleId = dto.roleId;
     let role: Role | null = null;
@@ -241,6 +248,11 @@ export class UsersService implements OnModuleInit {
 
     // Manager-only fields
     if (isManager) {
+      if (roleChanging && !ability.can(Action.Manage, Role)) {
+        throw new ForbiddenException(
+          'Only users with roles.manage permission can change a role',
+        );
+      }
       if (dto.roleId !== undefined) {
         target.roleId = dto.roleId;
         // Sync the eager-loaded relation too — otherwise TypeORM rewrites the

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -149,7 +149,8 @@
     "requests.manage": "Anfragen verwalten",
     "subtitles.manage": "Untertitel verwalten",
     "settings.access": "Zugriff auf Einstellungen",
-    "users.manage": "Benutzer verwalten"
+    "users.manage": "Benutzer verwalten",
+    "roles.manage": "Rollen verwalten"
   },
   "account": {
     "title": "Mein Konto",

--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -2089,7 +2089,9 @@
       "field_is_default": "Standardrolle (neuen Benutzern zugewiesen)",
       "default_libraries": "Standardmäßig zugewiesene Bibliotheken",
       "default_libraries_hint": "Neue Benutzer, die mit dieser Rolle erstellt werden, erben den Zugriff auf diese Bibliotheken.",
-      "confirm_delete": "Rolle „{{name}}“ löschen?"
+      "confirm_delete": "Rolle „{{name}}“ löschen?",
+      "plugin_permissions": "Plugin-Berechtigungen",
+      "permission_unavailable": "nicht mehr deklariert"
     },
     "auto_approval": {
       "title": "Automatische Genehmigungsregeln",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -2106,7 +2106,9 @@
       "field_is_default": "Default role (assigned to new users)",
       "default_libraries": "Libraries assigned by default",
       "default_libraries_hint": "New users created with this role will inherit access to these libraries.",
-      "confirm_delete": "Delete the role \"{{name}}\"?"
+      "confirm_delete": "Delete the role \"{{name}}\"?",
+      "plugin_permissions": "Plugin permissions",
+      "permission_unavailable": "no longer declared"
     },
     "auto_approval": {
       "title": "Auto-approval rules",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -154,7 +154,8 @@
     "requests.manage": "Manage requests",
     "subtitles.manage": "Manage subtitles",
     "settings.access": "Settings access",
-    "users.manage": "Manage users"
+    "users.manage": "Manage users",
+    "roles.manage": "Manage roles"
   },
   "account": {
     "title": "My account",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -2089,7 +2089,9 @@
       "field_is_default": "Rol por defecto (asignado a los nuevos usuarios)",
       "default_libraries": "Bibliotecas asignadas por defecto",
       "default_libraries_hint": "Los nuevos usuarios creados con este rol heredarán el acceso a estas bibliotecas.",
-      "confirm_delete": "¿Eliminar el rol «{{name}}»?"
+      "confirm_delete": "¿Eliminar el rol «{{name}}»?",
+      "plugin_permissions": "Permisos de plugins",
+      "permission_unavailable": "ya no declarado"
     },
     "auto_approval": {
       "title": "Reglas de aprobación automática",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -149,7 +149,8 @@
     "requests.manage": "Gestionar las solicitudes",
     "subtitles.manage": "Gestionar los subtítulos",
     "settings.access": "Acceso a los ajustes",
-    "users.manage": "Gestionar los usuarios"
+    "users.manage": "Gestionar los usuarios",
+    "roles.manage": "Gestionar roles"
   },
   "account": {
     "title": "Mi cuenta",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -154,7 +154,8 @@
     "requests.manage": "Gérer les demandes",
     "subtitles.manage": "Gérer les sous-titres",
     "settings.access": "Accès aux paramètres",
-    "users.manage": "Gérer les utilisateurs"
+    "users.manage": "Gérer les utilisateurs",
+    "roles.manage": "Gérer les rôles"
   },
   "account": {
     "title": "Mon compte",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -2106,7 +2106,9 @@
       "field_is_default": "Rôle par défaut (attribué aux nouveaux utilisateurs)",
       "default_libraries": "Bibliothèques attribuées par défaut",
       "default_libraries_hint": "Les nouveaux utilisateurs créés avec ce rôle hériteront de l'accès à ces bibliothèques.",
-      "confirm_delete": "Supprimer le rôle « {{name}} » ?"
+      "confirm_delete": "Supprimer le rôle « {{name}} » ?",
+      "plugin_permissions": "Permissions des plugins",
+      "permission_unavailable": "n'est plus déclarée"
     },
     "auto_approval": {
       "title": "Règles d'approbation automatique",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -2089,7 +2089,9 @@
       "field_is_default": "Ruolo predefinito (assegnato ai nuovi utenti)",
       "default_libraries": "Librerie assegnate per impostazione predefinita",
       "default_libraries_hint": "I nuovi utenti creati con questo ruolo erediteranno l'accesso a queste librerie.",
-      "confirm_delete": "Eliminare il ruolo « {{name}} »?"
+      "confirm_delete": "Eliminare il ruolo « {{name}} »?",
+      "plugin_permissions": "Permessi dei plugin",
+      "permission_unavailable": "non più dichiarato"
     },
     "auto_approval": {
       "title": "Regole di approvazione automatica",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -149,7 +149,8 @@
     "requests.manage": "Gestire le richieste",
     "subtitles.manage": "Gestire i sottotitoli",
     "settings.access": "Accesso alle impostazioni",
-    "users.manage": "Gestire gli utenti"
+    "users.manage": "Gestire gli utenti",
+    "roles.manage": "Gestire i ruoli"
   },
   "account": {
     "title": "Il mio account",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -149,7 +149,8 @@
     "requests.manage": "Gerir pedidos",
     "subtitles.manage": "Gerir legendas",
     "settings.access": "Acesso às definições",
-    "users.manage": "Gerir utilizadores"
+    "users.manage": "Gerir utilizadores",
+    "roles.manage": "Gerir funções"
   },
   "account": {
     "title": "A minha conta",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -2089,7 +2089,9 @@
       "field_is_default": "Função predefinida (atribuída aos novos utilizadores)",
       "default_libraries": "Bibliotecas atribuídas por predefinição",
       "default_libraries_hint": "Os novos utilizadores criados com esta função herdarão o acesso a estas bibliotecas.",
-      "confirm_delete": "Eliminar a função «{{name}}»?"
+      "confirm_delete": "Eliminar a função «{{name}}»?",
+      "plugin_permissions": "Permissões de plugins",
+      "permission_unavailable": "já não declarada"
     },
     "auto_approval": {
       "title": "Regras de aprovação automática",

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -435,7 +435,7 @@ export const routes: Routes = [
             ],
           },
           { path: 'users', canActivate: [permissionGuard('users.manage')], loadComponent: () => import('./features/settings/users/users').then((m) => m.UsersSettingsComponent) },
-          { path: 'roles', canActivate: [permissionGuard('users.manage')], loadComponent: () => import('./features/settings/roles/roles').then((m) => m.RolesSettingsComponent) },
+          { path: 'roles', canActivate: [permissionGuard('roles.manage')], loadComponent: () => import('./features/settings/roles/roles').then((m) => m.RolesSettingsComponent) },
           { path: 'subtitle-providers', loadComponent: () => import('./features/settings/subtitle-providers/subtitle-providers').then((m) => m.SubtitleProvidersSettingsComponent) },
           { path: 'subtitles-activity', canActivate: [permissionGuard('media.read')], loadComponent: () => import('./features/settings/subtitles-activity/subtitles-activity').then((m) => m.SubtitlesActivityComponent) },
           {

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { passwordChangeGuard } from './core/guards/password-change.guard';
 import { noTvGuard } from './core/guards/no-tv.guard';
 import { desktopGuard } from './core/guards/desktop.guard';
 import { pluginViewGuard } from './core/guards/plugin-view.guard';
+import { permissionGuard } from './core/guards/permission.guard';
 import { ProfileContextService } from './features/profile/profile-context.service';
 
 export const routes: Routes = [
@@ -382,6 +383,7 @@ export const routes: Routes = [
       { path: 'statistics', loadComponent: () => import('./features/dashboard/dashboard').then((m) => m.DashboardComponent) },
       {
         path: 'users/:id',
+        canActivate: [permissionGuard('users.manage')],
         loadComponent: () => import('./features/settings/users/user-detail/user-detail').then((m) => m.UserDetailComponent),
         children: [
           { path: '', loadComponent: () => import('./features/settings/users/user-detail/user-general').then((m) => m.UserGeneralComponent) },
@@ -432,10 +434,10 @@ export const routes: Routes = [
               { path: 'users', loadComponent: () => import('./features/settings/libraries/library-detail/library-users').then((m) => m.LibraryUsersComponent) },
             ],
           },
-          { path: 'users', loadComponent: () => import('./features/settings/users/users').then((m) => m.UsersSettingsComponent) },
-          { path: 'roles', loadComponent: () => import('./features/settings/roles/roles').then((m) => m.RolesSettingsComponent) },
+          { path: 'users', canActivate: [permissionGuard('users.manage')], loadComponent: () => import('./features/settings/users/users').then((m) => m.UsersSettingsComponent) },
+          { path: 'roles', canActivate: [permissionGuard('users.manage')], loadComponent: () => import('./features/settings/roles/roles').then((m) => m.RolesSettingsComponent) },
           { path: 'subtitle-providers', loadComponent: () => import('./features/settings/subtitle-providers/subtitle-providers').then((m) => m.SubtitleProvidersSettingsComponent) },
-          { path: 'subtitles-activity', loadComponent: () => import('./features/settings/subtitles-activity/subtitles-activity').then((m) => m.SubtitlesActivityComponent) },
+          { path: 'subtitles-activity', canActivate: [permissionGuard('media.read')], loadComponent: () => import('./features/settings/subtitles-activity/subtitles-activity').then((m) => m.SubtitlesActivityComponent) },
           {
             path: 'subtitles',
             loadComponent: () => import('./features/settings/subtitles/subtitles-shell').then((m) => m.SubtitlesShellComponent),

--- a/client/src/app/core/guards/permission.guard.ts
+++ b/client/src/app/core/guards/permission.guard.ts
@@ -1,0 +1,22 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { map } from 'rxjs';
+import { AuthService } from '../services/auth.service';
+
+/**
+ * Bars a route from a user lacking `permission`. The sidebar entry carries the same predicate in
+ * its `when`; this is what a typed URL hits, and what keeps a bookmark from reaching a 403 page.
+ */
+export function permissionGuard(permission: string): CanActivateFn {
+  return () => {
+    const auth = inject(AuthService);
+    const router = inject(Router);
+
+    return auth.ensureAuthenticated().pipe(
+      map((ok) => {
+        if (!ok) return router.createUrlTree(['/login']);
+        return auth.hasPermission(permission) ? true : router.createUrlTree(['/admin']);
+      }),
+    );
+  };
+}

--- a/client/src/app/core/plugin-ui/core-contributions.ts
+++ b/client/src/app/core/plugin-ui/core-contributions.ts
@@ -90,7 +90,7 @@ export const CORE_SETTINGS_SECTIONS: readonly CoreSettingsSection[] = [
     labelKey: 'admin.section_users',
     items: [
       { id: 'core.users', slot: 'settings.page', weight: 100, labelKey: 'settings.nav.users', when: ['hasPermission:users.manage'], action: { kind: 'route', path: '/admin/settings/users' } },
-      { id: 'core.roles', slot: 'settings.page', weight: 200, labelKey: 'settings.nav.roles', when: ['hasPermission:users.manage'], action: { kind: 'route', path: '/admin/settings/roles' } },
+      { id: 'core.roles', slot: 'settings.page', weight: 200, labelKey: 'settings.nav.roles', when: ['hasPermission:roles.manage'], action: { kind: 'route', path: '/admin/settings/roles' } },
     ],
   },
   {

--- a/client/src/app/core/plugin-ui/core-contributions.ts
+++ b/client/src/app/core/plugin-ui/core-contributions.ts
@@ -67,6 +67,7 @@ export const CORE_SETTINGS_SECTIONS: readonly CoreSettingsSection[] = [
       { id: 'core.language_profiles', slot: 'settings.page', weight: 200, labelKey: 'settings.nav.language_profiles', action: { kind: 'route', path: '/admin/settings/language-profiles' } },
       { id: 'core.quality_definitions', slot: 'settings.page', weight: 300, labelKey: 'settings.nav.quality_definitions', action: { kind: 'route', path: '/admin/settings/quality-definitions' } },
       { id: 'core.custom_formats', slot: 'settings.page', weight: 400, labelKey: 'settings.nav.custom_formats', action: { kind: 'route', path: '/admin/settings/custom-formats' } },
+      { id: 'core.auto_approval', slot: 'settings.page', weight: 500, labelKey: 'settings.nav.auto_approval', action: { kind: 'route', path: '/admin/settings/auto-approval' } },
     ],
   },
   {
@@ -74,7 +75,7 @@ export const CORE_SETTINGS_SECTIONS: readonly CoreSettingsSection[] = [
     items: [
       { id: 'core.subtitles', slot: 'settings.page', weight: 100, labelKey: 'settings.nav.subtitles', action: { kind: 'route', path: '/admin/settings/subtitles' } },
       { id: 'core.subtitle_providers', slot: 'settings.page', weight: 200, labelKey: 'settings.nav.subtitle_providers', action: { kind: 'route', path: '/admin/settings/subtitle-providers' } },
-      { id: 'core.subtitles_activity', slot: 'settings.page', weight: 300, labelKey: 'settings.nav.subtitles_activity', action: { kind: 'route', path: '/admin/settings/subtitles-activity' } },
+      { id: 'core.subtitles_activity', slot: 'settings.page', weight: 300, labelKey: 'settings.nav.subtitles_activity', when: ['hasPermission:media.read'], action: { kind: 'route', path: '/admin/settings/subtitles-activity' } },
     ],
   },
   {
@@ -88,9 +89,8 @@ export const CORE_SETTINGS_SECTIONS: readonly CoreSettingsSection[] = [
   {
     labelKey: 'admin.section_users',
     items: [
-      { id: 'core.users', slot: 'settings.page', weight: 100, labelKey: 'settings.nav.users', action: { kind: 'route', path: '/admin/settings/users' } },
-      { id: 'core.roles', slot: 'settings.page', weight: 200, labelKey: 'settings.nav.roles', action: { kind: 'route', path: '/admin/settings/roles' } },
-      { id: 'core.auto_approval', slot: 'settings.page', weight: 300, labelKey: 'settings.nav.auto_approval', action: { kind: 'route', path: '/admin/settings/auto-approval' } },
+      { id: 'core.users', slot: 'settings.page', weight: 100, labelKey: 'settings.nav.users', when: ['hasPermission:users.manage'], action: { kind: 'route', path: '/admin/settings/users' } },
+      { id: 'core.roles', slot: 'settings.page', weight: 200, labelKey: 'settings.nav.roles', when: ['hasPermission:users.manage'], action: { kind: 'route', path: '/admin/settings/roles' } },
     ],
   },
   {

--- a/client/src/app/core/services/auth.service.ts
+++ b/client/src/app/core/services/auth.service.ts
@@ -12,6 +12,7 @@ import {
   type SessionTokens,
 } from './session-store.service';
 import { IS_STANDALONE_BUNDLE, restartApp } from '../utils/standalone-bundle';
+import { grantSatisfies, parsePluginGrant } from '../utils/plugin-grant';
 
 export interface User {
   id: number;
@@ -187,7 +188,11 @@ export class AuthService {
   hasPermission(perm: string): boolean {
     const u = this._user();
     if (u?.isAdmin) return true;
-    return u?.permissions?.includes(perm) ?? false;
+    const held = u?.permissions ?? [];
+    if (held.includes(perm)) return true;
+    // A plugin permission can be granted whole or for one action, so the strings need not match.
+    const wanted = parsePluginGrant(perm);
+    return !!wanted && held.some((grant) => grantSatisfies(grant, wanted));
   }
 
   /** Convenience: true if the user has settings.access permission. */

--- a/client/src/app/core/utils/plugin-grant.spec.ts
+++ b/client/src/app/core/utils/plugin-grant.spec.ts
@@ -1,0 +1,44 @@
+import { grantSatisfies, parsePluginGrant } from './plugin-grant';
+
+/** The `when` a manifest writes, read against what a role actually holds. */
+function holds(held: string[], wanted: string): boolean {
+  const want = parsePluginGrant(wanted);
+  return !!want && held.some((g) => grantSatisfies(g, want));
+}
+
+describe('plugin grants', () => {
+  it('reads a bare subject as manage', () => {
+    expect(parsePluginGrant('plugin:fliks.download:queue')).toEqual({
+      action: 'manage',
+      subject: 'plugin:fliks.download:queue',
+    });
+  });
+
+  it('reads the action off a prefixed grant', () => {
+    expect(parsePluginGrant('read:plugin:fliks.download:queue')).toEqual({
+      action: 'read',
+      subject: 'plugin:fliks.download:queue',
+    });
+  });
+
+  it('is null for anything that is not a plugin grant', () => {
+    expect(parsePluginGrant('media.read')).toBeNull();
+    expect(parsePluginGrant('manage:all')).toBeNull();
+  });
+
+  it('lets manage cover a narrower action, in both spellings', () => {
+    expect(holds(['manage:plugin:a:queue'], 'read:plugin:a:queue')).toBe(true);
+    expect(holds(['plugin:a:queue'], 'read:plugin:a:queue')).toBe(true);
+  });
+
+  it('never lets a narrower action cover manage', () => {
+    expect(holds(['read:plugin:a:queue'], 'manage:plugin:a:queue')).toBe(false);
+    expect(holds(['read:plugin:a:queue'], 'plugin:a:queue')).toBe(false);
+  });
+
+  it('matches an action against itself and never across subjects', () => {
+    expect(holds(['read:plugin:a:queue'], 'read:plugin:a:queue')).toBe(true);
+    expect(holds(['manage:plugin:a:queue'], 'manage:plugin:a:blocklist')).toBe(false);
+    expect(holds(['manage:plugin:b:queue'], 'manage:plugin:a:queue')).toBe(false);
+  });
+});

--- a/client/src/app/core/utils/plugin-grant.ts
+++ b/client/src/app/core/utils/plugin-grant.ts
@@ -1,0 +1,21 @@
+/** Everything a plugin grant can be written as: the bare subject, or one action of it. */
+export interface PluginGrant {
+  action: string;
+  subject: string;
+}
+
+/**
+ * `plugin:<id>:<name>` (every action) or `<action>:plugin:<id>:<name>` (that one). A bare subject
+ * reads as `manage`, which is what core grants for it.
+ */
+export function parsePluginGrant(value: string): PluginGrant | null {
+  const match = /^(?:([a-z]+):)?(plugin:[^:]+:.+)$/.exec(value);
+  return match ? { action: match[1] ?? 'manage', subject: match[2] } : null;
+}
+
+/** Mirrors CASL: `manage` covers every action, any other action covers only itself. */
+export function grantSatisfies(held: string, wanted: PluginGrant): boolean {
+  const grant = parsePluginGrant(held);
+  if (!grant || grant.subject !== wanted.subject) return false;
+  return grant.action === 'manage' || grant.action === wanted.action;
+}

--- a/client/src/app/features/admin/admin-shell.spec.ts
+++ b/client/src/app/features/admin/admin-shell.spec.ts
@@ -123,7 +123,7 @@ function createFixture(opts: { isAdmin?: boolean; permissions?: string[]; entrie
   return fixture;
 }
 
-const ALL_PERMISSIONS = ['users.manage', 'media.read'];
+const ALL_PERMISSIONS = ['users.manage', 'roles.manage', 'media.read'];
 
 describe('AdminShellComponent — sidebar characterisation', () => {
   // An admin and a non-admin holding the same permissions see the same sidebar: entries gate on
@@ -146,11 +146,18 @@ describe('AdminShellComponent — sidebar characterisation', () => {
     ]);
   });
 
-  it('keeps the users pages for a viewer holding users.manage without being an admin', () => {
+  it('keeps a page per permission: users.manage alone opens Users, never Roles', () => {
     const sections = readSidebar(createFixture({ permissions: ['users.manage'] }));
 
     expect(sections.find((s) => s.label === 'admin.section_users')?.links.map((l) => l.href)).toEqual([
       '/admin/settings/users',
+    ]);
+  });
+
+  it('shows Roles alone to a viewer holding roles.manage without users.manage', () => {
+    const sections = readSidebar(createFixture({ permissions: ['roles.manage'] }));
+
+    expect(sections.find((s) => s.label === 'admin.section_users')?.links.map((l) => l.href)).toEqual([
       '/admin/settings/roles',
     ]);
   });

--- a/client/src/app/features/admin/admin-shell.spec.ts
+++ b/client/src/app/features/admin/admin-shell.spec.ts
@@ -32,6 +32,7 @@ const BASELINE_SIDEBAR = [
     { label: 'settings.nav.language_profiles', href: '/admin/settings/language-profiles' },
     { label: 'settings.nav.quality_definitions', href: '/admin/settings/quality-definitions' },
     { label: 'settings.nav.custom_formats', href: '/admin/settings/custom-formats' },
+    { label: 'settings.nav.auto_approval', href: '/admin/settings/auto-approval' },
   ] },
   { label: 'admin.section_subtitles', links: [
     { label: 'settings.nav.subtitles', href: '/admin/settings/subtitles' },
@@ -46,7 +47,6 @@ const BASELINE_SIDEBAR = [
   { label: 'admin.section_users', links: [
     { label: 'settings.nav.users', href: '/admin/settings/users' },
     { label: 'settings.nav.roles', href: '/admin/settings/roles' },
-    { label: 'settings.nav.auto_approval', href: '/admin/settings/auto-approval' },
   ] },
   { label: 'admin.section_advanced', links: [
     { label: 'settings.nav.schedulers', href: '/admin/settings/schedulers' },
@@ -92,7 +92,7 @@ function readSidebar(fixture: ComponentFixture<AdminShellComponent>) {
   return sections;
 }
 
-function createFixture(opts: { isAdmin?: boolean; entries?: PluginUiEntry[] } = {}) {
+function createFixture(opts: { isAdmin?: boolean; permissions?: string[]; entries?: PluginUiEntry[] } = {}) {
   TestBed.configureTestingModule({
     providers: [
       provideZonelessChangeDetection(),
@@ -104,7 +104,11 @@ function createFixture(opts: { isAdmin?: boolean; entries?: PluginUiEntry[] } = 
       { provide: Title, useValue: { setTitle: () => {} } },
       {
         provide: AuthService,
-        useValue: { user: () => ({ id: 1, isAdmin: !!opts.isAdmin }), hasPermission: () => false },
+        useValue: {
+          user: () => ({ id: 1, isAdmin: !!opts.isAdmin }),
+          // Mirrors the real service: an admin holds every permission.
+          hasPermission: (p: string) => !!opts.isAdmin || (opts.permissions ?? []).includes(p),
+        },
       },
       { provide: TvService, useValue: { isTv: () => false, isAndroidTv: () => false } },
       { provide: DeviceService, useValue: { isTouch: () => false } },
@@ -119,20 +123,41 @@ function createFixture(opts: { isAdmin?: boolean; entries?: PluginUiEntry[] } = 
   return fixture;
 }
 
+const ALL_PERMISSIONS = ['users.manage', 'media.read'];
+
 describe('AdminShellComponent — sidebar characterisation', () => {
-  // Same fixture run under both an admin and a non-admin auth context: the
-  // sidebar has never gated any of its 23 links on isAdmin (only the /admin
-  // route guard does), and the refactor must not start doing so implicitly.
+  // An admin and a non-admin holding the same permissions see the same sidebar: entries gate on
+  // the permission their own pages need, never on isAdmin.
   it.each([['admin', true], ['non-admin', false]] as const)(
     'renders the unchanged 7-section, 23-link sidebar for a %s context',
     (_label, isAdmin) => {
-      const fixture = createFixture({ isAdmin });
+      const fixture = createFixture({ isAdmin, permissions: ALL_PERMISSIONS });
       expect(readSidebar(fixture)).toEqual(BASELINE_SIDEBAR);
     },
   );
 
+  it('hides the pages a viewer\'s permissions cannot open, and the section left empty', () => {
+    const sections = readSidebar(createFixture({ permissions: [] }));
+
+    expect(sections.map((s) => s.label)).not.toContain('admin.section_users');
+    expect(sections.find((s) => s.label === 'admin.section_subtitles')?.links.map((l) => l.href)).toEqual([
+      '/admin/settings/subtitles',
+      '/admin/settings/subtitle-providers',
+    ]);
+  });
+
+  it('keeps the users pages for a viewer holding users.manage without being an admin', () => {
+    const sections = readSidebar(createFixture({ permissions: ['users.manage'] }));
+
+    expect(sections.find((s) => s.label === 'admin.section_users')?.links.map((l) => l.href)).toEqual([
+      '/admin/settings/users',
+      '/admin/settings/roles',
+    ]);
+  });
+
   it('appends a plugin section after every core section, labelled by manifest name', () => {
     const fixture = createFixture({
+      permissions: ALL_PERMISSIONS,
       entries: [
         entry('fliks.b', [contribution('page', 100, { labelKey: 'b.page' })], { name: 'B Plugin' }),
       ],
@@ -144,6 +169,7 @@ describe('AdminShellComponent — sidebar characterisation', () => {
 
   it('orders plugin sections by plugin id, not install/array order', () => {
     const fixture = createFixture({
+      permissions: ALL_PERMISSIONS,
       entries: [
         entry('fliks.zeta', [contribution('z', 100)], { name: 'Zeta' }),
         entry('fliks.alpha', [contribution('a', 100)], { name: 'Alpha' }),
@@ -155,6 +181,7 @@ describe('AdminShellComponent — sidebar characterisation', () => {
 
   it('produces no section for a plugin with zero settings.page contributions', () => {
     const fixture = createFixture({
+      permissions: ALL_PERMISSIONS,
       entries: [entry('fliks.empty', [contribution('nav-item', 100, { slot: 'nav.main' })], { name: 'Empty' })],
     });
     expect(readSidebar(fixture)).toHaveLength(7);
@@ -162,6 +189,7 @@ describe('AdminShellComponent — sidebar characterisation', () => {
 
   it('produces no section for a plugin whose only contribution is hidden by `when`', () => {
     const fixture = createFixture({
+      permissions: ALL_PERMISSIONS,
       entries: [entry('fliks.hidden', [contribution('gone', 100, { when: ['isAdmin'] })], { name: 'Hidden' })],
     });
     // isAdmin is false in this fixture's default context, so the predicate fails.
@@ -170,6 +198,7 @@ describe('AdminShellComponent — sidebar characterisation', () => {
 
   it('falls back to the plugin id when the manifest name is not yet in the response', () => {
     const fixture = createFixture({
+      permissions: ALL_PERMISSIONS,
       entries: [entry('fliks.noname', [contribution('page', 100)])],
     });
     expect(readSidebar(fixture)[7].label).toBe('fliks.noname');

--- a/client/src/app/features/admin/settings-sections.service.spec.ts
+++ b/client/src/app/features/admin/settings-sections.service.spec.ts
@@ -26,14 +26,21 @@ const entry = (pluginId: string, contributions: UiContribution[], extra: Partial
   ...extra,
 });
 
-function createService(opts: { isAdmin?: boolean; entries?: PluginUiEntry[]; url?: string } = {}) {
+/** Every permission a core settings entry gates on today. */
+const ALL_PERMISSIONS = ['users.manage', 'media.read'];
+
+function createService(opts: { isAdmin?: boolean; permissions?: string[]; entries?: PluginUiEntry[]; url?: string } = {}) {
   TestBed.resetTestingModule();
   TestBed.configureTestingModule({
     providers: [
       provideZonelessChangeDetection(),
       {
         provide: AuthService,
-        useValue: { user: () => ({ id: 1, isAdmin: !!opts.isAdmin }), hasPermission: () => false },
+        useValue: {
+          user: () => ({ id: 1, isAdmin: !!opts.isAdmin }),
+          // Mirrors the real service: an admin holds every permission.
+          hasPermission: (p: string) => !!opts.isAdmin || (opts.permissions ?? []).includes(p),
+        },
       },
       { provide: TvService, useValue: { isTv: () => false } },
       { provide: DeviceService, useValue: { isTouch: () => false } },
@@ -47,14 +54,24 @@ function createService(opts: { isAdmin?: boolean; entries?: PluginUiEntry[]; url
 
 describe('SettingsSectionsService', () => {
   it('resolves the 7 core sections with 22 items total, and nothing else, with an empty registry', () => {
-    const svc = createService();
+    const svc = createService({ permissions: ALL_PERMISSIONS });
     const sections = svc.sections();
     expect(sections).toHaveLength(7);
     expect(sections.reduce((n, s) => n + s.items.length, 0)).toBe(22);
   });
 
+  it('drops the core entries whose own pages the viewer has no permission for', () => {
+    const ids = createService().sections().flatMap((s) => s.items.map((i) => i.id));
+    expect(ids).not.toContain('core.users');
+    expect(ids).not.toContain('core.roles');
+    expect(ids).not.toContain('core.subtitles_activity');
+    // Its own endpoints are Settings-gated, so it stays: the rule follows the policy, not the section.
+    expect(ids).toContain('core.auto_approval');
+  });
+
   it('sorts a plugin section\'s own items by weight then id, independent of core', () => {
     const svc = createService({
+      permissions: ALL_PERMISSIONS,
       entries: [entry('fliks.a', [contribution('z', 100), contribution('a', 100), contribution('b', 50)], { name: 'A' })],
     });
     const plugin = svc.sections().at(-1)!;
@@ -63,6 +80,7 @@ describe('SettingsSectionsService', () => {
 
   it('never lets a plugin contribution join a core section, however its id or weight looks', () => {
     const svc = createService({
+      permissions: ALL_PERMISSIONS,
       // Deliberately mimics a core id/weight to prove grouping is by plugin
       // entry, never by string-matching an item into an existing section.
       entries: [entry('fliks.a', [contribution('core.system', 50)], { name: 'A' })],
@@ -75,6 +93,7 @@ describe('SettingsSectionsService', () => {
 
   it('ignores a plugin contribution outside settings.page when building its section', () => {
     const svc = createService({
+      permissions: ALL_PERMISSIONS,
       entries: [entry('fliks.a', [contribution('nav', 100, { slot: 'nav.main' })], { name: 'A' })],
     });
     expect(svc.sections()).toHaveLength(7);
@@ -82,14 +101,15 @@ describe('SettingsSectionsService', () => {
 
   it('drops a plugin settings.page contribution with an unrecognised action kind', () => {
     const svc = createService({
+      permissions: ALL_PERMISSIONS,
       entries: [entry('fliks.a', [contribution('broken', 100, { action: { kind: 'bogus' } as never })], { name: 'A' })],
     });
     expect(svc.sections()).toHaveLength(7);
   });
 
-  it('produces the identical section list for an admin and a non-admin context', () => {
+  it('produces the identical section list for an admin and a non-admin holding the same permissions', () => {
     const withAdmin = createService({ isAdmin: true }).sections();
-    const withoutAdmin = createService({ isAdmin: false }).sections();
+    const withoutAdmin = createService({ isAdmin: false, permissions: ALL_PERMISSIONS }).sections();
     expect(withoutAdmin).toEqual(withAdmin);
   });
 });

--- a/client/src/app/features/admin/settings-sections.service.spec.ts
+++ b/client/src/app/features/admin/settings-sections.service.spec.ts
@@ -27,7 +27,7 @@ const entry = (pluginId: string, contributions: UiContribution[], extra: Partial
 });
 
 /** Every permission a core settings entry gates on today. */
-const ALL_PERMISSIONS = ['users.manage', 'media.read'];
+const ALL_PERMISSIONS = ['users.manage', 'roles.manage', 'media.read'];
 
 function createService(opts: { isAdmin?: boolean; permissions?: string[]; entries?: PluginUiEntry[]; url?: string } = {}) {
   TestBed.resetTestingModule();

--- a/client/src/app/features/plugin-view/plugin-view.spec.ts
+++ b/client/src/app/features/plugin-view/plugin-view.spec.ts
@@ -430,6 +430,36 @@ describe('PluginViewComponent', () => {
     http.verify();
   });
 
+  it('drops a list action the viewer has no permission for, and keeps the ungated one', async () => {
+    const { fixture, http } = createComponent(
+      { pluginId: 'fliks.a', view: 'queue' },
+      {
+        hasPlugin: () => true,
+        configPage: () => ({
+          kind: 'table',
+          id: 'x',
+          labelKey: 'x.title',
+          list: '/queue',
+          columns: [{ key: 'name', labelKey: 'x.col_name' }],
+          listActions: [
+            { labelKey: 'x.clear_all', method: 'DELETE', path: '/history/all', when: ['hasPermission:plugin:fliks.a:queue-control'] },
+            { labelKey: 'x.refresh_all', method: 'POST', path: '/refresh' },
+          ],
+        }),
+      },
+    );
+    fixture.detectChanges();
+    http.expectOne({ url: '/api/plugins/fliks.a/queue', method: 'GET' }).flush([{ id: 1, name: 'Torrent A' }]);
+    await settle(fixture);
+
+    const labels = (Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[]).map(
+      (b) => b.textContent ?? '',
+    );
+    expect(labels.some((l) => l.includes('x.refresh_all'))).toBe(true);
+    expect(labels.some((l) => l.includes('x.clear_all'))).toBe(false);
+    http.verify();
+  });
+
   it('VERDICT: a `table.open-media` row action renders a button and navigates using the row\'s mediaId/mediaType', async () => {
     const { fixture, http, navigateByUrl } = createComponent(
       { pluginId: 'fliks.a', view: 'queue' },

--- a/client/src/app/features/plugin-view/plugin-view.ts
+++ b/client/src/app/features/plugin-view/plugin-view.ts
@@ -352,19 +352,25 @@ export class PluginViewComponent implements OnDestroy {
    * rides through untouched — only the table holds a row.
    */
   tableRowActions(view: TableView): RowAction[] {
-    const ctx = {
+    return (view.rowActions ?? [])
+      .filter((a) => evaluateWhen(a.when, this.whenContext()))
+      .map((a) => (a.kind === 'proxy' ? { ...a, path: this.resourceUrl(a.path) } : a));
+  }
+
+  /** Same rule as a row action: a clear-all the viewer's routes refuse is a button that 403s. */
+  tableListActions(view: TableView): ListAction[] {
+    return (view.listActions ?? [])
+      .filter((a) => evaluateWhen(a.when, this.whenContext()))
+      .map((a) => ({ ...a, path: this.resourceUrl(a.path) }));
+  }
+
+  private whenContext() {
+    return {
       isAdmin: this.auth.user()?.isAdmin ?? false,
       hasPermission: (p: string) => this.auth.hasPermission(p),
       isTv: this.tv.isTv(),
       isTouch: this.device.isTouch(),
     };
-    return (view.rowActions ?? [])
-      .filter((a) => evaluateWhen(a.when, ctx))
-      .map((a) => (a.kind === 'proxy' ? { ...a, path: this.resourceUrl(a.path) } : a));
-  }
-
-  tableListActions(view: TableView): ListAction[] {
-    return (view.listActions ?? []).map((a) => ({ ...a, path: this.resourceUrl(a.path) }));
   }
 
   /** Merges a page's own wording over the generic provider-list chrome. */

--- a/client/src/app/features/settings/auto-approval/auto-approval.html
+++ b/client/src/app/features/settings/auto-approval/auto-approval.html
@@ -126,6 +126,7 @@
             </p>
           </div>
 
+          @if (canPickUsers) {
           <div class="form-control">
             <span class="label-text">{{ 'settings.auto_approval.users' | translate }}</span>
             <app-multi-select
@@ -139,7 +140,9 @@
           <div class="divider my-0 text-xs text-base-content/50">
             {{ 'settings.auto_approval.or' | translate }}
           </div>
+          }
 
+          @if (canPickRoles) {
           <div class="form-control">
             <span class="label-text">{{ 'settings.auto_approval.roles' | translate }}</span>
             <app-multi-select
@@ -149,6 +152,7 @@
               [placeholder]="'settings.auto_approval.any_role' | translate"
             />
           </div>
+          }
         </section>
 
         <div class="divider md:divider-horizontal my-2 md:my-0"></div>

--- a/client/src/app/features/settings/auto-approval/auto-approval.html
+++ b/client/src/app/features/settings/auto-approval/auto-approval.html
@@ -117,6 +117,7 @@
       }
 
       <div class="flex flex-col md:flex-row md:gap-2">
+        @if (canPickWho) {
         <section class="flex flex-col gap-3 flex-1 min-w-0">
           <div>
             <h3 class="font-semibold">{{ 'settings.auto_approval.who' | translate }}</h3>
@@ -151,6 +152,7 @@
         </section>
 
         <div class="divider md:divider-horizontal my-2 md:my-0"></div>
+        }
 
         <section class="flex flex-col gap-3 flex-1 min-w-0">
           <div>

--- a/client/src/app/features/settings/auto-approval/auto-approval.ts
+++ b/client/src/app/features/settings/auto-approval/auto-approval.ts
@@ -20,6 +20,7 @@ import { UsersApiService, UserRow } from '../../../core/services/api/users-api.s
 import { RolesApiService, RoleRow } from '../../../core/services/api/roles-api.service';
 import { LibrariesApiService, Library } from '../../../core/services/api/libraries-api.service';
 import { MetadataService, TmdbGenre } from '../../../core/services/api/metadata.service';
+import { AuthService } from '../../../core/services/auth.service';
 import {
   MultiSelectComponent,
   MultiSelectOption,
@@ -42,6 +43,7 @@ type RuleMediaType = '' | 'movie' | 'series';
 })
 export class AutoApprovalSettingsComponent implements OnInit {
   private readonly api = inject(AutoApprovalApiService);
+  private readonly auth = inject(AuthService);
   private readonly usersApi = inject(UsersApiService);
   private readonly rolesApi = inject(RolesApiService);
   private readonly librariesApi = inject(LibrariesApiService);
@@ -127,10 +129,14 @@ export class AutoApprovalSettingsComponent implements OnInit {
     }
   }
 
+  /** The user and role lists are `users.manage`-gated; without it the two "who" pickers can only
+   *  render empty, so the criterion is hidden rather than shown as a select with no options. */
+  readonly canPickWho = this.auth.hasPermission('users.manage');
+
   private async loadPickers() {
     const [users, roles, libraries, movieGenres, tvGenres] = await Promise.all([
-      this.usersApi.list().catch(() => []),
-      this.rolesApi.list().catch(() => []),
+      this.canPickWho ? this.usersApi.list().catch(() => []) : Promise.resolve<UserRow[]>([]),
+      this.canPickWho ? this.rolesApi.list().catch(() => []) : Promise.resolve<RoleRow[]>([]),
       this.librariesApi.list().catch(() => []),
       this.metadata.getMovieGenres().catch(() => []),
       this.metadata.getTvGenres().catch(() => []),

--- a/client/src/app/features/settings/auto-approval/auto-approval.ts
+++ b/client/src/app/features/settings/auto-approval/auto-approval.ts
@@ -129,14 +129,16 @@ export class AutoApprovalSettingsComponent implements OnInit {
     }
   }
 
-  /** The user and role lists are `users.manage`-gated; without it the two "who" pickers can only
-   *  render empty, so the criterion is hidden rather than shown as a select with no options. */
-  readonly canPickWho = this.auth.hasPermission('users.manage');
+  /** Each "who" picker reads a list of its own, behind its own permission: shown empty, a select
+   *  reads as "no users exist" rather than "you may not see them". */
+  readonly canPickUsers = this.auth.hasPermission('users.manage');
+  readonly canPickRoles = this.canPickUsers || this.auth.hasPermission('roles.manage');
+  readonly canPickWho = this.canPickUsers || this.canPickRoles;
 
   private async loadPickers() {
     const [users, roles, libraries, movieGenres, tvGenres] = await Promise.all([
-      this.canPickWho ? this.usersApi.list().catch(() => []) : Promise.resolve<UserRow[]>([]),
-      this.canPickWho ? this.rolesApi.list().catch(() => []) : Promise.resolve<RoleRow[]>([]),
+      this.canPickUsers ? this.usersApi.list().catch(() => []) : Promise.resolve<UserRow[]>([]),
+      this.canPickRoles ? this.rolesApi.list().catch(() => []) : Promise.resolve<RoleRow[]>([]),
       this.librariesApi.list().catch(() => []),
       this.metadata.getMovieGenres().catch(() => []),
       this.metadata.getTvGenres().catch(() => []),

--- a/client/src/app/features/settings/roles/roles.html
+++ b/client/src/app/features/settings/roles/roles.html
@@ -43,7 +43,7 @@
               </td>
               <td>
                 @if (role.isDefault) {
-                  <span class="badge badge-success badge-sm">{{
+                  <span class="badge badge-success badge-sm whitespace-nowrap">{{
                     'settings.roles.default_badge' | translate
                   }}</span>
                 }

--- a/client/src/app/features/settings/roles/roles.html
+++ b/client/src/app/features/settings/roles/roles.html
@@ -88,7 +88,7 @@
       <div>
         <span class="label-text">{{ 'settings.roles.field_permissions' | translate }}</span>
         <div class="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
-          @for (perm of availablePermissions(); track perm) {
+          @for (perm of corePermissions(); track perm) {
             <label class="label cursor-pointer justify-start gap-2 p-2 rounded hover:bg-base-200">
               <input
                 type="checkbox"
@@ -100,6 +100,33 @@
             </label>
           }
         </div>
+
+        @if (pluginPermissionGroups().length) {
+          <div class="mt-4">
+            <span class="label-text">{{ 'settings.roles.plugin_permissions' | translate }}</span>
+          </div>
+        }
+        @for (group of pluginPermissionGroups(); track group.pluginId) {
+          <div class="mt-3">
+            <span class="label-text text-xs opacity-70">{{ group.name }}</span>
+            <div class="mt-1 grid grid-cols-1 sm:grid-cols-2 gap-2">
+              @for (grant of group.grants; track grant.value) {
+                <label class="label cursor-pointer justify-start gap-2 p-2 rounded hover:bg-base-200">
+                  <input
+                    type="checkbox"
+                    class="checkbox checkbox-sm"
+                    [checked]="formPermissions().has(grant.value)"
+                    (change)="togglePermission(grant.value)"
+                  />
+                  <span class="label-text text-sm">{{ grant.label }}</span>
+                  @if (grant.orphan) {
+                    <span class="badge badge-ghost badge-xs">{{ 'settings.roles.permission_unavailable' | translate }}</span>
+                  }
+                </label>
+              }
+            </div>
+          </div>
+        }
       </div>
 
       <label class="label cursor-pointer justify-start gap-3">

--- a/client/src/app/features/settings/roles/roles.ts
+++ b/client/src/app/features/settings/roles/roles.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   ElementRef,
+  computed,
   signal,
   viewChild,
   inject,
@@ -15,6 +16,13 @@ import { ConfirmationService } from '../../../core/services/confirmation.service
 import { ToastService } from '../../../core/services/toast.service';
 import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 import { ModalFooterComponent } from '../../../shared/components/modal-footer';
+import { PluginUiRegistryService } from '../../../core/plugin-ui/plugin-ui-registry.service';
+
+/** `read:plugin:fliks.download:queue`, or the bare subject, split into its parts. */
+function parseGrant(value: string): { action?: string; pluginId: string; name: string } | null {
+  const match = /^(?:([a-z]+):)?plugin:([^:]+):(.+)$/.exec(value);
+  return match ? { action: match[1], pluginId: match[2], name: match[3] } : null;
+}
 
 @Component({
   selector: 'app-roles-settings',
@@ -27,6 +35,7 @@ export class RolesSettingsComponent implements OnInit {
   private readonly translate = inject(TranslateService);
   private readonly confirmation = inject(ConfirmationService);
   private readonly toast = inject(ToastService);
+  private readonly plugins = inject(PluginUiRegistryService);
   private readonly editorDialog = viewChild<ElementRef<HTMLDialogElement>>('editorDialog');
 
   readonly rows = signal<RoleRow[]>([]);
@@ -38,6 +47,33 @@ export class RolesSettingsComponent implements OnInit {
   readonly saving = signal(false);
 
   readonly editingRole = signal<RoleRow | null>(null);
+
+  readonly corePermissions = computed(() => this.availablePermissions().filter((perm) => !parseGrant(perm)));
+
+  /** Plugin grants, grouped under the plugin that declares them. A grant the edited role holds
+   *  but no installed plugin offers is still listed, so saving cannot drop it unnoticed. */
+  readonly pluginPermissionGroups = computed(() => {
+    const available = this.availablePermissions();
+    const orphans = (this.editingRole()?.permissions ?? []).filter(
+      (perm) => parseGrant(perm) && !available.includes(perm),
+    );
+    const groups = new Map<string, { pluginId: string; name: string; grants: { value: string; name: string; label: string; orphan: boolean }[] }>();
+    for (const value of [...available, ...orphans]) {
+      const grant = parseGrant(value);
+      if (!grant) continue;
+      const group = groups.get(grant.pluginId) ?? {
+        pluginId: grant.pluginId,
+        name: this.plugins.pluginEntries().find((e) => e.pluginId === grant.pluginId)?.name ?? grant.pluginId,
+        grants: [],
+      };
+      group.grants.push({ value, name: grant.name, label: this.grantLabel(value, grant), orphan: orphans.includes(value) });
+      groups.set(grant.pluginId, group);
+    }
+    for (const group of groups.values()) {
+      group.grants.sort((a, b) => a.name.localeCompare(b.name) || a.label.localeCompare(b.label));
+    }
+    return [...groups.values()];
+  });
 
   readonly libraries = signal<Library[]>([]);
 
@@ -171,5 +207,13 @@ export class RolesSettingsComponent implements OnInit {
     const key = 'permissions.' + perm;
     const translated = this.translate.instant(key);
     return translated !== key ? translated : perm;
+  }
+
+  /** A plugin may label its own grants; otherwise the raw name and the action it is limited to. */
+  private grantLabel(value: string, grant: { action?: string; name: string }): string {
+    const key = 'permissions.' + value;
+    const translated = this.translate.instant(key);
+    if (translated !== key) return translated;
+    return grant.action ? `${grant.name} (${grant.action})` : grant.name;
   }
 }

--- a/client/src/app/features/settings/roles/roles.ts
+++ b/client/src/app/features/settings/roles/roles.ts
@@ -17,11 +17,14 @@ import { ToastService } from '../../../core/services/toast.service';
 import { ModalHeaderComponent } from '../../../shared/components/modal-header';
 import { ModalFooterComponent } from '../../../shared/components/modal-footer';
 import { PluginUiRegistryService } from '../../../core/plugin-ui/plugin-ui-registry.service';
+import { parsePluginGrant } from '../../../core/utils/plugin-grant';
 
-/** `read:plugin:fliks.download:queue`, or the bare subject, split into its parts. */
+/** `read:plugin:fliks.download:queue`, or the bare subject, split for display. */
 function parseGrant(value: string): { action?: string; pluginId: string; name: string } | null {
-  const match = /^(?:([a-z]+):)?plugin:([^:]+):(.+)$/.exec(value);
-  return match ? { action: match[1], pluginId: match[2], name: match[3] } : null;
+  const grant = parsePluginGrant(value);
+  if (!grant) return null;
+  const [, pluginId, ...rest] = grant.subject.split(':');
+  return { action: value.startsWith('plugin:') ? undefined : grant.action, pluginId, name: rest.join(':') };
 }
 
 @Component({

--- a/client/src/app/features/settings/users/user-detail/user-general.html
+++ b/client/src/app/features/settings/users/user-detail/user-general.html
@@ -43,6 +43,7 @@
         <select
     appTvSelect
           class="select select-bordered select-sm w-full"
+          [disabled]="!canAssignRole"
           [ngModel]="formRoleId()"
           (ngModelChange)="formRoleId.set($event)"
         >

--- a/client/src/app/features/settings/users/user-detail/user-general.ts
+++ b/client/src/app/features/settings/users/user-detail/user-general.ts
@@ -16,6 +16,7 @@ import {
   Library,
 } from '../../../../core/services/api/libraries-api.service';
 import { UserDetailState } from './user-detail.state';
+import { AuthService } from '../../../../core/services/auth.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { LucideIconComponent } from '../../../../shared/components/lucide-icon';
 
@@ -30,6 +31,8 @@ export class UserGeneralComponent implements OnInit {
   private readonly translate = inject(TranslateService);
   readonly state = inject(UserDetailState);
   private readonly toast = inject(ToastService);
+  /** Changing a role grants its permissions, so the server keeps it behind `roles.manage`. */
+  readonly canAssignRole = inject(AuthService).hasPermission('roles.manage');
 
   readonly saving = signal(false);
 
@@ -86,7 +89,7 @@ export class UserGeneralComponent implements OnInit {
     this.saving.set(true);
     const body: UpdateUserBody = {
       username: this.formUsername().trim() || undefined,
-      roleId: this.formRoleId() ?? undefined,
+      roleId: this.canAssignRole ? (this.formRoleId() ?? undefined) : undefined,
       isAdmin: this.formIsAdmin(),
       enabled: this.formEnabled(),
       requirePasswordChange: this.formRequirePasswordChange(),

--- a/client/src/app/features/settings/users/users.html
+++ b/client/src/app/features/settings/users/users.html
@@ -110,6 +110,7 @@
         <select
     appTvSelect
           class="select select-bordered select-sm w-full"
+          [disabled]="!canAssignRole"
           [ngModel]="formRoleId()"
           (ngModelChange)="formRoleId.set($event)"
         >

--- a/client/src/app/features/settings/users/users.ts
+++ b/client/src/app/features/settings/users/users.ts
@@ -40,6 +40,8 @@ export class UsersSettingsComponent implements OnInit {
 
   readonly rows = signal<UserRow[]>([]);
   readonly roles = signal<RoleRow[]>([]);
+  /** Choosing a role grants its permissions, so the server keeps it behind `roles.manage`. */
+  readonly canAssignRole = inject(AuthService).hasPermission('roles.manage');
   readonly libraries = signal<Library[]>([]);
   readonly loading = signal(true);
   readonly listError = signal('');
@@ -113,7 +115,7 @@ export class UsersSettingsComponent implements OnInit {
       const body: CreateUserBody = {
         username: this.formUsername().trim(),
         password: this.formPassword(),
-        roleId: this.formRoleId() ?? undefined,
+        roleId: this.canAssignRole ? (this.formRoleId() ?? undefined) : undefined,
         enabled: this.formEnabled(),
         libraryIds: [...this.formLibraryIds()],
       };

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -64,6 +64,10 @@ Optional beyond that:
 - `events[]` — domain events to receive. A `data` plugin gets an HTTPS POST from core; a `process`
   plugin gets a note over its socket.
 - `permissions[]` — raw names; core builds the CASL subject as `plugin:<id>:<name>`, so a plugin cannot claim another's or a core subject.
+  Every distinct `action:subject` policy your `routes[]` declare is offered as its own tick box in the
+  roles editor, so `read:plugin:<id>:queue` can be granted without `manage:plugin:<id>:queue`. A declared
+  name no route names is offered whole (it then allows every action). Nothing is granted by default:
+  until an admin ticks one, only admins pass the routes declared under it.
 - `ui.*` — see below.
 - `i18n` — every `labelKey` the plugin uses, per locale. Core merges them into the active language.
 
@@ -79,6 +83,13 @@ A plugin ships **no** Angular. It declares data; core renders it.
 predicate evaluates false, so a client that does not know a rule hides the entry rather than
 guessing. The action is either a route or a **core-declared `actionId`**: core keeps a closed
 catalogue per slot, and an id it does not know renders nothing.
+
+A contribution whose route opens one of your own views (`/plugins/<id>/<pageId>`, or
+`/admin/settings/plugins/<id>/<pageId>`) must name a page you declare in `ui.configPages[]`; anything
+else is refused at registration. Core then serves `GET /plugins/ui` per viewer: a `providers` or
+`table` page is sent only to a user whose ability satisfies the policy of the route it lists from,
+and the contributions opening a withheld page are withheld with it. So a nav entry never needs a
+`when` to restate its own route's policy; use `when` for what the policy cannot express.
 
 **`ui.configPages[]`** declares a page, discriminated on `kind`:
 


### PR DESCRIPTION
## The bug

A non-admin saw **Queue** in the sidebar and got `Forbidden resource` on opening it.

The server was right and the menu was wrong:

1. `GET /plugins/ui` served every manifest's `ui.contributions` verbatim to any authenticated session.
2. The only visibility filter was the plugin-authored `when`, and the download plugin's queue entry declares none.
3. The page reads `GET /queue`, declared under `read:plugin:fliks.download:queue`, and `PluginRouteGuard` refused it.

Underneath that sat a bigger hole: **no plugin permission was grantable at all**. `GET /roles/permissions`
returned only the ten core keys, so no role could ever hold `plugin:fliks.download:queue` and every plugin
route was admin-only in practice, whatever policy it declared.

## What changes

**Plugin permissions become grantable, per action.** The roles editor now lists each distinct
`action:subject` policy the installed plugins' routes declare, grouped under the plugin that declares
them, plus any declared permission no route names. A grant may name its action:
`read:plugin:<id>:queue` no longer implies write on the same subject, which a bare subject still does.
An action outside the enum is denied rather than widened. A grant a role holds that no installed plugin
offers stays listed and ticked, so saving a role cannot drop it unnoticed.

**Visibility is derived from the policy, not from `when`.** `GET /plugins/ui` sends a `table` or
`providers` page only to a caller whose ability satisfies the policy of the route it lists from, and
withholds the contributions that open a withheld page. One place, so every client (web, TV, desktop,
mobile) gets the same answer, and a direct URL lands on the "unavailable" card instead of a 403 toast.
`form` pages keep riding the admin gate of the settings area they live in.

**A contribution routing to a view nobody declares is refused at registration**, submenu children
included, instead of installing cleanly and rendering "unavailable" later.

## Verified on the dev stack

| | before | after |
|---|---|---|
| `GET /plugins/ui` as the default `User` role | queue page + nav entry present | both withheld, `general` kept |
| `GET /plugins/fliks.download/queue` for that user | 403 | 403, with nothing in the menu pointing at it |
| same user granted `read:plugin:fliks.download:queue` | grant impossible to express | nav entry back, route answers 200 |
| `POST /queue/:id/pause` for that same user | n/a | 403 (`queue-control` is a separate subject) |

`GET /roles/permissions` as admin now returns the ten core keys plus the eleven grants the download
plugin's routes declare. Backend suites for `plugins`, `auth` and `roles` are green (885 tests), `tsc`
clean on both sides, client builds.

## Not in scope

- `pluginViewGuard` still fails open for a path with no matching contribution: the component's
  "unavailable" card is the fail-closed presentation, and a redirect would hide why.
- No spec for the roles editor grouping: that page has no spec harness today. The grouping was checked
  in a real browser instead.
- No change needed in the download plugin's manifest. Adding a `when` there would have masked the
  symptom for one entry; the join now happens in core for every plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: the same rule for core admin pages

The `/admin` area gated on `settings.access` alone, so its sidebar showed every entry to anyone
holding it, including pages whose own routes need more. Each entry now declares the permission its
pages require, and the route carries the same predicate so a typed URL or a bookmark redirects
instead of landing on a 403 page. A section left empty disappears on its own.

| Page | Required by its own routes |
|---|---|
| Users, Roles | `users.manage` (Manage User) |
| Subtitle activity | `media.read` (Read SubtitleFile) |
| everything else under `/admin` | `settings.access`, unchanged |

Auto-approval moves from the Users section to Media and keeps no permission of its own: its
endpoints are `Settings`-gated like the rest of that section. Its "who" criteria are hidden without
`users.manage`, because the user and role lists behind them are Manage-User routes and could only
ever render empty there.

Verified with a real `settings.access` + `media.read` account on the dev stack: no Users heading in
the sidebar, `/admin/settings/users` and `/admin/users/1` both redirect to `/admin/statistics`, and
the auto-approval page opens with its "who" block absent. Client suite green (883 tests); the one
red file, `horizontal-scroller.spec.ts`, fails identically on `origin/main`.

---

## Follow-up: managing roles is its own permission

`users.manage` let an operator assign any role, the Admin one included: a straight escalation out
of the permission it was granted under. `roles.manage` is now separate.

| | `users.manage` | `roles.manage` |
|---|---|---|
| list/create/edit users | yes | no |
| list roles (`GET /roles`) | yes, `Read Role` | yes |
| roles editor, its permission catalogue, create/edit/delete a role | no | yes |
| set a user's role, at creation or later | no | yes |

The role selector on a user is disabled rather than hidden without `roles.manage`, so a user
manager still sees which role an account holds; the client stops sending `roleId` in that case, and
the server refuses it anyway. A data migration grants `roles.manage` to every role that already
holds `users.manage`, so an upgrade changes nobody's reach; `down()` removes it again.

Checked on the dev stack with a `users.manage`-only account (no `roles.manage`):

| request | result |
|---|---|
| `GET /roles` | 200 |
| `GET /roles/permissions`, `POST /roles` | 403 |
| `GET /users`, `PUT /users/2 {enabled}` | 200 |
| `PUT /users/2 {roleId}`, `POST /users {roleId}` | 403 |

Sidebar shows Users without Roles, `/admin/settings/roles` redirects, and the role select renders
disabled for that account and enabled for an admin. Migration run/revert/run tested against a
throwaway Postgres with seeded roles, and `migration:generate` reports no schema drift. Backend
2167 tests green, client 883.
