### PR TITLE
fix(requests): block the form when no reachable library accepts the type

### DIFF
--- a/client/public/i18n/de.json
+++ b/client/public/i18n/de.json
@@ -708,6 +708,7 @@
     "hint": "Geben Sie einen Titel ein, um die TMDB-Suche zu starten.",
     "no_results": "Keine Ergebnisse",
     "add_to_library": "Hinzufügen",
+    "no_compatible_library": "Keine für dich zugängliche Bibliothek nimmt diesen Medientyp auf. Bitte einen Administrator um Zugriff.",
     "search_error": "Die Suche ist fehlgeschlagen. Überprüfen Sie den TMDB-Schlüssel auf der Serverseite.",
     "already_in_library": "Dieser Titel ist bereits in der Bibliothek.",
     "tmdb_not_configured": "TMDB ist auf dem Server nicht konfiguriert.",

--- a/client/public/i18n/en.json
+++ b/client/public/i18n/en.json
@@ -713,6 +713,7 @@
     "hint": "Enter a title to start the TMDB search.",
     "no_results": "No results",
     "add_to_library": "Add",
+    "no_compatible_library": "No library you can reach accepts this type of media. Ask an administrator to give you access to one.",
     "search_error": "The search failed. Check the TMDB key on the server side.",
     "already_in_library": "This title is already in the library.",
     "tmdb_not_configured": "TMDB is not configured on the server.",

--- a/client/public/i18n/es.json
+++ b/client/public/i18n/es.json
@@ -708,6 +708,7 @@
     "hint": "Introduzca un título para iniciar la búsqueda en TMDB.",
     "no_results": "Sin resultados",
     "add_to_library": "Añadir",
+    "no_compatible_library": "Ninguna biblioteca a la que tengas acceso admite este tipo de contenido. Pide acceso a un administrador.",
     "search_error": "La búsqueda ha fallado. Compruebe la clave TMDB en el servidor.",
     "already_in_library": "Este título ya está en la biblioteca.",
     "tmdb_not_configured": "TMDB no está configurado en el servidor.",

--- a/client/public/i18n/fr.json
+++ b/client/public/i18n/fr.json
@@ -713,6 +713,7 @@
     "hint": "Saisissez un titre pour lancer la recherche TMDB.",
     "no_results": "Aucun résultat",
     "add_to_library": "Ajouter",
+    "no_compatible_library": "Aucune bibliothèque accessible n'accepte ce type de média. Demandez à un administrateur de vous en donner l'accès.",
     "search_error": "La recherche a échoué. Vérifiez la clé TMDB côté serveur.",
     "already_in_library": "Ce titre est déjà dans la bibliothèque.",
     "tmdb_not_configured": "TMDB n'est pas configuré sur le serveur.",

--- a/client/public/i18n/it.json
+++ b/client/public/i18n/it.json
@@ -708,6 +708,7 @@
     "hint": "Inserisci un titolo per avviare la ricerca TMDB.",
     "no_results": "Nessun risultato",
     "add_to_library": "Aggiungi",
+    "no_compatible_library": "Nessuna libreria a cui hai accesso accetta questo tipo di media. Chiedi a un amministratore di darti accesso.",
     "search_error": "La ricerca è fallita. Verifica la chiave TMDB lato server.",
     "already_in_library": "Questo titolo è già nella libreria.",
     "tmdb_not_configured": "TMDB non è configurato sul server.",

--- a/client/public/i18n/pt.json
+++ b/client/public/i18n/pt.json
@@ -708,6 +708,7 @@
     "hint": "Introduza um título para iniciar a pesquisa TMDB.",
     "no_results": "Nenhum resultado",
     "add_to_library": "Adicionar",
+    "no_compatible_library": "Nenhuma biblioteca a que tenhas acesso aceita este tipo de media. Pede acesso a um administrador.",
     "search_error": "A pesquisa falhou. Verifique a chave TMDB no servidor.",
     "already_in_library": "Este título já está na biblioteca.",
     "tmdb_not_configured": "O TMDB não está configurado no servidor.",

--- a/client/src/app/features/media-detail/media-detail.html
+++ b/client/src/app/features/media-detail/media-detail.html
@@ -658,6 +658,7 @@
     [qualityProfiles]="qualityProfileOptions()"
     [languageProfiles]="languageProfileOptions()"
     [libraries]="libraries()"
+    [librariesLoading]="profilesOptionsLoading()"
     (requested)="onRequestSubmitted()"
   />
 }

