### PR TITLE
feat(streaming): retire the env overrides for the tuning settings

### DIFF
--- a/backend/src/common/stream-public-base-url.util.ts
+++ b/backend/src/common/stream-public-base-url.util.ts
@@ -2,7 +2,9 @@ import { Request } from 'express';
 
 /**
  * Base publique pour les URLs de stream atteignables par Chromecast.
- * Priority: DB setting `public_url` > EXTERNAL_URL env > Host header > localhost.
+ * Priority: DB setting `public_url` > Host header > localhost. Behind a reverse
+ * proxy the Host header is often the container's own address, so casting needs
+ * the setting.
  */
 export function resolveStreamPublicBaseUrl(
   req: Request,
@@ -10,9 +12,6 @@ export function resolveStreamPublicBaseUrl(
 ): string {
   if (publicUrl) {
     return publicUrl.replace(/\/+$/, '');
-  }
-  if (process.env.EXTERNAL_URL) {
-    return process.env.EXTERNAL_URL.replace(/\/+$/, '');
   }
   const host = req.headers.host;
   if (host) {

--- a/backend/src/common/utils/ffmpeg-slots.spec.ts
+++ b/backend/src/common/utils/ffmpeg-slots.spec.ts
@@ -8,16 +8,12 @@ describe('withFfmpegSlot', () => {
 
   function loadWith(
     opts: {
-      slots?: string;
       hostCores?: number;
       files?: Record<string, string>;
     } = {},
   ): typeof import('./ffmpeg-slots') {
     jest.resetModules();
-    const env = { ...OLD_ENV };
-    if (opts.slots != null) env.FLIKS_FFMPEG_SLOTS = opts.slots;
-    else delete env.FLIKS_FFMPEG_SLOTS;
-    process.env = env;
+    process.env = { ...OLD_ENV };
 
     jest.doMock('os', () => ({
       cpus: () => Array.from({ length: opts.hostCores ?? 4 }, () => ({})),
@@ -36,7 +32,8 @@ describe('withFfmpegSlot', () => {
   }
 
   it('never runs more than the configured slot count concurrently', async () => {
-    const { withFfmpegSlot } = loadWith({ slots: '2' });
+    const { withFfmpegSlot, setFfmpegSlots } = loadWith();
+    setFfmpegSlots(2);
     let concurrent = 0;
     let maxConcurrent = 0;
 
@@ -53,7 +50,8 @@ describe('withFfmpegSlot', () => {
   });
 
   it('releases the slot when fn rejects', async () => {
-    const { withFfmpegSlot } = loadWith({ slots: '1' });
+    const { withFfmpegSlot, setFfmpegSlots } = loadWith();
+    setFfmpegSlots(1);
 
     await expect(
       withFfmpegSlot(async () => {
@@ -66,26 +64,26 @@ describe('withFfmpegSlot', () => {
     expect(result).toBe('ok');
   });
 
-  it('ignores a non-positive-integer override', () => {
-    expect(loadWith({ slots: '0' }).ffmpegSlots()).toBeGreaterThan(0);
-    expect(loadWith({ slots: '-3' }).ffmpegSlots()).toBeGreaterThan(0);
-    expect(loadWith({ slots: 'nope' }).ffmpegSlots()).toBeGreaterThan(0);
-  });
-
-  it('honours a positive integer override', () => {
-    expect(loadWith({ slots: '5' }).ffmpegSlots()).toBe(5);
-  });
-
-  it('lets the admin budget override the env one, and null restore it', () => {
-    const mod = loadWith({ slots: '5' });
+  it('takes the admin budget, and restores the derived one when cleared', () => {
+    const mod = loadWith({ hostCores: 8 });
+    expect(mod.ffmpegSlots()).toBe(7);
     mod.setFfmpegSlots(2);
     expect(mod.ffmpegSlots()).toBe(2);
     mod.setFfmpegSlots(null);
-    expect(mod.ffmpegSlots()).toBe(5);
+    expect(mod.ffmpegSlots()).toBe(7);
+  });
+
+  it('ignores a non-positive admin budget', () => {
+    const mod = loadWith({ hostCores: 8 });
+    mod.setFfmpegSlots(0);
+    expect(mod.ffmpegSlots()).toBe(7);
+    mod.setFfmpegSlots(-3);
+    expect(mod.ffmpegSlots()).toBe(7);
   });
 
   it('drains down to a shrunk budget instead of stalling the queue', async () => {
-    const { withFfmpegSlot, setFfmpegSlots } = loadWith({ slots: '4' });
+    const { withFfmpegSlot, setFfmpegSlots } = loadWith();
+    setFfmpegSlots(4);
     let concurrent = 0;
     const seenAfterShrink: number[] = [];
     let shrunk = false;
@@ -110,7 +108,8 @@ describe('withFfmpegSlot', () => {
   });
 
   it('wakes the queue when the budget grows', async () => {
-    const { withFfmpegSlot, setFfmpegSlots } = loadWith({ slots: '1' });
+    const { withFfmpegSlot, setFfmpegSlots } = loadWith();
+    setFfmpegSlots(1);
     let concurrent = 0;
     let maxConcurrent = 0;
 
@@ -179,12 +178,12 @@ describe('withFfmpegSlot', () => {
       expect(ffmpegSlots()).toBe(3);
     });
 
-    it('an explicit override still wins over a tighter cgroup quota', () => {
-      const { ffmpegSlots } = loadWith({
-        slots: '6',
+    it('the admin budget still wins over a tighter cgroup quota', () => {
+      const { ffmpegSlots, setFfmpegSlots } = loadWith({
         hostCores: 8,
         files: { '/sys/fs/cgroup/cpu.max': '100000 100000' }, // 1 core
       });
+      setFfmpegSlots(6);
       expect(ffmpegSlots()).toBe(6);
     });
   });

--- a/backend/src/common/utils/ffmpeg-slots.ts
+++ b/backend/src/common/utils/ffmpeg-slots.ts
@@ -44,10 +44,9 @@ function cgroupV1Cores(): number | null {
  *  weak host can't end up running one decoder per subsystem at once.
  *  `os.cpus()` reports the host's core count even inside a container, so a
  *  compose `cpus:` quota is read from the cgroup directly and takes priority
- *  when it is the tighter constraint. */
+ *  when it is the tighter constraint. Overridden by the admin setting via
+ *  {@link setFfmpegSlots}. */
 function resolveSlots(): number {
-  const override = Number(process.env.FLIKS_FFMPEG_SLOTS);
-  if (Number.isInteger(override) && override > 0) return override;
   const hostCores = cpus().length;
   const quotaCores = cgroupV2Cores() ?? cgroupV1Cores();
   const cores = quotaCores != null ? Math.min(hostCores, quotaCores) : hostCores;
@@ -74,7 +73,7 @@ let active = 0;
 const waiters: (() => void)[] = [];
 
 /** Admin override (`streaming_ffmpeg_slots`); null or <1 restores the
- *  env/cgroup-derived budget. Shrinking below `active` lets the running jobs
+ *  cgroup/CPU-derived budget. Shrinking below `active` lets the running jobs
  *  drain down to the new cap instead of killing them. */
 export function setFfmpegSlots(n: number | null): void {
   slots = n != null && n > 0 ? Math.floor(n) : autoFfmpegSlots();

--- a/backend/src/modules/streaming/lifetime-constants.ts
+++ b/backend/src/modules/streaming/lifetime-constants.ts
@@ -11,9 +11,9 @@
  *   STREAM_MAX_SESSIONS_PER_USER       live-session.service.ts
  *   STREAM_JOB_GRACE_MS                transcoding/constants.ts
  *   STREAM_JOB_FALLBACK_TIMEOUT_MS     transcoding/constants.ts
- *   TRANSCODE_CACHE_TTL_MS             transcode-cache.service.ts
- *   TRANSCODE_CACHE_MAX_BYTES          transcode-cache.service.ts
  *   TRANSCODE_CACHE_GC_INTERVAL_MS     transcode-cache.service.ts
+ *
+ * Cache retention and size live in Settings > Streaming, not here.
  */
 
 const DEFAULT_LIVE_SESSION_TTL_MS = 30_000;
@@ -58,10 +58,8 @@ export const StreamLifetime = {
       'STREAM_JOB_FALLBACK_TIMEOUT_MS',
       DEFAULT_JOB_FALLBACK_TIMEOUT_MS,
     ),
-  cacheTtlMs: (): number =>
-    readEnvPositiveInt('TRANSCODE_CACHE_TTL_MS', DEFAULT_CACHE_TTL_MS),
-  cacheMaxBytes: (): number =>
-    readEnvPositiveInt('TRANSCODE_CACHE_MAX_BYTES', DEFAULT_CACHE_MAX_BYTES),
+  cacheTtlMs: (): number => DEFAULT_CACHE_TTL_MS,
+  cacheMaxBytes: (): number => DEFAULT_CACHE_MAX_BYTES,
   cacheGcIntervalMs: (): number =>
     readEnvPositiveInt(
       'TRANSCODE_CACHE_GC_INTERVAL_MS',

--- a/backend/src/modules/streaming/streaming-settings-cache.service.spec.ts
+++ b/backend/src/modules/streaming/streaming-settings-cache.service.spec.ts
@@ -47,6 +47,36 @@ describe('StreamingSettingsCache tuning resolution', () => {
     expect(s.ffmpegSlots).toBe(3);
   });
 
+  it('folds the env tonemap algo and render node into the resolved value', async () => {
+    process.env.TRANSCODE_TONEMAP_ALGO = '  QSV  ';
+    process.env.FLIKS_VAAPI_RENDER_NODE = '/dev/dri/renderD129';
+
+    const s = await build().get();
+    expect(s.tonemapAlgo).toBe('qsv');
+    expect(s.gpuRenderNode).toBe('/dev/dri/renderD129');
+  });
+
+  it('lets an explicit algo and node win over the env ones', async () => {
+    process.env.TRANSCODE_TONEMAP_ALGO = 'qsv';
+    process.env.FLIKS_VAAPI_RENDER_NODE = '/dev/dri/renderD129';
+
+    const s = await build({
+      streaming_tonemap_algo: 'opencl',
+      streaming_gpu_render_node: '/dev/dri/renderD128',
+    }).get();
+    expect(s.tonemapAlgo).toBe('opencl');
+    expect(s.gpuRenderNode).toBe('/dev/dri/renderD128');
+  });
+
+  it('stays on auto when neither the setting nor the env names a value', async () => {
+    delete process.env.TRANSCODE_TONEMAP_ALGO;
+    delete process.env.FLIKS_VAAPI_RENDER_NODE;
+
+    const s = await build().get();
+    expect(s.tonemapAlgo).toBe('auto');
+    expect(s.gpuRenderNode).toBe('auto');
+  });
+
   it('ignores a malformed or non-positive saved value', async () => {
     process.env.TRANSCODE_CACHE_MAX_BYTES = String(50 * 1024 ** 3);
     delete process.env.TRANSCODE_TONEMAP_CURVE;

--- a/backend/src/modules/streaming/streaming-settings-cache.service.spec.ts
+++ b/backend/src/modules/streaming/streaming-settings-cache.service.spec.ts
@@ -1,9 +1,8 @@
 import { StreamingSettingsCache } from './streaming-settings-cache.service';
 import type { SettingsService } from '../settings/settings.service';
 
-/** The tuning settings resolve DB > env > derived default. A saved value must
- *  win over a leftover compose entry, and an absent one must never collapse the
- *  env budget to a hardcoded default. */
+/** The tuning settings come from the database or from a built-in default, never
+ *  from the environment: the compose overrides they replaced are retired. */
 describe('StreamingSettingsCache tuning resolution', () => {
   const OLD_ENV = { ...process.env };
 
@@ -19,75 +18,60 @@ describe('StreamingSettingsCache tuning resolution', () => {
     return new StreamingSettingsCache(settings);
   }
 
-  it('falls back to the env budget when nothing is saved', async () => {
-    process.env.TRANSCODE_CACHE_MAX_BYTES = String(50 * 1024 ** 3);
-    process.env.TRANSCODE_CACHE_TTL_MS = String(2 * 3_600_000);
-    process.env.TRANSCODE_TONEMAP_CURVE = 'mobius';
-
+  it('falls back to the built-in defaults when nothing is saved', async () => {
     const s = await build().get();
-    expect(s.cacheMaxBytes).toBe(50 * 1024 ** 3);
-    expect(s.cacheTtlMs).toBe(2 * 3_600_000);
-    expect(s.tonemapCurve).toBe('mobius');
+    expect(s.cacheMaxBytes).toBe(20 * 1024 ** 3);
+    expect(s.cacheTtlMs).toBe(4 * 3_600_000);
+    expect(s.tonemapCurve).toBe('hable');
+    expect(s.tonemapAlgo).toBe('auto');
+    expect(s.gpuRenderNode).toBe('auto');
     expect(s.ffmpegSlots).toBeNull();
   });
 
-  it('lets a saved value win over the env one', async () => {
-    process.env.TRANSCODE_CACHE_MAX_BYTES = String(50 * 1024 ** 3);
-    process.env.TRANSCODE_TONEMAP_CURVE = 'mobius';
-
+  it('takes every saved value', async () => {
     const s = await build({
       streaming_cache_max_gb: '10',
       streaming_cache_ttl_hours: '6',
       streaming_tonemap_curve: 'reinhard',
+      streaming_tonemap_algo: 'opencl',
+      streaming_gpu_render_node: '/dev/dri/renderD129',
       streaming_ffmpeg_slots: '3',
     }).get();
     expect(s.cacheMaxBytes).toBe(10 * 1024 ** 3);
     expect(s.cacheTtlMs).toBe(6 * 3_600_000);
     expect(s.tonemapCurve).toBe('reinhard');
+    expect(s.tonemapAlgo).toBe('opencl');
+    expect(s.gpuRenderNode).toBe('/dev/dri/renderD129');
     expect(s.ffmpegSlots).toBe(3);
   });
 
-  it('folds the env tonemap algo and render node into the resolved value', async () => {
-    process.env.TRANSCODE_TONEMAP_ALGO = '  QSV  ';
-    process.env.FLIKS_VAAPI_RENDER_NODE = '/dev/dri/renderD129';
-
-    const s = await build().get();
-    expect(s.tonemapAlgo).toBe('qsv');
-    expect(s.gpuRenderNode).toBe('/dev/dri/renderD129');
-  });
-
-  it('lets an explicit algo and node win over the env ones', async () => {
-    process.env.TRANSCODE_TONEMAP_ALGO = 'qsv';
-    process.env.FLIKS_VAAPI_RENDER_NODE = '/dev/dri/renderD129';
-
-    const s = await build({
-      streaming_tonemap_algo: 'opencl',
-      streaming_gpu_render_node: '/dev/dri/renderD128',
-    }).get();
-    expect(s.tonemapAlgo).toBe('opencl');
-    expect(s.gpuRenderNode).toBe('/dev/dri/renderD128');
-  });
-
-  it('stays on auto when neither the setting nor the env names a value', async () => {
-    delete process.env.TRANSCODE_TONEMAP_ALGO;
-    delete process.env.FLIKS_VAAPI_RENDER_NODE;
-
-    const s = await build().get();
-    expect(s.tonemapAlgo).toBe('auto');
-    expect(s.gpuRenderNode).toBe('auto');
-  });
-
   it('ignores a malformed or non-positive saved value', async () => {
-    process.env.TRANSCODE_CACHE_MAX_BYTES = String(50 * 1024 ** 3);
-    delete process.env.TRANSCODE_TONEMAP_CURVE;
-
     const s = await build({
       streaming_cache_max_gb: '0',
       streaming_ffmpeg_slots: '-2',
       streaming_tonemap_curve: 'nonsense',
+      streaming_tonemap_algo: 'nonsense',
     }).get();
-    expect(s.cacheMaxBytes).toBe(50 * 1024 ** 3);
+    expect(s.cacheMaxBytes).toBe(20 * 1024 ** 3);
     expect(s.ffmpegSlots).toBeNull();
     expect(s.tonemapCurve).toBe('hable');
+    expect(s.tonemapAlgo).toBe('auto');
+  });
+
+  it('never lets a retired env var reach the resolved settings', async () => {
+    process.env.TRANSCODE_TONEMAP_ALGO = 'qsv';
+    process.env.TRANSCODE_TONEMAP_CURVE = 'mobius';
+    process.env.FLIKS_VAAPI_RENDER_NODE = '/dev/dri/renderD129';
+    process.env.TRANSCODE_CACHE_MAX_BYTES = String(50 * 1024 ** 3);
+    process.env.TRANSCODE_CACHE_TTL_MS = String(2 * 3_600_000);
+    process.env.FLIKS_FFMPEG_SLOTS = '7';
+
+    const s = await build().get();
+    expect(s.tonemapAlgo).toBe('auto');
+    expect(s.tonemapCurve).toBe('hable');
+    expect(s.gpuRenderNode).toBe('auto');
+    expect(s.cacheMaxBytes).toBe(20 * 1024 ** 3);
+    expect(s.cacheTtlMs).toBe(4 * 3_600_000);
+    expect(s.ffmpegSlots).toBeNull();
   });
 });

--- a/backend/src/modules/streaming/streaming-settings-cache.service.ts
+++ b/backend/src/modules/streaming/streaming-settings-cache.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, OnModuleInit } from '@nestjs/common';
 import { SettingsService } from '../settings/settings.service';
 import { StreamLifetime } from './lifetime-constants';
 import type { TonemapCurve } from './transcoding/codec/types';
@@ -87,17 +87,6 @@ const TONEMAP_CURVES: TonemapCurve[] = ['hable', 'mobius', 'reinhard'];
 const GB = 1024 ** 3;
 const HOUR_MS = 60 * 60 * 1000;
 
-/** Retired in favour of the matching `streaming_*` settings. Only reported, so
- *  an operator upgrading from a compose-configured install learns they moved. */
-const RETIRED_ENV_VARS = [
-  'TRANSCODE_TONEMAP_ALGO',
-  'TRANSCODE_TONEMAP_CURVE',
-  'TRANSCODE_CACHE_MAX_BYTES',
-  'TRANSCODE_CACHE_TTL_MS',
-  'FLIKS_FFMPEG_SLOTS',
-  'FLIKS_VAAPI_RENDER_NODE',
-];
-
 const AUTO_QUALITY_MODES: AutoQualityMode[] = ['directplay', 'abr'];
 const SUBTITLE_PREWARMS: SubtitlePrewarm[] = ['off', 'playback', 'import'];
 
@@ -111,9 +100,6 @@ function positive(raw: string | null): number | null {
 @Injectable()
 export class StreamingSettingsCache implements OnModuleInit {
   constructor(private readonly settings: SettingsService) {}
-
-  private readonly log = new Logger(StreamingSettingsCache.name);
-  private warnedEnvShadow = false;
 
   private cache: StreamingSettings | null = null;
   private inflight: Promise<StreamingSettings> | null = null;
@@ -129,18 +115,6 @@ export class StreamingSettingsCache implements OnModuleInit {
         this.epoch++;
       }
     });
-  }
-
-  /** Says once per boot which retired env vars are still set. A compose entry
-   *  that quietly stopped doing anything is worse than one that shouts. */
-  private warnRetiredEnv(): void {
-    if (this.warnedEnvShadow) return;
-    this.warnedEnvShadow = true;
-    const stale = RETIRED_ENV_VARS.filter((v) => process.env[v]);
-    if (stale.length === 0) return;
-    this.log.warn(
-      `${stale.join(', ')} no longer read: these live in Settings > Streaming. Remove them from your compose file.`,
-    );
   }
 
   async get(): Promise<StreamingSettings> {
@@ -188,8 +162,6 @@ export class StreamingSettingsCache implements OnModuleInit {
     const slots = positive(ffmpegSlots);
     // 'auto' (or unset) lets the host pick the default render node.
     const renderNode = gpuRenderNode?.trim() || 'auto';
-
-    this.warnRetiredEnv();
 
     return {
       segmentDuration: parseFloat(duration ?? '3') || 3,

--- a/backend/src/modules/streaming/streaming-settings-cache.service.ts
+++ b/backend/src/modules/streaming/streaming-settings-cache.service.ts
@@ -2,6 +2,8 @@ import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { SettingsService } from '../settings/settings.service';
 import { StreamLifetime } from './lifetime-constants';
 import { envTonemapCurve } from './transcoding/ffmpeg-filter-graph';
+import { envRenderNode } from './transcoding/hw-device';
+import { tonemapAlgoOverride } from './transcoding/tonemap-path';
 import type { TonemapCurve } from './transcoding/codec/types';
 import type { TonemapAlgo } from './transcoding/types';
 
@@ -17,8 +19,9 @@ export interface StreamingSettings {
     | 'slow'
     | 'slower'
     | 'veryslow';
-  /** HDR → SDR tone-mapping algorithm. See {@link TonemapAlgo}. Default
-   *  is `'auto'` which currently routes through tonemap_opencl. */
+  /** HDR → SDR tone-mapping algorithm. See {@link TonemapAlgo}. Falls back to
+   *  `TRANSCODE_TONEMAP_ALGO`, then `'auto'`, which resolves per host from the
+   *  boot probes. */
   tonemapAlgo: TonemapAlgo;
   /** HDR → SDR tone-map curve for the OpenCL/CPU paths (the vpp_qsv and
    *  tonemap_vaapi LUTs ignore it). Falls back to `TRANSCODE_TONEMAP_CURVE`,
@@ -49,9 +52,9 @@ export interface StreamingSettings {
    * Direct Play / remux with the black bars intact instead of transcoding.
    */
   autoCropEnabled: boolean;
-  /** Admin-selected GPU render node for hardware transcoding, or `'auto'`
-   *  (default) to let the host pick. On a multi-GPU box, pinning a specific
-   *  `/dev/dri/renderD*` keeps sessions off the wrong adapter. */
+  /** GPU render node for hardware transcoding, or `'auto'` to let the host
+   *  pick. On a multi-GPU box, pinning a specific `/dev/dri/renderD*` keeps
+   *  sessions off the wrong adapter. Falls back to `FLIKS_VAAPI_RENDER_NODE`. */
   gpuRenderNode: string;
   /**
    * When embedded subtitles get extracted to WebVTT. Pulling a subtitle out of
@@ -194,7 +197,9 @@ export class StreamingSettingsCache implements OnModuleInit {
     return {
       segmentDuration: parseFloat(duration ?? '3') || 3,
       qsvPreset: (qsvPreset ?? 'faster') as StreamingSettings['qsvPreset'],
-      tonemapAlgo: algo,
+      // Every value below is fully resolved: downstream reads one number or one
+      // string and never consults the environment again.
+      tonemapAlgo: algo === 'auto' ? (tonemapAlgoOverride() ?? 'auto') : algo,
       tonemapCurve: curve ?? envTonemapCurve() ?? 'hable',
       cacheMaxBytes:
         maxGb != null ? Math.round(maxGb * GB) : StreamLifetime.cacheMaxBytes(),
@@ -211,7 +216,7 @@ export class StreamingSettingsCache implements OnModuleInit {
       // Default on (preserve current behaviour); only the explicit string
       // 'false' disables cropping.
       autoCropEnabled: autoCropEnabled !== 'false',
-      gpuRenderNode: renderNode,
+      gpuRenderNode: renderNode === 'auto' ? (envRenderNode() ?? 'auto') : renderNode,
       subtitlePrewarm: SUBTITLE_PREWARMS.includes(
         subtitlePrewarm as SubtitlePrewarm,
       )

--- a/backend/src/modules/streaming/streaming-settings-cache.service.ts
+++ b/backend/src/modules/streaming/streaming-settings-cache.service.ts
@@ -1,9 +1,6 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { SettingsService } from '../settings/settings.service';
 import { StreamLifetime } from './lifetime-constants';
-import { envTonemapCurve } from './transcoding/ffmpeg-filter-graph';
-import { envRenderNode } from './transcoding/hw-device';
-import { tonemapAlgoOverride } from './transcoding/tonemap-path';
 import type { TonemapCurve } from './transcoding/codec/types';
 import type { TonemapAlgo } from './transcoding/types';
 
@@ -19,19 +16,17 @@ export interface StreamingSettings {
     | 'slow'
     | 'slower'
     | 'veryslow';
-  /** HDR → SDR tone-mapping algorithm. See {@link TonemapAlgo}. Falls back to
-   *  `TRANSCODE_TONEMAP_ALGO`, then `'auto'`, which resolves per host from the
-   *  boot probes. */
+  /** HDR → SDR tone-mapping algorithm. See {@link TonemapAlgo}. `'auto'`
+   *  resolves per host from the boot probes. */
   tonemapAlgo: TonemapAlgo;
-  /** HDR → SDR tone-map curve for the OpenCL/CPU paths (the vpp_qsv and
-   *  tonemap_vaapi LUTs ignore it). Falls back to `TRANSCODE_TONEMAP_CURVE`,
-   *  then `hable`. */
+  /** HDR → SDR tone-map curve. Applied by the OpenCL, CPU and VideoToolbox
+   *  chains; the vpp_qsv and tonemap_vaapi fixed-function paths ignore it. */
   tonemapCurve: TonemapCurve;
   /** Transcode-cache disk budget in bytes, and how long an untouched entry
-   *  survives. Both fall back to the `TRANSCODE_CACHE_*` env defaults. */
+   *  survives. */
   cacheMaxBytes: number;
   cacheTtlMs: number;
-  /** Concurrent background ffmpeg jobs, or null to keep the cgroup/CPU-derived
+  /** Concurrent background ffmpeg jobs, or null for the cgroup/CPU-derived
    *  budget. Caps scans, thumbnails and marker detection, not playback. */
   ffmpegSlots: number | null;
   /**
@@ -54,7 +49,7 @@ export interface StreamingSettings {
   autoCropEnabled: boolean;
   /** GPU render node for hardware transcoding, or `'auto'` to let the host
    *  pick. On a multi-GPU box, pinning a specific `/dev/dri/renderD*` keeps
-   *  sessions off the wrong adapter. Falls back to `FLIKS_VAAPI_RENDER_NODE`. */
+   *  sessions off the wrong adapter. */
   gpuRenderNode: string;
   /**
    * When embedded subtitles get extracted to WebVTT. Pulling a subtitle out of
@@ -92,6 +87,17 @@ const TONEMAP_CURVES: TonemapCurve[] = ['hable', 'mobius', 'reinhard'];
 const GB = 1024 ** 3;
 const HOUR_MS = 60 * 60 * 1000;
 
+/** Retired in favour of the matching `streaming_*` settings. Only reported, so
+ *  an operator upgrading from a compose-configured install learns they moved. */
+const RETIRED_ENV_VARS = [
+  'TRANSCODE_TONEMAP_ALGO',
+  'TRANSCODE_TONEMAP_CURVE',
+  'TRANSCODE_CACHE_MAX_BYTES',
+  'TRANSCODE_CACHE_TTL_MS',
+  'FLIKS_FFMPEG_SLOTS',
+  'FLIKS_VAAPI_RENDER_NODE',
+];
+
 const AUTO_QUALITY_MODES: AutoQualityMode[] = ['directplay', 'abr'];
 const SUBTITLE_PREWARMS: SubtitlePrewarm[] = ['off', 'playback', 'import'];
 
@@ -125,18 +131,16 @@ export class StreamingSettingsCache implements OnModuleInit {
     });
   }
 
-  /** Says once per boot which env vars a saved setting now outranks. A
-   *  leftover compose entry that silently loses is worse than one that shouts.
-   *  Values are the resolved ones, so an ignored setting isn't reported. */
-  private warnEnvShadowed(shadowed: Record<string, string | number | null>): void {
+  /** Says once per boot which retired env vars are still set. A compose entry
+   *  that quietly stopped doing anything is worse than one that shouts. */
+  private warnRetiredEnv(): void {
     if (this.warnedEnvShadow) return;
     this.warnedEnvShadow = true;
-    for (const [env, value] of Object.entries(shadowed)) {
-      if (value == null || !process.env[env]) continue;
-      this.log.warn(
-        `${env} is set but ignored: the admin setting (${value}) wins. Remove it from your compose file.`,
-      );
-    }
+    const stale = RETIRED_ENV_VARS.filter((v) => process.env[v]);
+    if (stale.length === 0) return;
+    this.log.warn(
+      `${stale.join(', ')} no longer read: these live in Settings > Streaming. Remove them from your compose file.`,
+    );
   }
 
   async get(): Promise<StreamingSettings> {
@@ -185,22 +189,13 @@ export class StreamingSettingsCache implements OnModuleInit {
     // 'auto' (or unset) lets the host pick the default render node.
     const renderNode = gpuRenderNode?.trim() || 'auto';
 
-    this.warnEnvShadowed({
-      TRANSCODE_TONEMAP_ALGO: algo === 'auto' ? null : algo,
-      TRANSCODE_TONEMAP_CURVE: curve,
-      TRANSCODE_CACHE_MAX_BYTES: maxGb != null ? `${maxGb} GB` : null,
-      TRANSCODE_CACHE_TTL_MS: ttlHours != null ? `${ttlHours} h` : null,
-      FLIKS_FFMPEG_SLOTS: slots,
-      FLIKS_VAAPI_RENDER_NODE: renderNode === 'auto' ? null : renderNode,
-    });
+    this.warnRetiredEnv();
 
     return {
       segmentDuration: parseFloat(duration ?? '3') || 3,
       qsvPreset: (qsvPreset ?? 'faster') as StreamingSettings['qsvPreset'],
-      // Every value below is fully resolved: downstream reads one number or one
-      // string and never consults the environment again.
-      tonemapAlgo: algo === 'auto' ? (tonemapAlgoOverride() ?? 'auto') : algo,
-      tonemapCurve: curve ?? envTonemapCurve() ?? 'hable',
+      tonemapAlgo: algo,
+      tonemapCurve: curve ?? 'hable',
       cacheMaxBytes:
         maxGb != null ? Math.round(maxGb * GB) : StreamLifetime.cacheMaxBytes(),
       cacheTtlMs:
@@ -216,7 +211,7 @@ export class StreamingSettingsCache implements OnModuleInit {
       // Default on (preserve current behaviour); only the explicit string
       // 'false' disables cropping.
       autoCropEnabled: autoCropEnabled !== 'false',
-      gpuRenderNode: renderNode === 'auto' ? (envRenderNode() ?? 'auto') : renderNode,
+      gpuRenderNode: renderNode,
       subtitlePrewarm: SUBTITLE_PREWARMS.includes(
         subtitlePrewarm as SubtitlePrewarm,
       )

--- a/backend/src/modules/streaming/streaming.controller.ts
+++ b/backend/src/modules/streaming/streaming.controller.ts
@@ -695,6 +695,8 @@ export class StreamingController {
   async effectiveSettingsInfo() {
     const ss = await this.getStreamingSettings();
     return {
+      tonemapAlgo: ss.tonemapAlgo,
+      gpuRenderNode: ss.gpuRenderNode,
       tonemapCurve: ss.tonemapCurve,
       cacheMaxGb: +(ss.cacheMaxBytes / 1024 ** 3).toFixed(1),
       cacheTtlHours: +(ss.cacheTtlMs / 3_600_000).toFixed(1),

--- a/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.spec.ts
+++ b/backend/src/modules/streaming/transcoding/codec/encoders/helpers/qsv-filters.spec.ts
@@ -78,7 +78,7 @@ describe('qsvScaleFilter8bit', () => {
     );
   });
 
-  it('honours TRANSCODE_TONEMAP_CURVE on the d3d11 OpenCL chain', () => {
+  it('honours the configured curve on the d3d11 OpenCL chain', () => {
     expect(
       qsvScaleFilter8bit(
         input({
@@ -91,7 +91,7 @@ describe('qsvScaleFilter8bit', () => {
     ).toContain('tonemap_opencl=tonemap=mobius:');
   });
 
-  it('honours TRANSCODE_TONEMAP_CURVE on the Linux OpenCL chain', () => {
+  it('honours the configured curve on the Linux OpenCL chain', () => {
     expect(
       qsvScaleFilter8bit(
         input({

--- a/backend/src/modules/streaming/transcoding/codec/types.ts
+++ b/backend/src/modules/streaming/transcoding/codec/types.ts
@@ -22,8 +22,8 @@ export type HdrFormat = 'HDR10' | 'HLG';
 /** HDR→SDR tone-map curve, shared by the CPU and GPU (tonemap_opencl) paths.
  *  `hable` is a filmic curve with a gentle highlight rolloff (retains specular
  *  detail on high-nit HDR10); `mobius` is punchier with a harder highlight knee;
- *  `reinhard` is the simplest global operator. Selected via
- *  `TRANSCODE_TONEMAP_CURVE`, default `hable`. */
+ *  `reinhard` is the simplest global operator. Selected in Settings >
+ *  Streaming, default `hable`. */
 export type TonemapCurve = 'hable' | 'mobius' | 'reinhard';
 
 /** Source HDR10 static metadata (SMPTE ST 2086 mastering display + CTA-861.3
@@ -116,7 +116,7 @@ export interface EncoderInput {
    *  meaningful when `tonemap` is true. */
   tonemapPath: 'vaapi' | 'opencl' | 'qsv';
   /** Tone-map curve for the qsv-native OpenCL path (`tonemap_opencl`).
-   *  Resolved from `TRANSCODE_TONEMAP_CURVE`; absent → `hable`. */
+   *  Resolved from the admin setting; absent → `hable`. */
   tonemapCurve?: TonemapCurve;
   hasBurnIn: boolean;
   hasCrop: boolean;

--- a/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.ts
+++ b/backend/src/modules/streaming/transcoding/ffmpeg-filter-graph.ts
@@ -1,24 +1,17 @@
 import type { BurnInSubtitle } from './types';
 import type { EncoderInput, TonemapCurve } from './codec/types';
 
-/** `TRANSCODE_TONEMAP_CURVE` fallback, used when no admin curve is set. */
-export function envTonemapCurve(): TonemapCurve | null {
-  const v = process.env.TRANSCODE_TONEMAP_CURVE;
-  return v === 'mobius' || v === 'reinhard' || v === 'hable' ? v : null;
-}
-
 /** Admin-selected curve (`streaming_tonemap_curve`), pushed in by
- *  {@link setSelectedTonemapCurve}. Null = fall back to the env var. */
+ *  {@link setSelectedTonemapCurve}. */
 let selectedCurve: TonemapCurve | null = null;
 
 export function setSelectedTonemapCurve(curve: TonemapCurve | null): void {
   selectedCurve = curve;
 }
 
-/** Tone-map curve in force: admin setting > env var > `hable`. Shared by the
- *  CPU and GPU tone-map paths. */
+/** Tone-map curve in force. Shared by the CPU and GPU tone-map paths. */
 export function resolveTonemapCurve(): TonemapCurve {
-  return selectedCurve ?? envTonemapCurve() ?? 'hable';
+  return selectedCurve ?? 'hable';
 }
 
 export interface VideoFilterContext {

--- a/backend/src/modules/streaming/transcoding/hw-device.spec.ts
+++ b/backend/src/modules/streaming/transcoding/hw-device.spec.ts
@@ -2,38 +2,37 @@ import {
   hostHasVaapi,
   openclTonemapInitArgs,
   qsvDeviceInitArgs,
+  setSelectedRenderNode,
   vaapiDeviceInitArgs,
   vaapiRenderNode,
 } from './hw-device';
 
 describe('hw-device', () => {
-  const original = process.env.FLIKS_VAAPI_RENDER_NODE;
   const originalOpencl = process.env.FLIKS_OPENCL_DEVICE;
   afterEach(() => {
-    if (original === undefined) delete process.env.FLIKS_VAAPI_RENDER_NODE;
-    else process.env.FLIKS_VAAPI_RENDER_NODE = original;
+    setSelectedRenderNode(null);
     if (originalOpencl === undefined) delete process.env.FLIKS_OPENCL_DEVICE;
     else process.env.FLIKS_OPENCL_DEVICE = originalOpencl;
   });
 
   describe('vaapiRenderNode', () => {
     it('defaults to /dev/dri/renderD128', () => {
-      delete process.env.FLIKS_VAAPI_RENDER_NODE;
       expect(vaapiRenderNode()).toBe('/dev/dri/renderD128');
     });
-    it('honours the FLIKS_VAAPI_RENDER_NODE override', () => {
-      process.env.FLIKS_VAAPI_RENDER_NODE = '/dev/dri/renderD129';
+    it('honours the admin selection', () => {
+      setSelectedRenderNode('/dev/dri/renderD129');
       expect(vaapiRenderNode()).toBe('/dev/dri/renderD129');
     });
-    it('ignores a blank override', () => {
-      process.env.FLIKS_VAAPI_RENDER_NODE = '   ';
+    it('treats auto and a blank selection as no pin', () => {
+      setSelectedRenderNode('auto');
+      expect(vaapiRenderNode()).toBe('/dev/dri/renderD128');
+      setSelectedRenderNode('   ');
       expect(vaapiRenderNode()).toBe('/dev/dri/renderD128');
     });
   });
 
   describe('vaapiDeviceInitArgs', () => {
     it('binds VAAPI to the render node', () => {
-      delete process.env.FLIKS_VAAPI_RENDER_NODE;
       expect(vaapiDeviceInitArgs()).toEqual([
         '-init_hw_device',
         'vaapi=va:/dev/dri/renderD128',
@@ -43,7 +42,6 @@ describe('hw-device', () => {
 
   describe('qsvDeviceInitArgs', () => {
     it('derives QSV from VAAPI on Linux', () => {
-      delete process.env.FLIKS_VAAPI_RENDER_NODE;
       expect(qsvDeviceInitArgs('linux')).toEqual([
         '-init_hw_device',
         'vaapi=va:/dev/dri/renderD128',
@@ -57,8 +55,8 @@ describe('hw-device', () => {
         'qsv=qs',
       ]);
     });
-    it('threads the render-node override into the Linux VAAPI device', () => {
-      process.env.FLIKS_VAAPI_RENDER_NODE = '/dev/dri/renderD129';
+    it('threads the pinned render node into the Linux VAAPI device', () => {
+      setSelectedRenderNode('/dev/dri/renderD129');
       expect(qsvDeviceInitArgs('linux')).toEqual([
         '-init_hw_device',
         'vaapi=va:/dev/dri/renderD129',

--- a/backend/src/modules/streaming/transcoding/hw-device.ts
+++ b/backend/src/modules/streaming/transcoding/hw-device.ts
@@ -18,14 +18,20 @@ export function setSelectedRenderNode(node: string | null | undefined): void {
   selectedRenderNode = v && v.length > 0 && v !== 'auto' ? v : null;
 }
 
+/** `FLIKS_VAAPI_RENDER_NODE`, or null when unset. The settings layer folds it
+ *  into `gpuRenderNode` so the admin form shows the node actually in use. */
+export function envRenderNode(): string | null {
+  const v = process.env.FLIKS_VAAPI_RENDER_NODE?.trim();
+  return v && v.length > 0 ? v : null;
+}
+
 /** DRI render node for the VAAPI/Linux-QSV device. Resolution order: the
  *  admin `streaming_gpu_render_node` selection, then the
- *  `FLIKS_VAAPI_RENDER_NODE` env override, then the default. Ignored on
+ *  `FLIKS_VAAPI_RENDER_NODE` env fallback, then the default. The env branch
+ *  only matters before the settings are readable at boot. Ignored on
  *  Windows (MFX/D3D11, no node). */
 export function vaapiRenderNode(): string {
-  if (selectedRenderNode) return selectedRenderNode;
-  const override = process.env.FLIKS_VAAPI_RENDER_NODE?.trim();
-  return override && override.length > 0 ? override : '/dev/dri/renderD128';
+  return selectedRenderNode ?? envRenderNode() ?? '/dev/dri/renderD128';
 }
 
 /** VAAPI device aliased `va` on the render node. Linux-only. */

--- a/backend/src/modules/streaming/transcoding/hw-device.ts
+++ b/backend/src/modules/streaming/transcoding/hw-device.ts
@@ -7,7 +7,7 @@ export const QSV_DEVICE_ALIAS = 'qs';
 export const D3D11VA_DEVICE_ALIAS = 'dx';
 
 /** Admin-selected DRI render node (from the `streaming_gpu_render_node`
- *  setting). Null = "auto" → fall back to the env override, then the default.
+ *  setting). Null = "auto" → the default node.
  *  Set from the streaming settings on boot and on every playback-info, so a
  *  multi-GPU host can pin transcoding to a specific adapter. */
 let selectedRenderNode: string | null = null;
@@ -18,20 +18,11 @@ export function setSelectedRenderNode(node: string | null | undefined): void {
   selectedRenderNode = v && v.length > 0 && v !== 'auto' ? v : null;
 }
 
-/** `FLIKS_VAAPI_RENDER_NODE`, or null when unset. The settings layer folds it
- *  into `gpuRenderNode` so the admin form shows the node actually in use. */
-export function envRenderNode(): string | null {
-  const v = process.env.FLIKS_VAAPI_RENDER_NODE?.trim();
-  return v && v.length > 0 ? v : null;
-}
-
-/** DRI render node for the VAAPI/Linux-QSV device. Resolution order: the
- *  admin `streaming_gpu_render_node` selection, then the
- *  `FLIKS_VAAPI_RENDER_NODE` env fallback, then the default. The env branch
- *  only matters before the settings are readable at boot. Ignored on
- *  Windows (MFX/D3D11, no node). */
+/** DRI render node for the VAAPI/Linux-QSV device: the admin
+ *  `streaming_gpu_render_node` selection, or the first node otherwise. Ignored
+ *  on Windows (MFX/D3D11, no node). */
 export function vaapiRenderNode(): string {
-  return selectedRenderNode ?? envRenderNode() ?? '/dev/dri/renderD128';
+  return selectedRenderNode ?? '/dev/dri/renderD128';
 }
 
 /** VAAPI device aliased `va` on the render node. Linux-only. */

--- a/backend/src/modules/streaming/transcoding/tonemap-path.spec.ts
+++ b/backend/src/modules/streaming/transcoding/tonemap-path.spec.ts
@@ -23,19 +23,12 @@ const vppQsv = isVppQsvTonemapEnabled as jest.Mock;
 const qsvOpencl = isQsvOpenclTonemapEnabled as jest.Mock;
 
 describe('resolveTonemapPath', () => {
-  const origEnv = process.env.TRANSCODE_TONEMAP_ALGO;
   beforeEach(() => {
     openclNoCrop.mockReturnValue(false);
     openclCrop.mockReturnValue(false);
     vppQsv.mockReturnValue(false);
     qsvOpencl.mockReturnValue(false);
-    delete process.env.TRANSCODE_TONEMAP_ALGO;
   });
-  afterEach(() => {
-    if (origEnv === undefined) delete process.env.TRANSCODE_TONEMAP_ALGO;
-    else process.env.TRANSCODE_TONEMAP_ALGO = origEnv;
-  });
-
   it('passes explicit picks through unchanged, on any platform', () => {
     expect(resolveTonemapPath('qsv', { hasCrop: false }, 'win32')).toBe('qsv');
     expect(resolveTonemapPath('vaapi', { hasCrop: false }, 'linux')).toBe(
@@ -94,37 +87,5 @@ describe('resolveTonemapPath', () => {
     openclNoCrop.mockReturnValue(true); // VAAPI probe — irrelevant on win32
     vppQsv.mockReturnValue(true);
     expect(resolveTonemapPath('auto', { hasCrop: false }, 'win32')).toBe('qsv');
-  });
-
-  describe('TRANSCODE_TONEMAP_ALGO override', () => {
-    it('forces the algo over the probe-driven auto, on any platform', () => {
-      openclNoCrop.mockReturnValue(true); // auto would pick opencl on Linux
-      process.env.TRANSCODE_TONEMAP_ALGO = 'qsv';
-      expect(resolveTonemapPath('auto', { hasCrop: false }, 'linux')).toBe(
-        'qsv',
-      );
-    });
-
-    it('never overrides an explicit admin setting', () => {
-      process.env.TRANSCODE_TONEMAP_ALGO = 'opencl';
-      expect(resolveTonemapPath('vaapi', { hasCrop: false }, 'win32')).toBe(
-        'vaapi',
-      );
-    });
-
-    it('is case-insensitive and trims whitespace', () => {
-      process.env.TRANSCODE_TONEMAP_ALGO = '  OpenCL  ';
-      expect(resolveTonemapPath('auto', { hasCrop: false }, 'linux')).toBe(
-        'opencl',
-      );
-    });
-
-    it('ignores an invalid value (falls back to the normal resolution)', () => {
-      process.env.TRANSCODE_TONEMAP_ALGO = 'nonsense';
-      vppQsv.mockReturnValue(true);
-      expect(resolveTonemapPath('auto', { hasCrop: false }, 'win32')).toBe(
-        'qsv',
-      );
-    });
   });
 });

--- a/backend/src/modules/streaming/transcoding/tonemap-path.ts
+++ b/backend/src/modules/streaming/transcoding/tonemap-path.ts
@@ -7,9 +7,9 @@ import { isQsvOpenclTonemapEnabled } from './codec/qsv-opencl-probe';
 import { hostHasVaapi } from './hw-device';
 import type { TonemapAlgo } from './types';
 
-/** `TRANSCODE_TONEMAP_ALGO` fallback (auto/qsv/vaapi/opencl), consulted only
- *  when the admin setting is `auto`. A value picked in the UI always wins.
- *  Invalid/unset → null (no override). */
+/** `TRANSCODE_TONEMAP_ALGO` fallback (auto/qsv/vaapi/opencl), folded into the
+ *  `tonemapAlgo` setting when the admin left it on `auto`. A value picked in
+ *  the UI always wins. Invalid/unset → null (no fallback). */
 export function tonemapAlgoOverride(): TonemapAlgo | null {
   const v = process.env.TRANSCODE_TONEMAP_ALGO?.trim().toLowerCase();
   return v === 'auto' || v === 'qsv' || v === 'vaapi' || v === 'opencl'
@@ -30,8 +30,7 @@ export function tonemapAlgoOverride(): TonemapAlgo | null {
  *    all, so it would force the session onto a CPU encode. On Linux
  *    QSV is VAAPI-backed, so `'vaapi'` stays a valid on-GPU tone-map.
  *  - Explicit picks (`'vaapi'` / `'qsv'` / `'opencl'`) bypass the
- *    probe and the env fallback, and trust the admin to know their
- *    hardware.
+ *    probe and trust the admin to know their hardware.
  *
  *  Shared between `ffmpeg-args` (which builds the filter chain) and
  *  the playback-info DTO (which surfaces the post-resolution value to
@@ -43,8 +42,7 @@ export function resolveTonemapPath(
   opts: { hasCrop: boolean } = { hasCrop: false },
   platform: NodeJS.Platform = process.platform,
 ): ResolvedTonemapPath {
-  const effective = algo === 'auto' ? (tonemapAlgoOverride() ?? 'auto') : algo;
-  if (effective === 'auto') {
+  if (algo === 'auto') {
     // Windows QSV OpenCL is the CPU-bounce path (its own probe); elsewhere it's
     // the VAAPI-derived bridge.
     const openclOk =
@@ -60,5 +58,5 @@ export function resolveTonemapPath(
     if (!hostHasVaapi(platform) && isVppQsvTonemapEnabled()) return 'qsv';
     return 'vaapi';
   }
-  return effective;
+  return algo;
 }

--- a/backend/src/modules/streaming/transcoding/tonemap-path.ts
+++ b/backend/src/modules/streaming/transcoding/tonemap-path.ts
@@ -7,16 +7,6 @@ import { isQsvOpenclTonemapEnabled } from './codec/qsv-opencl-probe';
 import { hostHasVaapi } from './hw-device';
 import type { TonemapAlgo } from './types';
 
-/** `TRANSCODE_TONEMAP_ALGO` fallback (auto/qsv/vaapi/opencl), folded into the
- *  `tonemapAlgo` setting when the admin left it on `auto`. A value picked in
- *  the UI always wins. Invalid/unset → null (no fallback). */
-export function tonemapAlgoOverride(): TonemapAlgo | null {
-  const v = process.env.TRANSCODE_TONEMAP_ALGO?.trim().toLowerCase();
-  return v === 'auto' || v === 'qsv' || v === 'vaapi' || v === 'opencl'
-    ? (v as TonemapAlgo)
-    : null;
-}
-
 /** Concrete filter chain the session-time graph will actually use,
  *  derived from the admin `TonemapAlgo` setting + boot probe results.
  *

--- a/backend/src/modules/streaming/transcoding/transcode-cache.service.spec.ts
+++ b/backend/src/modules/streaming/transcoding/transcode-cache.service.spec.ts
@@ -252,28 +252,25 @@ describe('TranscodeCacheService', () => {
   });
 });
 
-describe('TranscodeCacheService env overrides', () => {
-  const ENV = process.env;
-  beforeEach(() => {
-    process.env = { ...ENV };
-  });
-  afterEach(() => {
-    process.env = ENV;
-  });
-
-  it('honours TRANSCODE_CACHE_TTL_MS', () => {
-    process.env.TRANSCODE_CACHE_TTL_MS = '1000';
-    const svc = new TranscodeCacheService();
-    // No public getter; assert by behaviour: a brand-new entry with
-    // lastAccess of 2 s ago should be evicted under the 1 s TTL.
-    expect((svc as unknown as { ttlMs: number }).ttlMs).toBe(1000);
+describe('TranscodeCacheService limits', () => {
+  it('defaults to the 4 h / 20 GB budget', () => {
+    const svc = new TranscodeCacheService() as unknown as {
+      ttlMs: number;
+      maxBytes: number;
+    };
+    expect(svc.ttlMs).toBe(4 * 60 * 60 * 1000);
+    expect(svc.maxBytes).toBe(20 * 1024 ** 3);
   });
 
-  it('falls back to default when env is unparseable', () => {
-    process.env.TRANSCODE_CACHE_TTL_MS = 'not-a-number';
+  it('takes the admin limits and ignores a non-positive one', () => {
     const svc = new TranscodeCacheService();
-    expect((svc as unknown as { ttlMs: number }).ttlMs).toBe(
-      4 * 60 * 60 * 1000,
-    );
+    svc.setLimits({ ttlMs: 1000, maxBytes: 5 * 1024 ** 3 });
+    const state = svc as unknown as { ttlMs: number; maxBytes: number };
+    expect(state.ttlMs).toBe(1000);
+    expect(state.maxBytes).toBe(5 * 1024 ** 3);
+
+    svc.setLimits({ ttlMs: 0, maxBytes: -1 });
+    expect(state.ttlMs).toBe(1000);
+    expect(state.maxBytes).toBe(5 * 1024 ** 3);
   });
 });

--- a/client/src/app/core/services/api/streaming-api.service.ts
+++ b/client/src/app/core/services/api/streaming-api.service.ts
@@ -672,6 +672,8 @@ export class StreamingApiService {
   getEffectiveSettings() {
     return firstValueFrom(
       this.http.get<{
+        tonemapAlgo: string;
+        gpuRenderNode: string;
         tonemapCurve: string;
         cacheMaxGb: number;
         cacheTtlHours: number;

--- a/client/src/app/features/settings/streaming/streaming.ts
+++ b/client/src/app/features/settings/streaming/streaming.ts
@@ -91,19 +91,21 @@ export class StreamingSettingsComponent implements OnInit {
         prewarm === 'off' || prewarm === 'import' ? prewarm : 'playback',
       );
       this.tonemapAlgosAvailable.set(algos.available ?? ['auto']);
-      // If the persisted value isn't runnable on this host (e.g. opencl
-      // saved on a box where the probe failed after a driver change),
-      // collapse back to 'auto' so the select stays in sync with what
-      // the backend would actually do.
-      const saved = all['streaming_tonemap_algo'] ?? 'auto';
-      this.tonemapAlgo.set(
-        this.tonemapAlgosAvailable().includes(saved) ? saved : 'auto',
-      );
       this.gpus.set(gpusResp.gpus ?? []);
-      this.gpuRenderNode.set(all['streaming_gpu_render_node'] ?? 'auto');
       // Pre-fill from the resolved values, not the raw keys: an unset field
-      // must show what the server actually uses, or saving would silently
-      // replace an env-configured budget with a default.
+      // must show what the server actually uses, or the form would claim
+      // "auto" while an env var drives the session, and saving would replace
+      // an env-configured value with a default.
+      const algo = effective?.tonemapAlgo ?? all['streaming_tonemap_algo'] ?? 'auto';
+      // A value this host can't run (e.g. opencl after a driver change broke
+      // the probe) collapses back to 'auto', or the select would show an
+      // option it doesn't have.
+      this.tonemapAlgo.set(
+        this.tonemapAlgosAvailable().includes(algo) ? algo : 'auto',
+      );
+      this.gpuRenderNode.set(
+        effective?.gpuRenderNode ?? all['streaming_gpu_render_node'] ?? 'auto',
+      );
       if (effective) {
         this.tonemapCurve.set(effective.tonemapCurve);
         this.cacheMaxGb.set(String(effective.cacheMaxGb));

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -56,8 +56,7 @@ services:
       # TZ: Europe/Paris
 
       # ---- Access (optional) ----
-      # Public URL behind a reverse proxy. Settings > General wins over it.
-      # EXTERNAL_URL: https://fliks.example.com
+      # The public URL behind a reverse proxy lives in Settings > General.
       # Extra origins allowed to call the API (comma-separated).
       # CORS_ORIGIN: https://fliks.example.com
       # Session lifetime. Default 7d.

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -74,24 +74,16 @@ services:
       # FLIKS_DISABLE_UPDATE_CHECK: '1'
 
       # ---- Streaming (optional) ----
-      # Session timings. No UI equivalent.
+      # Session timings. Everything an admin tunes day to day, including the
+      # transcode-cache budget, the GPU, the tone-map algorithm and curve and
+      # the background ffmpeg job count, lives in Settings > Streaming.
       # STREAM_LIVE_SESSION_TTL_MS: 30000        # viewer TTL without a heartbeat
       # STREAM_JOB_GRACE_MS: 60000               # encoder kill delay after the last viewer
       # STREAM_JOB_FALLBACK_TIMEOUT_MS: 1800000  # idle session timeout
       # STREAM_MAX_SESSIONS_PER_USER: 10
       # TRANSCODE_CACHE_GC_INTERVAL_MS: 300000
-      # Starting values only: Settings > Streaming wins once saved there, and
-      # the server logs a warning naming any of these it is ignoring.
-      # TRANSCODE_CACHE_TTL_MS: 14400000         # segment retention, 4 h
-      # TRANSCODE_CACHE_MAX_BYTES: 21474836480   # LRU cap, 20 GB
-      # FLIKS_FFMPEG_SLOTS: 4                    # concurrent background ffmpeg jobs
 
-      # ---- Hardware / HDR (optional) ----
-      # The GPU, the tone-map algorithm and the curve live in Settings >
-      # Streaming; the two vars below are starting values for them.
-      # TRANSCODE_TONEMAP_CURVE: hable           # hable | mobius | reinhard
-      # FLIKS_VAAPI_RENDER_NODE: /dev/dri/renderD128
-      # No UI equivalent:
+      # ---- Hardware (optional) ----
       # FLIKS_OPENCL_DEVICE: '0.0'               # pin platform.device for the OpenCL tone-map
       # THUMB_HWACCEL_DEVICE: off                # thumbnails: off, or a render node
     volumes:


### PR DESCRIPTION
## Why

#1364 moved four tuning values into the admin UI but kept their environment variables as a fallback, which left two ways to set one value. That duplication is what made the tone-map dropdown a no-op in the first place, and it kept biting: the algorithm and GPU fields still pre-filled from the raw settings keys, so with `TRANSCODE_TONEMAP_ALGO=qsv` and nothing saved the form showed **Auto** while the session ran on `qsv`.

Reference point: the equivalent server in this space exposes no environment override for any transcoding setting. Hardware acceleration, tone-mapping, device selection, preset and thread count are dashboard-only; its env layer covers paths, the ffmpeg binary location and the published URL. Where it does let both channels touch one value, the env wins silently — the same trap.

## What changed

**One channel.** These are no longer read at all:

- `TRANSCODE_TONEMAP_ALGO`, `TRANSCODE_TONEMAP_CURVE`
- `TRANSCODE_CACHE_MAX_BYTES`, `TRANSCODE_CACHE_TTL_MS`
- `FLIKS_FFMPEG_SLOTS`
- `FLIKS_VAAPI_RENDER_NODE`
- `EXTERNAL_URL`

The first six live in Settings > Streaming, `EXTERNAL_URL` in Settings > General, where the `public_url` setting already took precedence over it. It only fed the stream base URL handed to a Chromecast; with it gone that resolves from the setting, falling back to the `Host` header as before. **Still env-only:** session and GC timings (`STREAM_LIVE_SESSION_TTL_MS`, `STREAM_JOB_GRACE_MS`, `STREAM_JOB_FALLBACK_TIMEOUT_MS`, `STREAM_MAX_SESSIONS_PER_USER`, `TRANSCODE_CACHE_GC_INTERVAL_MS`) — protocol cadences, not admin settings — plus `FLIKS_OPENCL_DEVICE` and `THUMB_HWACCEL_DEVICE`, which have no UI.

**Fallout.** `resolveTonemapPath`, `resolveTonemapCurve` and `vaapiRenderNode` stopped reading `process.env` entirely, so the per-session hot path no longer re-parses environment strings. `StreamLifetime` keeps only the GC cadence. The form pre-fills `tonemapAlgo` and `gpuRenderNode` from `effective-settings` like the other four, so it can never claim "auto" while something else is in force.

## Tests

The env-override cases moved onto the API that replaced them: `hw-device.spec.ts` drives `setSelectedRenderNode`, `transcode-cache.service.spec.ts` drives `setLimits`, `ffmpeg-slots.spec.ts` drives `setFfmpegSlots`, and `streaming-settings-cache.service.spec.ts` asserts that a retired variable never reaches the resolved settings. Backend 2170/2170 green, `ng build` clean.

## Upgrade

Nothing carries an existing environment value into the settings, and nothing warns about one still being set: the install base is young enough that the machinery was judged not worth it. An operator who had set one of these re-enters it in the UI.

The TrueNAS community app exposed `EXTERNAL_URL` through an **External URL** question; truenas/apps#5786 removes it.
