### PR TITLE
docs(cast): stop naming the removed EXTERNAL_URL in the cast-info comment

### DIFF
--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -155,8 +155,9 @@ export class AuthController {
   }
 
   /**
-   * Cast JWT (4h) + the stream base URL (EXTERNAL_URL / Host). Called right
-   * before loadMedia so it can't drift from the receiver's own requests.
+   * Cast JWT (4h) + the stream base URL, from the public-URL setting or the
+   * Host header. Called right before loadMedia so it can't drift from the
+   * receiver's own requests.
    */
   @Post('cast-info')
   @UseGuards(JwtOrApiKeyGuard)


### PR DESCRIPTION
Leftover from #1365: the `cast-info` doc comment still described the stream base URL as coming from `EXTERNAL_URL / Host`. The variable is gone; the URL now resolves from the public-URL setting, falling back to the `Host` header.