--- a/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.html
+++ b/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.html
@@ -11,6 +11,12 @@
       <div role="alert" class="alert alert-error text-sm mt-4 py-2">{{ error() }}</div>
     }
 
+    @if (noCompatibleLibrary()) {
+      <div role="alert" class="alert alert-warning text-sm mt-4 py-2">
+        {{ 'discover.no_compatible_library' | translate }}
+      </div>
+    }
+
     @if (mediaType() === 'series') {
       @if (seasonsFailed()) {
         <div role="alert" class="alert alert-warning text-sm mt-4 py-2">
@@ -96,7 +102,9 @@
       <button
         type="button"
         class="btn btn-primary"
-        [disabled]="importing() || loading() || seasonsLoading() || nothingToMonitor()"
+        [disabled]="
+          importing() || loading() || seasonsLoading() || nothingToMonitor() || noCompatibleLibrary()
+        "
         (click)="confirm()"
       >
         @if (importing()) {

--- a/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.ts
+++ b/client/src/app/features/tmdb-preview/components/import-modal/import-modal.component.ts
@@ -75,6 +75,13 @@ export class ImportModalComponent {
     this.libraries().filter((l) => l.mediaTypes.includes(this.mediaType())),
   );
 
+  /** Nothing to submit to: the destination is resolved from this very list,
+   *  so an empty one can only end in a server-side refusal. Silent while the
+   *  list is still in flight, where empty means unknown. */
+  readonly noCompatibleLibrary = computed(
+    () => !this.loading() && this.compatibleLibraries().length === 0,
+  );
+
   /** A series with no season monitored would import and then sit idle, so the
    *  confirm button waits for a pick, same rule as the request modal. */
   protected readonly nothingToMonitor = computed(

--- a/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.html
+++ b/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.html
@@ -13,6 +13,12 @@
       </div>
     </app-modal-header>
 
+    @if (noCompatibleLibrary()) {
+      <div role="alert" class="alert alert-warning text-sm mt-4 py-2">
+        {{ 'discover.no_compatible_library' | translate }}
+      </div>
+    }
+
     @if (mediaType() === 'series') {
       @if (seasonsFailed()) {
         <div role="alert" class="alert alert-warning text-sm mt-4 py-2">
@@ -98,7 +104,7 @@
       <button
         type="button"
         class="btn btn-primary"
-        [disabled]="requesting() || nothingPicked()"
+        [disabled]="requesting() || nothingPicked() || noCompatibleLibrary()"
         (click)="confirm()"
       >
         @if (requesting()) {

--- a/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.ts
+++ b/client/src/app/features/tmdb-preview/components/request-modal/request-modal.component.ts
@@ -41,6 +41,8 @@ export class RequestModalComponent {
   readonly qualityProfiles = input<{ id: number; name: string }[]>([]);
   readonly languageProfiles = input<{ id: number; name: string }[]>([]);
   readonly libraries = input<LibrarySummary[]>([]);
+  /** An empty `libraries` means "none" only once the parent has loaded them. */
+  readonly librariesLoading = input(false);
   readonly requested = output<void>();
 
   readonly compatibleLibraries = computed(() =>
@@ -69,6 +71,12 @@ export class RequestModalComponent {
   /** A series already has an active request: its profiles are fixed and the
    *  selectors are locked to them (all seasons share one profile set). */
   readonly profilesLocked = signal(false);
+
+  /** Nothing to submit to: the destination is resolved from this very list,
+   *  so an empty one can only end in a server-side refusal. */
+  readonly noCompatibleLibrary = computed(
+    () => !this.librariesLoading() && this.compatibleLibraries().length === 0,
+  );
 
   /** Series only: a pick is required, unless the season list never loaded. */
   readonly nothingPicked = computed(


### PR DESCRIPTION
## Why

Follow-up to #1362. The destination of a request is now resolved from the libraries the
requester can reach, and refused when none of them accepts the media type. The form did not
say so: a user with access to no library accepting series could pick seasons, submit, and
get a generic error toast from the interceptor with nothing actionable in it.

## What

`noCompatibleLibrary` disables the submit button in both the request and the import modal,
and a warning explains that no reachable library accepts this type of media and that an
administrator has to grant access.

The check stays silent while the list is still in flight, where an empty list means unknown
rather than none. The import modal already tracks its own load; the request modal is fed by
its parent, so it takes a `librariesLoading` input. `media-detail` binds it to the profiles
load it already exposes, and `tmdb-preview` awaits its libraries before the page can render
a request button, so it needs nothing.

## Checks

`ng build` clean, 890 tests green. The one failure in `horizontal-scroller.spec.ts` predates
this branch and is untouched by it.
