### PR TITLE
chore: release the permission gating as 4.1.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,10 @@
 #   - `chore`, `docs`, … → no bump (they show in the changelog under
 #                         "Miscellaneous Chores" only if explicitly
 #                         configured to)
+#
+# A `Release-As: <X.Y.Z>` footer on any commit overrides the computed
+# version for the next release. It is the only way to correct a bump
+# once the commit that caused it is on a protected branch.
 name: Release please
 
 on:


### PR DESCRIPTION
The permission work merged with a `BREAKING CHANGE` footer, which made release-please propose
5.0.0. It is the wrong reading: a menu entry that could only answer 403 was broken, and gating it
on the policy behind it repairs that rather than changing a contract anyone could rely on.

`Release-As: 4.1.0` in this commit's footer overrides the computed version. It is the only
correction available once the commit that caused the bump sits on a protected branch.

Also documents the escape hatch in the workflow header, next to the bump rules it overrides.