### PR TITLE
docs(readme): add a plugins section and correct the iOS minimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ its own native SwiftUI app talking to the same backend.
 | Client | Where to get it | Minimum | Notes |
 |---|---|---|---|
 | **Web / PWA** | your browser, at the server URL | any current browser | installable to the home screen |
-| **iOS · iPadOS** | App Store | iOS 14 | |
+| **iOS · iPadOS** | App Store | iOS 16.6 | |
 | **Android** | Play Store | Android 6 (API 23) | phone + tablet |
 | **Android TV** | Play Store | Android 6 | 10-foot UI, D-pad navigation |
 | **Samsung TV (Tizen)** | sideload for now | Tizen 5.5 — 2020 sets and newer | works fully, not yet on Samsung Apps |
@@ -219,6 +219,37 @@ connects to your server like the mobile apps do, it doesn't host one.
   quality, on which hardware path, and why a transcode was needed.
 - **Images cached locally** — no hotlinking to external services while
   you browse.
+
+---
+
+## Plugins
+
+Fliks ships with no way to acquire media, on purpose. Searching indexers,
+talking to a download client, grabbing a release: none of it is built in,
+and the server holds no trace of a plugin it doesn't have. You add what
+you want.
+
+It all happens in **Settings > Plugins**. The official catalog is
+configured out of the box, so you browse, install and update from there.
+You can add other sources, or import a `.fkplugin` archive by hand.
+
+- **The Download plugin**, for instance, brings indexer search,
+  download-client management and the grab pipeline. Install it and the
+  search, the clients and their settings pages appear in the interface.
+  Remove it and they are gone, along with its data.
+- **Archives are signed**, and the signature is checked before anything
+  is written to disk.
+- **A plugin that runs code runs apart.** There are two tiers: a `data`
+  plugin ships JSON and executes nothing at all, while a `process`
+  plugin gets its own child process under its own uid, plus its own
+  PostgreSQL role and schema. It cannot reach another plugin's tables,
+  or yours.
+- **Plugins extend the interface**, not just the backend. Their pages,
+  menu entries and settings appear where they belong and follow your
+  permissions like everything else.
+- **Updates** are checked daily, and you can turn that off.
+
+Writing one: [docs/plugins.md](docs/plugins.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -224,19 +224,14 @@ connects to your server like the mobile apps do, it doesn't host one.
 
 ## Plugins
 
-Fliks ships with no way to acquire media, on purpose. Searching indexers,
-talking to a download client, grabbing a release: none of it is built in,
-and the server holds no trace of a plugin it doesn't have. You add what
-you want.
+Fliks ships with no way to acquire media. You install what you want from
+**Settings > Plugins**: the official catalog is configured out of the
+box, and you can add other sources or import a `.fkplugin` archive by
+hand.
 
-It all happens in **Settings > Plugins**. The official catalog is
-configured out of the box, so you browse, install and update from there.
-You can add other sources, or import a `.fkplugin` archive by hand.
-
-- **The Download plugin**, for instance, brings indexer search,
+- **The Download plugin** brings torrent indexer search,
   download-client management and the grab pipeline. Install it and the
   search, the clients and their settings pages appear in the interface.
-  Remove it and they are gone, along with its data.
 - **Archives are signed**, and the signature is checked before anything
   is written to disk.
 - **A plugin that runs code runs apart.** There are two tiers: a `data`


### PR DESCRIPTION
## iOS minimum: 14 → 16.6

The table said iOS 14. The app target `media.fliks.app` has `IPHONEOS_DEPLOYMENT_TARGET = 16.6` in `client/ios/App/App.xcodeproj/project.pbxproj`, which is what the App Store listing derives "Requires iOS ... or later" from. The Podfile's `platform :ios, '16.0'` and the project-level default are both overridden by the target, so 16.6 is the real floor.

The other rows check out: Android `minSdkVersion = 23` is Android 6, macOS is `MACOSX_DEPLOYMENT_TARGET = 13.0`, and `appletv/project.yml` declares `tvOS: "17.0"`.

## New Plugins section

The README described no acquisition capability at all, which was accurate but left out how you get one. The section leads with the deliberate part: core ships empty, and the server holds no trace of a plugin it doesn't have.

The Download plugin is named as the example, as an illustration of what you install rather than something bundled. Claims made were checked against the code:

- Signature verified before extraction (`modules/plugins/archive/`).
- A `process` plugin runs under its own uid (`supervisor/plugin-supervisor.ts`) and gets its own PostgreSQL role, its own schema, and a `search_path` set to that schema only, never `,public` (`plugin-database.service.ts`).
- The official catalog is pre-configured (`migrations/1783100000000-seed-official-plugin-source.ts`).
- Daily update pass, disabled by the `plugins.auto_update` setting.

## Compose examples

Checked, no change needed. Every variable named in `docker-compose.example.yml` is still read by the backend; the five that are not (`POSTGRES_*`, `NVIDIA_*`) belong to the postgres image and the nvidia runtime. The `postgres:18.3` pin matches what the README claims. The variables retired in #1365 were already removed from the file there.
